### PR TITLE
Attach existing Polar activations to Premium accounts

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -928,18 +928,18 @@
         }
       }
     },
-    "2 devices": {
+    "3 devices": {
       "localizations": {
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "2 Geräte"
+            "value": "3 Geräte"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "2台のデバイス"
+            "value": "3台のデバイス"
           }
         }
       }
@@ -8141,22 +8141,22 @@
         }
       }
     },
-    "Individual commercial license terms for up to 2 devices with recurring billing.": {
+    "Individual commercial license terms for up to 3 devices with recurring billing.": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "継続課金による最大2台のデバイス向けのIndividual商用ライセンス条件。"
+            "value": "継続課金による最大3台のデバイス向けのIndividual商用ライセンス条件。"
           }
         }
       }
     },
-    "Individual covers one person who needs non-GPL terms, procurement, support, or proprietary distribution on up to 2 devices.": {
+    "Individual covers one person who needs non-GPL terms, procurement, support, or proprietary distribution on up to 3 devices.": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Individualは、非GPL条件、調達、サポート、または最大2台のデバイスでの独自の配布を必要とする1人のユーザーを対象とします。"
+            "value": "Individualは、非GPL条件、調達、サポート、または最大3台のデバイスでの独自の配布を必要とする1人のユーザーを対象とします。"
           }
         }
       }
@@ -11624,12 +11624,12 @@
         }
       }
     },
-    "One payment for the same 2-device Individual tier, with no monthly renewal.": {
+    "One payment for the same 3-device Individual tier, with no monthly renewal.": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "月々の更新なしで、同じ2デバイスのIndividual階層への1回のお支払い。"
+            "value": "月々の更新なしで、同じ3デバイスのIndividual階層への1回のお支払い。"
           }
         }
       }
@@ -17516,12 +17516,12 @@
         }
       }
     },
-    "This Mac is covered by Individual commercial license terms on up to 2 devices.": {
+    "This Mac is covered by Individual commercial license terms on up to 3 devices.": {
       "localizations": {
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このMacは、最大2台のデバイスを対象としたIndividual商用ライセンス条件でカバーされています。"
+            "value": "このMacは、最大3台のデバイスを対象としたIndividual商用ライセンス条件でカバーされています。"
           }
         }
       }

--- a/TypeWhisper/Services/LicenseService.swift
+++ b/TypeWhisper/Services/LicenseService.swift
@@ -200,9 +200,13 @@ final class LicenseService: ObservableObject {
 
     var isSupporter: Bool { supporterStatus == .active && supporterTier != nil }
     var hasCommercialLicense: Bool { licenseStatus == .active }
-    var commercialLicenseKeyForAccountLink: String? {
-        guard hasCommercialLicense else { return nil }
-        return loadLicenseFromKeychain()?.key
+    var commercialLicenseProofForAccountLink: CommercialLicenseLinkProof? {
+        guard hasCommercialLicense,
+              let stored = loadLicenseFromKeychain() else { return nil }
+        return CommercialLicenseLinkProof(
+            key: stored.key,
+            activationId: stored.activationId
+        )
     }
     var canUseProTranscriptionFallback: Bool { hasCommercialLicense || isSupporter }
     var supporterClaimProof: SupporterClaimProof? {
@@ -1001,6 +1005,11 @@ enum LicenseError: LocalizedError {
 }
 
 // MARK: - Discord Claim Models
+
+struct CommercialLicenseLinkProof: Equatable, Sendable {
+    let key: String
+    let activationId: String
+}
 
 struct SupporterClaimProof: Equatable, Sendable {
     let key: String

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -105,7 +105,9 @@ struct CrossDevicePremiumEntitlementVerifier: Sendable {
         }
 
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom(
+            decodeISO8601DateWithOptionalFractionalSeconds
+        )
         guard let claims = try? decoder.decode(
             CrossDevicePremiumEntitlement.SignedClaims.self,
             from: payload
@@ -254,6 +256,10 @@ final class PremiumAccountService: ObservableObject {
         let entitlement: CrossDevicePremiumEntitlement?
     }
     private struct EntitlementResponse: Decodable { let entitlement: CrossDevicePremiumEntitlement? }
+    private struct DeviceDetachResponse: Decodable {
+        let ok: Bool
+        let released: Bool
+    }
     private struct ErrorResponse: Decodable { let error: String }
     private struct AppleWebStartResponse: Decodable {
         let authorizationURL: URL
@@ -352,7 +358,9 @@ final class PremiumAccountService: ObservableObject {
         }
     }
 
-    func signInWithApple(polarLicenseKey: String?) async {
+    func signInWithApple(
+        commercialLicenseProof: CommercialLicenseLinkProof?
+    ) async {
         await perform {
             let nonce = try Self.randomBase64URLToken()
             let codeVerifier = try Self.randomBase64URLToken()
@@ -414,7 +422,10 @@ final class PremiumAccountService: ObservableObject {
                 ]),
                 authenticated: false
             )
-            try await acceptAccountSession(accountSession, polarLicenseKey: polarLicenseKey)
+            try await acceptAccountSession(
+                accountSession,
+                commercialLicenseProof: commercialLicenseProof
+            )
         }
     }
 
@@ -428,6 +439,18 @@ final class PremiumAccountService: ObservableObject {
 
     func signOut() {
         clearAuthorizationState()
+    }
+
+    func signOutFromAccount() async {
+        await perform {
+            let response: DeviceDetachResponse = try await request(
+                path: "/v1/entitlements/polar/device/current",
+                method: "DELETE"
+            )
+            guard response.ok else { throw URLError(.badServerResponse) }
+            _ = response.released
+            clearAuthorizationState()
+        }
     }
 
     func deleteAccount() async {
@@ -445,18 +468,23 @@ final class PremiumAccountService: ObservableObject {
 
     private func acceptAccountSession(
         _ accountSession: AccountSession,
-        polarLicenseKey: String?
+        commercialLicenseProof: CommercialLicenseLinkProof?
     ) async throws {
         startupTokenTask?.cancel()
         startupTokenTask = nil
         try Self.saveToken(accountSession.accessToken, service: keychainService)
         isSignedIn = true
         try acceptEntitlement(accountSession.entitlement)
-        if let polarLicenseKey, !polarLicenseKey.isEmpty {
+        if let commercialLicenseProof,
+           !commercialLicenseProof.key.isEmpty,
+           !commercialLicenseProof.activationId.isEmpty {
             let response: EntitlementResponse = try await request(
-                path: "/v1/entitlements/polar/link",
+                path: "/v1/entitlements/polar/device/attach",
                 method: "POST",
-                body: try encoder.encode(["licenseKey": polarLicenseKey])
+                body: try encoder.encode([
+                    "licenseKey": commercialLicenseProof.key,
+                    "activationId": commercialLicenseProof.activationId,
+                ])
             )
             try acceptEntitlement(response.entitlement)
         } else {
@@ -502,6 +530,7 @@ final class PremiumAccountService: ObservableObject {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue(deviceID, forHTTPHeaderField: "X-TypeWhisper-Device-ID")
         request.setValue("macos", forHTTPHeaderField: "X-TypeWhisper-Platform")
+        request.setValue("2", forHTTPHeaderField: "X-TypeWhisper-Entitlement-Version")
         if let body {
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.httpBody = body

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -478,15 +478,20 @@ final class PremiumAccountService: ObservableObject {
         if let commercialLicenseProof,
            !commercialLicenseProof.key.isEmpty,
            !commercialLicenseProof.activationId.isEmpty {
-            let response: EntitlementResponse = try await request(
-                path: "/v1/entitlements/polar/device/attach",
-                method: "POST",
-                body: try encoder.encode([
-                    "licenseKey": commercialLicenseProof.key,
-                    "activationId": commercialLicenseProof.activationId,
-                ])
-            )
-            try acceptEntitlement(response.entitlement)
+            do {
+                let response: EntitlementResponse = try await request(
+                    path: "/v1/entitlements/polar/device/attach",
+                    method: "POST",
+                    body: try encoder.encode([
+                        "licenseKey": commercialLicenseProof.key,
+                        "activationId": commercialLicenseProof.activationId,
+                    ])
+                )
+                try acceptEntitlement(response.entitlement)
+            } catch {
+                clearAuthorizationState()
+                throw error
+            }
         } else {
             try await refresh()
         }

--- a/TypeWhisper/Views/LicenseSettingsView.swift
+++ b/TypeWhisper/Views/LicenseSettingsView.swift
@@ -644,8 +644,8 @@ struct LicenseSettingsView: View {
             return ""
         case .workSolo:
             return localizedAppText(
-                "Individual covers one person who needs non-GPL terms, procurement, support, or proprietary distribution on up to 2 devices.",
-                de: "Der Einzelnutzer-Plan deckt eine Person ab, die Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung auf bis zu 2 Geräten braucht."
+                "Individual covers one person who needs non-GPL terms, procurement, support, or proprietary distribution on up to 3 devices.",
+                de: "Der Einzelnutzer-Plan deckt eine Person ab, die Nicht-GPL-Bedingungen, Beschaffung, Support oder proprietäre Weiterverteilung auf bis zu 3 Geräten braucht."
             )
         case .team:
             return localizedAppText(
@@ -687,8 +687,8 @@ struct LicenseSettingsView: View {
             switch tier {
             case .individual:
                 return localizedAppText(
-                    "This Mac is covered by Individual commercial license terms on up to 2 devices.",
-                    de: "Dieser Mac ist durch kommerzielle Einzelnutzer-Bedingungen auf bis zu 2 Geräten abgedeckt."
+                    "This Mac is covered by Individual commercial license terms on up to 3 devices.",
+                    de: "Dieser Mac ist durch kommerzielle Einzelnutzer-Bedingungen auf bis zu 3 Geräten abgedeckt."
                 )
             case .team:
                 return localizedAppText(
@@ -713,8 +713,8 @@ struct LicenseSettingsView: View {
         switch tier {
         case .individual:
             return localizedAppText(
-                "Individual commercial license terms for up to 2 devices with recurring billing.",
-                de: "Kommerzielle Einzelnutzer-Bedingungen für bis zu 2 Geräte mit wiederkehrender Abrechnung."
+                "Individual commercial license terms for up to 3 devices with recurring billing.",
+                de: "Kommerzielle Einzelnutzer-Bedingungen für bis zu 3 Geräte mit wiederkehrender Abrechnung."
             )
         case .team:
             return localizedAppText(
@@ -733,8 +733,8 @@ struct LicenseSettingsView: View {
         switch tier {
         case .individual:
             return localizedAppText(
-                "One payment for the same 2-device Individual tier, with no monthly renewal.",
-                de: "Eine Zahlung für dasselbe Einzelnutzer-Paket mit 2 Geräten, ohne monatliche Verlängerung."
+                "One payment for the same 3-device Individual tier, with no monthly renewal.",
+                de: "Eine Zahlung für dasselbe Einzelnutzer-Paket mit 3 Geräten, ohne monatliche Verlängerung."
             )
         case .team:
             return localizedAppText(

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -81,6 +81,7 @@ struct PremiumSettingsView: View {
                         }
                         .disabled(premiumAccount.isWorking)
                         Button(String(localized: "Delete Account"), role: .destructive) { confirmingAccountDeletion = true }
+                            .disabled(premiumAccount.isWorking)
                     }
                 } else {
                     AppKitSignInWithAppleButton {

--- a/TypeWhisper/Views/PremiumSettingsView.swift
+++ b/TypeWhisper/Views/PremiumSettingsView.swift
@@ -76,14 +76,17 @@ struct PremiumSettingsView: View {
                         .font(.callout)
                         .foregroundStyle(.secondary)
                     HStack {
-                        Button(String(localized: "Sign Out")) { premiumAccount.signOut() }
+                        Button(String(localized: "Sign Out")) {
+                            Task { await premiumAccount.signOutFromAccount() }
+                        }
+                        .disabled(premiumAccount.isWorking)
                         Button(String(localized: "Delete Account"), role: .destructive) { confirmingAccountDeletion = true }
                     }
                 } else {
                     AppKitSignInWithAppleButton {
                         Task {
                             await premiumAccount.signInWithApple(
-                                polarLicenseKey: license.commercialLicenseKeyForAccountLink
+                                commercialLicenseProof: license.commercialLicenseProofForAccountLink
                             )
                         }
                     }

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -428,7 +428,7 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(
             LicenseService.inferLicenseTier(
                 benefitID: "legacy-benefit",
-                benefitDescription: "Freelancer single-seat license for 2 devices"
+                benefitDescription: "Freelancer single-seat license for 3 devices"
             ),
             .individual
         )

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -73,10 +73,15 @@ private final class InMemoryUserDataSyncStore: UserDataSyncStore, @unchecked Sen
 
 private actor PremiumAccountHTTPRecorder {
     private let responses: [String: String]
+    private let statusCodes: [String: Int]
     private(set) var requests: [URLRequest] = []
 
-    init(responses: [String: String]) {
+    init(
+        responses: [String: String],
+        statusCodes: [String: Int] = [:]
+    ) {
         self.responses = responses
+        self.statusCodes = statusCodes
     }
 
     func execute(_ request: URLRequest) throws -> (Data, URLResponse) {
@@ -86,7 +91,7 @@ private actor PremiumAccountHTTPRecorder {
               let url = request.url,
               let response = HTTPURLResponse(
                   url: url,
-                  statusCode: 200,
+                  statusCode: statusCodes[path] ?? 200,
                   httpVersion: "HTTP/1.1",
                   headerFields: ["Content-Type": "application/json"]
               ) else {
@@ -415,6 +420,71 @@ final class CloudFolderSyncTests: XCTestCase {
             "/v1/entitlements/polar/device/current"
         )
         XCTAssertEqual(finalRequests.last?.httpMethod, "DELETE")
+    }
+
+    @MainActor
+    func testPremiumAccountRollsBackSessionWhenPolarAttachmentFails() async throws {
+        let suiteName = "PremiumAppleWebAuthAttachFailure-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let recorder = PremiumAccountHTTPRecorder(
+            responses: [
+                "/v1/auth/apple/web/start": """
+                {
+                  "authorizationURL": "https://appleid.apple.com/auth/authorize?state=server-state",
+                  "state": "server-state",
+                  "expiresAt": "2099-07-19T12:10:00.000Z"
+                }
+                """,
+                "/v1/auth/apple/web/exchange": """
+                {"accessToken": "account-token", "entitlement": null}
+                """,
+                "/v1/entitlements/polar/device/attach": """
+                {"error": "Polar activation could not be attached."}
+                """,
+            ],
+            statusCodes: [
+                "/v1/entitlements/polar/device/attach": 503,
+            ]
+        )
+        let authenticator = PremiumAppleWebAuthenticator(
+            callbackURL: try XCTUnwrap(URL(
+                string: "typewhisper://premium-auth/callback?state=server-state&code=exchange-code"
+            ))
+        )
+        let service = PremiumAccountService(
+            defaults: defaults,
+            baseURL: URL(string: "https://app.typewhisper.com"),
+            requestExecutor: { request in try await recorder.execute(request) },
+            appleWebAuthenticator: authenticator,
+            keychainService: suiteName,
+            isSignedInOverride: false,
+            automaticallyRefresh: false
+        )
+        defer { service.signOut() }
+
+        await service.signInWithApple(
+            commercialLicenseProof: CommercialLicenseLinkProof(
+                key: "polar-license",
+                activationId: "polar-activation"
+            )
+        )
+
+        XCTAssertFalse(service.isSignedIn)
+        XCTAssertNil(service.entitlement)
+        XCTAssertEqual(
+            service.errorMessage,
+            "Polar activation could not be attached."
+        )
+        let requests = await recorder.recordedRequests()
+        XCTAssertEqual(
+            requests.compactMap(\.url?.path),
+            [
+                "/v1/auth/apple/web/start",
+                "/v1/auth/apple/web/exchange",
+                "/v1/entitlements/polar/device/attach",
+            ]
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -188,7 +188,7 @@ final class CloudFolderSyncTests: XCTestCase {
         XCTAssertTrue(service.isSignedIn)
     }
 
-    func testProductionPublicKeyVerifiesBackendGeneratedEntitlement() throws {
+    func testProductionPublicKeyStillVerifiesLegacyTwoDeviceEntitlement() throws {
         let response = """
         {
           "status": "active",
@@ -296,7 +296,7 @@ final class CloudFolderSyncTests: XCTestCase {
     }
 
     @MainActor
-    func testPremiumAccountUsesAppleWebAuthWithStatePKCEAndPolarLink() async throws {
+    func testPremiumAccountUsesAppleWebAuthWithStatePKCEAndAttachesExistingPolarActivation() async throws {
         let suiteName = "PremiumAppleWebAuth-\(UUID().uuidString)"
         let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
@@ -311,8 +311,11 @@ final class CloudFolderSyncTests: XCTestCase {
             "/v1/auth/apple/web/exchange": """
             {"accessToken": "account-token", "entitlement": null}
             """,
-            "/v1/entitlements/polar/link": """
+            "/v1/entitlements/polar/device/attach": """
             {"entitlement": null}
+            """,
+            "/v1/entitlements/polar/device/current": """
+            {"ok": true, "released": false}
             """,
         ])
         let authenticator = PremiumAppleWebAuthenticator(
@@ -331,7 +334,12 @@ final class CloudFolderSyncTests: XCTestCase {
         )
         defer { service.signOut() }
 
-        await service.signInWithApple(polarLicenseKey: "polar-license")
+        await service.signInWithApple(
+            commercialLicenseProof: CommercialLicenseLinkProof(
+                key: "polar-license",
+                activationId: "polar-activation"
+            )
+        )
 
         XCTAssertTrue(service.isSignedIn)
         XCTAssertNil(service.errorMessage)
@@ -345,7 +353,7 @@ final class CloudFolderSyncTests: XCTestCase {
             [
                 "/v1/auth/apple/web/start",
                 "/v1/auth/apple/web/exchange",
-                "/v1/entitlements/polar/link",
+                "/v1/entitlements/polar/device/attach",
             ]
         )
 
@@ -355,8 +363,10 @@ final class CloudFolderSyncTests: XCTestCase {
         let exchangeRequest = try XCTUnwrap(
             requests.first { $0.url?.path == "/v1/auth/apple/web/exchange" }
         )
-        let linkRequest = try XCTUnwrap(
-            requests.first { $0.url?.path == "/v1/entitlements/polar/link" }
+        let attachRequest = try XCTUnwrap(
+            requests.first {
+                $0.url?.path == "/v1/entitlements/polar/device/attach"
+            }
         )
 
         let startBody = try XCTUnwrap(startRequest.httpBody)
@@ -380,9 +390,31 @@ final class CloudFolderSyncTests: XCTestCase {
             .replacingOccurrences(of: "=", with: "")
         XCTAssertEqual(startJSON["codeChallenge"], expectedChallenge)
         XCTAssertEqual(
-            linkRequest.value(forHTTPHeaderField: "Authorization"),
+            attachRequest.value(forHTTPHeaderField: "Authorization"),
             "Bearer account-token"
         )
+        XCTAssertEqual(
+            attachRequest.value(
+                forHTTPHeaderField: "X-TypeWhisper-Entitlement-Version"
+            ),
+            "2"
+        )
+        let attachBody = try XCTUnwrap(attachRequest.httpBody)
+        let attachJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: attachBody)
+                as? [String: String]
+        )
+        XCTAssertEqual(attachJSON["licenseKey"], "polar-license")
+        XCTAssertEqual(attachJSON["activationId"], "polar-activation")
+
+        await service.signOutFromAccount()
+        XCTAssertFalse(service.isSignedIn)
+        let finalRequests = await recorder.recordedRequests()
+        XCTAssertEqual(
+            finalRequests.last?.url?.path,
+            "/v1/entitlements/polar/device/current"
+        )
+        XCTAssertEqual(finalRequests.last?.httpMethod, "DELETE")
     }
 
     @MainActor
@@ -414,7 +446,7 @@ final class CloudFolderSyncTests: XCTestCase {
             automaticallyRefresh: false
         )
 
-        await service.signInWithApple(polarLicenseKey: nil)
+        await service.signInWithApple(commercialLicenseProof: nil)
 
         XCTAssertFalse(service.isSignedIn)
         XCTAssertNil(service.errorMessage)
@@ -451,7 +483,7 @@ final class CloudFolderSyncTests: XCTestCase {
             automaticallyRefresh: false
         )
 
-        await service.signInWithApple(polarLicenseKey: nil)
+        await service.signInWithApple(commercialLicenseProof: nil)
 
         XCTAssertFalse(service.isSignedIn)
         XCTAssertNotNil(service.errorMessage)
@@ -488,7 +520,7 @@ final class CloudFolderSyncTests: XCTestCase {
             automaticallyRefresh: false
         )
 
-        await service.signInWithApple(polarLicenseKey: nil)
+        await service.signInWithApple(commercialLicenseProof: nil)
 
         XCTAssertFalse(service.isSignedIn)
         XCTAssertNotNil(service.errorMessage)
@@ -1315,7 +1347,7 @@ final class CloudFolderSyncTests: XCTestCase {
             source: "polar",
             isLifetime: true,
             expiresAt: nil,
-            deviceLimit: 2,
+            deviceLimit: 3,
             verifiedAt: date(10),
             signature: nil
         )
@@ -1375,7 +1407,15 @@ final class CloudFolderSyncTests: XCTestCase {
 
     private static let entitlementEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [
+                .withInternetDateTime,
+                .withFractionalSeconds,
+            ]
+            var container = encoder.singleValueContainer()
+            try container.encode(formatter.string(from: date))
+        }
         return encoder
     }()
 


### PR DESCRIPTION
## Summary

- attach the Mac's existing Polar activation to the signed Premium account after Apple sign-in
- avoid consuming a second Polar activation for the same Mac
- keep Premium account sign-out separate from local license deactivation
- update the Individual device limit and localized license messaging from two to three
- preserve compatibility with legacy two-device signed entitlements during the transition

## Rollout

- the device-entitlement backend must be deployed before this client is released
- macOS release publication remains a separate release step

## Validation

- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/CloudFolderSyncTests test`
- 35 focused tests passed, including existing-activation attachment and signed-entitlement compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Individual commercial licenses now cover up to **3 devices**, reflected across device-limit and pricing information.
  - Premium Apple sign-in now links entitlements using the provided activation details when available.
  - Signing out removes the current device from the linked account before clearing local access.

- **Bug Fixes**
  - Improved premium entitlement verification to handle ISO-8601 timestamps with optional fractional seconds.
  - More reliable device detach/sign-out handling and response validation.
  - “Sign Out” and “Delete Account” are disabled while the account operation is in progress.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
