### PR TITLE
Sync per-term CTC to the Parakeet plugin

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -7410,8 +7410,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = exactVersion;
+				version = 0.15.5;
 			};
 		};
 		RR00000000000000000004 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -1094,6 +1094,9 @@ final class DictionaryService: ObservableObject {
                 caseSensitive: entry.caseSensitive,
                 isEnabled: entry.isEnabled,
                 source: entry.source == .manual ? nil : entry.source,
+                ctcMinSimilarity: entry.type == .term
+                    ? entry.ctcMinSimilarity
+                    : nil,
                 createdAt: entry.createdAt,
                 updatedAt: entry.effectiveUpdatedAt
             )
@@ -1140,6 +1143,11 @@ final class DictionaryService: ObservableObject {
             entry.caseSensitive = synced.caseSensitive
             entry.isEnabled = synced.isEnabled
             entry.source = synced.source ?? .manual
+            if targetType == .correction {
+                entry.ctcMinSimilarity = nil
+            } else if synced.ctcMinSimilarityFieldPresent {
+                entry.ctcMinSimilarity = synced.ctcMinSimilarity
+            }
             entry.updatedAt = synced.updatedAt
             return
         }
@@ -1150,6 +1158,9 @@ final class DictionaryService: ObservableObject {
             replacement: replacement,
             caseSensitive: synced.caseSensitive,
             isEnabled: synced.isEnabled,
+            ctcMinSimilarity: targetType == .term
+                ? synced.ctcMinSimilarity
+                : nil,
             source: synced.source ?? .manual,
             createdAt: synced.createdAt,
             updatedAt: synced.updatedAt

--- a/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncEngine.swift
@@ -262,6 +262,11 @@ enum CloudFolderSyncEngine {
         let synchronizedRecords = records(afterApplying: mutations, to: initialRecords)
         state.knownLocalItemIDs = Set(synchronizedRecords.keys)
         state.exportedItemVersions = synchronizedRecords.mapValues(\.version)
+        for itemID in dictionaryItemIDsRequiringRepublish(
+            afterApplying: mutations
+        ) {
+            state.exportedItemVersions.removeValue(forKey: itemID)
+        }
         state.appliedOperationIDs.formUnion(operations.map(\.operationId))
         state.lastSyncAt = now
 
@@ -283,7 +288,7 @@ enum CloudFolderSyncEngine {
                     collection: .dictionary,
                     itemID: itemID,
                     updatedAt: entry.updatedAt,
-                    version: versionString(for: entry.updatedAt),
+                    version: dictionaryVersionString(for: entry),
                     dictionary: entry,
                     snippet: nil
                 ),
@@ -359,6 +364,9 @@ enum CloudFolderSyncEngine {
 
     private static func recordTieBreaker(_ record: CloudFolderSyncRecord) -> String {
         if let dictionary = record.dictionary {
+            let ctcValue = dictionary.ctcMinSimilarity.map {
+                String($0)
+            } ?? "null"
             return [
                 record.collection.rawValue,
                 dictionary.entryType.rawValue,
@@ -366,6 +374,8 @@ enum CloudFolderSyncEngine {
                 dictionary.replacement ?? "",
                 String(dictionary.caseSensitive),
                 String(dictionary.isEnabled),
+                String(dictionary.ctcMinSimilarityFieldPresent),
+                ctcValue,
                 versionString(for: dictionary.createdAt)
             ].joined(separator: "|")
         }
@@ -465,8 +475,14 @@ enum CloudFolderSyncEngine {
         if operation.updatedAt > local.updatedAt {
             return true
         }
-        if operation.updatedAt == local.updatedAt && operation.deviceId > localDeviceId {
-            return true
+        if operation.updatedAt == local.updatedAt {
+            if let presencePreference = ctcPresencePreference(
+                candidate: operation.dictionary,
+                existing: local.dictionary
+            ) {
+                return presencePreference
+            }
+            return operation.deviceId > localDeviceId
         }
         return false
     }
@@ -474,6 +490,12 @@ enum CloudFolderSyncEngine {
     private static func prefers(_ candidate: CloudFolderSyncOperation, over existing: CloudFolderSyncOperation) -> Bool {
         if candidate.updatedAt != existing.updatedAt {
             return candidate.updatedAt > existing.updatedAt
+        }
+        if let presencePreference = ctcPresencePreference(
+            candidate: candidate.dictionary,
+            existing: existing.dictionary
+        ) {
+            return presencePreference
         }
         if candidate.deviceId != existing.deviceId {
             return candidate.deviceId > existing.deviceId
@@ -587,6 +609,41 @@ enum CloudFolderSyncEngine {
 
     private static func versionString(for date: Date) -> String {
         iso8601String(from: date)
+    }
+
+    private static func dictionaryVersionString(
+        for entry: UserDataSyncDictionaryEntry
+    ) -> String {
+        "dictionary-v2|\(versionString(for: entry.updatedAt))"
+    }
+
+    private static func ctcPresencePreference(
+        candidate: UserDataSyncDictionaryEntry?,
+        existing: UserDataSyncDictionaryEntry?
+    ) -> Bool? {
+        guard candidate?.entryType == .term,
+              existing?.entryType == .term,
+              candidate?.ctcMinSimilarityFieldPresent
+                != existing?.ctcMinSimilarityFieldPresent else {
+            return nil
+        }
+        return candidate?.ctcMinSimilarityFieldPresent == true
+    }
+
+    private static func dictionaryItemIDsRequiringRepublish(
+        afterApplying mutations: [UserDataSyncMutation]
+    ) -> Set<String> {
+        Set(mutations.compactMap { mutation in
+            guard case .upsertDictionary(let entry) = mutation,
+                  entry.entryType == .term,
+                  !entry.ctcMinSimilarityFieldPresent else {
+                return nil
+            }
+            return UserDataSyncIdentity.dictionaryItemID(
+                entryType: entry.entryType,
+                original: entry.original
+            )
+        })
     }
 
     private static func iso8601String(from date: Date) -> String {

--- a/TypeWhisper/Services/Sync/UserDataSync.swift
+++ b/TypeWhisper/Services/Sync/UserDataSync.swift
@@ -25,6 +25,8 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
     let caseSensitive: Bool
     let isEnabled: Bool
     let source: DictionaryEntrySource?
+    let ctcMinSimilarity: Float?
+    let ctcMinSimilarityFieldPresent: Bool
     let createdAt: Date
     let updatedAt: Date
 
@@ -35,6 +37,8 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         caseSensitive: Bool,
         isEnabled: Bool,
         source: DictionaryEntrySource? = nil,
+        ctcMinSimilarity: Float? = nil,
+        ctcMinSimilarityFieldPresent: Bool? = nil,
         createdAt: Date,
         updatedAt: Date
     ) {
@@ -44,6 +48,12 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         self.caseSensitive = caseSensitive
         self.isEnabled = isEnabled
         self.source = source
+        self.ctcMinSimilarity = entryType == .term
+            ? Self.normalizedCtcMinSimilarity(ctcMinSimilarity)
+            : nil
+        self.ctcMinSimilarityFieldPresent = entryType == .term
+            ? (ctcMinSimilarityFieldPresent ?? true)
+            : false
         self.createdAt = createdAt
         self.updatedAt = updatedAt
     }
@@ -55,6 +65,7 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         case caseSensitive
         case isEnabled
         case source
+        case ctcMinSimilarity
         case createdAt
         case updatedAt
     }
@@ -68,6 +79,16 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
         let sourceRawValue = try container.decodeIfPresent(String.self, forKey: .source)
         source = sourceRawValue.flatMap(DictionaryEntrySource.init(rawValue:))
+        ctcMinSimilarityFieldPresent =
+            entryType == .term && container.contains(.ctcMinSimilarity)
+        ctcMinSimilarity = entryType == .term
+            ? Self.normalizedCtcMinSimilarity(
+                try container.decodeIfPresent(
+                    Float.self,
+                    forKey: .ctcMinSimilarity
+                )
+            )
+            : nil
         createdAt = try container.decode(Date.self, forKey: .createdAt)
         updatedAt = try container.decode(Date.self, forKey: .updatedAt)
     }
@@ -80,8 +101,16 @@ struct UserDataSyncDictionaryEntry: Codable, Equatable, Sendable {
         try container.encode(caseSensitive, forKey: .caseSensitive)
         try container.encode(isEnabled, forKey: .isEnabled)
         try container.encodeIfPresent(source?.rawValue, forKey: .source)
+        if entryType == .term {
+            try container.encode(ctcMinSimilarity, forKey: .ctcMinSimilarity)
+        }
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
+    }
+
+    private static func normalizedCtcMinSimilarity(_ value: Float?) -> Float? {
+        guard let value, value.isFinite else { return nil }
+        return min(max(value, 0), 1)
     }
 }
 

--- a/TypeWhisperPluginSDK/Package.resolved
+++ b/TypeWhisperPluginSDK/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "8664fb505ff73aec3a218868c595305d6a9a1a113162ffd24c651267b6e3cdc2",
+  "originHash" : "fdef139cb6f2f4aae86a7764c69b549291dae051f7bcfad27d9ba31fe7fb37f2",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "bd64824505da71a1a403adb221f6e25413c0bc7f",
-        "version" : "1.4.0"
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
       }
     },
     {
@@ -17,15 +17,6 @@
       "state" : {
         "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
         "version" : "0.15.5"
-      }
-    },
-    {
-      "identity" : "mediaremote-adapter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ejbills/mediaremote-adapter.git",
-      "state" : {
-        "branch" : "master",
-        "revision" : "b4ae765bbfa111f1e8fad240a8ea74f01e91d325"
       }
     },
     {
@@ -64,30 +55,21 @@
       }
     },
     {
-      "identity" : "sparkle",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/sparkle-project/Sparkle.git",
-      "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
-      }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser.git",
-      "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
-      }
-    },
-    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -95,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -104,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -122,8 +104,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
-        "version" : "2.3.1"
+        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
+        "version" : "2.3.6"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -145,21 +136,21 @@
       }
     },
     {
-      "identity" : "swift-transformers",
+      "identity" : "swift-system",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/huggingface/swift-transformers",
+      "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
-        "version" : "1.2.1"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {
-      "identity" : "whisperkit",
+      "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/argmaxinc/WhisperKit.git",
+      "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "branch" : "main",
-        "revision" : "80d96762fa727f816ffceab76a6529cd12c2726f"
+        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
+        "version" : "1.3.3"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "TypeWhisperPluginSDKTesting", targets: ["TypeWhisperPluginSDKTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", revision: "2ea0727541135c34189194084531337a3518e1bf"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.15.5"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
         .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
         // swift-transformers 1.3.3 is incompatible with swift-jinja 2.4's ObjectKey API.

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -464,13 +464,14 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
             return
         }
 
-        // FluidAudio currently exposes only vocabulary-level minSimilarity; per-term
-        // thresholds are preserved in structured hints until the upstream API exists.
         let terms = termHints.compactMap { hint -> CustomVocabularyTerm? in
             let text = hint.text
             let ids = ctcTokenizer.encode(text)
             guard !ids.isEmpty else { return nil }
-            return CustomVocabularyTerm(text: text, weight: 10.0, ctcTokenIds: ids)
+            return Self.customVocabularyTerm(
+                from: hint,
+                ctcTokenIds: ids
+            )
         }
 
         guard !terms.isEmpty else {
@@ -499,6 +500,18 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
             lastBoostingTermCount = 0
             lastConfiguredPrompt = nil
         }
+    }
+
+    static func customVocabularyTerm(
+        from hint: PluginDictionaryTermHint,
+        ctcTokenIds: [Int]
+    ) -> CustomVocabularyTerm {
+        CustomVocabularyTerm(
+            text: hint.text,
+            weight: 10.0,
+            ctcTokenIds: ctcTokenIds,
+            minSimilarity: hint.ctcMinSimilarity
+        )
     }
 
     private func applyVocabularyRescoringIfNeeded(

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -376,6 +376,19 @@ final class ParakeetPluginTests: XCTestCase {
         XCTAssertEqual(signature, "Alpha|auto\u{1F}Beta|0.6500")
     }
 
+    func testFluidVocabularyTermReceivesIndividualThreshold() {
+        let term = ParakeetPlugin.customVocabularyTerm(
+            from: PluginDictionaryTermHint(
+                text: "Caivex",
+                ctcMinSimilarity: 0.9
+            ),
+            ctcTokenIds: [1, 2, 3]
+        )
+
+        XCTAssertEqual(term.text, "Caivex")
+        XCTAssertEqual(term.minSimilarity, 0.9)
+    }
+
     func testSettingsDismissalRequiresOnlyBaseModelReadiness() throws {
         let host = try PluginTestHostServices(defaults: ["vocabularyBoostingEnabled": true])
         let plugin = makePlugin()

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -31,10 +31,33 @@ private final class InMemoryUserDataSyncStore: UserDataSyncStore, @unchecked Sen
             switch mutation {
             case .upsertDictionary(let entry):
                 let itemID = UserDataSyncIdentity.dictionaryItemID(entryType: entry.entryType, original: entry.original)
+                let existing = dictionaryEntries.first {
+                    UserDataSyncIdentity.dictionaryItemID(
+                        entryType: $0.entryType,
+                        original: $0.original
+                    ) == itemID
+                }
                 dictionaryEntries.removeAll {
                     UserDataSyncIdentity.dictionaryItemID(entryType: $0.entryType, original: $0.original) == itemID
                 }
-                dictionaryEntries.append(entry)
+                if entry.entryType == .term,
+                   !entry.ctcMinSimilarityFieldPresent {
+                    dictionaryEntries.append(
+                        UserDataSyncDictionaryEntry(
+                            entryType: entry.entryType,
+                            original: entry.original,
+                            replacement: entry.replacement,
+                            caseSensitive: entry.caseSensitive,
+                            isEnabled: entry.isEnabled,
+                            source: entry.source,
+                            ctcMinSimilarity: existing?.ctcMinSimilarity,
+                            createdAt: entry.createdAt,
+                            updatedAt: entry.updatedAt
+                        )
+                    )
+                } else {
+                    dictionaryEntries.append(entry)
+                }
             case .deleteDictionary(let itemID):
                 dictionaryEntries.removeAll {
                     UserDataSyncIdentity.dictionaryItemID(entryType: $0.entryType, original: $0.original) == itemID
@@ -744,6 +767,15 @@ final class CloudFolderSyncTests: XCTestCase {
         let legacy: CloudFolderSyncOperation = try Self.decodeFixture("upsert-snippet-legacy-v1")
         XCTAssertEqual(legacy.snippet?.tags, [])
 
+        let ctc: CloudFolderSyncOperation = try Self.decodeFixture(
+            "upsert-dictionary-ctc-v1"
+        )
+        XCTAssertEqual(ctc.dictionary?.ctcMinSimilarity, 0.65)
+        XCTAssertEqual(
+            ctc.dictionary?.ctcMinSimilarityFieldPresent,
+            true
+        )
+
         let unknown: CloudFolderSyncOperation = try Self.decodeFixture("unknown-schema")
         XCTAssertEqual(unknown.schemaVersion, 2)
         XCTAssertTrue(CloudFolderSyncEngine.winningOperations(from: [unknown]).isEmpty)
@@ -1178,6 +1210,238 @@ final class CloudFolderSyncTests: XCTestCase {
         XCTAssertEqual(winner?.operationId, "tie")
     }
 
+    func testTermEncodingUsesExplicitNullAndLegacyDecodingTracksAbsence()
+        throws
+    {
+        let automatic = Self.dictionaryEntry(
+            original: "Automatic",
+            updatedAt: Self.date(10)
+        )
+        let encoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: Self.entitlementEncoder.encode(automatic)
+            ) as? [String: Any]
+        )
+        XCTAssertTrue(encoded["ctcMinSimilarity"] is NSNull)
+
+        let legacyData = Data(
+            """
+            {
+              "entryType": "term",
+              "original": "Legacy",
+              "caseSensitive": false,
+              "isEnabled": true,
+              "createdAt": "2023-11-14T22:13:21.000Z",
+              "updatedAt": "2023-11-14T22:13:30.000Z"
+            }
+            """.utf8
+        )
+        let legacy = try Self.fixtureDecoder.decode(
+            UserDataSyncDictionaryEntry.self,
+            from: legacyData
+        )
+        XCTAssertNil(legacy.ctcMinSimilarity)
+        XCTAssertFalse(legacy.ctcMinSimilarityFieldPresent)
+    }
+
+    @MainActor
+    func testExplicitCTCFieldWinsEqualTimestampBeforeDeviceID() {
+        let itemID = UserDataSyncIdentity.dictionaryItemID(
+            entryType: UserDataSyncDictionaryEntryType.term,
+            original: "TypeWhisper"
+        )
+        let explicit = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(20),
+                ctcMinSimilarity: 0.65
+            ),
+            itemID: itemID,
+            deviceId: "mac-a",
+            operationId: "explicit"
+        )
+        let legacy = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(20),
+                ctcMinSimilarityFieldPresent: false
+            ),
+            itemID: itemID,
+            deviceId: "mac-z",
+            operationId: "legacy"
+        )
+
+        XCTAssertEqual(
+            CloudFolderSyncEngine.winningOperations(
+                from: [legacy, explicit]
+            )[itemID]?.operationId,
+            "explicit"
+        )
+    }
+
+    @MainActor
+    func testCTCValueAndExplicitNullRoundTripAcrossTwoDevices()
+        async throws
+    {
+        let folder = try TestSupport.makeTemporaryDirectory(
+            prefix: "CloudFolderSyncCTCRoundTrip"
+        )
+        defer { TestSupport.remove(folder) }
+        let first = InMemoryUserDataSyncStore(dictionaryEntries: [
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(10),
+                ctcMinSimilarity: 0.65
+            )
+        ])
+        let second = InMemoryUserDataSyncStore()
+        var firstState = CloudFolderSyncState(deviceId: "mac-a")
+        var secondState = CloudFolderSyncState(deviceId: "ios-b")
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: first,
+            state: &firstState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(20)
+        )
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: second,
+            state: &secondState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+        XCTAssertEqual(
+            second.dictionaryEntries.first?.ctcMinSimilarity,
+            0.65
+        )
+
+        second.dictionaryEntries = [
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(40)
+            )
+        ]
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: second,
+            state: &secondState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(50)
+        )
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: first,
+            state: &firstState,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(60)
+        )
+
+        XCTAssertNil(first.dictionaryEntries.first?.ctcMinSimilarity)
+        XCTAssertEqual(
+            first.dictionaryEntries.first?.ctcMinSimilarityFieldPresent,
+            true
+        )
+    }
+
+    @MainActor
+    func testLegacyCTCFieldPreservesValueAndRepublishesOnce()
+        async throws
+    {
+        let folder = try TestSupport.makeTemporaryDirectory(
+            prefix: "CloudFolderSyncLegacyCTC"
+        )
+        defer { TestSupport.remove(folder) }
+        let store = InMemoryUserDataSyncStore(dictionaryEntries: [
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(10),
+                ctcMinSimilarity: 0.8
+            )
+        ])
+        let legacy = CloudFolderSyncOperation.upsertDictionary(
+            Self.dictionaryEntry(
+                original: "TypeWhisper",
+                updatedAt: Self.date(20),
+                ctcMinSimilarityFieldPresent: false
+            ),
+            itemID: UserDataSyncIdentity.dictionaryItemID(
+                entryType: UserDataSyncDictionaryEntryType.term,
+                original: "TypeWhisper"
+            ),
+            deviceId: "legacy-ios",
+            operationId: "legacy"
+        )
+        try Self.writeLegacyOperation(legacy, to: folder)
+        var state = CloudFolderSyncState(deviceId: "mac-a")
+
+        _ = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(25)
+        )
+        XCTAssertEqual(
+            store.dictionaryEntries.first?.ctcMinSimilarity,
+            0.8
+        )
+        let itemID = UserDataSyncIdentity.dictionaryItemID(
+            entryType: UserDataSyncDictionaryEntryType.term,
+            original: "TypeWhisper"
+        )
+        XCTAssertNil(state.exportedItemVersions[itemID])
+
+        let republish = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(30)
+        )
+        let repeated = try await CloudFolderSyncEngine.sync(
+            folderURL: folder,
+            store: store,
+            state: &state,
+            entitlements: PaidEntitlements(canUseCloudFolderSync: true),
+            now: Self.date(35)
+        )
+        XCTAssertEqual(republish.operationsWritten, 1)
+        XCTAssertEqual(repeated.operationsWritten, 0)
+    }
+
+    @MainActor
+    func testLegacyMutationDoesNotOverwriteStoredCTC() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "CloudFolderSyncStoredCTC"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = DictionaryService(
+            appSupportDirectory: appSupportDirectory
+        )
+        service.addEntry(
+            type: .term,
+            original: "TypeWhisper",
+            ctcMinSimilarity: 0.8
+        )
+        try service.applyUserDataSyncMutations([
+            .upsertDictionary(
+                Self.dictionaryEntry(
+                    original: "TypeWhisper",
+                    updatedAt: Self.date(20),
+                    ctcMinSimilarityFieldPresent: false
+                )
+            )
+        ])
+
+        XCTAssertEqual(service.entries.first?.ctcMinSimilarity, 0.8)
+        XCTAssertTrue(
+            service.userDataSyncEntries().first?
+                .ctcMinSimilarityFieldPresent == true
+        )
+    }
+
     @MainActor
     func testHostStoreSnapshotsObserversBeforeNotifying() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "CloudFolderSyncObservers")
@@ -1375,7 +1639,9 @@ final class CloudFolderSyncTests: XCTestCase {
         original: String,
         replacement: String? = nil,
         source: DictionaryEntrySource? = nil,
-        updatedAt: Date
+        updatedAt: Date,
+        ctcMinSimilarity: Float? = nil,
+        ctcMinSimilarityFieldPresent: Bool? = nil
     ) -> UserDataSyncDictionaryEntry {
         UserDataSyncDictionaryEntry(
             entryType: entryType,
@@ -1384,8 +1650,43 @@ final class CloudFolderSyncTests: XCTestCase {
             caseSensitive: false,
             isEnabled: true,
             source: source,
+            ctcMinSimilarity: ctcMinSimilarity,
+            ctcMinSimilarityFieldPresent:
+                ctcMinSimilarityFieldPresent,
             createdAt: date(1),
             updatedAt: updatedAt
+        )
+    }
+
+    private static func writeLegacyOperation(
+        _ operation: CloudFolderSyncOperation,
+        to folder: URL
+    ) throws {
+        let directory = CloudFolderSyncEngine.packageURL(for: folder)
+            .appendingPathComponent(
+                "ops/\(operation.deviceId)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        let encoded = try entitlementEncoder.encode(operation)
+        var object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: encoded) as? [String: Any]
+        )
+        var dictionary = try XCTUnwrap(
+            object["dictionary"] as? [String: Any]
+        )
+        dictionary.removeValue(forKey: "ctcMinSimilarity")
+        object["dictionary"] = dictionary
+        let data = try JSONSerialization.data(
+            withJSONObject: object,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try data.write(
+            to: directory.appendingPathComponent("legacy.json"),
+            options: [.atomic]
         )
     }
 

--- a/TypeWhisperTests/Fixtures/PremiumSync/upsert-dictionary-ctc-v1.json
+++ b/TypeWhisperTests/Fixtures/PremiumSync/upsert-dictionary-ctc-v1.json
@@ -1,0 +1,18 @@
+{
+  "collection" : "dictionary",
+  "deviceId" : "fixture-ios",
+  "dictionary" : {
+    "caseSensitive" : true,
+    "createdAt" : "2026-07-28T10:00:00.000Z",
+    "ctcMinSimilarity" : 0.65,
+    "entryType" : "term",
+    "isEnabled" : true,
+    "original" : "TypeWhisper",
+    "updatedAt" : "2026-07-28T10:05:00.000Z"
+  },
+  "itemId" : "dictionary:term:dHlwZXdoaXNwZXI",
+  "kind" : "upsert",
+  "operationId" : "fixture-upsert-dictionary-ctc",
+  "schemaVersion" : 1,
+  "updatedAt" : "2026-07-28T10:05:00.000Z"
+}


### PR DESCRIPTION
## Summary

- extend dictionary Premium Sync with optional per-term CTC values and explicit value/null/legacy-missing semantics
- preserve local CTC values when reading legacy records and republish dictionary entries once with the new field
- prefer explicit CTC presence on equal timestamps while retaining the existing last-write-wins ordering otherwise
- update FluidAudio to the official 0.15.5 release in the project and both lockfiles
- pass `PluginDictionaryTermHint.ctcMinSimilarity` to FluidAudio `CustomVocabularyTerm`

## Verification

- `TypeWhisperPluginSDK` package suite on the final head: 438 passed
- focused `CloudFolderSyncTests` on the final head: passed
- signed TypeWhisper dev app build and launch from the final head: passed
- Parakeet dev plugin build, install, enable, launch, Apple Development signature, and loaded-binary verification: passed
- built FluidAudio module reports version 0.15.5
- all GitHub Actions app-test, plugin-SDK, release-build, policy, and analysis checks: passed

## Cross-platform dependency

Companion iOS PR: https://github.com/TypeWhisper/typewhisper-ios/pull/52

Both sides must ship together for lossless Premium Sync behavior.

## Remaining manual release gates

- real Mac ↔ iPhone file roundtrip and Premium Sync in both directions
- controlled same-audio comparison at CTC `0.50` and `0.90` in both batch and live transcription

These are intentionally not claimed as passed. Merging this PR does not publish a Daily build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-term pronunciation similarity thresholds for improved vocabulary matching.
  - Preserved and synchronized threshold settings across devices, including explicit null and legacy data cases.

- **Bug Fixes**
  - Prevented older sync data from unintentionally overwriting existing threshold settings.
  - Improved conflict resolution and republishing behavior for dictionary entries.

- **Tests**
  - Added coverage for threshold encoding, decoding, synchronization, conflict handling, and vocabulary configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->