### PR TITLE
Fix Safari maximized window indicator suppression

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -401,8 +401,12 @@ enum IndicatorWindowFrameLookup {
         guard let focusedWindow = focusedWindowElement() else {
             return nil
         }
-        let windowElement = focusedWindow as! AXUIElement
+        return accessibilityWindowFrame(focusedWindow as! AXUIElement)
+    }
 
+    private nonisolated static func accessibilityWindowFrame(
+        _ windowElement: AXUIElement
+    ) -> CGRect? {
         var positionValue: AnyObject?
         guard AXUIElementCopyAttributeValue(
             windowElement,
@@ -442,23 +446,31 @@ enum IndicatorWindowFrameLookup {
         guard let focusedWindow = focusedWindowElement() else {
             return nil
         }
-        let windowElement = focusedWindow as! AXUIElement
-
-        var fullScreenValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            windowElement,
+        return accessibilityBoolAttribute(
             "AXFullScreen" as CFString,
-            &fullScreenValue
+            on: focusedWindow as! AXUIElement
+        )
+    }
+
+    private nonisolated static func accessibilityBoolAttribute(
+        _ attribute: CFString,
+        on element: AXUIElement
+    ) -> Bool? {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            attribute,
+            &value
         ) == .success,
-              let fullScreenValue else {
+              let value else {
             return nil
         }
 
-        if let isFullscreen = fullScreenValue as? Bool {
-            return isFullscreen
+        if let boolValue = value as? Bool {
+            return boolValue
         }
 
-        return (fullScreenValue as? NSNumber)?.boolValue
+        return (value as? NSNumber)?.boolValue
     }
 
     private nonisolated static func focusedWindowElement() -> AnyObject? {
@@ -501,20 +513,7 @@ enum IndicatorWindowFrameLookup {
         }
 
         return windows.compactMap { windowElement in
-            var frameValue: AnyObject?
-            guard AXUIElementCopyAttributeValue(
-                windowElement,
-                "AXFrame" as CFString,
-                &frameValue
-            ) == .success,
-                  let frameValue else {
-                return nil
-            }
-            let axFrame = frameValue as! AXValue
-
-            var frame = CGRect.zero
-            guard AXValueGetValue(axFrame, .cgRect, &frame),
-                  !frame.isEmpty else {
+            guard let frame = accessibilityWindowFrame(windowElement) else {
                 return nil
             }
 
@@ -526,21 +525,7 @@ enum IndicatorWindowFrameLookup {
     }
 
     private static func accessibilityWindowIsFullscreen(_ windowElement: AXUIElement) -> Bool? {
-        var fullScreenValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(
-            windowElement,
-            "AXFullScreen" as CFString,
-            &fullScreenValue
-        ) == .success,
-              let fullScreenValue else {
-            return nil
-        }
-
-        if let isFullscreen = fullScreenValue as? Bool {
-            return isFullscreen
-        }
-
-        return (fullScreenValue as? NSNumber)?.boolValue
+        accessibilityBoolAttribute("AXFullScreen" as CFString, on: windowElement)
     }
 
     private static func framesApproximatelyMatch(_ lhs: CGRect, _ rhs: CGRect) -> Bool {

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -258,14 +258,48 @@ private enum SafariBundleIdentifiers {
     }
 }
 
+struct SafariWindowSnapshot: Equatable {
+    let frame: CGRect
+    let isFullscreen: Bool?
+}
+
 enum IndicatorWindowFrameLookup {
+    private struct OwnedWindowFrame {
+        let ownerPID: pid_t
+        let frame: CGRect
+    }
+
+    private static let accessibilityFrameTolerance: CGFloat = 2
+
     @MainActor
-    static func safariWindowFrames(intersecting screenFrame: CGRect) -> [CGRect] {
-        windowFrames(intersecting: screenFrame) { ownerPID, _ in
+    static func safariWindows(intersecting screenFrame: CGRect) -> [SafariWindowSnapshot] {
+        let ownedWindowFrames = windowFrameRecords(intersecting: screenFrame) { ownerPID, _ in
             guard let application = NSRunningApplication(processIdentifier: ownerPID) else {
                 return false
             }
             return isSafariWindowOwner(application.bundleIdentifier)
+        }
+
+        var accessibilityWindowsByPID: [pid_t: [SafariWindowSnapshot]] = [:]
+        return ownedWindowFrames.map { ownedWindowFrame in
+            let accessibilitySnapshots: [SafariWindowSnapshot]
+            if let cachedWindows = accessibilityWindowsByPID[ownedWindowFrame.ownerPID] {
+                accessibilitySnapshots = cachedWindows
+            } else {
+                let windows = Self.accessibilityWindows(for: ownedWindowFrame.ownerPID)
+                accessibilityWindowsByPID[ownedWindowFrame.ownerPID] = windows
+                accessibilitySnapshots = windows
+            }
+
+            let isFullscreen = accessibilitySnapshots
+                .filter { framesApproximatelyMatch($0.frame, ownedWindowFrame.frame) }
+                .compactMap(\.isFullscreen)
+                .first
+
+            return SafariWindowSnapshot(
+                frame: ownedWindowFrame.frame,
+                isFullscreen: isFullscreen
+            )
         }
     }
 
@@ -281,6 +315,17 @@ enum IndicatorWindowFrameLookup {
         intersecting screenFrame: CGRect,
         matchingOwner: (pid_t, [String: Any]) -> Bool
     ) -> [CGRect] {
+        windowFrameRecords(
+            intersecting: screenFrame,
+            matchingOwner: matchingOwner
+        ).map(\.frame)
+    }
+
+    @MainActor
+    private static func windowFrameRecords(
+        intersecting screenFrame: CGRect,
+        matchingOwner: (pid_t, [String: Any]) -> Bool
+    ) -> [OwnedWindowFrame] {
         guard let windowList = CGWindowListCopyWindowInfo(
             [.optionOnScreenOnly, .excludeDesktopElements],
             kCGNullWindowID
@@ -306,7 +351,7 @@ enum IndicatorWindowFrameLookup {
             let alpha = windowInfo[kCGWindowAlpha as String] as? Double ?? 1
             guard alpha > 0 else { return nil }
 
-            return bounds
+            return OwnedWindowFrame(ownerPID: ownerPID, frame: bounds)
         }
     }
 
@@ -442,6 +487,71 @@ enum IndicatorWindowFrameLookup {
         return focusedWindow
     }
 
+    private static func accessibilityWindows(for processIdentifier: pid_t) -> [SafariWindowSnapshot] {
+        let applicationElement = AXUIElementCreateApplication(processIdentifier)
+
+        var windowsValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            applicationElement,
+            kAXWindowsAttribute as CFString,
+            &windowsValue
+        ) == .success,
+              let windows = windowsValue as? [AXUIElement] else {
+            return []
+        }
+
+        return windows.compactMap { windowElement in
+            var frameValue: AnyObject?
+            guard AXUIElementCopyAttributeValue(
+                windowElement,
+                "AXFrame" as CFString,
+                &frameValue
+            ) == .success,
+                  let frameValue else {
+                return nil
+            }
+            let axFrame = frameValue as! AXValue
+
+            var frame = CGRect.zero
+            guard AXValueGetValue(axFrame, .cgRect, &frame),
+                  !frame.isEmpty else {
+                return nil
+            }
+
+            return SafariWindowSnapshot(
+                frame: frame,
+                isFullscreen: accessibilityWindowIsFullscreen(windowElement)
+            )
+        }
+    }
+
+    private static func accessibilityWindowIsFullscreen(_ windowElement: AXUIElement) -> Bool? {
+        var fullScreenValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            windowElement,
+            "AXFullScreen" as CFString,
+            &fullScreenValue
+        ) == .success,
+              let fullScreenValue else {
+            return nil
+        }
+
+        if let isFullscreen = fullScreenValue as? Bool {
+            return isFullscreen
+        }
+
+        return (fullScreenValue as? NSNumber)?.boolValue
+    }
+
+    private static func framesApproximatelyMatch(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        let lhs = lhs.standardized
+        let rhs = rhs.standardized
+        return abs(lhs.minX - rhs.minX) <= accessibilityFrameTolerance
+            && abs(lhs.minY - rhs.minY) <= accessibilityFrameTolerance
+            && abs(lhs.width - rhs.width) <= accessibilityFrameTolerance
+            && abs(lhs.height - rhs.height) <= accessibilityFrameTolerance
+    }
+
     private static func isSafariWindowOwner(_ bundleIdentifier: String?) -> Bool {
         SafariBundleIdentifiers.contains(bundleIdentifier)
     }
@@ -484,7 +594,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         focusedWindowFrameProvider: () -> CGRect? = IndicatorWindowFrameLookup.focusedWindowFrame,
         focusedWindowFullscreenProvider: () -> Bool? = IndicatorWindowFrameLookup.focusedWindowIsFullscreen,
         windowFrameProvider: (pid_t) -> CGRect? = IndicatorWindowFrameLookup.frontmostWindowFrame(for:),
-        safariWindowFramesProvider: @MainActor (CGRect) -> [CGRect] = IndicatorWindowFrameLookup.safariWindowFrames(intersecting:),
+        safariWindowsProvider: @MainActor (CGRect) -> [SafariWindowSnapshot] = IndicatorWindowFrameLookup.safariWindows(intersecting:),
         applicationWindowFramesProvider: @MainActor (pid_t, CGRect) -> [CGRect] = IndicatorWindowFrameLookup.applicationWindowFrames(for:intersecting:),
         appBundleIdentifier: String? = Bundle.main.bundleIdentifier
     ) -> Bool {
@@ -499,7 +609,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         }
         let focusedWindowIsFullscreen = focusedWindowFullscreenProvider()
         let safeAreaTopInset = screen.safeAreaInsets.top
-        let safariWindowFrames = safariWindowFramesProvider(screen.frame)
+        let safariWindows = safariWindowsProvider(screen.frame)
         let applicationWindowFrames: [CGRect]
         if placement == .notchStrip,
            safeAreaTopInset > 0,
@@ -518,7 +628,7 @@ enum IndicatorFullscreenSuppressionPolicy {
             frontmostBundleIdentifier: application?.bundleIdentifier,
             appBundleIdentifier: appBundleIdentifier,
             placement: placement,
-            safariWindowFrames: safariWindowFrames,
+            safariWindows: safariWindows,
             applicationWindowFrames: applicationWindowFrames
         )
 
@@ -543,7 +653,7 @@ enum IndicatorFullscreenSuppressionPolicy {
         frontmostBundleIdentifier: String?,
         appBundleIdentifier: String?,
         placement: IndicatorPlacement = .notchStrip,
-        safariWindowFrames: [CGRect] = [],
+        safariWindows: [SafariWindowSnapshot] = [],
         applicationWindowFrames: [CGRect] = []
     ) -> Bool {
         guard safeAreaTopInset > 0, !screenFrame.isEmpty else {
@@ -552,12 +662,13 @@ enum IndicatorFullscreenSuppressionPolicy {
 
         let screenFrame = screenFrame.standardized
 
-        if safariWindowFrames.contains(where: {
+        if safariWindows.contains(where: {
             isFullscreenLikeOrContentWindowBelowNotch(
                 screenFrame: screenFrame,
                 safeAreaTopInset: safeAreaTopInset,
-                windowFrame: $0.standardized
+                windowFrame: $0.frame.standardized
             )
+                && $0.isFullscreen != false
         }) {
             return true
         }
@@ -610,7 +721,7 @@ enum IndicatorFullscreenSuppressionPolicy {
                 safeAreaTopInset: safeAreaTopInset,
                 windowFrame: windowFrame
            ) {
-            return true
+            return focusedWindowIsFullscreen != false
         }
 
         guard placement == .notchStrip else {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -599,14 +599,14 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
         )
     }
 
-    func testSuppressesSafariFullscreenLikeWindowWhenAXReportsNotFullscreen() {
-        let safariFullscreenWindow = CGRect(x: 0, y: 0, width: 3024, height: 1964)
+    func testDoesNotSuppressSafariMaximizedWindowWhenAXReportsNotFullscreen() {
+        let safariMaximizedWindow = CGRect(x: 0, y: 33, width: 1512, height: 949)
 
-        XCTAssertTrue(
+        XCTAssertFalse(
             IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
-                screenFrame: notchedScreenFrame,
-                safeAreaTopInset: 74,
-                windowFrame: safariFullscreenWindow,
+                screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+                safeAreaTopInset: 32,
+                windowFrame: safariMaximizedWindow,
                 focusedWindowIsFullscreen: false,
                 frontmostBundleIdentifier: "com.apple.Safari",
                 appBundleIdentifier: "com.typewhisper.mac.dev"
@@ -622,7 +622,7 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 screenFrame: notchedScreenFrame,
                 safeAreaTopInset: 74,
                 windowFrame: safariFullscreenWindow,
-                focusedWindowIsFullscreen: false,
+                focusedWindowIsFullscreen: true,
                 frontmostBundleIdentifier: "com.apple.SafariTechnologyPreview",
                 appBundleIdentifier: "com.typewhisper.mac.dev"
             )
@@ -637,7 +637,7 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 screenFrame: notchedScreenFrame,
                 safeAreaTopInset: 74,
                 windowFrame: safariFullscreenWindow,
-                focusedWindowIsFullscreen: false,
+                focusedWindowIsFullscreen: true,
                 frontmostBundleIdentifier: "com.apple.Safari",
                 appBundleIdentifier: "com.typewhisper.mac.dev",
                 placement: .nonNotchArea
@@ -657,7 +657,9 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 frontmostBundleIdentifier: nil,
                 appBundleIdentifier: "com.typewhisper.mac.dev",
                 placement: .nonNotchArea,
-                safariWindowFrames: [safariFullscreenWindow]
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariFullscreenWindow, isFullscreen: true)
+                ]
             )
         )
     }
@@ -674,7 +676,9 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 frontmostBundleIdentifier: "com.typewhisper.mac.dev",
                 appBundleIdentifier: "com.typewhisper.mac.dev",
                 placement: .nonNotchArea,
-                safariWindowFrames: [safariFullscreenWindow]
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariFullscreenWindow, isFullscreen: true)
+                ]
             )
         )
     }
@@ -692,7 +696,49 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 frontmostBundleIdentifier: "com.typewhisper.mac.dev",
                 appBundleIdentifier: "com.typewhisper.mac.dev",
                 placement: .nonNotchArea,
-                safariWindowFrames: [safariContentWindowBelowNotch]
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariContentWindowBelowNotch, isFullscreen: true)
+                ]
+            )
+        )
+    }
+
+    func testDoesNotSuppressMaximizedSafariWindowScanWhenAXReportsNotFullscreen() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let safariMaximizedWindow = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertFalse(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.typewhisper.mac.dev",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariMaximizedWindow, isFullscreen: false)
+                ]
+            )
+        )
+    }
+
+    func testKeepsSafariGeometryFallbackWhenAXFullscreenIsUnavailable() {
+        let screenFrame = CGRect(x: 0, y: 0, width: 1512, height: 982)
+        let safariFullscreenWindow = CGRect(x: 0, y: 33, width: 1512, height: 949)
+
+        XCTAssertTrue(
+            IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(
+                screenFrame: screenFrame,
+                safeAreaTopInset: 32,
+                windowFrame: nil,
+                focusedWindowIsFullscreen: nil,
+                frontmostBundleIdentifier: "com.typewhisper.mac.dev",
+                appBundleIdentifier: "com.typewhisper.mac.dev",
+                placement: .nonNotchArea,
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariFullscreenWindow, isFullscreen: nil)
+                ]
             )
         )
     }
@@ -709,7 +755,9 @@ final class IndicatorFullscreenSuppressionPolicyTests: XCTestCase {
                 frontmostBundleIdentifier: nil,
                 appBundleIdentifier: "com.typewhisper.mac.dev",
                 placement: .nonNotchArea,
-                safariWindowFrames: [safariWindowBelowMenuBar]
+                safariWindows: [
+                    SafariWindowSnapshot(frame: safariWindowBelowMenuBar, isFullscreen: nil)
+                ]
             )
         )
     }


### PR DESCRIPTION
## Context

Issue #1008 reports that a normally maximized Safari window on a notched MacBook is treated as a dedicated fullscreen window. Because the Safari geometry fallback runs before placement-aware suppression, this hides even a bottom-aligned Overlay and its live transcript preview.

## What changed

- Preserve Safari window fullscreen state alongside each CG window frame by matching it to Safari's Accessibility `AXFrame`/`AXFullScreen` values.
- Treat an explicit `AXFullScreen == false` as a normal maximized window instead of applying the geometry-only fullscreen fallback.
- Continue suppressing genuine Safari fullscreen windows, including when TypeWhisper is temporarily frontmost.
- Keep the existing geometry fallback when Accessibility cannot determine the fullscreen state.
- Add regression coverage for the reported below-notch maximized geometry, genuine fullscreen, TypeWhisper-frontmost scanning, and unavailable AX state.

## User impact

A bottom Overlay remains visible when Safari is maximized in a regular desktop Space. Safari in a dedicated fullscreen Space retains the existing suppression behavior that protects its hidden fullscreen toolbar.

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/IndicatorFullscreenSuppressionPolicyTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-1008-targeted.log
scripts/pr-preflight.sh origin/main
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$PWD"
```

Manual smoke on the built-in 1512x982 notched display (`safeTop=32`):

- Regular Safari window at `(100,100,1200,750)`: bottom Overlay visible.
- Normally maximized Safari at `(0,33,1512,949)`, without a fullscreen Space: bottom Overlay visible.
- Dedicated Safari fullscreen Space with the same main-window geometry and `AXFullScreen == true`: Overlay suppressed.
- Resizing Safari back to a regular window: Overlay remains visible.

Closes #1008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Safari fullscreen indicator suppression by combining window geometry with accessibility-reported fullscreen state.
  * Prevented suppression when Safari is maximized but explicitly reported as not fullscreen.
  * Refined fullscreen-like handling for Safari auxiliary panels and hidden-toolbar scenarios.
* **Tests**
  * Updated and expanded indicator suppression tests to cover fullscreen, non-fullscreen, and unknown accessibility states, including geometry fallback cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->