### PR TITLE
Retry Soniox async transcription with WAV

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -119,6 +119,26 @@ struct SonioxRegion: Sendable, Hashable, Identifiable {
     }
 }
 
+private struct SonioxAsyncTranscriptionRequest: Sendable {
+    let region: SonioxRegion
+    let modelID: String
+    let language: String?
+    let languageHints: [String]
+    let translate: Bool
+    let apiKey: String
+    let prompt: String?
+}
+
+private struct SonioxUploadedAudio: Sendable {
+    let fileID: String
+    let format: String
+}
+
+private struct SonioxAsyncJobFailure: Error, Sendable {
+    let errorType: String?
+    let transcriptionError: PluginTranscriptionError
+}
+
 struct SonioxFetchedLanguage: Codable, Equatable, Sendable {
     let code: String
     let name: String?
@@ -1345,30 +1365,76 @@ final class SonioxPlugin: NSObject,
         apiKey: String,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        let fileId = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { upload in
-            try await uploadFile(uploadFile: upload, apiKey: apiKey)
-        }
-        let transcriptionId = try await createTranscription(
-            fileId: fileId,
+        let request = SonioxAsyncTranscriptionRequest(
+            region: _selectedRegion,
+            modelID: effectiveAsyncModelId,
             language: language,
             languageHints: languageHints,
             translate: translate,
             apiKey: apiKey,
             prompt: prompt
         )
-        try await pollUntilCompleted(id: transcriptionId, apiKey: apiKey)
-        return try await fetchTranscript(id: transcriptionId, apiKey: apiKey, language: language)
+        let uploadAudio = PluginAudioUploadEncoder.normalizedAudioForUpload(audio)
+
+        do {
+            let uploadedAudio = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(
+                from: uploadAudio
+            ) { upload in
+                SonioxUploadedAudio(
+                    fileID: try await uploadFile(uploadFile: upload, request: request),
+                    format: upload.format
+                )
+            }
+
+            do {
+                return try await completeRESTTransaction(
+                    fileID: uploadedAudio.fileID,
+                    request: request
+                )
+            } catch let failure as SonioxAsyncJobFailure
+                where uploadedAudio.format == "m4a" && failure.errorType == "invalid_audio_file" {
+                return try await transcribeRESTTransaction(
+                    uploadFile: PluginAudioUploadEncoder.wavUpload(from: uploadAudio),
+                    request: request
+                )
+            }
+        } catch let failure as SonioxAsyncJobFailure {
+            throw failure.transcriptionError
+        }
     }
 
-    private func uploadFile(uploadFile: PluginAudioUploadFile, apiKey: String) async throws -> String {
-        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/files") else {
+    private func transcribeRESTTransaction(
+        uploadFile upload: PluginAudioUploadFile,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async throws -> PluginTranscriptionResult {
+        let fileID = try await uploadFile(uploadFile: upload, request: configuration)
+        return try await completeRESTTransaction(fileID: fileID, request: configuration)
+    }
+
+    private func completeRESTTransaction(
+        fileID: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async throws -> PluginTranscriptionResult {
+        let transcriptionID = try await createTranscription(
+            fileID: fileID,
+            request: configuration
+        )
+        try await pollUntilCompleted(id: transcriptionID, request: configuration)
+        return try await fetchTranscript(id: transcriptionID, request: configuration)
+    }
+
+    private func uploadFile(
+        uploadFile: PluginAudioUploadFile,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async throws -> String {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/files") else {
             throw PluginTranscriptionError.apiError("Invalid upload URL")
         }
 
         let boundary = UUID().uuidString
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = 120
 
@@ -1405,22 +1471,18 @@ final class SonioxPlugin: NSObject,
     }
 
     private func createTranscription(
-        fileId: String,
-        language: String?,
-        languageHints: [String] = [],
-        translate: Bool,
-        apiKey: String,
-        prompt: String?
+        fileID: String,
+        request configuration: SonioxAsyncTranscriptionRequest
     ) async throws -> String {
         let request = try Self.makeCreateTranscriptionRequest(
-            fileId: fileId,
-            language: language,
-            languageHints: languageHints,
-            translate: translate,
-            apiKey: apiKey,
-            prompt: prompt,
-            modelID: effectiveAsyncModelId,
-            regionID: _selectedRegion.id
+            fileId: fileID,
+            language: configuration.language,
+            languageHints: configuration.languageHints,
+            translate: configuration.translate,
+            apiKey: configuration.apiKey,
+            prompt: configuration.prompt,
+            modelID: configuration.modelID,
+            regionID: configuration.region.id
         )
 
         let (data, response) = try await PluginHTTPClient.data(for: request)
@@ -1860,13 +1922,16 @@ final class SonioxPlugin: NSObject,
         return "en"
     }
 
-    private func pollUntilCompleted(id: String, apiKey: String) async throws {
-        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/transcriptions/\(id)") else {
+    private func pollUntilCompleted(
+        id: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async throws {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/transcriptions/\(id)") else {
             throw PluginTranscriptionError.apiError("Invalid poll URL")
         }
 
         var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 15
 
         for _ in 0..<300 {
@@ -1901,7 +1966,10 @@ final class SonioxPlugin: NSObject,
                     logger.error("Soniox transcription failed, full response: \(responseStr)")
                     errorMsg = "Transcription failed (status: \(status))"
                 }
-                throw PluginTranscriptionError.apiError(errorMsg)
+                throw SonioxAsyncJobFailure(
+                    errorType: json["error_type"] as? String,
+                    transcriptionError: PluginTranscriptionError.apiError(errorMsg)
+                )
             default:
                 continue
             }
@@ -1910,13 +1978,16 @@ final class SonioxPlugin: NSObject,
         throw PluginTranscriptionError.apiError("Transcription timed out after 5 minutes")
     }
 
-    private func fetchTranscript(id: String, apiKey: String, language: String?) async throws -> PluginTranscriptionResult {
-        guard let url = URL(string: "\(_selectedRegion.apiBaseURL)/v1/transcriptions/\(id)/transcript") else {
+    private func fetchTranscript(
+        id: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async throws -> PluginTranscriptionResult {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/transcriptions/\(id)/transcript") else {
             throw PluginTranscriptionError.apiError("Invalid transcript URL")
         }
 
         var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
         request.timeoutInterval = 30
 
         let (data, response) = try await PluginHTTPClient.data(for: request)
@@ -1948,7 +2019,7 @@ final class SonioxPlugin: NSObject,
             text = json["text"] as? String ?? ""
         }
 
-        return PluginTranscriptionResult(text: text, detectedLanguage: language)
+        return PluginTranscriptionResult(text: text, detectedLanguage: configuration.language)
     }
 
     // MARK: - Audio Conversion

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -414,6 +414,262 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertEqual(context["terms"] as? [String], ["TypeWhisper"])
     }
 
+    func testSourceProgressTranscriptionRetriesCompleteTransactionWithWavWhenM4AJobFails() async throws {
+        let models = [
+            SonioxFetchedModel(
+                id: "stt-async-v6",
+                aliasedModelId: nil,
+                name: "STT Async v6",
+                transcriptionMode: "async",
+                languages: []
+            ),
+        ]
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedRegion": "eu",
+                "fetchedModels": try JSONEncoder().encode(models),
+            ],
+            secrets: ["api-key": "soniox-key"]
+        )
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(
+                        #"{"status":"failed","error_type":"invalid_audio_file","error_message":"M4A rejected"}"#.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"id":"file_wav"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_wav"}"#.utf8),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_wav",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"WAV transaction transcript"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_wav/transcript",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1.0)
+        let result = try await plugin.transcribe(
+            audio: audio,
+            languageSelection: PluginLanguageSelection(
+                requestedLanguage: "de",
+                languageHints: ["de", "en"]
+            ),
+            translate: true,
+            prompt: "TypeWhisper",
+            onProgress: { _ in true },
+            onSourceProgress: { _ in true }
+        )
+
+        XCTAssertEqual(result.text, "WAV transaction transcript")
+        XCTAssertEqual(result.detectedLanguage, "de")
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_m4a",
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_wav",
+            "/v1/transcriptions/transcription_wav/transcript",
+        ])
+        XCTAssertTrue(requests.allSatisfy { $0.url?.host == "api.eu.soniox.com" })
+
+        let firstUploadBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstUploadBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(firstUploadBody.contains("Content-Type: audio/mp4"))
+
+        let retryUploadBody = String(decoding: try XCTUnwrap(requests[3].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryUploadBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryUploadBody.contains("Content-Type: audio/wav"))
+
+        XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(requests[4].value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+
+        var firstCreateBody = try Self.jsonBody(from: requests[1])
+        var retryCreateBody = try Self.jsonBody(from: requests[4])
+        XCTAssertEqual(firstCreateBody.removeValue(forKey: "file_id") as? String, "file_m4a")
+        XCTAssertEqual(retryCreateBody.removeValue(forKey: "file_id") as? String, "file_wav")
+        XCTAssertTrue(NSDictionary(dictionary: firstCreateBody).isEqual(to: retryCreateBody))
+
+        XCTAssertEqual(firstCreateBody["model"] as? String, "stt-async-v6")
+        XCTAssertEqual(firstCreateBody["language_hints"] as? [String], ["de", "en"])
+        let context = try XCTUnwrap(firstCreateBody["context"] as? [String: Any])
+        XCTAssertEqual(context["terms"] as? [String], ["TypeWhisper"])
+        let translation = try XCTUnwrap(firstCreateBody["translation"] as? [String: Any])
+        XCTAssertEqual(translation["type"] as? String, "one_way")
+        XCTAssertEqual(translation["target_language"] as? String, "en")
+    }
+
+    func testSourceProgressTranscriptionDoesNotRetryOtherAsyncJobFailures() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(
+                        #"{"status":"error","error_type":"organization_monthly_budget_exhausted","error_message":"Monthly budget exhausted"}"#.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+                languageSelection: PluginLanguageSelection(languageHints: ["en"]),
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true },
+                onSourceProgress: { _ in true }
+            )
+            XCTFail("Expected the Soniox job failure")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: Monthly budget exhausted"
+            )
+        }
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_m4a",
+        ])
+        let uploadBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        XCTAssertTrue(uploadBody.contains(#"filename="audio.m4a""#))
+    }
+
+    func testSourceProgressTranscriptionSurfacesWavJobFailureWithoutThirdAttempt() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_m4a"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(
+                        #"{"status":"failed","error_type":"invalid_audio_file","error_message":"M4A rejected"}"#.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"id":"file_wav"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_wav"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(
+                        #"{"status":"failed","error_type":"invalid_audio_file","error_message":"WAV rejected too"}"#.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_wav",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        do {
+            _ = try await plugin.transcribe(
+                audio: AudioData(
+                    samples: samples,
+                    wavData: PluginWavEncoder.encode(samples),
+                    duration: 1.0
+                ),
+                languageSelection: PluginLanguageSelection(languageHints: ["en"]),
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true },
+                onSourceProgress: { _ in true }
+            )
+            XCTFail("Expected the WAV job failure")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: WAV rejected too"
+            )
+        }
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_m4a",
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_wav",
+        ])
+        let retryUploadBody = String(decoding: try XCTUnwrap(requests[3].httpBody), as: UTF8.self)
+        XCTAssertTrue(retryUploadBody.contains(#"filename="audio.wav""#))
+        XCTAssertTrue(retryUploadBody.contains("Content-Type: audio/wav"))
+    }
+
     func testSourceProgressTranscriptionUsesSelectedRegionalRESTPath() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedRegion": "eu"],


### PR DESCRIPTION
## Summary

- retry the complete Soniox async transcription transaction once with WAV when an accepted M4A job fails with `error_type: invalid_audio_file`
- preserve the selected region, async model, language hints, dictionary context, translation settings, and API key across the retry
- keep the existing upload-level M4A-to-WAV fallback and surface all non-audio or second-attempt failures unchanged

## Issue context and root cause

The existing WAV fallback wrapped only `POST /v1/files`. Soniox can accept an M4A upload and create a transcription before rejecting the asynchronous job during polling, so that later failure never reached the format fallback described in #1011.

## Impact

M4A remains preferred. Only an async `invalid_audio_file` failure for an actual M4A upload triggers one complete WAV retry. Authentication, quota, rate-limit, network, timeout, cancellation, and other provider failures do not trigger a format retry. The retry does not add cleanup requests, public API changes, manifest changes, or SDK changes.

Closes #1011

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests`
- `git diff --check`
- `scripts/pr-preflight.sh origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription reliability by retrying failed M4A uploads as WAV when the audio format is rejected.
  * Preserved regional endpoint selection, authorization, language, and translation settings during retries.
  * Prevented unnecessary retries for non-audio failures and limited retries when the fallback upload also fails.
  * Improved error reporting by surfacing the final transcription failure message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->