### PR TITLE
Bump Soniox plugin to 1.2.5

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
-    "version": "1.2.0",
+    "version": "1.2.5",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump the Soniox plugin manifest from 1.2.0 to 1.2.5
- prepare the official plugin release containing the async M4A-to-WAV transaction retry from #1012

## Why

The current plugin release workflow requires the source manifest version on `main` to match the requested release version. The latest published Soniox version is 1.2.4, so 1.2.5 is the next available patch release.

## Impact

This changes release metadata only. The plugin ID, minimum host version, SDK compatibility line, minimum macOS version, and runtime implementation remain unchanged.

## Test plan

- `jq empty TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json`
- `git diff --check`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PluginManifestValidationTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Soniox plugin version to 1.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->