### PR TITLE
Optimize startup and dictation responsiveness

### DIFF
--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -6,6 +6,20 @@ import Foundation
 import Security
 import SwiftUI
 
+private func readPremiumAccountToken(service: String) -> String? {
+    let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecAttrAccount as String: "access-token",
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+    var value: CFTypeRef?
+    guard SecItemCopyMatching(query as CFDictionary, &value) == errSecSuccess,
+          let data = value as? Data else { return nil }
+    return String(data: data, encoding: .utf8)
+}
+
 enum PremiumSyncMode: String, CaseIterable, Identifiable, Sendable {
     case off
     case automaticICloud
@@ -267,6 +281,7 @@ final class PremiumAccountService: ObservableObject {
     private let deviceID: String
     private let entitlementVerifier: CrossDevicePremiumEntitlementVerifier?
     private let appleWebAuthenticator: any AppleWebAuthenticating
+    private var startupTokenTask: Task<Void, Never>?
 
     private static let productionEntitlementPublicKeyBase64 =
         "8ZwFh+yrpkZZ1VsZgjpZcOz2h3jKpGG93MTdRaCPqXFn/Loqh8u36hB9FLho+ozwuHbaNeoN1MxM2/AJKyBNvQ=="
@@ -282,7 +297,8 @@ final class PremiumAccountService: ObservableObject {
         keychainService: String = "com.typewhisper.mac.premium-account",
         entitlementPublicKeyBase64: String = PremiumAccountService.productionEntitlementPublicKeyBase64,
         isSignedInOverride: Bool? = nil,
-        automaticallyRefresh: Bool = true
+        automaticallyRefresh: Bool = true,
+        startupTokenReader: @escaping @Sendable (String) -> String? = readPremiumAccountToken
     ) {
         self.defaults = defaults
         self.baseURL = baseURL
@@ -316,8 +332,24 @@ final class PremiumAccountService: ObservableObject {
             entitlement = nil
             defaults.removeObject(forKey: Keys.cachedEntitlement)
         }
-        isSignedIn = isSignedInOverride ?? (Self.readToken(service: keychainService) != nil)
-        if isSignedIn, automaticallyRefresh { Task { await refreshIfNeeded() } }
+        isSignedIn = isSignedInOverride ?? false
+        if let isSignedInOverride {
+            if isSignedInOverride, automaticallyRefresh {
+                Task { await refreshIfNeeded() }
+            }
+        } else {
+            startupTokenTask = Task { @MainActor [weak self] in
+                let hasStoredToken = await Task.detached {
+                    startupTokenReader(keychainService) != nil
+                }.value
+                guard !Task.isCancelled, let self else { return }
+                self.isSignedIn = hasStoredToken
+                self.startupTokenTask = nil
+                if hasStoredToken, automaticallyRefresh {
+                    await self.refreshIfNeeded()
+                }
+            }
+        }
     }
 
     func signInWithApple(polarLicenseKey: String?) async {
@@ -415,6 +447,8 @@ final class PremiumAccountService: ObservableObject {
         _ accountSession: AccountSession,
         polarLicenseKey: String?
     ) async throws {
+        startupTokenTask?.cancel()
+        startupTokenTask = nil
         try Self.saveToken(accountSession.accessToken, service: keychainService)
         isSignedIn = true
         try acceptEntitlement(accountSession.entitlement)
@@ -496,6 +530,8 @@ final class PremiumAccountService: ObservableObject {
     }
 
     private func clearAuthorizationState() {
+        startupTokenTask?.cancel()
+        startupTokenTask = nil
         Self.deleteToken(service: keychainService)
         isSignedIn = false
         entitlement = nil
@@ -504,17 +540,7 @@ final class PremiumAccountService: ObservableObject {
     }
 
     private static func readToken(service: String) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: "access-token",
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var value: CFTypeRef?
-        guard SecItemCopyMatching(query as CFDictionary, &value) == errSecSuccess,
-              let data = value as? Data else { return nil }
-        return String(data: data, encoding: .utf8)
+        readPremiumAccountToken(service: service)
     }
 
     private static func saveToken(_ token: String, service: String) throws {

--- a/TypeWhisper/ViewModels/APIServerViewModel.swift
+++ b/TypeWhisper/ViewModels/APIServerViewModel.swift
@@ -30,6 +30,7 @@ final class APIServerViewModel: ObservableObject {
 
     private let httpServer: HTTPServer
     private let apiAuthenticator: LocalAPIAuthenticator
+    private var startTask: Task<Void, Never>?
 
     init(httpServer: HTTPServer, apiAuthenticator: LocalAPIAuthenticator) {
         self.httpServer = httpServer
@@ -52,23 +53,33 @@ final class APIServerViewModel: ObservableObject {
     }
 
     func startServer() {
+        startTask?.cancel()
         errorMessage = nil
-        do {
-            let apiToken = try apiAuthenticator.loadOrCreateToken()
-            try httpServer.start(port: port)
+        let selectedPort = port
+        startTask = Task { @MainActor [weak self] in
+            guard let self else { return }
             do {
-                try writeDiscoveryFiles(apiToken: apiToken)
+                let apiToken = try await apiAuthenticator.loadOrCreateToken()
+                try Task.checkCancellation()
+                try httpServer.start(port: selectedPort)
+                do {
+                    try writeDiscoveryFiles(apiToken: apiToken, port: selectedPort)
+                } catch {
+                    httpServer.stop()
+                    throw error
+                }
+            } catch is CancellationError {
+                return
             } catch {
-                httpServer.stop()
-                throw error
+                errorMessage = error.localizedDescription
+                isRunning = false
             }
-        } catch {
-            errorMessage = error.localizedDescription
-            isRunning = false
         }
     }
 
     func stopServer() {
+        startTask?.cancel()
+        startTask = nil
         httpServer.stop()
         isRunning = false
         errorMessage = nil
@@ -94,7 +105,7 @@ final class APIServerViewModel: ObservableObject {
             .appendingPathComponent("api-discovery.json")
     }
 
-    private func writeDiscoveryFiles(apiToken: String) throws {
+    private func writeDiscoveryFiles(apiToken: String, port: UInt16) throws {
         let url = Self.portFileURL
         let directory = url.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -127,19 +138,23 @@ final class LocalAPIAuthenticator: @unchecked Sendable {
 
     private let token: OSAllocatedUnfairLock<String?>
     private let requiresAuthentication: OSAllocatedUnfairLock<Bool>
+    private let tokenLoader: @Sendable () -> String?
+    private let tokenSaver: @Sendable (String) throws -> Void
 
     init(
         initialToken: String? = nil,
-        requiresAuthentication: Bool = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerRequiresAuthentication)
+        requiresAuthentication: Bool = UserDefaults.standard.bool(forKey: UserDefaultsKeys.apiServerRequiresAuthentication),
+        tokenLoader: @escaping @Sendable () -> String? = {
+            KeychainService.load(service: LocalAPIAuthenticator.keychainService)
+        },
+        tokenSaver: @escaping @Sendable (String) throws -> Void = {
+            try KeychainService.save(key: $0, service: LocalAPIAuthenticator.keychainService)
+        }
     ) {
         token = OSAllocatedUnfairLock<String?>(initialState: initialToken)
         self.requiresAuthentication = OSAllocatedUnfairLock<Bool>(initialState: requiresAuthentication)
-
-        if initialToken == nil,
-           let existingToken = KeychainService.load(service: Self.keychainService),
-           !existingToken.isEmpty {
-            token.withLock { $0 = existingToken }
-        }
+        self.tokenLoader = tokenLoader
+        self.tokenSaver = tokenSaver
     }
 
     func currentToken() -> String? {
@@ -155,20 +170,24 @@ final class LocalAPIAuthenticator: @unchecked Sendable {
         requiresAuthentication.withLock { $0 = enabled }
     }
 
-    func loadOrCreateToken() throws -> String {
-        if let existingToken = currentToken(), !existingToken.isEmpty {
-            return existingToken
-        }
+    func loadOrCreateToken() async throws -> String {
+        try await Task.detached { [token, tokenLoader, tokenSaver] in
+            try token.withLock { cachedToken in
+                if let cachedToken, !cachedToken.isEmpty {
+                    return cachedToken
+                }
 
-        if let storedToken = KeychainService.load(service: Self.keychainService), !storedToken.isEmpty {
-            token.withLock { $0 = storedToken }
-            return storedToken
-        }
+                if let storedToken = tokenLoader(), !storedToken.isEmpty {
+                    cachedToken = storedToken
+                    return storedToken
+                }
 
-        let newToken = try Self.makeToken()
-        try KeychainService.save(key: newToken, service: Self.keychainService)
-        token.withLock { $0 = newToken }
-        return newToken
+                let newToken = try Self.makeToken()
+                try tokenSaver(newToken)
+                cachedToken = newToken
+                return newToken
+            }
+        }.value
     }
 
     private static func makeToken() throws -> String {

--- a/TypeWhisper/ViewModels/APIServerViewModel.swift
+++ b/TypeWhisper/ViewModels/APIServerViewModel.swift
@@ -45,7 +45,9 @@ final class APIServerViewModel: ObservableObject {
             DispatchQueue.main.async {
                 self?.isRunning = running
                 if !running {
-                    self?.errorMessage = "Server stopped unexpectedly"
+                    if self?.errorMessage == nil {
+                        self?.errorMessage = "Server stopped unexpectedly"
+                    }
                     self?.removeDiscoveryFiles()
                 }
             }

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -10,6 +10,10 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhis
 @MainActor
 final class AudioRecorderViewModel: ObservableObject {
     typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
+    typealias RecordingsLoader = @Sendable (
+        URL,
+        [String: RecordingTranscriptionFailure]
+    ) -> [RecordingItem]
 
     nonisolated(unsafe) static var _shared: AudioRecorderViewModel?
     static var shared: AudioRecorderViewModel {
@@ -111,7 +115,7 @@ final class AudioRecorderViewModel: ObservableObject {
         }
     }
 
-    struct RecordingItem: Identifiable {
+    struct RecordingItem: Identifiable, Sendable {
         let id = UUID()
         let url: URL
         let date: Date
@@ -217,6 +221,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private let modelManager: ModelManagerService
     private let dictionaryService: DictionaryService
     private let audioSamplesLoader: AudioSamplesLoader
+    private let recordingsLoader: RecordingsLoader
     private let defaults: UserDefaults
     private let streamingHandler: StreamingHandler
     private let livePreviewStartObserver: (() -> Void)?
@@ -225,6 +230,8 @@ final class AudioRecorderViewModel: ObservableObject {
     private var activeRecorderAPISessionID: UUID?
     private var recorderAPISessions: [UUID: RecorderAPISessionSnapshot] = [:]
     private var transientTranscriptionFailures: [String: RecordingTranscriptionFailure] = [:]
+    private var recordingsLoadTask: Task<Void, Never>?
+    private var recordingsLoadGeneration = 0
     private var isInitialized = false
 
     init(
@@ -235,6 +242,7 @@ final class AudioRecorderViewModel: ObservableObject {
         audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         defaults: UserDefaults = .standard,
         audioSamplesLoader: AudioSamplesLoader? = nil,
+        recordingsLoader: RecordingsLoader? = nil,
         livePreviewStartObserver: (() -> Void)? = nil
     ) {
         self.recorderService = recorderService
@@ -243,6 +251,9 @@ final class AudioRecorderViewModel: ObservableObject {
         self.dictionaryService = dictionaryService
         self.audioSamplesLoader = audioSamplesLoader ?? { [audioFileService] url in
             try await audioFileService.loadAudioSamples(from: url)
+        }
+        self.recordingsLoader = recordingsLoader ?? { directory, transientFailures in
+            Self.readRecordings(from: directory, transientFailures: transientFailures)
         }
         self.defaults = defaults
         self.livePreviewStartObserver = livePreviewStartObserver
@@ -782,47 +793,62 @@ final class AudioRecorderViewModel: ObservableObject {
 
     func loadRecordings() {
         let dir = recorderService.recordingsDirectory
-        guard FileManager.default.fileExists(atPath: dir.path) else {
-            recordings = []
-            return
+        let transientFailures = transientTranscriptionFailures
+        let loader = recordingsLoader
+        recordingsLoadGeneration += 1
+        let generation = recordingsLoadGeneration
+
+        recordingsLoadTask?.cancel()
+        let worker = Task.detached(priority: .userInitiated) {
+            loader(dir, transientFailures)
         }
-
-        do {
-            let files = try FileManager.default.contentsOfDirectory(
-                at: dir,
-                includingPropertiesForKeys: [.creationDateKey, .fileSizeKey, .contentModificationDateKey],
-                options: [.skipsHiddenFiles]
-            )
-
-            let audioExtensions: Set<String> = ["wav", "m4a", "mp3", "aac", "caf"]
-            let items: [RecordingItem] = files
-                .filter { audioExtensions.contains($0.pathExtension.lowercased()) }
-                .compactMap { url in
-                    guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else { return nil }
-                    let date = (attrs[.creationDate] as? Date) ?? Date.distantPast
-                    let size = (attrs[.size] as? Int64) ?? 0
-                    let duration = audioDuration(for: url)
-                    let transcript = loadTranscript(for: url)
-                    let transcriptionFailure = loadTranscriptionFailure(for: url)
-                        ?? transientTranscriptionFailures[transcriptionFailureKey(for: url)]
-                    return RecordingItem(
-                        url: url,
-                        date: date,
-                        duration: duration,
-                        fileSize: size,
-                        transcript: transcript,
-                        transcriptionFailure: transcriptionFailure
-                    )
-                }
-                .sorted { $0.date > $1.date }
-
-            recordings = items
-        } catch {
-            recordings = []
+        recordingsLoadTask = Task { [weak self] in
+            let items = await worker.value
+            guard !Task.isCancelled, let self, generation == self.recordingsLoadGeneration else { return }
+            self.recordings = items
         }
     }
 
-    private func audioDuration(for url: URL) -> TimeInterval {
+    nonisolated private static func readRecordings(
+        from directory: URL,
+        transientFailures: [String: RecordingTranscriptionFailure]
+    ) -> [RecordingItem] {
+        guard FileManager.default.fileExists(atPath: directory.path),
+              let files = try? FileManager.default.contentsOfDirectory(
+                  at: directory,
+                  includingPropertiesForKeys: [.creationDateKey, .fileSizeKey, .contentModificationDateKey],
+                  options: [.skipsHiddenFiles]
+              ) else {
+            return []
+        }
+
+        let audioExtensions: Set<String> = ["wav", "m4a", "mp3", "aac", "caf"]
+        return files
+            .filter { audioExtensions.contains($0.pathExtension.lowercased()) }
+            .compactMap { url in
+                guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path) else { return nil }
+                let date = (attrs[.creationDate] as? Date) ?? Date.distantPast
+                let size = (attrs[.size] as? Int64) ?? 0
+                let duration = audioDuration(for: url)
+                let transcriptURL = url.deletingPathExtension().appendingPathExtension("txt")
+                let transcript = try? String(contentsOf: transcriptURL, encoding: .utf8)
+                let failureURL = url.appendingPathExtension("transcription-failure.json")
+                let persistedFailure = (try? Data(contentsOf: failureURL))
+                    .flatMap { try? JSONDecoder().decode(RecordingTranscriptionFailure.self, from: $0) }
+                let failureKey = url.resolvingSymlinksInPath().path
+                return RecordingItem(
+                    url: url,
+                    date: date,
+                    duration: duration,
+                    fileSize: size,
+                    transcript: transcript,
+                    transcriptionFailure: persistedFailure ?? transientFailures[failureKey]
+                )
+            }
+            .sorted { $0.date > $1.date }
+    }
+
+    nonisolated private static func audioDuration(for url: URL) -> TimeInterval {
         guard let player = try? AVAudioPlayer(contentsOf: url) else { return 0 }
         return player.duration.isFinite ? player.duration : 0
     }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -174,6 +174,11 @@ final class DictationViewModel: ObservableObject {
         case processing
     }
 
+    private struct PendingHotkeyDictationStart {
+        let forcedWorkflowId: UUID?
+        let requestUptimeNanoseconds: UInt64
+    }
+
     @Published var state: State = .idle {
         didSet { clearCancelWarningIfStateNoLongerMatches() }
     }
@@ -321,6 +326,7 @@ final class DictationViewModel: ObservableObject {
     private var pendingLearnedCorrections: [LearnedDictionaryCorrection] = []
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
+    private var pendingHotkeyStartTask: Task<Void, Never>?
     @Published private var cancelWarningTarget: CancelWarningTarget?
     private var urlResolutionTask: Task<Void, Never>?
     private var metadataCaptureTask: Task<Void, Never>?
@@ -341,6 +347,7 @@ final class DictationViewModel: ObservableObject {
     private var lastStreamingParams: StreamingParamsSnapshot?
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
+    private var pendingHotkeyDictationStart: PendingHotkeyDictationStart?
     private var pendingPushToTalkDiscardMessage: String?
     private var recordingStartCuePending = false
     private var firstRecordingAudioBufferSeen = false
@@ -916,17 +923,27 @@ final class DictationViewModel: ObservableObject {
         hotkeyService.onDictationStart = { [weak self] requestTimestamp in
             guard let self else { return }
             logger.info("hotkey→onDictationStart (state=\(String(describing: self.state), privacy: .public))")
-            self.startRecording(requestUptimeNanoseconds: requestTimestamp)
+            self.handleHotkeyDictationStart(requestUptimeNanoseconds: requestTimestamp)
         }
 
         hotkeyService.onDictationStop = { [weak self] in
             guard let self else { return }
             logger.info("hotkey→onDictationStop (state=\(String(describing: self.state), privacy: .public), stopInFlight=\(String(describing: self.isStopInFlight), privacy: .public))")
+            if self.pendingHotkeyDictationStart != nil {
+                logger.info("Cancelling queued dictation start")
+                self.pendingHotkeyDictationStart = nil
+                self.pendingHotkeyStartTask?.cancel()
+                self.pendingHotkeyStartTask = nil
+                return
+            }
             self.stopDictation()
         }
 
         hotkeyService.onWorkflowDictationStart = { [weak self] workflowId, requestTimestamp in
-            self?.startRecording(forcedWorkflowId: workflowId, requestUptimeNanoseconds: requestTimestamp)
+            self?.handleHotkeyDictationStart(
+                forcedWorkflowId: workflowId,
+                requestUptimeNanoseconds: requestTimestamp
+            )
         }
 
         hotkeyService.onWorkflowTextProcessing = { [weak self] workflowId in
@@ -1197,6 +1214,35 @@ final class DictationViewModel: ObservableObject {
                 sessionID: sessionID,
                 resolvedInputSelection: resolvedInputSelection
             )
+        }
+    }
+
+    private func handleHotkeyDictationStart(
+        forcedWorkflowId: UUID? = nil,
+        requestUptimeNanoseconds: UInt64
+    ) {
+        guard state == .processing || state == .inserting else {
+            startRecording(
+                forcedWorkflowId: forcedWorkflowId,
+                requestUptimeNanoseconds: requestUptimeNanoseconds
+            )
+            return
+        }
+
+        if pendingHotkeyDictationStart == nil {
+            pendingHotkeyDictationStart = PendingHotkeyDictationStart(
+                forcedWorkflowId: forcedWorkflowId,
+                requestUptimeNanoseconds: requestUptimeNanoseconds
+            )
+            logger.info(
+                "Queued dictation start while state=\(String(describing: self.state), privacy: .public)"
+            )
+        } else {
+            logger.info("Keeping existing queued dictation start")
+        }
+
+        if state == .inserting {
+            scheduleInsertingReset(after: .seconds(actionDisplayDuration))
         }
     }
 
@@ -1863,13 +1909,8 @@ final class DictationViewModel: ObservableObject {
                 lastTranscriptionLanguage = detectedLang
 
                 state = .inserting
-                insertingResetTask?.cancel()
                 let resetDelay: Duration = actionFeedbackMessage != nil ? .seconds(actionDisplayDuration) : .seconds(1.5)
-                insertingResetTask = Task {
-                    try? await Task.sleep(for: resetDelay)
-                    guard !Task.isCancelled else { return }
-                    resetDictationState()
-                }
+                scheduleInsertingReset(after: resetDelay)
             } catch {
                 guard !Task.isCancelled else { return }
                 audioRecordingService.preserveActiveRecoveryRecording()
@@ -2081,6 +2122,25 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackIsError = false
         clearPendingUndoActionFeedback()
         actionDisplayDuration = 3.5
+
+        guard pendingHotkeyDictationStart != nil else { return }
+        pendingHotkeyStartTask?.cancel()
+        pendingHotkeyStartTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled, let self else { return }
+            defer { self.pendingHotkeyStartTask = nil }
+            guard self.state == .idle,
+                  let pendingHotkeyStart = self.pendingHotkeyDictationStart else {
+                self.pendingHotkeyDictationStart = nil
+                return
+            }
+            self.pendingHotkeyDictationStart = nil
+            logger.info("Starting queued dictation")
+            self.startRecording(
+                forcedWorkflowId: pendingHotkeyStart.forcedWorkflowId,
+                requestUptimeNanoseconds: pendingHotkeyStart.requestUptimeNanoseconds
+            )
+        }
     }
 
     private func handlePushToTalkInterruption() {
@@ -2549,9 +2609,18 @@ final class DictationViewModel: ObservableObject {
             errorLogService.addEntry(message: message, category: errorCategory)
         }
 
+        scheduleInsertingReset(after: .seconds(duration))
+    }
+
+    private func scheduleInsertingReset(after delay: Duration) {
         insertingResetTask?.cancel()
+        let shouldStartQueuedDictation = pendingHotkeyDictationStart != nil
         insertingResetTask = Task {
-            try? await Task.sleep(for: .seconds(duration))
+            if shouldStartQueuedDictation {
+                await Task.yield()
+            } else {
+                try? await Task.sleep(for: delay)
+            }
             guard !Task.isCancelled else { return }
             resetDictationState()
         }

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -281,6 +281,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertNil(session.text)
         XCTAssertTrue(session.error?.contains("HTTP 413") == true)
 
+        try await waitForRecordingsToLoad(viewModel, count: 1)
         let recording = try XCTUnwrap(viewModel.recordings.first)
         XCTAssertEqual(
             recording.url.resolvingSymlinksInPath().path,
@@ -316,6 +317,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertNotNil(session.outputFile)
         XCTAssertNil(session.text)
 
+        try await waitForRecordingsToLoad(viewModel, count: 1)
         let recording = try XCTUnwrap(viewModel.recordings.first)
         XCTAssertNil(recording.transcript)
         let failure = try XCTUnwrap(recording.transcriptionFailure)

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -51,6 +51,41 @@ private final class BlockingRecordingsLoader: @unchecked Sendable {
     }
 }
 
+private final class OutOfOrderRecordingsLoader: @unchecked Sendable {
+    let firstStarted = DispatchSemaphore(value: 0)
+    let releaseFirst = DispatchSemaphore(value: 0)
+    let firstFinished = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private var callCount = 0
+    private let firstResult: [AudioRecorderViewModel.RecordingItem]
+    private let secondResult: [AudioRecorderViewModel.RecordingItem]
+
+    init(
+        firstResult: [AudioRecorderViewModel.RecordingItem],
+        secondResult: [AudioRecorderViewModel.RecordingItem]
+    ) {
+        self.firstResult = firstResult
+        self.secondResult = secondResult
+    }
+
+    func load(
+        directory: URL,
+        transientFailures: [String: AudioRecorderViewModel.RecordingTranscriptionFailure]
+    ) -> [AudioRecorderViewModel.RecordingItem] {
+        let invocation = lock.withLock {
+            callCount += 1
+            return callCount
+        }
+        guard invocation == 1 else { return secondResult }
+
+        firstStarted.signal()
+        releaseFirst.wait()
+        firstFinished.signal()
+        return firstResult
+    }
+}
+
 @MainActor
 final class AudioRecorderViewModelTests: XCTestCase {
     func testRecorderFilesAreLoadedOffMainThreadDuringInitialization() throws {
@@ -65,6 +100,48 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(probe.started.wait(timeout: .now() + 1), .success)
         XCTAssertFalse(probe.ranOnMainThread)
         XCTAssertTrue(viewModel.recordings.isEmpty)
+    }
+
+    func testRecorderLoadIgnoresOlderResultThatFinishesLast() async throws {
+        let directory = makeTemporaryDirectory()
+        let olderURL = directory.appendingPathComponent("Older.wav")
+        let newerURL = directory.appendingPathComponent("Newer.wav")
+        let older = AudioRecorderViewModel.RecordingItem(
+            url: olderURL,
+            date: .distantPast,
+            duration: 1,
+            fileSize: 1,
+            transcript: nil,
+            transcriptionFailure: nil
+        )
+        let newer = AudioRecorderViewModel.RecordingItem(
+            url: newerURL,
+            date: .now,
+            duration: 2,
+            fileSize: 2,
+            transcript: "new",
+            transcriptionFailure: nil
+        )
+        let loader = OutOfOrderRecordingsLoader(firstResult: [older], secondResult: [newer])
+        defer { loader.releaseFirst.signal() }
+        let recorderService = makeRecorderService(recordingsDirectory: directory)
+        let viewModel = makeViewModel(
+            defaults: try makeDefaults(),
+            recorderService: recorderService,
+            recordingsLoader: loader.load
+        )
+
+        XCTAssertEqual(loader.firstStarted.wait(timeout: .now() + 1), .success)
+        viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+        XCTAssertEqual(viewModel.recordings.first?.url, newerURL)
+
+        loader.releaseFirst.signal()
+        XCTAssertEqual(loader.firstFinished.wait(timeout: .now() + 1), .success)
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        XCTAssertEqual(viewModel.recordings.first?.url, newerURL)
     }
 
     func testRecorderSelectionPersistsSeparatelyFromGlobalDefault() throws {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -27,8 +27,46 @@ private actor RecorderStopFinalizationGate {
     }
 }
 
+private final class BlockingRecordingsLoader: @unchecked Sendable {
+    let started = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+
+    private let lock = NSLock()
+    private var _ranOnMainThread = false
+
+    var ranOnMainThread: Bool {
+        lock.withLock { _ranOnMainThread }
+    }
+
+    func load(
+        directory: URL,
+        transientFailures: [String: AudioRecorderViewModel.RecordingTranscriptionFailure]
+    ) -> [AudioRecorderViewModel.RecordingItem] {
+        lock.withLock {
+            _ranOnMainThread = Thread.isMainThread
+        }
+        started.signal()
+        release.wait()
+        return []
+    }
+}
+
 @MainActor
 final class AudioRecorderViewModelTests: XCTestCase {
+    func testRecorderFilesAreLoadedOffMainThreadDuringInitialization() throws {
+        let probe = BlockingRecordingsLoader()
+        defer { probe.release.signal() }
+
+        let viewModel = makeViewModel(
+            defaults: try makeDefaults(),
+            recordingsLoader: probe.load
+        )
+
+        XCTAssertEqual(probe.started.wait(timeout: .now() + 1), .success)
+        XCTAssertFalse(probe.ranOnMainThread)
+        XCTAssertTrue(viewModel.recordings.isEmpty)
+    }
+
     func testRecorderSelectionPersistsSeparatelyFromGlobalDefault() throws {
         try preserveStandardDefaults()
         let defaults = try makeDefaults()
@@ -443,6 +481,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         viewModel.languageSelection = .exact("de")
         viewModel.selectedTask = .translate
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
 
         let recording = try XCTUnwrap(viewModel.recordings.first)
         viewModel.transcribeRecording(recording)
@@ -484,6 +523,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioSamplesLoader: { _ in throw AudioFileService.AudioFileError.unsupportedFormat }
         )
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
         try await waitForRetranscriptionToFinish(viewModel)
@@ -511,6 +551,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioSamplesLoader: { _ in [0.25, -0.25] }
         )
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
         try await waitForRetranscriptionToFinish(viewModel)
@@ -536,6 +577,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioSamplesLoader: { _ in [0.25, -0.25] }
         )
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
         try await waitForRetranscriptionToFinish(viewModel)
@@ -567,6 +609,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioSamplesLoader: { _ in [0.25, -0.25] }
         )
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
         try await waitForRetranscriptionToFinish(viewModel)
@@ -599,6 +642,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             }
         )
         viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 2)
         XCTAssertEqual(viewModel.recordings.count, 2)
         let first = try XCTUnwrap(viewModel.recordings.first)
         let second = try XCTUnwrap(viewModel.recordings.dropFirst().first)
@@ -785,6 +829,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         dictionaryService: DictionaryService? = nil,
         audioDeviceService: AudioDeviceService = AudioDeviceService(initialInputDevices: [], monitorDeviceChanges: false),
         audioSamplesLoader: AudioRecorderViewModel.AudioSamplesLoader? = nil,
+        recordingsLoader: AudioRecorderViewModel.RecordingsLoader? = nil,
         livePreviewStartObserver: (() -> Void)? = nil
     ) -> AudioRecorderViewModel {
         setupEventBus()
@@ -800,6 +845,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             audioDeviceService: audioDeviceService,
             defaults: defaults,
             audioSamplesLoader: audioSamplesLoader,
+            recordingsLoader: recordingsLoader,
             livePreviewStartObserver: livePreviewStartObserver
         )
     }
@@ -893,6 +939,25 @@ final class AudioRecorderViewModelTests: XCTestCase {
             try await Task.sleep(for: .milliseconds(20))
         }
         XCTFail("Recorder retranscription did not finish", file: file, line: line)
+    }
+
+    private func waitForRecordingsToLoad(
+        _ viewModel: AudioRecorderViewModel,
+        count: Int,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        for _ in 0..<100 {
+            if viewModel.recordings.count == count {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        XCTFail(
+            "Recorder library did not load \(count) items. Current count: \(viewModel.recordings.count)",
+            file: file,
+            line: line
+        )
     }
 
     private func livePreviewStartCount(

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -100,6 +100,42 @@ private actor PremiumAccountHTTPRecorder {
     }
 }
 
+private final class BlockingPremiumTokenReader: @unchecked Sendable {
+    private let lock = NSLock()
+    private let releaseSemaphore = DispatchSemaphore(value: 0)
+    private var released = false
+    private var storedReadCount = 0
+    private var storedReadWasOnMainThread = false
+
+    var readCount: Int {
+        lock.withLock { storedReadCount }
+    }
+
+    var readWasOnMainThread: Bool {
+        lock.withLock { storedReadWasOnMainThread }
+    }
+
+    func read(service: String) -> String? {
+        lock.withLock {
+            storedReadCount += 1
+            storedReadWasOnMainThread = Thread.isMainThread
+        }
+        releaseSemaphore.wait()
+        return "stored-token"
+    }
+
+    func release() {
+        let shouldSignal = lock.withLock {
+            guard !released else { return false }
+            released = true
+            return true
+        }
+        if shouldSignal {
+            releaseSemaphore.signal()
+        }
+    }
+}
+
 @MainActor
 private final class PremiumAppleWebAuthenticator: AppleWebAuthenticating {
     private(set) var authorizationURLs: [URL] = []
@@ -117,6 +153,41 @@ private final class PremiumAppleWebAuthenticator: AppleWebAuthenticating {
 }
 
 final class CloudFolderSyncTests: XCTestCase {
+    @MainActor
+    func testPremiumAccountDefersStartupTokenReadOffMainThread() async throws {
+        let suiteName = "PremiumStartupToken-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let reader = BlockingPremiumTokenReader()
+        defer { reader.release() }
+
+        let service = PremiumAccountService(
+            defaults: defaults,
+            keychainService: suiteName,
+            isSignedInOverride: nil,
+            automaticallyRefresh: false,
+            startupTokenReader: { reader.read(service: $0) }
+        )
+
+        XCTAssertEqual(reader.readCount, 0)
+        XCTAssertFalse(service.isSignedIn)
+
+        for _ in 0..<100 {
+            if reader.readCount == 1 { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(reader.readCount, 1)
+        XCTAssertFalse(reader.readWasOnMainThread)
+        XCTAssertFalse(service.isSignedIn)
+
+        reader.release()
+        for _ in 0..<100 {
+            if service.isSignedIn { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertTrue(service.isSignedIn)
+    }
+
     func testProductionPublicKeyVerifiesBackendGeneratedEntitlement() throws {
         let response = """
         {

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -148,6 +148,29 @@ final class SecureInputDiagnosticsProviderTests: XCTestCase {
 }
 
 final class TypeWhisperIntegrationTests: XCTestCase {
+    private final class KeychainTokenProbe: @unchecked Sendable {
+        private let lock = NSLock()
+        private var loadCalls = 0
+        private var saveCalls = 0
+        private var loadWasOnMainThread = false
+
+        var snapshot: (loadCalls: Int, saveCalls: Int, loadWasOnMainThread: Bool) {
+            lock.withLock { (loadCalls, saveCalls, loadWasOnMainThread) }
+        }
+
+        func load() -> String? {
+            lock.withLock {
+                loadCalls += 1
+                loadWasOnMainThread = Thread.isMainThread
+            }
+            return "stored-token"
+        }
+
+        func save(_ token: String) {
+            lock.withLock { saveCalls += 1 }
+        }
+    }
+
     private final class LockedFlag: @unchecked Sendable {
         private let lock = NSLock()
         private var storedValue = false
@@ -1296,6 +1319,25 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         authenticator.setRequiresAuthentication(false)
         XCTAssertNil(authenticator.tokenForEnforcedRequests())
+    }
+
+    func testLocalAPIAuthenticatorDefersKeychainReadOffMainThread() async throws {
+        let probe = KeychainTokenProbe()
+        let authenticator = LocalAPIAuthenticator(
+            requiresAuthentication: true,
+            tokenLoader: { probe.load() },
+            tokenSaver: { probe.save($0) }
+        )
+
+        XCTAssertEqual(probe.snapshot.loadCalls, 0)
+
+        let token = try await authenticator.loadOrCreateToken()
+
+        XCTAssertEqual(token, "stored-token")
+        XCTAssertEqual(authenticator.currentToken(), "stored-token")
+        XCTAssertEqual(probe.snapshot.loadCalls, 1)
+        XCTAssertEqual(probe.snapshot.saveCalls, 0)
+        XCTAssertFalse(probe.snapshot.loadWasOnMainThread)
     }
 
     func testSerializedResponseOmitsWildcardCORSHeaders() {
@@ -4196,6 +4238,69 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         await fulfillment(of: [selectedTextCaptured], timeout: 1.0)
         XCTAssertEqual(Array(events.prefix(3)), ["start_audio", "capture_app", "selected_text"])
+    }
+
+    @MainActor
+    func testHotkeyStartDuringInsertingIsBufferedExactlyOnce() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        var startCount = 0
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            startCount += 1
+        }
+        context.dictationViewModel.state = .inserting
+
+        let requestTimestamp = DispatchTime.now().uptimeNanoseconds
+        context.hotkeyService.onDictationStart?(requestTimestamp)
+        context.hotkeyService.onDictationStart?(requestTimestamp + 1)
+
+        for _ in 0..<100 {
+            if context.dictationViewModel.state == .recording { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertEqual(startCount, 1)
+    }
+
+    @MainActor
+    func testBufferedHotkeyStartIsCancelledWhenPushToTalkStops() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        var startCount = 0
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            startCount += 1
+        }
+        context.dictationViewModel.state = .inserting
+
+        context.hotkeyService.onDictationStart?(DispatchTime.now().uptimeNanoseconds)
+        context.hotkeyService.onDictationStop?()
+
+        for _ in 0..<100 {
+            if context.dictationViewModel.state == .idle { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(context.dictationViewModel.state, .idle)
+        XCTAssertEqual(startCount, 0)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- move premium-account and local-API Keychain reads off the main thread during startup
- load the recorder library, transcripts, metadata, and audio durations in the background with stale-result protection
- buffer one hotkey dictation request while the previous dictation is processing or inserting, while still allowing push-to-talk release to cancel the queued request
- add regression coverage for all three responsiveness fixes

## Root cause

Startup performed potentially blocking Keychain and recorder-file I/O synchronously while constructing main-actor services. On the current local data set, recorder metadata loading alone delayed the app's ready signal by about 40 seconds. Separately, hotkey starts received during the processing/inserting states were discarded, so users had to wait for the black completion banner to disappear before starting another dictation.

## Impact

The app can present its UI without waiting for Keychain or recorder-library I/O. Rapid consecutive dictations now start automatically once the previous insertion finishes, independent of the selected transcription provider. API start semantics remain unchanged.

A signed local Dev build using the existing recorder data improved the measured `BringForward` to `SignalReady` interval from about 40.8 seconds to about 0.55 seconds.

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' -allowProvisioningUpdates DEVELOPMENT_TEAM=2D8ALY3LCL CODE_SIGN_STYLE=Automatic 'CODE_SIGN_IDENTITY=Apple Development' APP_GROUP_ID=2D8ALY3LCL.com.typewhisper.mac -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/CloudFolderSyncTests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLocalAPIAuthenticatorDefersKeychainReadOffMainThread -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testHotkeyStartDuringInsertingIsBufferedExactlyOnce -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testBufferedHotkeyStartIsCancelledWhenPushToTalkStops -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLocalAPIAuthenticatorEnforcesTokenOnlyWhenEnabled -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testApiStartRecording_startsAudioBeforeContextAndDeferredSelectedTextCapture -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testApiStopRecordingMovesToProcessingAndRejectsRestartWhileRecorderDrains
```

Result: 66 tests passed, 0 failures.

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/cfd3/typewhisper-mac
```

Result: signed Dev build succeeded, signature and Dev App Group validated, and the local startup smoke test passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Premium and local API token loading is now deferred via cancellable async work and performed off the main thread.
  * API server start/stop is more reliable with cancellation and updated discovery output that reflects the active port.
  * Recordings load asynchronously with generation/cancellation safeguards to prevent stale updates.
  * Dictation hotkey “start” is queued during inserting/processing and cancelled if stop happens before readiness.
* **Tests**
  * Expanded coverage for off-main-thread token loading, task cancellation, server startup behavior, recordings loading timing, and buffered/cancelled dictation hotkeys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
