### PR TITLE
Add context-aware transcription and dynamic ChatGPT models

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Localizable.xcstrings
@@ -145,6 +145,22 @@
         }
       }
     },
+    "Describe the recording topic, setting, or relevant context.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Beschreiben Sie Thema, Umgebung oder relevanten Kontext der Aufnahme."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "録音のトピック、状況、または関連するコンテキストを説明します。"
+          }
+        }
+      }
+    },
     "GPT-4o models do not support Whisper Translate (translation to English).": {
       "localizations": {
         "de": {
@@ -157,6 +173,134 @@
           "stringUnit": {
             "state": "translated",
             "value": "GPT-4oモデルはWhisper Translate（英語への翻訳）をサポートしていません。"
+          }
+        }
+      }
+    },
+    "Language hints and dictionary terms are added automatically.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprachhinweise und Wörterbucheinträge werden automatisch ergänzt."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "言語ヒントと辞書用語は自動的に追加されます。"
+          }
+        }
+      }
+    },
+    "Live Transcription Delay": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verzögerung der Live-Transkription"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブ文字起こしの遅延"
+          }
+        }
+      }
+    },
+    "Lower delay shows partial text sooner; higher delay gives the model more audio context.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eine niedrigere Verzögerung zeigt Teiltext früher; eine höhere gibt dem Modell mehr Audiokontext."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "遅延を低くすると部分テキストが早く表示され、高くするとモデルがより多くの音声コンテキストを利用できます。"
+          }
+        }
+      }
+    },
+    "Minimal": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Minimal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最小"
+          }
+        }
+      }
+    },
+    "Realtime transcription streams 24 kHz PCM through OpenAI's Realtime API.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Echtzeittranskription streamt 24-kHz-PCM über die Realtime API von OpenAI."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リアルタイム文字起こしは、OpenAIのRealtime APIを通じて24 kHz PCMをストリーミングします。"
+          }
+        }
+      }
+    },
+    "Transcription Context": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionskontext"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしコンテキスト"
+          }
+        }
+      }
+    },
+    "Translate requires Whisper 1.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für Übersetzungen ist Whisper 1 erforderlich."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "翻訳にはWhisper 1が必要です。"
+          }
+        }
+      }
+    },
+    "X High": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sehr hoch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -601,6 +601,279 @@ struct OpenAIResponsesClient: Sendable {
     }
 }
 
+enum OpenAILiveTranscriptionDelay: String, CaseIterable, Sendable {
+    case minimal
+    case low
+    case medium
+    case high
+    case xhigh
+
+    var displayName: String {
+        switch self {
+        case .minimal:
+            "Minimal"
+        case .low:
+            "Low"
+        case .medium:
+            "Medium"
+        case .high:
+            "High"
+        case .xhigh:
+            "X High"
+        }
+    }
+}
+
+private struct OpenAITranscriptionModelCapability {
+    enum Transport {
+        case legacyFile(responseFormat: String)
+        case contextAwareFile
+        case legacyRealtime
+        case contextAwareRealtime
+    }
+
+    let modelInfo: PluginModelInfo
+    let transport: Transport
+    let supportsTranslation: Bool
+
+    var usesContextAwareHints: Bool {
+        switch transport {
+        case .contextAwareFile, .contextAwareRealtime:
+            true
+        case .legacyFile, .legacyRealtime:
+            false
+        }
+    }
+
+    var isRealtime: Bool {
+        switch transport {
+        case .legacyRealtime, .contextAwareRealtime:
+            true
+        case .legacyFile, .contextAwareFile:
+            false
+        }
+    }
+
+    static let gptTranscribeModelID = "gpt-transcribe"
+    static let gptLiveTranscribeModelID = "gpt-live-transcribe"
+    static let legacyRealtimeModelID = "gpt-realtime-whisper"
+
+    static let all: [OpenAITranscriptionModelCapability] = [
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: gptTranscribeModelID, displayName: "GPT Transcribe"),
+            transport: .contextAwareFile,
+            supportsTranslation: false
+        ),
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: gptLiveTranscribeModelID, displayName: "GPT Live Transcribe"),
+            transport: .contextAwareRealtime,
+            supportsTranslation: false
+        ),
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: "whisper-1", displayName: "Whisper 1"),
+            transport: .legacyFile(responseFormat: "verbose_json"),
+            supportsTranslation: true
+        ),
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: "gpt-4o-transcribe", displayName: "GPT-4o Transcribe"),
+            transport: .legacyFile(responseFormat: "json"),
+            supportsTranslation: false
+        ),
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: "gpt-4o-mini-transcribe", displayName: "GPT-4o Mini Transcribe"),
+            transport: .legacyFile(responseFormat: "json"),
+            supportsTranslation: false
+        ),
+        OpenAITranscriptionModelCapability(
+            modelInfo: PluginModelInfo(id: legacyRealtimeModelID, displayName: "GPT Realtime Whisper"),
+            transport: .legacyRealtime,
+            supportsTranslation: false
+        ),
+    ]
+
+    static func capability(for modelID: String) -> OpenAITranscriptionModelCapability? {
+        all.first { $0.modelInfo.id == modelID }
+    }
+}
+
+struct OpenAIRealtimeTranscriptionConfiguration: Sendable {
+    let modelID: String
+    let languageSelection: PluginLanguageSelection
+    let prompt: String?
+    let keywords: [String]
+    let delay: OpenAILiveTranscriptionDelay?
+
+    var usesContextAwareHints: Bool {
+        modelID == OpenAITranscriptionModelCapability.gptLiveTranscribeModelID
+    }
+
+    var fallbackLanguage: String? {
+        if let requestedLanguage = languageSelection.requestedLanguage?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !requestedLanguage.isEmpty {
+            return requestedLanguage
+        }
+
+        let languages = Self.normalizedLanguages(from: languageSelection)
+        return languages.count == 1 ? languages[0] : nil
+    }
+
+    static func normalizedLanguages(from selection: PluginLanguageSelection) -> [String] {
+        var seen = Set<String>()
+        var languages: [String] = []
+        let candidates = [selection.requestedLanguage].compactMap { $0 } + selection.languageHints
+
+        for candidate in candidates {
+            let language = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !language.isEmpty else { continue }
+            let dedupeKey = language.lowercased()
+            guard seen.insert(dedupeKey).inserted else { continue }
+            languages.append(language)
+        }
+
+        return languages
+    }
+}
+
+private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
+    private struct APIResponse: Decodable {
+        struct Language: Decodable {
+            let code: String
+        }
+
+        let text: String
+        let languages: [Language]?
+    }
+
+    private let baseURL = "https://api.openai.com"
+
+    func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        prompt: String?,
+        keywords: [String],
+        languages: [String]
+    ) async throws -> PluginTranscriptionResult {
+        try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            try await performTranscription(
+                uploadFile: uploadFile,
+                apiKey: apiKey,
+                prompt: prompt,
+                keywords: keywords,
+                languages: languages
+            )
+        }
+    }
+
+    private func performTranscription(
+        uploadFile: PluginAudioUploadFile,
+        apiKey: String,
+        prompt: String?,
+        keywords: [String],
+        languages: [String]
+    ) async throws -> PluginTranscriptionResult {
+        let endpoint = "\(baseURL)/v1/audio/transcriptions"
+        guard let url = URL(string: endpoint) else {
+            throw OpenAIPluginError.invalidURL(endpoint)
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 30
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n"
+                .data(using: .utf8)!
+        )
+        body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+        body.append(uploadFile.data)
+        body.append("\r\n".data(using: .utf8)!)
+        body.appendOpenAIFormField(
+            boundary: boundary,
+            name: "model",
+            value: OpenAITranscriptionModelCapability.gptTranscribeModelID
+        )
+        body.appendOpenAIFormField(boundary: boundary, name: "response_format", value: "json")
+
+        if let prompt = prompt?.trimmingCharacters(in: .whitespacesAndNewlines), !prompt.isEmpty {
+            body.appendOpenAIFormField(boundary: boundary, name: "prompt", value: prompt)
+        }
+        for keyword in keywords {
+            body.appendOpenAIFormField(boundary: boundary, name: "keywords[]", value: keyword)
+        }
+        for language in languages {
+            body.appendOpenAIFormField(boundary: boundary, name: "languages[]", value: language)
+        }
+
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (responseData, response) = try await PluginHTTPClient.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401:
+            throw PluginTranscriptionError.invalidApiKey
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        default:
+            throw PluginTranscriptionError.apiError(
+                Self.errorMessage(from: responseData, statusCode: httpResponse.statusCode)
+            )
+        }
+
+        do {
+            let response = try JSONDecoder().decode(APIResponse.self, from: responseData)
+            let detectedLanguage = response.languages?
+                .lazy
+                .map(\.code)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first { !$0.isEmpty }
+            return PluginTranscriptionResult(
+                text: response.text,
+                detectedLanguage: detectedLanguage
+            )
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse response: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let error = json["error"] as? [String: Any],
+           let message = error["message"] as? String,
+           !message.isEmpty {
+            return "HTTP \(statusCode): \(message)"
+        }
+        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
+            return "HTTP \(statusCode): \(body)"
+        }
+        return "HTTP \(statusCode)"
+    }
+}
+
+private extension Data {
+    mutating func appendOpenAIFormField(boundary: String, name: String, value: String) {
+        append("--\(boundary)\r\n".data(using: .utf8)!)
+        append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        append(value.data(using: .utf8)!)
+        append("\r\n".data(using: .utf8)!)
+    }
+}
+
 // MARK: - Realtime STT
 
 actor OpenAIRealtimeTranscriptCollector {
@@ -766,7 +1039,8 @@ private final class OpenAIRealtimeWebSocketDelegate: NSObject, URLSessionWebSock
 }
 
 final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
-    static let modelId = "gpt-realtime-whisper"
+    static let modelId = OpenAITranscriptionModelCapability.legacyRealtimeModelID
+    static let liveModelId = OpenAITranscriptionModelCapability.gptLiveTranscribeModelID
     static let sourceSampleRate = 16_000
     static let targetSampleRate = 24_000
     static let socketOpenTimeoutNanoseconds: UInt64 = 10_000_000_000
@@ -781,7 +1055,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
     private let webSocketTask: URLSessionWebSocketTask?
     private let receiveTask: Task<Void, Never>?
     private let collector: OpenAIRealtimeTranscriptCollector
-    private let language: String?
+    private let fallbackLanguage: String?
     private let onProgress: @Sendable (String) -> Bool
     private let state = OSAllocatedUnfairLock(initialState: State())
 
@@ -797,7 +1071,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
         self.webSocketTask = webSocketTask
         self.receiveTask = receiveTask
         self.collector = collector
-        self.language = language
+        self.fallbackLanguage = language
         self.onProgress = onProgress
     }
 
@@ -805,6 +1079,24 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
         apiKey: String,
         language: String?,
         prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> OpenAIRealtimeTranscriptionSession {
+        try await connect(
+            apiKey: apiKey,
+            configuration: OpenAIRealtimeTranscriptionConfiguration(
+                modelID: modelId,
+                languageSelection: PluginLanguageSelection(requestedLanguage: language),
+                prompt: prompt,
+                keywords: [],
+                delay: nil
+            ),
+            onProgress: onProgress
+        )
+    }
+
+    static func connect(
+        apiKey: String,
+        configuration: OpenAIRealtimeTranscriptionConfiguration,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> OpenAIRealtimeTranscriptionSession {
         let request = try makeRequest(apiKey: apiKey)
@@ -834,7 +1126,9 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
         }
 
         do {
-            try await webSocketTask.send(.string(try jsonString(sessionUpdatePayload(language: language, prompt: prompt))))
+            try await webSocketTask.send(
+                .string(try jsonString(sessionUpdatePayload(configuration: configuration)))
+            )
             try await waitForSessionReady(collector)
         } catch {
             receiveTask.cancel()
@@ -851,7 +1145,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
             webSocketTask: webSocketTask,
             receiveTask: receiveTask,
             collector: collector,
-            language: language,
+            language: configuration.fallbackLanguage,
             onProgress: onProgress
         )
     }
@@ -897,10 +1191,60 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
     }
 
     static func sessionUpdatePayload(language: String?, prompt: String?) -> [String: Any] {
-        var transcription: [String: Any] = ["model": modelId]
-        if let language, !language.isEmpty {
+        sessionUpdatePayload(configuration: OpenAIRealtimeTranscriptionConfiguration(
+            modelID: modelId,
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            prompt: prompt,
+            keywords: [],
+            delay: nil
+        ))
+    }
+
+    static func sessionUpdatePayload(
+        modelID: String,
+        languageSelection: PluginLanguageSelection,
+        prompt: String?,
+        keywords: [String],
+        delay: OpenAILiveTranscriptionDelay?
+    ) -> [String: Any] {
+        sessionUpdatePayload(configuration: OpenAIRealtimeTranscriptionConfiguration(
+            modelID: modelID,
+            languageSelection: languageSelection,
+            prompt: prompt,
+            keywords: keywords,
+            delay: delay
+        ))
+    }
+
+    private static func sessionUpdatePayload(
+        configuration: OpenAIRealtimeTranscriptionConfiguration
+    ) -> [String: Any] {
+        var transcription: [String: Any] = ["model": configuration.modelID]
+
+        if configuration.usesContextAwareHints {
+            let languages = OpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(
+                from: configuration.languageSelection
+            )
+            if !languages.isEmpty {
+                transcription["languages"] = languages
+            }
+            if let prompt = configuration.prompt?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !prompt.isEmpty {
+                transcription["prompt"] = prompt
+            }
+            if !configuration.keywords.isEmpty {
+                transcription["keywords"] = configuration.keywords
+            }
+            if let delay = configuration.delay {
+                transcription["delay"] = delay.rawValue
+            }
+        } else if let language = configuration.languageSelection.requestedLanguage?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !language.isEmpty {
             transcription["language"] = language
         }
+
         return [
             "type": "session.update",
             "session": [
@@ -974,7 +1318,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
             throw PluginTranscriptionError.apiError(error)
         }
 
-        let result = await collector.finalResult(fallbackLanguage: language)
+        let result = await collector.finalResult(fallbackLanguage: fallbackLanguage)
         if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, webSocketTask != nil {
             throw PluginTranscriptionError.apiError("Realtime API returned no transcript")
         }
@@ -1262,9 +1606,9 @@ private final class OpenAIAVAudioPlayback: OpenAITTSAudioPlayback, @unchecked Se
 
 @objc(OpenAIPlugin)
 final class OpenAIPlugin: NSObject,
-    TranscriptionEnginePlugin,
+    LanguageHintDictionaryTermHintTranscriptionEnginePlugin,
+    LiveLanguageHintDictionaryTermHintTranscriptionCapablePlugin,
     DictionaryTermsCapabilityProviding,
-    LiveTranscriptionCapablePlugin,
     LLMProviderPlugin,
     TTSProviderPlugin,
     PluginAuthRoleStatusProviding,
@@ -1280,6 +1624,8 @@ final class OpenAIPlugin: NSObject,
     fileprivate var _fetchedLLMModels: [OpenAIFetchedModel] = []
     fileprivate var _selectedVoiceId: String?
     fileprivate var _ttsInstructions: String = ""
+    fileprivate var _transcriptionContext: String = ""
+    fileprivate var _liveTranscriptionDelay: OpenAILiveTranscriptionDelay = .low
     fileprivate var _authMode: OpenAIAuthMode = .apiKey
     fileprivate var _reasoningEffort: OpenAIReasoningEffort = .medium
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
@@ -1295,6 +1641,7 @@ final class OpenAIPlugin: NSObject,
         baseURL: "https://api.openai.com",
         responseFormat: "verbose_json"
     )
+    private let contextAwareFileTranscriptionClient = OpenAIContextAwareFileTranscriptionClient()
 
     private let chatHelper = PluginOpenAIChatHelper(baseURL: "https://api.openai.com")
 
@@ -1316,6 +1663,8 @@ final class OpenAIPlugin: NSObject,
         selectedLLMModel: "selectedLLMModel",
         selectedVoice: "selectedVoice",
         ttsInstructions: "ttsInstructions",
+        transcriptionContext: "transcriptionContext",
+        liveTranscriptionDelay: "liveTranscriptionDelay",
         llmTemperatureMode: "llmTemperatureMode",
         llmTemperatureValue: "llmTemperatureValue",
         fetchedLLMModels: "fetchedLLMModels",
@@ -1380,6 +1729,13 @@ final class OpenAIPlugin: NSObject,
         _selectedVoiceId = host.userDefault(forKey: Self.storageKeys.selectedVoice) as? String
             ?? OpenAITTSConfiguration.defaultVoiceId
         _ttsInstructions = host.userDefault(forKey: Self.storageKeys.ttsInstructions) as? String ?? ""
+        _transcriptionContext = host.userDefault(forKey: Self.storageKeys.transcriptionContext) as? String ?? ""
+        if let rawDelay = host.userDefault(forKey: Self.storageKeys.liveTranscriptionDelay) as? String,
+           let delay = OpenAILiveTranscriptionDelay(rawValue: rawDelay) {
+            _liveTranscriptionDelay = delay
+        } else {
+            _liveTranscriptionDelay = .low
+        }
         _llmTemperatureModeRaw = host.userDefault(forKey: Self.storageKeys.llmTemperatureMode) as? String
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
         _llmTemperatureValue = host.userDefault(forKey: Self.storageKeys.llmTemperatureValue) as? Double
@@ -1447,12 +1803,7 @@ final class OpenAIPlugin: NSObject,
     }
 
     var transcriptionModels: [PluginModelInfo] {
-        [
-            PluginModelInfo(id: "whisper-1", displayName: "Whisper 1"),
-            PluginModelInfo(id: "gpt-4o-transcribe", displayName: "GPT-4o Transcribe"),
-            PluginModelInfo(id: "gpt-4o-mini-transcribe", displayName: "GPT-4o Mini Transcribe"),
-            PluginModelInfo(id: OpenAIRealtimeTranscriptionSession.modelId, displayName: "GPT Realtime Whisper"),
-        ]
+        OpenAITranscriptionModelCapability.all.map(\.modelInfo)
     }
 
     var selectedModelId: String? { _selectedModelId }
@@ -1483,31 +1834,13 @@ final class OpenAIPlugin: NSObject,
     }
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
-            throw PluginTranscriptionError.notConfigured
-        }
-        guard let modelId = _selectedModelId else {
-            throw PluginTranscriptionError.noModelSelected
-        }
-
-        if modelId == OpenAIRealtimeTranscriptionSession.modelId {
-            guard !translate else {
-                throw PluginTranscriptionError.apiError("GPT Realtime Whisper does not support Whisper Translate.")
-            }
-            return try await transcribeRealtime(audio: audio, language: language, prompt: prompt, apiKey: apiKey) { _ in true }
-        }
-
-        let responseFormat = modelId.hasPrefix("gpt-4o") ? "json" : "verbose_json"
-
-        return try await transcriptionHelper.transcribeCompressedAudioWithWavFallback(
+        try await performTranscription(
             audio: audio,
-            apiKey: apiKey,
-            modelName: modelId,
-            language: language,
-            translate: translate && !modelId.hasPrefix("gpt-4o"),
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
             prompt: prompt,
-            requestTimeout: 30,
-            responseFormat: responseFormat
+            dictionaryTermHints: [],
+            onProgress: { _ in true }
         )
     }
 
@@ -1518,17 +1851,117 @@ final class OpenAIPlugin: NSObject,
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
-            throw PluginTranscriptionError.notConfigured
-        }
-        guard _selectedModelId == OpenAIRealtimeTranscriptionSession.modelId else {
-            return try await transcribe(audio: audio, language: language, translate: translate, prompt: prompt)
-        }
-        guard !translate else {
-            throw PluginTranscriptionError.apiError("GPT Realtime Whisper does not support Whisper Translate.")
-        }
+        try await performTranscription(
+            audio: audio,
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
 
-        return try await transcribeRealtime(audio: audio, language: language, prompt: prompt, apiKey: apiKey, onProgress: onProgress)
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: { _ in true }
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: { _ in true }
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: { _ in true }
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        try await performTranscription(
+            audio: audio,
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
     }
 
     func createLiveTranscriptionSession(
@@ -1537,19 +1970,200 @@ final class OpenAIPlugin: NSObject,
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> any LiveTranscriptionSession {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
-        guard !translate else {
-            throw PluginTranscriptionError.apiError("GPT Realtime Whisper does not support Whisper Translate.")
+        let capability = try selectedTranscriptionCapability()
+        guard capability.isRealtime else {
+            throw PluginTranscriptionError.apiError(
+                "\(capability.modelInfo.displayName) is a file transcription model."
+            )
         }
+        try validateTranslationRequest(translate, capability: capability)
 
         return try await OpenAIRealtimeTranscriptionSession.connect(
             apiKey: apiKey,
-            language: language,
-            prompt: prompt,
+            configuration: realtimeConfiguration(
+                capability: capability,
+                languageSelection: languageSelection,
+                hostPrompt: prompt,
+                dictionaryTermHints: dictionaryTermHints
+            ),
             onProgress: onProgress
         )
+    }
+
+    private func performTranscription(
+        audio: AudioData,
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = normalizedAPIKey else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        let capability = try selectedTranscriptionCapability()
+        try validateTranslationRequest(translate, capability: capability)
+
+        switch capability.transport {
+        case .legacyFile(let responseFormat):
+            return try await transcriptionHelper.transcribeCompressedAudioWithWavFallback(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: capability.modelInfo.id,
+                language: Self.legacyLanguage(from: languageSelection),
+                translate: translate,
+                prompt: prompt,
+                requestTimeout: 30,
+                responseFormat: responseFormat
+            )
+
+        case .contextAwareFile:
+            return try await contextAwareFileTranscriptionClient.transcribe(
+                audio: audio,
+                apiKey: apiKey,
+                prompt: normalizedTranscriptionContext,
+                keywords: Self.normalizedKeywords(from: dictionaryTermHints),
+                languages: OpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(
+                    from: languageSelection
+                )
+            )
+
+        case .legacyRealtime, .contextAwareRealtime:
+            return try await transcribeRealtime(
+                audio: audio,
+                apiKey: apiKey,
+                configuration: realtimeConfiguration(
+                    capability: capability,
+                    languageSelection: languageSelection,
+                    hostPrompt: prompt,
+                    dictionaryTermHints: dictionaryTermHints
+                ),
+                onProgress: onProgress
+            )
+        }
+    }
+
+    private func selectedTranscriptionCapability() throws -> OpenAITranscriptionModelCapability {
+        guard let modelID = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+        guard let capability = OpenAITranscriptionModelCapability.capability(for: modelID) else {
+            throw PluginTranscriptionError.apiError(
+                "Unsupported OpenAI transcription model: \(modelID)"
+            )
+        }
+        return capability
+    }
+
+    private func validateTranslationRequest(
+        _ translate: Bool,
+        capability: OpenAITranscriptionModelCapability
+    ) throws {
+        guard !translate || capability.supportsTranslation else {
+            throw PluginTranscriptionError.apiError("Translate requires Whisper 1.")
+        }
+    }
+
+    private func realtimeConfiguration(
+        capability: OpenAITranscriptionModelCapability,
+        languageSelection: PluginLanguageSelection,
+        hostPrompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) -> OpenAIRealtimeTranscriptionConfiguration {
+        switch capability.transport {
+        case .legacyRealtime:
+            return OpenAIRealtimeTranscriptionConfiguration(
+                modelID: capability.modelInfo.id,
+                languageSelection: PluginLanguageSelection(
+                    requestedLanguage: Self.legacyLanguage(from: languageSelection)
+                ),
+                prompt: hostPrompt,
+                keywords: [],
+                delay: nil
+            )
+        case .contextAwareRealtime:
+            return OpenAIRealtimeTranscriptionConfiguration(
+                modelID: capability.modelInfo.id,
+                languageSelection: languageSelection,
+                prompt: normalizedTranscriptionContext,
+                keywords: Self.normalizedKeywords(from: dictionaryTermHints),
+                delay: _liveTranscriptionDelay
+            )
+        case .legacyFile, .contextAwareFile:
+            preconditionFailure("A file model cannot create a realtime configuration.")
+        }
+    }
+
+    private static func legacyLanguage(from selection: PluginLanguageSelection) -> String? {
+        OpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(from: selection).first
+    }
+
+    private static func normalizedKeywords(
+        from dictionaryTermHints: [PluginDictionaryTermHint]
+    ) -> [String] {
+        PluginDictionaryTerms.normalizedTermHints(from: dictionaryTermHints)
+            .map(\.text)
+            .filter { keyword in
+                !keyword.contains("<")
+                    && !keyword.contains(">")
+                    && !keyword.contains("\r")
+                    && !keyword.contains("\n")
+            }
+    }
+
+    private var normalizedTranscriptionContext: String? {
+        let context = _transcriptionContext.trimmingCharacters(in: .whitespacesAndNewlines)
+        return context.isEmpty ? nil : context
     }
 
     // MARK: - LLMProviderPlugin
@@ -1864,6 +2478,32 @@ final class OpenAIPlugin: NSObject,
         host?.setUserDefault(instructions, forKey: Self.storageKeys.ttsInstructions)
     }
 
+    var transcriptionContext: String { _transcriptionContext }
+
+    func setTranscriptionContext(_ context: String) {
+        _transcriptionContext = context
+        host?.setUserDefault(context, forKey: Self.storageKeys.transcriptionContext)
+    }
+
+    var liveTranscriptionDelay: OpenAILiveTranscriptionDelay { _liveTranscriptionDelay }
+
+    func setLiveTranscriptionDelay(_ delay: OpenAILiveTranscriptionDelay) {
+        _liveTranscriptionDelay = delay
+        host?.setUserDefault(delay.rawValue, forKey: Self.storageKeys.liveTranscriptionDelay)
+    }
+
+    func transcriptionModelUsesContextAwareHints(_ modelID: String) -> Bool {
+        OpenAITranscriptionModelCapability.capability(for: modelID)?.usesContextAwareHints == true
+    }
+
+    func transcriptionModelIsRealtime(_ modelID: String) -> Bool {
+        OpenAITranscriptionModelCapability.capability(for: modelID)?.isRealtime == true
+    }
+
+    func transcriptionModelSupportsTranslation(_ modelID: String) -> Bool {
+        OpenAITranscriptionModelCapability.capability(for: modelID)?.supportsTranslation == true
+    }
+
     private var normalizedAPIKey: String? {
         let trimmed = (_apiKey ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
@@ -1871,15 +2511,13 @@ final class OpenAIPlugin: NSObject,
 
     private func transcribeRealtime(
         audio: AudioData,
-        language: String?,
-        prompt: String?,
         apiKey: String,
+        configuration: OpenAIRealtimeTranscriptionConfiguration,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
         let session = try await OpenAIRealtimeTranscriptionSession.connect(
             apiKey: apiKey,
-            language: language,
-            prompt: prompt,
+            configuration: configuration,
             onProgress: onProgress
         )
 
@@ -2314,6 +2952,8 @@ private struct OpenAISettingsView: View {
     @State private var selectedLLMModel: String = ""
     @State private var selectedVoiceId: String = ""
     @State private var ttsInstructions: String = ""
+    @State private var transcriptionContext: String = ""
+    @State private var liveTranscriptionDelay: OpenAILiveTranscriptionDelay = .low
     @State private var selectedReasoningEffort: OpenAIReasoningEffort = .medium
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
@@ -2368,13 +3008,48 @@ private struct OpenAISettingsView: View {
                         plugin.selectModel(selectedModel)
                     }
 
-                    if selectedModel.hasPrefix("gpt-4o") {
-                        Text("GPT-4o models do not support Whisper Translate (translation to English).", bundle: bundle)
+                    if !plugin.transcriptionModelSupportsTranslation(selectedModel) {
+                        Text("Translate requires Whisper 1.", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
 
-                    if selectedModel == OpenAIRealtimeTranscriptionSession.modelId {
+                    if plugin.transcriptionModelUsesContextAwareHints(selectedModel) {
+                        Text("Transcription Context", bundle: bundle)
+                            .font(.subheadline.weight(.medium))
+
+                        TextField(
+                            "Describe the recording topic, setting, or relevant context.",
+                            text: $transcriptionContext,
+                            axis: .vertical
+                        )
+                        .lineLimit(3...6)
+                        .textFieldStyle(.roundedBorder)
+                        .onChange(of: transcriptionContext) {
+                            plugin.setTranscriptionContext(transcriptionContext)
+                        }
+
+                        Text("Language hints and dictionary terms are added automatically.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if selectedModel == OpenAIRealtimeTranscriptionSession.liveModelId {
+                        Picker("Live Transcription Delay", selection: $liveTranscriptionDelay) {
+                            ForEach(OpenAILiveTranscriptionDelay.allCases, id: \.self) { delay in
+                                Text(LocalizedStringKey(delay.displayName), bundle: bundle).tag(delay)
+                            }
+                        }
+                        .onChange(of: liveTranscriptionDelay) {
+                            plugin.setLiveTranscriptionDelay(liveTranscriptionDelay)
+                        }
+
+                        Text("Lower delay shows partial text sooner; higher delay gives the model more audio context.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    if plugin.transcriptionModelIsRealtime(selectedModel) {
                         Text("Realtime transcription streams 24 kHz PCM through OpenAI's Realtime API.", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -2400,6 +3075,8 @@ private struct OpenAISettingsView: View {
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             selectedVoiceId = plugin.selectedVoiceId ?? OpenAITTSConfiguration.defaultVoiceId
             ttsInstructions = plugin.ttsInstructions
+            transcriptionContext = plugin.transcriptionContext
+            liveTranscriptionDelay = plugin.liveTranscriptionDelay
             selectedReasoningEffort = plugin.reasoningEffort
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -58,6 +58,7 @@ private enum OpenAIOAuthConfig {
     static let clientID = "app_EMoamEEZ73f0CkXaXp7hrann"
     static let issuer = "https://auth.openai.com"
     static let codexAPIEndpoint = "https://chatgpt.com/backend-api/codex/responses"
+    static let codexModelsEndpoint = "https://chatgpt.com/backend-api/codex/models"
     static let callbackHost = "localhost"
     static let callbackPort: UInt16 = 1455
     static let callbackPath = "/auth/callback"
@@ -1622,6 +1623,7 @@ final class OpenAIPlugin: NSObject,
     fileprivate var _selectedModelId: String?
     fileprivate var _selectedLLMModelId: String?
     fileprivate var _fetchedLLMModels: [OpenAIFetchedModel] = []
+    fileprivate var _fetchedChatGPTModels: [OpenAIChatGPTModel] = []
     fileprivate var _selectedVoiceId: String?
     fileprivate var _ttsInstructions: String = ""
     fileprivate var _transcriptionContext: String = ""
@@ -1668,18 +1670,24 @@ final class OpenAIPlugin: NSObject,
         llmTemperatureMode: "llmTemperatureMode",
         llmTemperatureValue: "llmTemperatureValue",
         fetchedLLMModels: "fetchedLLMModels",
+        fetchedChatGPTModels: "fetchedChatGPTModels",
         oauthAccountID: "oauthAccountID",
         oauthPlanType: "oauthPlanType",
         oauthExpiresAt: "oauthExpiresAt"
     )
 
-    private static let chatGPTOAuthModels: [PluginModelInfo] = [
+    private static let chatGPTOAuthFallbackModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "gpt-5.6-sol", displayName: "GPT-5.6 Sol"),
+        PluginModelInfo(id: "gpt-5.6-terra", displayName: "GPT-5.6 Terra"),
+        PluginModelInfo(id: "gpt-5.6-luna", displayName: "GPT-5.6 Luna"),
         PluginModelInfo(id: "gpt-5.5", displayName: "GPT-5.5"),
         PluginModelInfo(id: "gpt-5.4", displayName: "GPT-5.4"),
         PluginModelInfo(id: "gpt-5.4-mini", displayName: "GPT-5.4 Mini"),
+        PluginModelInfo(id: "gpt-5.3-codex-spark", displayName: "GPT-5.3 Codex Spark"),
+        // Keep legacy selections available while offline. A successful refresh
+        // replaces this fallback with the account-specific server catalog.
         PluginModelInfo(id: "gpt-5.4-nano", displayName: "GPT-5.4 Nano"),
         PluginModelInfo(id: "gpt-5.3-codex", displayName: "GPT-5.3 Codex"),
-        PluginModelInfo(id: "gpt-5.3-codex-spark", displayName: "GPT-5.3 Codex Spark"),
         PluginModelInfo(id: "gpt-5.2", displayName: "GPT-5.2"),
         PluginModelInfo(id: "gpt-5.2-codex", displayName: "GPT-5.2 Codex"),
         PluginModelInfo(id: "gpt-5.1-codex", displayName: "GPT-5.1 Codex"),
@@ -1717,9 +1725,18 @@ final class OpenAIPlugin: NSObject,
             _reasoningEffort = reasoningEffort
         }
 
+        _oauthAccountID = host.userDefault(forKey: Self.storageKeys.oauthAccountID) as? String
+        _oauthPlanType = host.userDefault(forKey: Self.storageKeys.oauthPlanType) as? String
+        _oauthExpiresAt = host.userDefault(forKey: Self.storageKeys.oauthExpiresAt) as? Date
+
         if let data = host.userDefault(forKey: Self.storageKeys.fetchedLLMModels) as? Data,
            let models = try? JSONDecoder().decode([OpenAIFetchedModel].self, from: data) {
             _fetchedLLMModels = models
+        }
+        if let data = host.userDefault(forKey: Self.storageKeys.fetchedChatGPTModels) as? Data,
+           let cache = try? JSONDecoder().decode(OpenAIChatGPTModelCache.self, from: data),
+           cache.accountID == _oauthAccountID {
+            _fetchedChatGPTModels = cache.models
         }
 
         _selectedModelId = host.userDefault(forKey: Self.storageKeys.selectedModel) as? String
@@ -1740,9 +1757,6 @@ final class OpenAIPlugin: NSObject,
             ?? PluginLLMTemperatureMode.providerDefault.rawValue
         _llmTemperatureValue = host.userDefault(forKey: Self.storageKeys.llmTemperatureValue) as? Double
             ?? 0.3
-        _oauthAccountID = host.userDefault(forKey: Self.storageKeys.oauthAccountID) as? String
-        _oauthPlanType = host.userDefault(forKey: Self.storageKeys.oauthPlanType) as? String
-        _oauthExpiresAt = host.userDefault(forKey: Self.storageKeys.oauthExpiresAt) as? Date
 
         normalizeSelectedLLMModel()
     }
@@ -2181,7 +2195,12 @@ final class OpenAIPlugin: NSObject,
 
     var supportedModels: [PluginModelInfo] {
         if _authMode == .chatGPT {
-            return Self.chatGPTOAuthModels
+            if !_fetchedChatGPTModels.isEmpty {
+                return _fetchedChatGPTModels.map {
+                    PluginModelInfo(id: $0.id, displayName: $0.displayName)
+                }
+            }
+            return Self.chatGPTOAuthFallbackModels
         }
         if !_fetchedLLMModels.isEmpty {
             return _fetchedLLMModels.map { PluginModelInfo(id: $0.id, displayName: $0.id) }
@@ -2423,6 +2442,16 @@ final class OpenAIPlugin: NSObject,
         host?.notifyCapabilitiesChanged()
     }
 
+    fileprivate func setFetchedChatGPTModels(_ models: [OpenAIChatGPTModel]) {
+        _fetchedChatGPTModels = models
+        let cache = OpenAIChatGPTModelCache(accountID: _oauthAccountID, models: models)
+        if let data = try? JSONEncoder().encode(cache) {
+            host?.setUserDefault(data, forKey: Self.storageKeys.fetchedChatGPTModels)
+        }
+        normalizeSelectedLLMModel()
+        host?.notifyCapabilitiesChanged()
+    }
+
     @discardableResult
     func refreshFetchedLLMModels() async -> [OpenAIFetchedModel] {
         guard _authMode == .apiKey else { return [] }
@@ -2439,9 +2468,10 @@ final class OpenAIPlugin: NSObject,
             let models = await refreshFetchedLLMModels()
             return models.map { PluginModelInfo(id: $0.id, displayName: $0.id) }
         case .chatGPT:
-            normalizeSelectedLLMModel()
-            host?.notifyCapabilitiesChanged()
-            return Self.chatGPTOAuthModels
+            let models = await fetchChatGPTModels()
+            guard !models.isEmpty else { return [] }
+            setFetchedChatGPTModels(models)
+            return models.map { PluginModelInfo(id: $0.id, displayName: $0.displayName) }
         }
     }
 
@@ -2469,6 +2499,69 @@ final class OpenAIPlugin: NSObject,
         } catch {
             return []
         }
+    }
+
+    fileprivate func fetchChatGPTModels() async -> [OpenAIChatGPTModel] {
+        do {
+            let accessToken = try await validOAuthAccessToken()
+            let request = try Self.makeChatGPTModelsRequest(
+                accessToken: accessToken,
+                accountID: _oauthAccountID,
+                clientVersion: Self.chatGPTModelsClientVersion
+            )
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else {
+                return []
+            }
+
+            let decoded = try JSONDecoder().decode(OpenAIChatGPTModelsResponse.self, from: data)
+            let sortedModels = decoded.models.enumerated()
+                .filter { !$0.element.id.isEmpty && $0.element.isVisibleInPicker }
+                .sorted {
+                    if $0.element.priority == $1.element.priority {
+                        return $0.offset < $1.offset
+                    }
+                    return $0.element.priority < $1.element.priority
+                }
+                .map(\.element)
+
+            var seenModelIDs = Set<String>()
+            return sortedModels.filter { seenModelIDs.insert($0.id).inserted }
+        } catch {
+            return []
+        }
+    }
+
+    nonisolated static func makeChatGPTModelsRequest(
+        accessToken: String,
+        accountID: String?,
+        clientVersion: String
+    ) throws -> URLRequest {
+        guard var components = URLComponents(string: OpenAIOAuthConfig.codexModelsEndpoint) else {
+            throw OpenAIPluginError.invalidURL(OpenAIOAuthConfig.codexModelsEndpoint)
+        }
+        components.queryItems = [
+            URLQueryItem(name: "client_version", value: clientVersion),
+        ]
+        guard let url = components.url else {
+            throw OpenAIPluginError.invalidURL(OpenAIOAuthConfig.codexModelsEndpoint)
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        if let accountID, !accountID.isEmpty {
+            request.setValue(accountID, forHTTPHeaderField: "ChatGPT-Account-ID")
+        }
+        request.timeoutInterval = 10
+        return request
+    }
+
+    private static var chatGPTModelsClientVersion: String {
+        let bundle = Bundle(for: OpenAIPlugin.self)
+        return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "1.3.0"
     }
 
     fileprivate var ttsInstructions: String { _ttsInstructions }
@@ -2628,6 +2721,7 @@ final class OpenAIPlugin: NSObject,
         _oauthAccountID = nil
         _oauthPlanType = nil
         _oauthExpiresAt = nil
+        _fetchedChatGPTModels = []
 
         if let host {
             do {
@@ -2641,6 +2735,8 @@ final class OpenAIPlugin: NSObject,
             host.setUserDefault(nil, forKey: Self.storageKeys.oauthAccountID)
             host.setUserDefault(nil, forKey: Self.storageKeys.oauthPlanType)
             host.setUserDefault(nil, forKey: Self.storageKeys.oauthExpiresAt)
+            host.setUserDefault(nil, forKey: Self.storageKeys.fetchedChatGPTModels)
+            normalizeSelectedLLMModel()
             host.notifyCapabilitiesChanged()
         }
     }
@@ -2657,10 +2753,17 @@ final class OpenAIPlugin: NSObject,
 
     private func storeOAuthTokens(_ tokens: OpenAIOAuthTokenResponse, preferredAccountID: String? = nil) {
         let metadata = extractOAuthMetadata(from: tokens)
+        let nextAccountID = preferredAccountID ?? metadata.accountID
+        let accountChanged = _oauthAccountID != nextAccountID
+        if accountChanged {
+            _fetchedChatGPTModels = []
+            host?.setUserDefault(nil, forKey: Self.storageKeys.fetchedChatGPTModels)
+        }
+
         _oauthAccessToken = tokens.access_token
         _oauthRefreshToken = tokens.refresh_token
         _oauthIDToken = tokens.id_token
-        _oauthAccountID = preferredAccountID ?? metadata.accountID
+        _oauthAccountID = nextAccountID
         _oauthPlanType = metadata.planType
         _oauthExpiresAt = metadata.expiresAt ?? Date().addingTimeInterval(Double(tokens.expires_in ?? 3600))
 
@@ -2939,6 +3042,60 @@ struct OpenAIFetchedModel: Codable, Sendable {
     }
 }
 
+struct OpenAIChatGPTModel: Codable, Sendable {
+    let id: String
+    let displayName: String
+    let priority: Int
+    let visibility: String?
+
+    var isVisibleInPicker: Bool {
+        visibility?.lowercased() == "list" || visibility == nil
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id = "slug"
+        case displayName = "display_name"
+        case priority
+        case visibility
+    }
+
+    init(
+        id: String,
+        displayName: String,
+        priority: Int,
+        visibility: String?
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.priority = priority
+        self.visibility = visibility
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let decodedDisplayName = try container.decodeIfPresent(String.self, forKey: .displayName)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if let decodedDisplayName, !decodedDisplayName.isEmpty {
+            displayName = decodedDisplayName
+        } else {
+            displayName = id
+        }
+        priority = try container.decodeIfPresent(Int.self, forKey: .priority) ?? Int.max
+        visibility = try container.decodeIfPresent(String.self, forKey: .visibility)
+    }
+}
+
+private struct OpenAIChatGPTModelsResponse: Decodable, Sendable {
+    let models: [OpenAIChatGPTModel]
+}
+
+struct OpenAIChatGPTModelCache: Codable, Sendable {
+    let accountID: String?
+    let models: [OpenAIChatGPTModel]
+}
+
 // MARK: - Settings View
 
 private struct OpenAISettingsView: View {
@@ -2982,6 +3139,9 @@ private struct OpenAISettingsView: View {
                     llmRefreshMessage = nil
                     oauthErrorMessage = nil
                     oauthStatusMessage = nil
+                    if plugin.isAvailable {
+                        refreshLLMModels(showStatus: false)
+                    }
                 }
             }
 
@@ -3081,7 +3241,7 @@ private struct OpenAISettingsView: View {
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
-            if authMode == .apiKey, plugin.isConfigured {
+            if plugin.isAvailable {
                 refreshLLMModels(showStatus: false)
             }
         }
@@ -3435,6 +3595,7 @@ private struct OpenAISettingsView: View {
                     oauthStatusMessage = String(localized: "ChatGPT login connected.", bundle: bundle)
                     selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
                     selectedReasoningEffort = plugin.reasoningEffort
+                    refreshLLMModels(showStatus: false)
                 }
             } catch {
                 await MainActor.run {
@@ -3454,6 +3615,7 @@ private struct OpenAISettingsView: View {
             oauthStatusMessage = String(localized: "Imported your existing Codex login.", bundle: bundle)
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
             selectedReasoningEffort = plugin.reasoningEffort
+            refreshLLMModels(showStatus: false)
         } catch {
             oauthErrorMessage = error.localizedDescription
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -705,7 +705,7 @@ struct OpenAIRealtimeTranscriptionConfiguration: Sendable {
     let delay: OpenAILiveTranscriptionDelay?
 
     var usesContextAwareHints: Bool {
-        modelID == OpenAITranscriptionModelCapability.gptLiveTranscribeModelID
+        OpenAITranscriptionModelCapability.capability(for: modelID)?.usesContextAwareHints ?? false
     }
 
     var fallbackLanguage: String? {
@@ -751,6 +751,7 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
     func transcribe(
         audio: AudioData,
         apiKey: String,
+        modelID: String,
         prompt: String?,
         keywords: [String],
         languages: [String]
@@ -759,6 +760,7 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
             try await performTranscription(
                 uploadFile: uploadFile,
                 apiKey: apiKey,
+                modelID: modelID,
                 prompt: prompt,
                 keywords: keywords,
                 languages: languages
@@ -769,6 +771,7 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
     private func performTranscription(
         uploadFile: PluginAudioUploadFile,
         apiKey: String,
+        modelID: String,
         prompt: String?,
         keywords: [String],
         languages: [String]
@@ -797,7 +800,7 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
         body.appendOpenAIFormField(
             boundary: boundary,
             name: "model",
-            value: OpenAITranscriptionModelCapability.gptTranscribeModelID
+            value: modelID
         )
         body.appendOpenAIFormField(boundary: boundary, name: "response_format", value: "json")
 
@@ -1041,7 +1044,6 @@ private final class OpenAIRealtimeWebSocketDelegate: NSObject, URLSessionWebSock
 
 final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
     static let modelId = OpenAITranscriptionModelCapability.legacyRealtimeModelID
-    static let liveModelId = OpenAITranscriptionModelCapability.gptLiveTranscribeModelID
     static let sourceSampleRate = 16_000
     static let targetSampleRate = 24_000
     static let socketOpenTimeoutNanoseconds: UInt64 = 10_000_000_000
@@ -2085,6 +2087,7 @@ final class OpenAIPlugin: NSObject,
             return try await contextAwareFileTranscriptionClient.transcribe(
                 audio: audio,
                 apiKey: apiKey,
+                modelID: capability.modelInfo.id,
                 prompt: normalizedTranscriptionContext,
                 keywords: Self.normalizedKeywords(from: dictionaryTermHints),
                 languages: OpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(
@@ -3179,7 +3182,10 @@ private struct OpenAISettingsView: View {
                             .font(.subheadline.weight(.medium))
 
                         TextField(
-                            "Describe the recording topic, setting, or relevant context.",
+                            String(
+                                localized: "Describe the recording topic, setting, or relevant context.",
+                                bundle: bundle
+                            ),
                             text: $transcriptionContext,
                             axis: .vertical
                         )
@@ -3194,7 +3200,8 @@ private struct OpenAISettingsView: View {
                             .foregroundStyle(.secondary)
                     }
 
-                    if selectedModel == OpenAIRealtimeTranscriptionSession.liveModelId {
+                    if plugin.transcriptionModelIsRealtime(selectedModel)
+                        && plugin.transcriptionModelUsesContextAwareHints(selectedModel) {
                         Picker("Live Transcription Delay", selection: $liveTranscriptionDelay) {
                             ForEach(OpenAILiveTranscriptionDelay.allCases, id: \.self) { delay in
                                 Text(LocalizedStringKey(delay.displayName), bundle: bundle).tag(delay)

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -14,7 +14,63 @@ final class OpenAIPluginTests: XCTestCase {
         let plugin: Any = OpenAIPlugin()
 
         XCTAssertTrue(plugin is any LiveTranscriptionCapablePlugin)
+        XCTAssertTrue(plugin is any LanguageHintDictionaryTermHintTranscriptionEnginePlugin)
+        XCTAssertTrue(plugin is any LiveLanguageHintDictionaryTermHintTranscriptionCapablePlugin)
         XCTAssertTrue(plugin is any TTSProviderPlugin)
+    }
+
+    func testOpenAINewInstallDefaultsToGPTTranscribeAndKeepsLegacyModels() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenAIPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "gpt-transcribe")
+        XCTAssertEqual(
+            plugin.transcriptionModels.map(\.id),
+            [
+                "gpt-transcribe",
+                "gpt-live-transcribe",
+                "whisper-1",
+                "gpt-4o-transcribe",
+                "gpt-4o-mini-transcribe",
+                "gpt-realtime-whisper",
+            ]
+        )
+        XCTAssertNil(host.userDefault(forKey: "selectedModel"))
+    }
+
+    func testOpenAIActivationPreservesPersistedLegacyModelSelection() throws {
+        let host = try PluginTestHostServices(defaults: ["selectedModel": "gpt-4o-mini-transcribe"])
+        let plugin = OpenAIPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "gpt-4o-mini-transcribe")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gpt-4o-mini-transcribe")
+    }
+
+    func testOpenAIContextAndLiveDelayPersistWithLowAsDefault() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.transcriptionContext, "")
+        XCTAssertEqual(plugin.liveTranscriptionDelay, .low)
+
+        plugin.setTranscriptionContext("A TypeWhisper product interview.")
+        plugin.setLiveTranscriptionDelay(.high)
+
+        XCTAssertEqual(
+            host.userDefault(forKey: "transcriptionContext") as? String,
+            "A TypeWhisper product interview."
+        )
+        XCTAssertEqual(host.userDefault(forKey: "liveTranscriptionDelay") as? String, "high")
+
+        let restoredPlugin = OpenAIPlugin()
+        restoredPlugin.activate(host: host)
+        XCTAssertEqual(restoredPlugin.transcriptionContext, "A TypeWhisper product interview.")
+        XCTAssertEqual(restoredPlugin.liveTranscriptionDelay, .high)
     }
 
     func testOpenAIFallbackModelsIncludeGPT55First() {
@@ -148,6 +204,364 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertTrue(retryBody.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
     }
 
+    func testGPTTranscribeSendsContextKeywordsAndOrderedLanguageHints() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedModel": "gpt-transcribe",
+                "transcriptionContext": "  A support call about account AC-42.  ",
+            ],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"Bonjour","languages":[{"code":"fr"},{"code":"en"}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.testAudio(),
+            languageSelection: PluginLanguageSelection(
+                languageHints: ["de", "en", "DE", " "]
+            ),
+            translate: false,
+            prompt: "legacy dictionary prompt",
+            dictionaryTermHints: [
+                PluginDictionaryTermHint(text: " TypeWhisper "),
+                PluginDictionaryTermHint(text: "typewhisper"),
+                PluginDictionaryTermHint(text: "AC-42"),
+                PluginDictionaryTermHint(text: "bad<term"),
+                PluginDictionaryTermHint(text: "bad\nterm"),
+                PluginDictionaryTermHint(text: "München"),
+            ]
+        )
+
+        XCTAssertEqual(result.text, "Bonjour")
+        XCTAssertEqual(result.detectedLanguage, "fr")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/v1/audio/transcriptions")
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
+        XCTAssertTrue(body.contains("name=\"model\"\r\n\r\ngpt-transcribe"))
+        XCTAssertTrue(body.contains("name=\"response_format\"\r\n\r\njson"))
+        XCTAssertTrue(body.contains(
+            "name=\"prompt\"\r\n\r\nA support call about account AC-42."
+        ))
+        XCTAssertFalse(body.contains("legacy dictionary prompt"))
+        XCTAssertEqual(Self.formValues(named: "keywords[]", in: body), [
+            "TypeWhisper",
+            "AC-42",
+            "München",
+        ])
+        XCTAssertEqual(Self.formValues(named: "languages[]", in: body), ["de", "en"])
+        XCTAssertFalse(body.contains("name=\"language\"\r\n"))
+    }
+
+    func testGPTTranscribeOmitsEmptyContextKeywordsAndLanguages() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedModel": "gpt-transcribe",
+                "transcriptionContext": " \n ",
+            ],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"Hello","languages":[]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.testAudio(),
+            languageSelection: PluginLanguageSelection(),
+            translate: false,
+            prompt: nil,
+            dictionaryTermHints: [
+                PluginDictionaryTermHint(text: "invalid>keyword"),
+                PluginDictionaryTermHint(text: "\n"),
+            ]
+        )
+
+        XCTAssertNil(result.detectedLanguage)
+        let body = String(
+            decoding: try XCTUnwrap(store.sessions.first?.requestedRequests.first?.httpBody),
+            as: UTF8.self
+        )
+        XCTAssertFalse(body.contains("name=\"prompt\"\r\n"))
+        XCTAssertFalse(body.contains("name=\"keywords[]\"\r\n"))
+        XCTAssertFalse(body.contains("name=\"languages[]\"\r\n"))
+        XCTAssertFalse(body.contains("name=\"language\"\r\n"))
+    }
+
+    func testGPTTranscribeRetriesWithWavAndKeepsContextFields() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedModel": "gpt-transcribe",
+                "transcriptionContext": "A support call.",
+            ],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 415
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"Hello","languages":[{"code":"en"}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.testAudio(),
+            languageSelection: PluginLanguageSelection(languageHints: ["en", "de"]),
+            translate: false,
+            prompt: nil,
+            dictionaryTermHints: [PluginDictionaryTermHint(text: "TypeWhisper")]
+        )
+
+        XCTAssertEqual(result.detectedLanguage, "en")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+
+        let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
+        let retryBody = String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self)
+        XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(retryBody.contains(#"filename="audio.wav""#))
+        for body in [firstBody, retryBody] {
+            XCTAssertTrue(body.contains("name=\"prompt\"\r\n\r\nA support call."))
+            XCTAssertEqual(Self.formValues(named: "keywords[]", in: body), ["TypeWhisper"])
+            XCTAssertEqual(Self.formValues(named: "languages[]", in: body), ["en", "de"])
+        }
+    }
+
+    func testLegacyGPTTranscribeKeepsSingularLanguageAndPromptPayload() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "gpt-4o-transcribe"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"Hallo"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        _ = try await plugin.transcribe(
+            audio: Self.testAudio(),
+            languageSelection: PluginLanguageSelection(languageHints: ["de", "en"]),
+            translate: false,
+            prompt: "TypeWhisper",
+            dictionaryTermHints: [PluginDictionaryTermHint(text: "ignored keyword")]
+        )
+
+        let body = String(
+            decoding: try XCTUnwrap(store.sessions.first?.requestedRequests.first?.httpBody),
+            as: UTF8.self
+        )
+        XCTAssertTrue(body.contains("name=\"response_format\"\r\n\r\njson"))
+        XCTAssertTrue(body.contains("name=\"language\"\r\n\r\nde"))
+        XCTAssertTrue(body.contains("name=\"prompt\"\r\n\r\nTypeWhisper"))
+        XCTAssertFalse(body.contains("name=\"languages[]\"\r\n"))
+        XCTAssertFalse(body.contains("name=\"keywords[]\"\r\n"))
+    }
+
+    func testGPTTranscribeMapsAuthenticationSizeAndRateLimitErrors() async throws {
+        for statusCode in [401, 413, 429] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(
+                defaults: ["selectedModel": "gpt-transcribe"],
+                secrets: ["api-key": "sk-live"]
+            )
+            let plugin = OpenAIPlugin()
+            plugin.activate(host: host)
+
+            let store = PluginHTTPClientSessionStore()
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: [
+                    .success(
+                        Data(#"{"error":{"message":"request failed"}}"#.utf8),
+                        Self.httpResponse(
+                            url: "https://api.openai.com/v1/audio/transcriptions",
+                            statusCode: statusCode
+                        )
+                    ),
+                ])
+            }
+
+            do {
+                _ = try await plugin.transcribe(
+                    audio: Self.testAudio(),
+                    language: nil,
+                    translate: false,
+                    prompt: nil
+                )
+                XCTFail("Expected HTTP \(statusCode) to fail")
+            } catch let error as PluginTranscriptionError {
+                switch (statusCode, error) {
+                case (401, .invalidApiKey), (413, .fileTooLarge), (429, .rateLimited):
+                    break
+                default:
+                    XCTFail("Unexpected mapping for HTTP \(statusCode): \(error)")
+                }
+            } catch {
+                XCTFail("Unexpected error for HTTP \(statusCode): \(error)")
+            }
+
+            XCTAssertEqual(store.sessions.first?.requestedRequests.count, 1)
+        }
+    }
+
+    func testGPTTranscribeSurfacesValidationErrorWithoutModelFallback() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "gpt-transcribe"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"prompt exceeds the model length limit"}}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/transcriptions",
+                        statusCode: 400
+                    )
+                ),
+            ])
+        }
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.testAudio(),
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected validation error")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(message, "HTTP 400: prompt exceeds the model length limit")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        XCTAssertEqual(store.sessions.first?.requestedRequests.count, 1)
+    }
+
+    func testTranslateIsBlockedForEveryModelExceptWhisperOne() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "gpt-transcribe"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [.failure(URLError(.badServerResponse))])
+        }
+
+        XCTAssertTrue(plugin.transcriptionModelSupportsTranslation("whisper-1"))
+        for modelID in plugin.transcriptionModels.map(\.id) where modelID != "whisper-1" {
+            XCTAssertFalse(plugin.transcriptionModelSupportsTranslation(modelID))
+        }
+
+        do {
+            _ = try await plugin.transcribe(
+                audio: Self.testAudio(),
+                language: "de",
+                translate: true,
+                prompt: nil
+            )
+            XCTFail("Expected Translate to be blocked")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(message, "Translate requires Whisper 1.")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    func testWhisperOneTranslateUsesTranslationsEndpoint() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "whisper-1"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"Hello","language":"en"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.openai.com/v1/audio/translations",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.testAudio(),
+            language: "de",
+            translate: true,
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "Hello")
+        XCTAssertEqual(store.sessions.first?.requestedPaths, ["/v1/audio/translations"])
+        let body = String(
+            decoding: try XCTUnwrap(store.sessions.first?.requestedRequests.first?.httpBody),
+            as: UTF8.self
+        )
+        XCTAssertTrue(body.contains("name=\"model\"\r\n\r\nwhisper-1"))
+        XCTAssertFalse(body.contains("name=\"language\"\r\n"))
+    }
+
     func testOpenAIWithoutCredentialsMakesCloudAuthRolesUnavailable() throws {
         let host = try PluginTestHostServices()
         let plugin = OpenAIPlugin()
@@ -201,6 +615,57 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertNil(transcription["prompt"])
 
         XCTAssertTrue(input["turn_detection"] is NSNull)
+    }
+
+    func testGPTLiveTranscribeSessionPayloadIncludesContextHintsAndLowDelay() throws {
+        let payload = OpenAIRealtimeTranscriptionSession.sessionUpdatePayload(
+            modelID: "gpt-live-transcribe",
+            languageSelection: PluginLanguageSelection(
+                languageHints: ["de", "en", "DE"]
+            ),
+            prompt: "A TypeWhisper product interview.",
+            keywords: ["TypeWhisper", "AC-42"],
+            delay: .low
+        )
+
+        let session = try XCTUnwrap(payload["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertEqual(transcription["model"] as? String, "gpt-live-transcribe")
+        XCTAssertEqual(
+            transcription["prompt"] as? String,
+            "A TypeWhisper product interview."
+        )
+        XCTAssertEqual(transcription["keywords"] as? [String], ["TypeWhisper", "AC-42"])
+        XCTAssertEqual(transcription["languages"] as? [String], ["de", "en"])
+        XCTAssertEqual(transcription["delay"] as? String, "low")
+        XCTAssertNil(transcription["language"])
+        XCTAssertTrue(input["turn_detection"] is NSNull)
+    }
+
+    func testFileModelRejectsNativeLiveSessionBeforeOpeningSocket() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "gpt-transcribe"],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.createLiveTranscriptionSession(
+                language: "de",
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true }
+            )
+            XCTFail("Expected file model to reject native live transcription")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(message, "GPT Transcribe is a file transcription model.")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
     }
 
     func testOpenAIRealtimePCMConversionResamples16kTo24kPCM16() {
@@ -416,6 +881,25 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.5")
         XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gpt-5.5")
         XCTAssertTrue(store.sessions.isEmpty)
+    }
+
+    private static func testAudio() -> AudioData {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        return AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+    }
+
+    private static func formValues(named name: String, in body: String) -> [String] {
+        let marker = "name=\"\(name)\"\r\n\r\n"
+        return body
+            .components(separatedBy: marker)
+            .dropFirst()
+            .compactMap { component in
+                component.components(separatedBy: "\r\n").first
+            }
     }
 
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -80,13 +80,17 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertTrue(plugin.supportedModels.contains { $0.id == "gpt-5.5" })
     }
 
-    func testOpenAIChatGPTLoginModelsIncludeGPT55First() throws {
+    func testOpenAIChatGPTLoginFallbackIncludesCurrentGPT56Models() throws {
         let host = try PluginTestHostServices(defaults: ["authMode": "chatgpt"])
         let plugin = OpenAIPlugin()
         plugin.activate(host: host)
 
-        XCTAssertEqual(plugin.supportedModels.first?.id, "gpt-5.5")
-        XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.5")
+        XCTAssertEqual(
+            Array(plugin.supportedModels.prefix(3).map(\.id)),
+            ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]
+        )
+        XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.6-sol")
+        XCTAssertTrue(plugin.supportedModels.contains { $0.id == "gpt-5.5" })
     }
 
     func testOpenAIChatGPTLoginOnlyMakesLLMAuthRoleAvailable() throws {
@@ -862,25 +866,177 @@ final class OpenAIPluginTests: XCTestCase {
         )
     }
 
-    func testOpenAIRefreshAvailableLLMModelsUsesChatGPTCatalogWithoutModelsEndpoint() async throws {
-        let host = try PluginTestHostServices(defaults: [
-            "authMode": "chatgpt",
-            "selectedLLMModel": "stale-model",
-        ])
+    func testOpenAIChatGPTModelsRequestUsesAccountScopedCodexEndpoint() throws {
+        let request = try OpenAIPlugin.makeChatGPTModelsRequest(
+            accessToken: "oauth-token",
+            accountID: "account-123",
+            clientVersion: "1.3.0"
+        )
+
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.url?.host, "chatgpt.com")
+        XCTAssertEqual(request.url?.path, "/backend-api/codex/models")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ChatGPT-Account-ID"), "account-123")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Accept"), "application/json")
+
+        let components = try XCTUnwrap(
+            URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+        )
+        let query = Dictionary(
+            uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value ?? "") }
+        )
+        XCTAssertEqual(query["client_version"], "1.3.0")
+    }
+
+    func testOpenAIRefreshAvailableLLMModelsFetchesFutureChatGPTCatalogAndPersistsSelection() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "authMode": "chatgpt",
+                "selectedLLMModel": "gpt-5.6-sol",
+                "oauthAccountID": "account-123",
+                "oauthExpiresAt": Date().addingTimeInterval(3_600),
+            ],
+            secrets: [
+                "oauth-access-token": "oauth-token",
+                "oauth-refresh-token": "refresh-token",
+            ]
+        )
         let plugin = OpenAIPlugin()
         plugin.activate(host: host)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
-            store.makeSession(outcomes: [.failure(URLError(.badURL))])
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "models": [
+                            {
+                              "slug": "gpt-hidden",
+                              "display_name": "Hidden",
+                              "priority": 0,
+                              "visibility": "hide"
+                            },
+                            {
+                              "slug": "gpt-5.6-sol",
+                              "display_name": "GPT-5.6 Sol",
+                              "priority": 2,
+                              "visibility": "list"
+                            },
+                            {
+                              "slug": "gpt-5.7",
+                              "display_name": "GPT-5.7",
+                              "priority": 1,
+                              "visibility": "list"
+                            },
+                            {
+                              "slug": "gpt-internal",
+                              "display_name": "Internal",
+                              "priority": 3,
+                              "visibility": "none"
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(
+                        url: "https://chatgpt.com/backend-api/codex/models",
+                        statusCode: 200
+                    )
+                ),
+            ])
         }
 
         let models = await plugin.refreshAvailableLLMModels()
 
-        XCTAssertEqual(models.first?.id, "gpt-5.5")
+        XCTAssertEqual(models.map(\.id), ["gpt-5.7", "gpt-5.6-sol"])
+        XCTAssertEqual(models.map(\.displayName), ["GPT-5.7", "GPT-5.6 Sol"])
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["gpt-5.7", "gpt-5.6-sol"])
+        XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.6-sol")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gpt-5.6-sol")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/backend-api/codex/models")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer oauth-token")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ChatGPT-Account-ID"), "account-123")
+        let components = try XCTUnwrap(
+            URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)
+        )
+        XCTAssertFalse(
+            components.queryItems?
+                .first(where: { $0.name == "client_version" })?
+                .value?
+                .isEmpty ?? true
+        )
+
+        let cachedData = try XCTUnwrap(host.userDefault(forKey: "fetchedChatGPTModels") as? Data)
+        let cache = try JSONDecoder().decode(OpenAIChatGPTModelCache.self, from: cachedData)
+        XCTAssertEqual(cache.accountID, "account-123")
+        XCTAssertEqual(cache.models.map(\.id), ["gpt-5.7", "gpt-5.6-sol"])
+
+        let restoredPlugin = OpenAIPlugin()
+        restoredPlugin.activate(host: host)
+        XCTAssertEqual(restoredPlugin.supportedModels.map(\.id), ["gpt-5.7", "gpt-5.6-sol"])
+        XCTAssertEqual(restoredPlugin.selectedLLMModelId, "gpt-5.6-sol")
+    }
+
+    func testOpenAIChatGPTModelRefreshFailureKeepsFallbackAndSelection() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "authMode": "chatgpt",
+                "selectedLLMModel": "gpt-5.5",
+                "oauthAccountID": "account-123",
+                "oauthExpiresAt": Date().addingTimeInterval(3_600),
+            ],
+            secrets: [
+                "oauth-access-token": "oauth-token",
+                "oauth-refresh-token": "refresh-token",
+            ]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [.failure(URLError(.cannotConnectToHost))])
+        }
+
+        let models = await plugin.refreshAvailableLLMModels()
+
+        XCTAssertTrue(models.isEmpty)
+        XCTAssertEqual(plugin.supportedModels.first?.id, "gpt-5.6-sol")
         XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.5")
         XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "gpt-5.5")
-        XCTAssertTrue(store.sessions.isEmpty)
+        XCTAssertEqual(store.sessions.first?.requestedPaths, ["/backend-api/codex/models"])
+    }
+
+    func testOpenAIChatGPTModelCacheIsScopedToAccount() throws {
+        let cache = OpenAIChatGPTModelCache(
+            accountID: "old-account",
+            models: [
+                OpenAIChatGPTModel(
+                    id: "gpt-5.7",
+                    displayName: "GPT-5.7",
+                    priority: 1,
+                    visibility: "list"
+                ),
+            ]
+        )
+        let host = try PluginTestHostServices(defaults: [
+            "authMode": "chatgpt",
+            "selectedLLMModel": "gpt-5.5",
+            "oauthAccountID": "new-account",
+            "fetchedChatGPTModels": try JSONEncoder().encode(cache),
+        ])
+        let plugin = OpenAIPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.supportedModels.first?.id, "gpt-5.6-sol")
+        XCTAssertFalse(plugin.supportedModels.contains { $0.id == "gpt-5.7" })
+        XCTAssertEqual(plugin.selectedLLMModelId, "gpt-5.5")
     }
 
     private static func testAudio() -> AudioData {

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openai",
     "name": "OpenAI / ChatGPT",
-    "version": "1.1.1",
+    "version": "1.3.0",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

OpenAI announced two new transcription models: [`gpt-transcribe` and `gpt-live-transcribe`](https://x.com/OpenAIDevs/status/2082164472261779688). This PR adds both models to the OpenAI plugin using the existing plugin SDK contracts and keeps the host compatibility floor unchanged.

The local development smoke also exposed that ChatGPT Login's Refresh button returned a hard-coded model snapshot instead of requesting the account-specific Codex catalog. The current Codex catalog includes GPT-5.6 Sol, Terra, and Luna, so this PR now uses the same dynamic `/backend-api/codex/models?client_version=...` contract as Codex. Future visible models can therefore appear after refresh without another plugin update.

Official references:

- [GPT Transcribe](https://developers.openai.com/api/docs/models/gpt-transcribe)
- [Realtime transcription](https://developers.openai.com/api/docs/guides/realtime-transcription)
- [Codex models](https://learn.chatgpt.com/docs/models)
- [Codex models endpoint implementation](https://github.com/openai/codex/blob/main/codex-rs/codex-api/src/endpoint/models.rs)

## What changed

- Add a private capability table for file/realtime routing, context-aware fields, response formats, and translation support.
- Add `gpt-transcribe` as the default only when no model selection has been persisted; existing selections remain unchanged.
- Send `gpt-transcribe` requests through `/v1/audio/transcriptions` with M4A-to-WAV fallback, context, sanitized ordered keywords, ordered language hints, and detected-language parsing.
- Add `gpt-live-transcribe` to the existing WebSocket transcription path with context, keywords, language hints, and configurable delay.
- Keep `gpt-realtime-whisper` and existing REST model payloads unchanged.
- Block Translate locally for every model except `whisper-1` before any network request.
- Dynamically fetch the ChatGPT/Codex model catalog with the OAuth access token and `ChatGPT-Account-ID`, then honor server visibility and priority.
- Cache the fetched ChatGPT catalog per account, preserve a still-available selected model, and keep the previous cache or fallback when refresh fails.
- Refresh ChatGPT models when settings open and after login/import, while retaining the manual Refresh action.
- Keep a current GPT-5.6 fallback for offline use without removing legacy selections until a successful server refresh replaces the fallback.
- Add context and live-delay settings with localized UI copy.
- Bump the OpenAI plugin manifest to `1.3.0` while keeping `minHostVersion: 1.5.0` and SDK compatibility `v1`.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter OpenAIPluginTests` (39 tests)
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme OpenAIPlugin -configuration Release CODE_SIGNING_ALLOWED=NO build`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run OpenAIPlugin /Users/marco/.codex/worktrees/c7bc/typewhisper-mac`
- [x] Verify the installed bundle is Apple Development signed and contains manifest version `1.3.0`.
- [x] Verify all newly referenced SDK symbols already exist in the `v1.5.0` host tag.
- [x] Run an account-scoped live Codex model-catalog smoke: HTTP 200 with `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark`.
- [ ] Run a real `gpt-transcribe` API smoke with context, multiple language hints, and dictionary terms.
- [ ] Run a real `gpt-live-transcribe` API smoke with delay `low`, partial updates, and a final committed result.
- [ ] Restart with a persisted legacy transcription selection and verify it remains selected.
- [ ] Run a successful `whisper-1` translation and verify a GPT transcription model is blocked locally with `Translate requires Whisper 1`.

The real transcription API checks remain required before merge. Merge and plugin release are separate approval gates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added transcription context, language hints, dictionary terms, and a selectable live transcription delay.
  * Enabled context-aware transcription for both file and realtime streaming.
  * Refreshed ChatGPT model discovery with account-scoped caching and improved model availability after login/import.
  * Updated multilingual UI text (German and Japanese) for the new transcription options and tiers.
  * Added translation support limited to **Whisper 1**.
* **Bug Fixes**
  * Improved request validation, retry behavior, and error handling to prevent incorrect model fallbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->