### PR TITLE
Fix CJK contextual insertion spacing

### DIFF
--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2881,6 +2881,9 @@ enum DictationInsertionTextFormatter {
         if closingPunctuation.contains(right) || openingPunctuation.contains(left) {
             return false
         }
+        if isCJKCharacter(left) && isCJKCharacter(right) {
+            return false
+        }
         if isWordLike(left) && isWordLike(right) {
             return true
         }
@@ -2893,9 +2896,18 @@ enum DictationInsertionTextFormatter {
     private static let openingPunctuation: Set<Character> = ["(", "[", "{", "\"", "'", "“", "‘"]
     private static let closingPunctuation: Set<Character> = [".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "”", "’"]
     private static let punctuationThatTakesFollowingSpace: Set<Character> = [".", ",", "!", "?", ";", ":", ")", "]", "}", "\"", "'", "”", "’"]
+    private static let cjkScriptCharacterRegex = try? NSRegularExpression(
+        pattern: #"[\p{Han}\p{Hiragana}\p{Katakana}\p{Hangul}]"#
+    )
 
     private static func isWordLike(_ character: Character) -> Bool {
         character.unicodeScalars.contains { CharacterSet.alphanumerics.contains($0) }
+    }
+
+    private static func isCJKCharacter(_ character: Character) -> Bool {
+        let text = String(character)
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return cjkScriptCharacterRegex?.firstMatch(in: text, range: range) != nil
     }
 
     private static func isWhitespace(_ character: Character) -> Bool {

--- a/TypeWhisperTests/DictationShortSpeechTests.swift
+++ b/TypeWhisperTests/DictationShortSpeechTests.swift
@@ -284,6 +284,48 @@ final class DictationInsertionTextFormatterTests: XCTestCase {
         )
     }
 
+    func testSmartInsertionDoesNotAddSpacesBetweenCJKCharacters() {
+        let cases: [(script: String, value: String, insertion: String)] = [
+            ("Han", "你好", "世"),
+            ("Kana", "あい", "カ"),
+            ("Hangul", "가나", "다")
+        ]
+
+        for testCase in cases {
+            let context = TextInsertionService.InsertionContext(
+                value: testCase.value,
+                selectedRange: NSRange(location: 1, length: 0),
+                selectedText: nil,
+                previousCharacter: nil,
+                nextCharacter: nil
+            )
+
+            XCTAssertEqual(
+                DictationInsertionTextFormatter.textForInsertion(
+                    testCase.insertion,
+                    insertionContext: context
+                ),
+                testCase.insertion,
+                testCase.script
+            )
+        }
+    }
+
+    func testSmartInsertionPreservesSpacesAtMixedLatinCJKBoundaries() {
+        let context = TextInsertionService.InsertionContext(
+            value: "AB",
+            selectedRange: NSRange(location: 1, length: 0),
+            selectedText: nil,
+            previousCharacter: "A",
+            nextCharacter: "B"
+        )
+
+        XCTAssertEqual(
+            DictationInsertionTextFormatter.textForInsertion("中", insertionContext: context),
+            " 中 "
+        )
+    }
+
     func testSmartInsertionAvoidsDuplicateLeadingSpace() {
         let context = TextInsertionService.InsertionContext(
             value: "coffee machine",


### PR DESCRIPTION
## Summary

- Avoid automatically adding spaces when both characters at an insertion boundary use Han, Hiragana, Katakana, or Hangul.
- Preserve the existing behavior for English, whitespace, punctuation, and mixed Latin-CJK boundaries.
- Keep the existing App-aware formatting setting as the only control; this adds no setting, preference key, migration, or localization.

## Context

[Discussion #1001](https://github.com/TypeWhisper/typewhisper-mac/discussions/1001) reports unwanted spaces when contextual insertion places CJK text next to existing CJK text.

The root cause was that the formatter treated CJK characters as generic alphanumeric word characters and therefore applied the same boundary-spacing rule used for Latin text. This change intentionally suppresses automatic spacing only when both adjacent characters match one of the four supported Unicode scripts. Mixed Latin-CJK boundaries continue to receive spaces.

## Test plan

```zsh
git diff --check
set -o pipefail && xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/DictationInsertionTextFormatterTests 2>&1 | tee /tmp/typewhisper-cjk-spacing.log
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-cjk-spacing.log
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/3e74/typewhisper-mac
```

Results:

- 21/21 focused formatter tests passed.
- No first-party warnings were found.
- The signed development app built and launched successfully.
- A native TextEdit smoke confirmed CJK-to-CJK insertion as `你世界好`, mixed CJK-Latin insertion with spaces as `你 guten Morgen 好`, and the existing `hello|world` boundary with spaces as `hello ich doch world`.
- The native smoke used synthetic German audio and temporary dictionary corrections solely to drive the insertion path; all temporary test state was removed afterward.

I do not speak Chinese, Japanese, or Korean myself, so the language-specific assumptions in this fix are AI-assisted and have not been validated by a native speaker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dictation text spacing for Chinese, Japanese, and Korean characters.
  * Prevented unwanted spaces between adjacent CJK characters while preserving appropriate spacing at Latin/CJK boundaries.

* **Tests**
  * Added coverage for CJK insertion and mixed Latin/CJK text spacing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->