### PR TITLE
Add indicator screen capture visibility setting

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -11,6 +11,7 @@ enum UserDefaultsKeys {
     static let soundTranscriptionSuccess = "soundTranscriptionSuccess"
     static let soundError = "soundError"
     static let indicatorStyle = "indicatorStyle"
+    static let indicatorVisibleInScreenCaptures = "indicatorVisibleInScreenCaptures"
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
     static let indicatorTranscriptPreviewFontSizeOffset = "indicatorTranscriptPreviewFontSizeOffset"
     static let preserveClipboard = "preserveClipboard"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -15890,6 +15890,22 @@
         }
       }
     },
+    "Show indicator in screen recordings and screen shares": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indikator in Bildschirmaufnahmen und Bildschirmfreigaben anzeigen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画面収録と画面共有にインジケーターを表示"
+          }
+        }
+      }
+    },
     "Show live transcript preview": {
       "localizations": {
         "de": {
@@ -18627,6 +18643,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "音声入力したメモを返信メールに変換します。"
+          }
+        }
+      }
+    },
+    "Turn this off to hide the indicator from supported capture apps while keeping it visible on your display.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deaktiviere diese Option, um den Indikator in unterstützten Aufnahme-Apps auszublenden, während er auf deinem Display sichtbar bleibt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフにすると、対応するキャプチャアプリではインジケーターを非表示にし、ディスプレイ上では表示したままにします。"
           }
         }
       }

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -563,7 +563,7 @@ final class ErrorLogService: ObservableObject {
         }
 
         return DiagnosticsReport(
-            schemaVersion: 9,
+            schemaVersion: 10,
             exportedAt: Date(),
             app: .init(
                 version: AppConstants.appVersion,

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -378,6 +378,7 @@ private struct DiagnosticsReport: Encodable {
         let modelAutoUnloadSeconds: Int
         let modelAutoUnloadPolicy: String
         let indicatorStyle: String
+        let indicatorVisibleInScreenCaptures: Bool
         let indicatorSupportsTranscriptPreview: Bool
         let indicatorTranscriptPreviewEnabled: Bool
         let indicatorTranscriptPreviewAvailable: Bool
@@ -484,6 +485,7 @@ final class ErrorLogService: ObservableObject {
         let outputSnapshot = CoreAudioOutputVolumeController().defaultOutputSnapshot()
         let modelAutoUnloadSeconds = ModelAutoUnloadPolicy.effectiveSeconds(defaults: defaults)
         let indicatorStyle = DictationViewModel.loadIndicatorStyle(defaults: defaults)
+        let indicatorVisibleInScreenCaptures = DictationViewModel.loadIndicatorVisibleInScreenCaptures(defaults: defaults)
         let indicatorPreviewEnabled = DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults)
         let indicatorPreviewOffset = DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults)
 
@@ -646,6 +648,7 @@ final class ErrorLogService: ObservableObject {
                 modelAutoUnloadSeconds: modelAutoUnloadSeconds,
                 modelAutoUnloadPolicy: ModelAutoUnloadPolicy.policyName(seconds: modelAutoUnloadSeconds),
                 indicatorStyle: indicatorStyle.rawValue,
+                indicatorVisibleInScreenCaptures: indicatorVisibleInScreenCaptures,
                 indicatorSupportsTranscriptPreview: indicatorStyle.supportsTranscriptPreview,
                 indicatorTranscriptPreviewEnabled: indicatorPreviewEnabled,
                 indicatorTranscriptPreviewAvailable: indicatorStyle.supportsTranscriptPreview && indicatorPreviewEnabled,

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -171,6 +171,7 @@ enum SettingsBackupExporter {
         var soundTranscriptionSuccess: Bool? = nil
         var soundError: Bool? = nil
         var indicatorStyle: String? = nil
+        var indicatorVisibleInScreenCaptures: Bool? = nil
         var indicatorTranscriptPreviewEnabled: Bool? = nil
         var indicatorTranscriptPreviewFontSizeOffset: Int? = nil
         var preserveClipboard: Bool? = nil
@@ -195,7 +196,7 @@ enum SettingsBackupExporter {
         /// Every field defaults to `nil`, so the synthesized memberwise init
         /// doubles as an "all preferences absent" value (used by `filtered`
         /// when the Preferences category is deselected) without hand-listing
-        /// 30 `nil` arguments.
+        /// every `nil` argument.
         static let empty = PreferencesDTO()
 
         /// Number of non-nil fields, used to show a count in the category
@@ -216,6 +217,7 @@ enum SettingsBackupExporter {
             if soundTranscriptionSuccess != nil { count += 1 }
             if soundError != nil { count += 1 }
             if indicatorStyle != nil { count += 1 }
+            if indicatorVisibleInScreenCaptures != nil { count += 1 }
             if indicatorTranscriptPreviewEnabled != nil { count += 1 }
             if indicatorTranscriptPreviewFontSizeOffset != nil { count += 1 }
             if preserveClipboard != nil { count += 1 }
@@ -559,6 +561,7 @@ enum SettingsBackupExporter {
                 soundTranscriptionSuccess: userDefaults.object(forKey: UserDefaultsKeys.soundTranscriptionSuccess) as? Bool,
                 soundError: userDefaults.object(forKey: UserDefaultsKeys.soundError) as? Bool,
                 indicatorStyle: userDefaults.string(forKey: UserDefaultsKeys.indicatorStyle),
+                indicatorVisibleInScreenCaptures: userDefaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
                 indicatorTranscriptPreviewEnabled: userDefaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled) as? Bool,
                 indicatorTranscriptPreviewFontSizeOffset: userDefaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset) as? Int,
                 preserveClipboard: userDefaults.object(forKey: UserDefaultsKeys.preserveClipboard) as? Bool,
@@ -830,6 +833,7 @@ enum SettingsBackupExporter {
         apply(preferences.soundTranscriptionSuccess, forKey: UserDefaultsKeys.soundTranscriptionSuccess)
         apply(preferences.soundError, forKey: UserDefaultsKeys.soundError)
         apply(preferences.indicatorStyle, forKey: UserDefaultsKeys.indicatorStyle)
+        apply(preferences.indicatorVisibleInScreenCaptures, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
         apply(preferences.indicatorTranscriptPreviewEnabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
         apply(preferences.indicatorTranscriptPreviewFontSizeOffset, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         apply(preferences.preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard)

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -200,6 +200,9 @@ final class DictationViewModel: ObservableObject {
     @Published var indicatorTranscriptPreviewEnabled: Bool {
         didSet { Self.persistIndicatorTranscriptPreviewEnabled(indicatorTranscriptPreviewEnabled) }
     }
+    @Published var indicatorVisibleInScreenCaptures: Bool {
+        didSet { Self.persistIndicatorVisibleInScreenCaptures(indicatorVisibleInScreenCaptures) }
+    }
     @Published var indicatorTranscriptPreviewFontSizeOffset: Int {
         didSet {
             let clampedOffset = Self.clampedIndicatorTranscriptPreviewFontSizeOffset(indicatorTranscriptPreviewFontSizeOffset)
@@ -498,6 +501,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
         self.soundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
+        self.indicatorVisibleInScreenCaptures = Self.loadIndicatorVisibleInScreenCaptures()
         self.indicatorTranscriptPreviewFontSizeOffset = Self.loadIndicatorTranscriptPreviewFontSizeOffset()
         self.preserveClipboard = UserDefaults.standard.bool(forKey: UserDefaultsKeys.preserveClipboard)
         self.mediaPauseEnabled = UserDefaults.standard.bool(forKey: UserDefaultsKeys.mediaPauseEnabled)
@@ -582,6 +586,14 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistIndicatorTranscriptPreviewEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+    }
+
+    nonisolated static func loadIndicatorVisibleInScreenCaptures(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool ?? true
+    }
+
+    nonisolated static func persistIndicatorVisibleInScreenCaptures(_ visible: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(visible, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
     }
 
     nonisolated static func loadIndicatorTranscriptPreviewFontSizeOffset(defaults: UserDefaults = .standard) -> Int {

--- a/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
+++ b/TypeWhisper/Views/FloatingPanelSpacePolicy.swift
@@ -39,22 +39,40 @@ enum FloatingPanelSpacePolicy {
     static func applyIndicatorPolicy(
         to panel: NSPanel,
         displayMode: NotchIndicatorDisplay,
-        windowLevel: NSWindow.Level = notchIndicatorWindowLevel
+        windowLevel: NSWindow.Level = notchIndicatorWindowLevel,
+        isVisibleInScreenCaptures: Bool
     ) {
         panel.level = windowLevel
         panel.collectionBehavior = indicatorCollectionBehavior(for: displayMode)
-        // Best-effort: keep passive indicators visible locally while excluding the
-        // window from capture APIs that honor AppKit sharing policy.
-        panel.sharingType = .none
+        applyIndicatorCapturePolicy(
+            to: panel,
+            isVisibleInScreenCaptures: isVisibleInScreenCaptures
+        )
+    }
+
+    @MainActor
+    static func applyIndicatorCapturePolicy(
+        to panel: NSPanel,
+        isVisibleInScreenCaptures: Bool
+    ) {
+        // Best-effort: AppKit sharing policy is honored by supported capture
+        // pipelines while the passive indicator remains visible locally.
+        panel.sharingType = isVisibleInScreenCaptures ? .readOnly : .none
     }
 
     @MainActor
     static func orderIndicatorFront(
         _ panel: NSPanel,
         displayMode: NotchIndicatorDisplay,
-        windowLevel: NSWindow.Level = notchIndicatorWindowLevel
+        windowLevel: NSWindow.Level = notchIndicatorWindowLevel,
+        isVisibleInScreenCaptures: Bool
     ) {
-        applyIndicatorPolicy(to: panel, displayMode: displayMode, windowLevel: windowLevel)
+        applyIndicatorPolicy(
+            to: panel,
+            displayMode: displayMode,
+            windowLevel: windowLevel,
+            isVisibleInScreenCaptures: isVisibleInScreenCaptures
+        )
         panel.orderFrontRegardless()
     }
 }

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -235,6 +235,15 @@ struct GeneralSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
+
+                Toggle(
+                    String(localized: "Show indicator in screen recordings and screen shares"),
+                    isOn: $dictation.indicatorVisibleInScreenCaptures
+                )
+
+                Text(String(localized: "Turn this off to hide the indicator from supported capture apps while keeping it visible on your display."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
                 }
             }
             .formStyle(.grouped)

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -35,7 +35,8 @@ class MinimalIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay,
-            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
+            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
         )
 
         let hostingView = MinimalFirstMouseHostingView(rootView: MinimalIndicatorView())
@@ -84,6 +85,18 @@ class MinimalIndicatorPanel: NSPanel {
             .sink { [weak self] _ in
                 guard let self, self.isVisible else { return }
                 self.show()
+            }
+            .store(in: &cancellables)
+
+        vm.$indicatorVisibleInScreenCaptures
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isVisibleInScreenCaptures in
+                guard let self else { return }
+                FloatingPanelSpacePolicy.applyIndicatorCapturePolicy(
+                    to: self,
+                    isVisibleInScreenCaptures: isVisibleInScreenCaptures
+                )
             }
             .store(in: &cancellables)
 
@@ -149,7 +162,8 @@ class MinimalIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay,
-            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
+            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
         )
     }
 

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -41,6 +41,7 @@ class NotchIndicatorPanel: NSPanel {
 
     private let screenResolver: IndicatorScreenResolver
     private let displayModeProvider: () -> NotchIndicatorDisplay
+    private let indicatorVisibleInScreenCapturesProvider: () -> Bool
     private let notchGeometry = NotchGeometry()
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
@@ -51,6 +52,9 @@ class NotchIndicatorPanel: NSPanel {
         self.init(
             screenResolver: screenResolver,
             displayModeProvider: { DictationViewModel.shared.notchIndicatorDisplay },
+            indicatorVisibleInScreenCapturesProvider: {
+                DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            },
             content: { NotchIndicatorView(geometry: $0) }
         )
     }
@@ -58,10 +62,12 @@ class NotchIndicatorPanel: NSPanel {
     init<Content: View>(
         screenResolver: IndicatorScreenResolver,
         displayModeProvider: @escaping () -> NotchIndicatorDisplay,
+        indicatorVisibleInScreenCapturesProvider: @escaping () -> Bool = { true },
         @ViewBuilder content: (NotchGeometry) -> Content
     ) {
         self.screenResolver = screenResolver
         self.displayModeProvider = displayModeProvider
+        self.indicatorVisibleInScreenCapturesProvider = indicatorVisibleInScreenCapturesProvider
         super.init(
             contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
@@ -80,7 +86,8 @@ class NotchIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
             displayMode: displayModeProvider(),
-            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel,
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
 
         let hostingView = FirstMouseHostingView(rootView: content(notchGeometry))
@@ -121,6 +128,18 @@ class NotchIndicatorPanel: NSPanel {
             .sink { [weak self] _ in
                 self?.cachedScreen = nil
                 self?.updateVisibility(vm: vm, recorder: recorder)
+            }
+            .store(in: &cancellables)
+
+        vm.$indicatorVisibleInScreenCaptures
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isVisibleInScreenCaptures in
+                guard let self else { return }
+                FloatingPanelSpacePolicy.applyIndicatorCapturePolicy(
+                    to: self,
+                    isVisibleInScreenCaptures: isVisibleInScreenCaptures
+                )
             }
             .store(in: &cancellables)
 
@@ -203,7 +222,8 @@ class NotchIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
             displayMode: displayModeProvider(),
-            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.notchIndicatorWindowLevel,
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
     }
 

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -35,7 +35,8 @@ class OverlayIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay,
-            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
+            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
         )
 
         let hostingView = OverlayFirstMouseHostingView(rootView: OverlayIndicatorView())
@@ -84,6 +85,18 @@ class OverlayIndicatorPanel: NSPanel {
             .sink { [weak self] _ in
                 guard let self, self.isVisible else { return }
                 self.show()
+            }
+            .store(in: &cancellables)
+
+        vm.$indicatorVisibleInScreenCaptures
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isVisibleInScreenCaptures in
+                guard let self else { return }
+                FloatingPanelSpacePolicy.applyIndicatorCapturePolicy(
+                    to: self,
+                    isVisibleInScreenCaptures: isVisibleInScreenCaptures
+                )
             }
             .store(in: &cancellables)
 
@@ -150,7 +163,8 @@ class OverlayIndicatorPanel: NSPanel {
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
             displayMode: DictationViewModel.shared.notchIndicatorDisplay,
-            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
+            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
         )
     }
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -53,6 +53,20 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
         XCTAssertTrue(DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults))
     }
 
+    func testIndicatorDefaultsToVisibleInScreenCaptures() {
+        XCTAssertTrue(DictationViewModel.loadIndicatorVisibleInScreenCaptures(defaults: defaults))
+    }
+
+    func testIndicatorScreenCaptureVisibilityPersistsWhenDisabled() {
+        DictationViewModel.persistIndicatorVisibleInScreenCaptures(false, defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
+            false
+        )
+        XCTAssertFalse(DictationViewModel.loadIndicatorVisibleInScreenCaptures(defaults: defaults))
+    }
+
     func testIndicatorTranscriptPreviewFontSizeOffsetDefaultsToZero() {
         XCTAssertEqual(DictationViewModel.loadIndicatorTranscriptPreviewFontSizeOffset(defaults: defaults), 0)
     }

--- a/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
+++ b/TypeWhisperTests/FloatingPanelSpacePolicyTests.swift
@@ -57,7 +57,7 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
     }
 
     @MainActor
-    func testIndicatorPolicyAppliesRequestedWindowLevelAndExcludesPanelFromScreenCapture() {
+    func testIndicatorPolicyAppliesRequestedWindowLevelAndAllowsScreenCapture() {
         let panel = NSPanel(
             contentRect: .zero,
             styleMask: [.borderless],
@@ -68,10 +68,28 @@ final class FloatingPanelSpacePolicyTests: XCTestCase {
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: panel,
             displayMode: .activeScreen,
-            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel
+            windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
+            isVisibleInScreenCaptures: true
         )
 
         XCTAssertEqual(panel.level, FloatingPanelSpacePolicy.floatingIndicatorWindowLevel)
+        XCTAssertEqual(panel.sharingType, .readOnly)
+    }
+
+    @MainActor
+    func testIndicatorCapturePolicyCanExcludePanelFromScreenCapture() {
+        let panel = NSPanel(
+            contentRect: .zero,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+
+        FloatingPanelSpacePolicy.applyIndicatorCapturePolicy(
+            to: panel,
+            isVisibleInScreenCaptures: false
+        )
+
         XCTAssertEqual(panel.sharingType, .none)
     }
 }

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -449,6 +449,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.userDefaults.set(0.35, forKey: UserDefaultsKeys.audioDuckingLevel)
         source.userDefaults.set(3, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         source.userDefaults.set("overlay", forKey: UserDefaultsKeys.indicatorStyle)
+        source.userDefaults.set(false, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
         source.userDefaults.set(true, forKey: UserDefaultsKeys.recorderSystemAudioEnabled)
         // Deliberately excluded: engine/model selections must not be exported.
         source.userDefaults.set("com.typewhisper.some-engine", forKey: UserDefaultsKeys.fileTranscriptionEngine)
@@ -471,6 +472,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         XCTAssertEqual(backup.preferences.audioDuckingLevel, 0.35)
         XCTAssertEqual(backup.preferences.indicatorTranscriptPreviewFontSizeOffset, 3)
         XCTAssertEqual(backup.preferences.indicatorStyle, "overlay")
+        XCTAssertEqual(backup.preferences.indicatorVisibleInScreenCaptures, false)
         XCTAssertEqual(backup.preferences.recorderSystemAudioEnabled, true)
 
         let destination = try makeFixture()
@@ -497,6 +499,10 @@ final class SettingsBackupExporterTests: XCTestCase {
         XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.translationEnabled), true)
         XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.showMenuBarIcon), false)
         XCTAssertEqual(destination.userDefaults.string(forKey: UserDefaultsKeys.indicatorStyle), "overlay")
+        XCTAssertEqual(
+            destination.userDefaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
+            false
+        )
         XCTAssertNil(destination.userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine))
     }
 


### PR DESCRIPTION
## Context

#584 requested an optional way to hide the dictation indicator from screen recordings and screen shares while keeping it visible locally. The indicator panels currently always apply `NSWindow.sharingType = .none`, which makes capture exclusion mandatory and changes the default behavior for every user.

This PR restores capture visibility as the default and gives streamers an explicit opt-out in the Indicator settings. It is intentionally separate from #1008, which tracks Safari fullscreen-suppression heuristics rather than screen-capture sharing policy.

Closes #584

## What changed

- add a persisted **Show indicator in screen recordings and screen shares** setting, defaulting to enabled
- switch all Notch, Overlay, and Minimal panels between `.readOnly` and `.none` immediately when the setting changes
- place the opt-out at the bottom of the Indicator settings section
- include the preference in settings backup/restore and diagnostics
- add German and Japanese localizations
- cover the default, persistence, panel policy, and backup round trip with tests

## User impact

Indicators remain visible in recordings and screen shares by default. Streamers can turn the setting off to exclude supported indicator panels from capture while keeping them visible on their own display.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests -only-testing:TypeWhisperTests/FloatingPanelSpacePolicyTests -only-testing:TypeWhisperTests/SettingsBackupExporterTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/292a/typewhisper-mac`
- [x] verify the enabled setting includes the Overlay indicator in a local system capture
- [x] verify the opt-out keeps the Overlay panel present locally while excluding it from the capture

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a “Indicator” toggle to show or hide the dictation indicator in screen recordings and screen shares.
  - When hidden from supported capture apps, the indicator remains visible on the display.
  - Added translated explanatory text (German and Japanese).
  - The setting is saved and included in settings backups and exported diagnostics.

- **Bug Fixes**
  - Screen capture visibility now updates immediately when the setting changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->