### PR TITLE
Add local Cohere Transcribe plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -118,6 +118,7 @@ jobs:
             sber-salutespeech) TARGET="SaluteSpeechPlugin" ;;
             reson8) TARGET="Reson8Plugin" ;;
             cohere) TARGET="CoherePlugin" ;;
+            cohere-transcribe) TARGET="CohereLocalPlugin" ;;
             speechmatics) TARGET="SpeechmaticsPlugin" ;;
             system-tts) TARGET="SystemTTSPlugin" ;;
             supertonic) TARGET="SupertonicPlugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -273,6 +273,13 @@
 		AA00000000000000000166 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000158 /* manifest.json */; };
 		AA00000000000000000167 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000016 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000168 /* FluidAudio in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000017 /* FluidAudio */; };
+		C0E300000000000000000001 /* CohereLocalPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E300000000000000000011 /* CohereLocalPlugin.swift */; };
+		C0E300000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = C0E300000000000000000012 /* manifest.json */; };
+		C0E300000000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = C0E300000000000000000013 /* Localizable.xcstrings */; };
+		C0E300000000000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = C0E300000000000000000060 /* TypeWhisperPluginSDK */; };
+		C0E300000000000000000006 /* HuggingFace in Frameworks */ = {isa = PBXBuildFile; productRef = C0E300000000000000000061 /* HuggingFace */; };
+		C0E300000000000000000007 /* CohereGGUFAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E300000000000000000014 /* CohereGGUFAssets.swift */; };
+		C0E300000000000000000008 /* CrispAsrServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E300000000000000000015 /* CrispAsrServer.swift */; };
 		AA00000000000000000169 /* SpeechAnalyzerPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000160 /* SpeechAnalyzerPlugin.swift */; };
 		AA00000000000000000170 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000161 /* manifest.json */; };
 		AA00000000000000000171 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000018 /* TypeWhisperPluginSDK */; };
@@ -746,6 +753,12 @@
 		BB00000000000000000156 /* ParakeetPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ParakeetPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000157 /* ParakeetPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParakeetPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000158 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		C0E300000000000000000010 /* CohereLocalPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CohereLocalPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		C0E300000000000000000011 /* CohereLocalPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohereLocalPlugin.swift; sourceTree = "<group>"; };
+		C0E300000000000000000012 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		C0E300000000000000000013 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		C0E300000000000000000014 /* CohereGGUFAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CohereGGUFAssets.swift; sourceTree = "<group>"; };
+		C0E300000000000000000015 /* CrispAsrServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrispAsrServer.swift; sourceTree = "<group>"; };
 		BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpeechAnalyzerPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000160 /* SpeechAnalyzerPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechAnalyzerPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000161 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1115,6 +1128,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		C0E300000000000000000041 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0E300000000000000000004 /* TypeWhisperPluginSDK in Frameworks */,
+				C0E300000000000000000006 /* HuggingFace in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		FF00000000000000000071 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1437,6 +1459,7 @@
 				CC00000000000000000020 /* Qwen3Plugin */,
 				CC00000000000000000021 /* WhisperKitPlugin */,
 				CC00000000000000000022 /* ParakeetPlugin */,
+				C0E300000000000000000020 /* CohereLocalPlugin */,
 				CC00000000000000000023 /* SpeechAnalyzerPlugin */,
 				CC00000000000000000024 /* OpenAICompatiblePlugin */,
 				CC00000000000000000027 /* VoxtralPlugin */,
@@ -1878,6 +1901,19 @@
 			path = TypeWhisperPluginSDK/Plugins/ParakeetPlugin;
 			sourceTree = "<group>";
 		};
+		C0E300000000000000000020 /* CohereLocalPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				C0E300000000000000000011 /* CohereLocalPlugin.swift */,
+				C0E300000000000000000014 /* CohereGGUFAssets.swift */,
+				C0E300000000000000000015 /* CrispAsrServer.swift */,
+				C0E300000000000000000012 /* manifest.json */,
+				C0E300000000000000000013 /* Localizable.xcstrings */,
+			);
+			name = CohereLocalPlugin;
+			path = TypeWhisperPluginSDK/Plugins/CohereLocalPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000023 /* SpeechAnalyzerPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2295,6 +2331,7 @@
 				BB00000000000000000149 /* Qwen3Plugin.bundle */,
 				BB00000000000000000153 /* WhisperKitPlugin.bundle */,
 				BB00000000000000000156 /* ParakeetPlugin.bundle */,
+				C0E300000000000000000010 /* CohereLocalPlugin.bundle */,
 				BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */,
 				BB00000000000000000175 /* OpenAICompatiblePlugin.bundle */,
 				BB00000000000000000190 /* VoxtralPlugin.bundle */,
@@ -2654,6 +2691,27 @@
 			);
 			productName = ParakeetPlugin;
 			productReference = BB00000000000000000156 /* ParakeetPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
+		C0E300000000000000000030 /* CohereLocalPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = C0E300000000000000000052 /* Build configuration list for PBXNativeTarget "CohereLocalPlugin" */;
+			buildPhases = (
+				C0E300000000000000000040 /* Sources */,
+				C0E300000000000000000041 /* Frameworks */,
+				C0E300000000000000000042 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CohereLocalPlugin;
+			packageProductDependencies = (
+				C0E300000000000000000060 /* TypeWhisperPluginSDK */,
+				C0E300000000000000000061 /* HuggingFace */,
+			);
+			productName = CohereLocalPlugin;
+			productReference = C0E300000000000000000010 /* CohereLocalPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
 		DD00000000000000000012 /* SpeechAnalyzerPlugin */ = {
@@ -3405,6 +3463,7 @@
 				RR00000000000000000007 /* XCRemoteSwiftPackageReference "mediaremote-adapter" */,
 				RR00000000000000000008 /* XCRemoteSwiftPackageReference "mlx-swift-lm" */,
 				RR00000000000000000009 /* XCRemoteSwiftPackageReference "swift-transformers" */,
+				C0E300000000000000000070 /* XCRemoteSwiftPackageReference "swift-huggingface" */,
 				D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */,
 			);
 			productRefGroup = CC00000000000000000090 /* Products */;
@@ -3422,6 +3481,7 @@
 				DD00000000000000000009 /* Qwen3Plugin */,
 				DD00000000000000000010 /* WhisperKitPlugin */,
 				DD00000000000000000011 /* ParakeetPlugin */,
+				C0E300000000000000000030 /* CohereLocalPlugin */,
 				DD00000000000000000012 /* SpeechAnalyzerPlugin */,
 				DD00000000000000000013 /* OpenAICompatiblePlugin */,
 				DD00000000000000000015 /* VoxtralPlugin */,
@@ -3565,6 +3625,15 @@
 			files = (
 				AA00000000000000000166 /* manifest.json in Resources */,
 				AA00000000000000000179 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C0E300000000000000000042 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0E300000000000000000002 /* manifest.json in Resources */,
+				C0E300000000000000000003 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4234,6 +4303,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000165 /* ParakeetPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		C0E300000000000000000040 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0E300000000000000000001 /* CohereLocalPlugin.swift in Sources */,
+				C0E300000000000000000007 /* CohereGGUFAssets.swift in Sources */,
+				C0E300000000000000000008 /* CrispAsrServer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5262,6 +5341,52 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.parakeet;
 				PRODUCT_NAME = ParakeetPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		C0E300000000000000000050 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Cohere Transcribe (Local)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CohereLocalPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cohere-transcribe";
+				PRODUCT_NAME = CohereLocalPlugin;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		C0E300000000000000000051 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Cohere Transcribe (Local)";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = CohereLocalPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 0.1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.cohere-transcribe";
+				PRODUCT_NAME = CohereLocalPlugin;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
@@ -7082,6 +7207,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		C0E300000000000000000052 /* Build configuration list for PBXNativeTarget "CohereLocalPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C0E300000000000000000050 /* Debug */,
+				C0E300000000000000000051 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		FF00000000000000000073 /* Build configuration list for PBXNativeTarget "SpeechAnalyzerPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -7454,6 +7588,14 @@
 				minimumVersion = 1.1.6;
 			};
 		};
+		C0E300000000000000000070 /* XCRemoteSwiftPackageReference "swift-huggingface" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/huggingface/swift-huggingface.git";
+			requirement = {
+				kind = exactVersion;
+				version = 0.9.0;
+			};
+		};
 		D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/onnxruntime-swift-package-manager.git";
@@ -7535,6 +7677,15 @@
 			isa = XCSwiftPackageProductDependency;
 			package = RR00000000000000000002 /* XCRemoteSwiftPackageReference "FluidAudio" */;
 			productName = FluidAudio;
+		};
+		C0E300000000000000000060 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		C0E300000000000000000061 /* HuggingFace */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C0E300000000000000000070 /* XCRemoteSwiftPackageReference "swift-huggingface" */;
+			productName = HuggingFace;
 		};
 		PP00000000000000000018 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5351,6 +5351,7 @@
 		C0E300000000000000000050 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = arm64;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -5374,6 +5375,7 @@
 		C0E300000000000000000051 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = arm64;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -134,6 +134,19 @@ let package = Package(
             ]
         ),
         .target(
+            name: "CohereLocalPlugin",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                .product(name: "HuggingFace", package: "swift-huggingface"),
+            ],
+            path: "Plugins/CohereLocalPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "FillerWordsPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/FillerWordsPlugin",
@@ -412,6 +425,15 @@ let package = Package(
                 "ParakeetPlugin",
             ],
             path: "Plugins/ParakeetPlugin/Tests"
+        ),
+        .testTarget(
+            name: "CohereLocalPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "CohereLocalPlugin",
+            ],
+            path: "Plugins/CohereLocalPlugin/Tests"
         ),
         .testTarget(
             name: "SpeechAnalyzerPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -1,0 +1,306 @@
+import CryptoKit
+import Foundation
+import HuggingFace
+import TypeWhisperPluginSDK
+
+struct CohereLocalModelAssets: Sendable {
+    static let modelRepositoryId = "cstr/cohere-transcribe-03-2026-GGUF"
+    static let modelRevision = "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f"
+
+    static let vadRepositoryId = "ggml-org/whisper-vad"
+    static let vadRevision = "9ffd54a1e1ee413ddf265af9913beaf518d1639b"
+    static let vadFileName = "ggml-silero-v6.2.0.bin"
+    static let vadSize = Int64(885_098)
+    static let vadSHA256 = "2aa269b785eeb53a82983a20501ddf7c1d9c48e33ab63a41391ac6c9f7fb6987"
+
+    static let crispAsrVersion = "0.8.24"
+    static let runtimeArchiveName = "crispasr-macos.tar.gz"
+    static let runtimeArchiveSize = Int64(15_656_391)
+    static let runtimeArchiveSHA256 = "78397afd5aef2dbd6fa73f8d60800dd4d5725589fb4b04800efd2fb3ff88930c"
+    static let runtimeArchiveURL = URL(
+        string: "https://github.com/CrispStrobe/CrispASR/releases/download/v\(crispAsrVersion)/\(runtimeArchiveName)"
+    )!
+
+    static let sharedRequiredRelativePaths = [
+        "Auxiliary/\(vadFileName)",
+        "Runtime/crispasr-macos/crispasr",
+        "Runtime/crispasr-macos/libc2pa_c.dylib",
+    ]
+
+    let pluginDataDirectory: URL
+    let model: CohereLocalModelDefinition
+
+    var modelsRootDirectory: URL {
+        pluginDataDirectory.appendingPathComponent("Models", isDirectory: true)
+    }
+
+    var rootDirectory: URL {
+        modelsRootDirectory.appendingPathComponent(
+            "cohere-transcribe-03-2026-q5_0",
+            isDirectory: true
+        )
+    }
+
+    var modelFileURL: URL {
+        rootDirectory.appendingPathComponent(model.fileName)
+    }
+
+    var auxiliaryDirectory: URL {
+        rootDirectory.appendingPathComponent("Auxiliary", isDirectory: true)
+    }
+
+    var vadModelURL: URL {
+        auxiliaryDirectory.appendingPathComponent(Self.vadFileName)
+    }
+
+    var runtimeRootDirectory: URL {
+        rootDirectory.appendingPathComponent("Runtime", isDirectory: true)
+    }
+
+    var runtimeDirectory: URL {
+        runtimeRootDirectory.appendingPathComponent("crispasr-macos", isDirectory: true)
+    }
+
+    var runtimeExecutableURL: URL {
+        runtimeDirectory.appendingPathComponent("crispasr")
+    }
+
+    var runtimeLibraryURL: URL {
+        runtimeDirectory.appendingPathComponent("libc2pa_c.dylib")
+    }
+
+    var cacheDirectory: URL {
+        rootDirectory.appendingPathComponent("Cache", isDirectory: true)
+    }
+
+    var isInstalled: Bool {
+        ([model.fileName] + Self.sharedRequiredRelativePaths).allSatisfy { relativePath in
+            let url = rootDirectory.appendingPathComponent(relativePath)
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                  !isDirectory.boolValue,
+                  let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+                  let size = attributes[.size] as? NSNumber else {
+                return false
+            }
+            return size.int64Value > 0
+        }
+    }
+
+    func download(
+        bearerToken: String? = nil,
+        progressHandler: @Sendable @escaping (Double) -> Void
+    ) async throws {
+        try FileManager.default.createDirectory(
+            at: rootDirectory,
+            withIntermediateDirectories: true
+        )
+
+        let session = URLSession(configuration: .default)
+        defer { session.invalidateAndCancel() }
+        let client = HubClient(
+            session: session,
+            host: HubClient.defaultHost,
+            userAgent: "TypeWhisper-CohereLocal/0.1.0",
+            bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(bearerToken),
+            cache: nil
+        )
+
+        if !isNonEmptyFile(modelFileURL) {
+            guard let repositoryId = Repo.ID(rawValue: Self.modelRepositoryId) else {
+                throw CohereLocalPluginError.invalidRepositoryIdentifier
+            }
+            _ = try await client.downloadSnapshot(
+                of: repositoryId,
+                to: rootDirectory,
+                revision: Self.modelRevision,
+                matching: [model.fileName],
+                maxConcurrentDownloads: 1,
+                progressHandler: { @MainActor progress in
+                    progressHandler(progress.fractionCompleted * 0.98)
+                }
+            )
+        }
+        try verify(
+            modelFileURL,
+            expectedSize: model.fileSize,
+            expectedSHA256: model.sha256
+        )
+        progressHandler(0.98)
+
+        if !isNonEmptyFile(vadModelURL) {
+            guard let repositoryId = Repo.ID(rawValue: Self.vadRepositoryId) else {
+                throw CohereLocalPluginError.invalidRepositoryIdentifier
+            }
+            try FileManager.default.createDirectory(
+                at: auxiliaryDirectory,
+                withIntermediateDirectories: true
+            )
+            _ = try await client.downloadSnapshot(
+                of: repositoryId,
+                to: auxiliaryDirectory,
+                revision: Self.vadRevision,
+                matching: [Self.vadFileName],
+                maxConcurrentDownloads: 1
+            )
+        }
+        try verify(
+            vadModelURL,
+            expectedSize: Self.vadSize,
+            expectedSHA256: Self.vadSHA256
+        )
+        progressHandler(0.99)
+
+        if !isRuntimeInstalled {
+            try await downloadAndInstallRuntime(using: session)
+        }
+        progressHandler(1)
+
+        guard isInstalled else {
+            throw CohereLocalPluginError.incompleteModelDownload
+        }
+    }
+
+    func deleteModelFiles(allModels: [CohereLocalModelDefinition]) throws {
+        if FileManager.default.fileExists(atPath: modelFileURL.path) {
+            try FileManager.default.removeItem(at: modelFileURL)
+        }
+
+        let hasAnotherModel = allModels.contains { candidate in
+            candidate.id != model.id
+                && isNonEmptyFile(rootDirectory.appendingPathComponent(candidate.fileName))
+        }
+        if !hasAnotherModel, FileManager.default.fileExists(atPath: rootDirectory.path) {
+            try FileManager.default.removeItem(at: rootDirectory)
+        }
+    }
+
+    private var isRuntimeInstalled: Bool {
+        isNonEmptyFile(runtimeExecutableURL) && isNonEmptyFile(runtimeLibraryURL)
+    }
+
+    private func downloadAndInstallRuntime(using session: URLSession) async throws {
+        let (temporaryArchive, response) = try await session.download(
+            from: Self.runtimeArchiveURL
+        )
+        guard let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            throw CohereLocalPluginError.runtimeDownloadFailed
+        }
+        try verify(
+            temporaryArchive,
+            expectedSize: Self.runtimeArchiveSize,
+            expectedSHA256: Self.runtimeArchiveSHA256
+        )
+
+        try FileManager.default.createDirectory(
+            at: runtimeRootDirectory,
+            withIntermediateDirectories: true
+        )
+        let stagingDirectory = runtimeRootDirectory.appendingPathComponent(
+            ".staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: stagingDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: stagingDirectory) }
+
+        try await extractRuntimeArchive(
+            temporaryArchive,
+            to: stagingDirectory
+        )
+
+        let extractedDirectory = stagingDirectory.appendingPathComponent(
+            "crispasr-macos",
+            isDirectory: true
+        )
+        let extractedExecutable = extractedDirectory.appendingPathComponent("crispasr")
+        let extractedLibrary = extractedDirectory.appendingPathComponent("libc2pa_c.dylib")
+        guard isNonEmptyFile(extractedExecutable), isNonEmptyFile(extractedLibrary) else {
+            throw CohereLocalPluginError.invalidRuntimeArchive
+        }
+
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: extractedExecutable.path
+        )
+        if FileManager.default.fileExists(atPath: runtimeDirectory.path) {
+            try FileManager.default.removeItem(at: runtimeDirectory)
+        }
+        try FileManager.default.moveItem(
+            at: extractedDirectory,
+            to: runtimeDirectory
+        )
+    }
+
+    private func extractRuntimeArchive(_ archive: URL, to destination: URL) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.global(qos: .utility).async {
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/tar")
+                process.arguments = [
+                    "-xzf",
+                    archive.path,
+                    "-C",
+                    destination.path,
+                ]
+                process.standardOutput = FileHandle.nullDevice
+                let errorPipe = Pipe()
+                process.standardError = errorPipe
+
+                do {
+                    try process.run()
+                    process.waitUntilExit()
+                    guard process.terminationStatus == 0 else {
+                        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
+                        let message = String(data: errorData, encoding: .utf8)
+                            ?? "Unknown tar error"
+                        continuation.resume(
+                            throwing: CohereLocalPluginError.runtimeExtractionFailed(message)
+                        )
+                        return
+                    }
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func verify(
+        _ file: URL,
+        expectedSize: Int64,
+        expectedSHA256: String
+    ) throws {
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        guard let size = attributes[.size] as? NSNumber,
+              size.int64Value == expectedSize else {
+            throw CohereLocalPluginError.assetVerificationFailed(file.lastPathComponent)
+        }
+        guard try sha256(of: file) == expectedSHA256 else {
+            throw CohereLocalPluginError.assetVerificationFailed(file.lastPathComponent)
+        }
+    }
+
+    private func sha256(of file: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+
+        var hasher = SHA256()
+        while let data = try handle.read(upToCount: 1_048_576), !data.isEmpty {
+            hasher.update(data: data)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func isNonEmptyFile(_ url: URL) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let size = attributes[.size] as? NSNumber else {
+            return false
+        }
+        return size.int64Value > 0
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -26,6 +26,8 @@ struct CohereLocalModelAssets: Sendable {
         "Runtime/crispasr-macos/crispasr",
         "Runtime/crispasr-macos/libc2pa_c.dylib",
     ]
+    static let sharedDirectoryName = "cohere-transcribe-03-2026"
+    static let legacySharedDirectoryName = "cohere-transcribe-03-2026-q5_0"
 
     let pluginDataDirectory: URL
     let model: CohereLocalModelDefinition
@@ -36,7 +38,14 @@ struct CohereLocalModelAssets: Sendable {
 
     var rootDirectory: URL {
         modelsRootDirectory.appendingPathComponent(
-            "cohere-transcribe-03-2026-q5_0",
+            Self.sharedDirectoryName,
+            isDirectory: true
+        )
+    }
+
+    var legacyRootDirectory: URL {
+        modelsRootDirectory.appendingPathComponent(
+            Self.legacySharedDirectoryName,
             isDirectory: true
         )
     }
@@ -74,7 +83,8 @@ struct CohereLocalModelAssets: Sendable {
     }
 
     var isInstalled: Bool {
-        ([model.fileName] + Self.sharedRequiredRelativePaths).allSatisfy { relativePath in
+        migrateLegacyRootIfNeeded()
+        return ([model.fileName] + Self.sharedRequiredRelativePaths).allSatisfy { relativePath in
             let url = rootDirectory.appendingPathComponent(relativePath)
             var isDirectory: ObjCBool = false
             guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory),
@@ -91,6 +101,7 @@ struct CohereLocalModelAssets: Sendable {
         bearerToken: String? = nil,
         progressHandler: @Sendable @escaping (Double) -> Void
     ) async throws {
+        migrateLegacyRootIfNeeded()
         try FileManager.default.createDirectory(
             at: rootDirectory,
             withIntermediateDirectories: true
@@ -121,7 +132,7 @@ struct CohereLocalModelAssets: Sendable {
                 }
             )
         }
-        try verify(
+        try verifyOrDiscard(
             modelFileURL,
             expectedSize: model.fileSize,
             expectedSHA256: model.sha256
@@ -144,7 +155,7 @@ struct CohereLocalModelAssets: Sendable {
                 maxConcurrentDownloads: 1
             )
         }
-        try verify(
+        try verifyOrDiscard(
             vadModelURL,
             expectedSize: Self.vadSize,
             expectedSHA256: Self.vadSHA256
@@ -162,6 +173,7 @@ struct CohereLocalModelAssets: Sendable {
     }
 
     func deleteModelFiles(allModels: [CohereLocalModelDefinition]) throws {
+        migrateLegacyRootIfNeeded()
         if FileManager.default.fileExists(atPath: modelFileURL.path) {
             try FileManager.default.removeItem(at: modelFileURL)
         }
@@ -187,16 +199,23 @@ struct CohereLocalModelAssets: Sendable {
               httpResponse.statusCode == 200 else {
             throw CohereLocalPluginError.runtimeDownloadFailed
         }
-        try verify(
-            temporaryArchive,
-            expectedSize: Self.runtimeArchiveSize,
-            expectedSHA256: Self.runtimeArchiveSHA256
-        )
 
         try FileManager.default.createDirectory(
             at: runtimeRootDirectory,
             withIntermediateDirectories: true
         )
+        let ownedArchive = runtimeRootDirectory.appendingPathComponent(
+            ".download-\(UUID().uuidString)-\(Self.runtimeArchiveName)"
+        )
+        try FileManager.default.moveItem(at: temporaryArchive, to: ownedArchive)
+        defer { try? FileManager.default.removeItem(at: ownedArchive) }
+
+        try verify(
+            ownedArchive,
+            expectedSize: Self.runtimeArchiveSize,
+            expectedSHA256: Self.runtimeArchiveSHA256
+        )
+
         let stagingDirectory = runtimeRootDirectory.appendingPathComponent(
             ".staging-\(UUID().uuidString)",
             isDirectory: true
@@ -208,7 +227,7 @@ struct CohereLocalModelAssets: Sendable {
         defer { try? FileManager.default.removeItem(at: stagingDirectory) }
 
         try await extractRuntimeArchive(
-            temporaryArchive,
+            ownedArchive,
             to: stagingDirectory
         )
 
@@ -252,9 +271,9 @@ struct CohereLocalModelAssets: Sendable {
 
                 do {
                     try process.run()
+                    let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
                     process.waitUntilExit()
                     guard process.terminationStatus == 0 else {
-                        let errorData = errorPipe.fileHandleForReading.readDataToEndOfFile()
                         let message = String(data: errorData, encoding: .utf8)
                             ?? "Unknown tar error"
                         continuation.resume(
@@ -267,6 +286,23 @@ struct CohereLocalModelAssets: Sendable {
                     continuation.resume(throwing: error)
                 }
             }
+        }
+    }
+
+    private func verifyOrDiscard(
+        _ file: URL,
+        expectedSize: Int64,
+        expectedSHA256: String
+    ) throws {
+        do {
+            try verify(
+                file,
+                expectedSize: expectedSize,
+                expectedSHA256: expectedSHA256
+            )
+        } catch {
+            try? FileManager.default.removeItem(at: file)
+            throw error
         }
     }
 
@@ -302,5 +338,20 @@ struct CohereLocalModelAssets: Sendable {
             return false
         }
         return size.int64Value > 0
+    }
+
+    private func migrateLegacyRootIfNeeded() {
+        guard !FileManager.default.fileExists(atPath: rootDirectory.path),
+              FileManager.default.fileExists(atPath: legacyRootDirectory.path) else {
+            return
+        }
+        try? FileManager.default.createDirectory(
+            at: modelsRootDirectory,
+            withIntermediateDirectories: true
+        )
+        try? FileManager.default.moveItem(
+            at: legacyRootDirectory,
+            to: rootDirectory
+        )
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -70,6 +70,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
         var selectedModelId: String?
         var loadedModelId: String?
         var runtime: Runtime?
+        var startingServer: CrispAsrServer?
         var modelState: CohereLocalModelState = .notLoaded
         var loadGeneration = 0
         var huggingFaceToken: String?
@@ -110,17 +111,20 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     }
 
     func deactivate() {
-        let runtime = state.withLock { state -> Runtime? in
+        let servers = state.withLock { state -> (Runtime?, CrispAsrServer?) in
             let runtime = state.runtime
+            let startingServer = state.startingServer
             state.loadGeneration += 1
             state.host = nil
             state.loadedModelId = nil
             state.runtime = nil
+            state.startingServer = nil
             state.modelState = .notLoaded
             state.huggingFaceToken = nil
-            return runtime
+            return (runtime, startingServer)
         }
-        runtime?.server.stop()
+        servers.0?.server.stop()
+        servers.1?.stop()
     }
 
     // MARK: - TranscriptionEnginePlugin
@@ -175,20 +179,27 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             state -> (
                 host: (any HostServices)?,
                 runtime: Runtime?,
+                startingServer: CrispAsrServer?,
                 shouldRestore: Bool,
                 shouldClearLoadedPersistence: Bool
             ) in
             let shouldClearLoadedPersistence = state.loadedModelId != modelId
-            let runtime = state.loadedModelId == modelId ? nil : state.runtime
-            if runtime != nil {
+            let shouldInvalidateLoad =
+                state.selectedModelId != modelId
+                || (state.loadedModelId != nil && state.loadedModelId != modelId)
+            let runtime = shouldInvalidateLoad ? state.runtime : nil
+            let startingServer = shouldInvalidateLoad ? state.startingServer : nil
+            if shouldInvalidateLoad {
                 state.loadGeneration += 1
                 state.runtime = nil
+                state.startingServer = nil
                 state.loadedModelId = nil
                 state.modelState = .notLoaded
             }
             state.selectedModelId = modelId
             let shouldRestore =
                 state.runtime == nil
+                && state.startingServer == nil
                 && state.host.map {
                     CohereLocalModelAssets(
                         pluginDataDirectory: $0.pluginDataDirectory,
@@ -198,12 +209,14 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             return (
                 state.host,
                 runtime,
+                startingServer,
                 shouldRestore,
                 shouldClearLoadedPersistence
             )
         }
 
         context.runtime?.server.stop()
+        context.startingServer?.stop()
         context.host?.setUserDefault(modelId, forKey: "selectedModel")
         if context.shouldClearLoadedPersistence {
             context.host?.setUserDefault(nil, forKey: "loadedModel")
@@ -287,6 +300,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             pluginDataDirectory: context.host.pluginDataDirectory,
             model: context.model
         )
+        var pendingServer: CrispAsrServer?
 
         do {
             if !assets.isInstalled {
@@ -304,33 +318,56 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             try Task.checkCancellation()
             guard transitionToPreparing(generation: context.generation) else { return }
 
+            let server = CrispAsrServer()
+            pendingServer = server
+            let didRegisterServer = state.withLock { state -> Bool in
+                guard state.loadGeneration == context.generation else { return false }
+                state.startingServer = server
+                return true
+            }
+            guard didRegisterServer else { return }
+
             let runtime = try await PluginLocalInferenceGate.shared.withLock {
                 try Task.checkCancellation()
-                let server = CrispAsrServer()
+                let isCurrent = state.withLock {
+                    $0.loadGeneration == context.generation
+                        && $0.startingServer === server
+                }
+                guard isCurrent else { throw CancellationError() }
                 try await server.start(assets: assets)
                 return Runtime(server: server)
             }
 
             let didInstall = state.withLock { state -> Bool in
-                guard state.loadGeneration == context.generation else { return false }
+                guard state.loadGeneration == context.generation,
+                      state.startingServer === server else {
+                    return false
+                }
+                state.startingServer = nil
                 state.runtime = runtime
                 state.loadedModelId = context.model.id
                 state.selectedModelId = context.model.id
                 state.modelState = .ready
                 return true
             }
-            guard didInstall else { return }
+            guard didInstall else {
+                server.stop()
+                return
+            }
+            pendingServer = nil
 
             context.host.setUserDefault(context.model.id, forKey: "selectedModel")
             context.host.setUserDefault(context.model.id, forKey: "loadedModel")
             context.host.notifyCapabilitiesChanged()
         } catch is CancellationError {
+            pendingServer?.stop()
             finishModelLoad(
                 generation: context.generation,
                 state: .notLoaded,
                 host: context.host
             )
         } catch {
+            pendingServer?.stop()
             finishModelLoad(
                 generation: context.generation,
                 state: .error(error.localizedDescription),
@@ -353,15 +390,23 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     }
 
     func unloadModel(clearPersistence: Bool = true) {
-        let context = state.withLock { state -> (host: (any HostServices)?, runtime: Runtime?) in
+        let context = state.withLock {
+            state -> (
+                host: (any HostServices)?,
+                runtime: Runtime?,
+                startingServer: CrispAsrServer?
+            ) in
             let runtime = state.runtime
+            let startingServer = state.startingServer
             state.loadGeneration += 1
             state.runtime = nil
+            state.startingServer = nil
             state.loadedModelId = nil
             state.modelState = .notLoaded
-            return (state.host, runtime)
+            return (state.host, runtime, startingServer)
         }
         context.runtime?.server.stop()
+        context.startingServer?.stop()
         if clearPersistence {
             context.host?.setUserDefault(nil, forKey: "loadedModel")
         }
@@ -474,6 +519,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
         let didFinish = state.withLock { state -> Bool in
             guard state.loadGeneration == generation else { return false }
             state.runtime = nil
+            state.startingServer = nil
             state.loadedModelId = nil
             state.modelState = newState
             return true

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -1,0 +1,1104 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+import os
+
+// MARK: - Plugin Entry Point
+
+@objc(CohereLocalPlugin)
+final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, PluginSettingsWindowLayoutProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.cohere-transcribe"
+    static let pluginName = "Cohere Transcribe (Local)"
+    static let providerIdentifier = "cohere-transcribe"
+
+    static let compactModel = CohereLocalModelDefinition(
+        id: "cohere-transcribe-03-2026-q4_k",
+        displayName: "Compact (Q4_K · Metal)",
+        sizeDescription: "1.51 GB",
+        ramRequirement: "8 GB+ Mac",
+        detail: "Smallest download and memory footprint",
+        fileName: "cohere-transcribe-q4_k.gguf",
+        fileSize: 1_510_362_752,
+        sha256: "2931fc0ac6d6708eef5389aadf1ebd5eec7b8e764bac385be585e910c0e7b410"
+    )
+
+    static let fastModel = CohereLocalModelDefinition(
+        id: "cohere-transcribe-03-2026-q5_0",
+        displayName: "Fast (Q5_0 · Recommended)",
+        sizeDescription: "1.74 GB",
+        ramRequirement: "8 GB+ Mac",
+        detail: "Best tested balance of size, speed, and accuracy",
+        fileName: "cohere-transcribe-q5_0.gguf",
+        fileSize: 1_738_722_944,
+        sha256: "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e"
+    )
+
+    static let q6Model = CohereLocalModelDefinition(
+        id: "cohere-transcribe-03-2026-q6_k",
+        displayName: "Higher precision (Q6_K · Metal)",
+        sizeDescription: "1.98 GB",
+        ramRequirement: "8 GB+ Mac",
+        detail: "Intermediate quantization between recommended Q5_0 and Q8_0",
+        fileName: "cohere-transcribe-q6_k.gguf",
+        fileSize: 1_981_355_648,
+        sha256: "0ad2634e0ba34efa38a47d4fd4cf34d7a2d738d8486d83b8d5a178f823109c52"
+    )
+
+    static let q8Model = CohereLocalModelDefinition(
+        id: "cohere-transcribe-03-2026-q8_0",
+        displayName: "Maximum precision (Q8_0 · Experimental)",
+        sizeDescription: "2.42 GB",
+        ramRequirement: "16 GB+ recommended",
+        detail: "Largest quantization; no overall accuracy gain measured yet",
+        fileName: "cohere-transcribe-q8_0.gguf",
+        fileSize: 2_423_803_520,
+        sha256: "c8620cb182a7c04e311e6c24e478b94f7ecd7f1b5230bf39fffa8daf94644f51"
+    )
+    static let models = [compactModel, fastModel, q6Model, q8Model]
+
+    static let supportedLanguageCodes = [
+        "en", "fr", "de", "es", "it", "pt", "nl",
+        "pl", "el", "ar", "ja", "zh", "vi", "ko",
+    ]
+
+    private struct Runtime: Sendable {
+        let server: CrispAsrServer
+    }
+
+    private struct State {
+        var host: (any HostServices)?
+        var selectedModelId: String?
+        var loadedModelId: String?
+        var runtime: Runtime?
+        var modelState: CohereLocalModelState = .notLoaded
+        var loadGeneration = 0
+        var huggingFaceToken: String?
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: any HostServices) {
+        let persistedSelection = host.userDefault(forKey: "selectedModel") as? String
+        let persistedLoadedModel = host.userDefault(forKey: "loadedModel") as? String
+        let selectedModelId =
+            Self.model(for: persistedSelection) != nil
+            ? persistedSelection
+            : Self.model(for: persistedLoadedModel)?.id ?? Self.fastModel.id
+        let shouldRestore =
+            host.shouldRestoreLoadedModelsPassively
+            && Self.model(for: persistedLoadedModel) != nil
+        let huggingFaceToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
+
+        state.withLock { state in
+            state.host = host
+            state.selectedModelId = selectedModelId
+            state.huggingFaceToken = huggingFaceToken
+        }
+
+        if persistedSelection != selectedModelId {
+            host.setUserDefault(selectedModelId, forKey: "selectedModel")
+        }
+        if shouldRestore {
+            Task { [weak self] in
+                await self?.restoreLoadedModel(allowDownloads: false)
+            }
+        }
+    }
+
+    func deactivate() {
+        let runtime = state.withLock { state -> Runtime? in
+            let runtime = state.runtime
+            state.loadGeneration += 1
+            state.host = nil
+            state.loadedModelId = nil
+            state.runtime = nil
+            state.modelState = .notLoaded
+            state.huggingFaceToken = nil
+            return runtime
+        }
+        runtime?.server.stop()
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { Self.providerIdentifier }
+    var providerDisplayName: String { Self.pluginName }
+
+    var isConfigured: Bool {
+        state.withLock {
+            $0.runtime?.server.isRunning == true
+                && $0.loadedModelId != nil
+        }
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        availableModels
+    }
+
+    var availableModels: [PluginModelInfo] {
+        let snapshot = state.withLock { state in
+            (host: state.host, loadedModelId: state.loadedModelId)
+        }
+        return Self.models.map { model in
+            let isDownloaded = snapshot.host.map {
+                CohereLocalModelAssets(
+                    pluginDataDirectory: $0.pluginDataDirectory,
+                    model: model
+                ).isInstalled
+            } ?? false
+            return PluginModelInfo(
+                id: model.id,
+                displayName: model.displayName,
+                sizeDescription: model.sizeDescription,
+                languageCount: Self.supportedLanguageCodes.count,
+                downloaded: isDownloaded,
+                loaded: snapshot.loadedModelId == model.id
+            )
+        }
+    }
+
+    var downloadedModels: [PluginModelInfo] {
+        availableModels.filter { $0.downloaded == true }
+    }
+
+    var selectedModelId: String? {
+        state.withLock { $0.selectedModelId }
+    }
+
+    func selectModel(_ modelId: String) {
+        guard let model = Self.model(for: modelId) else { return }
+        let context = state.withLock {
+            state -> (
+                host: (any HostServices)?,
+                runtime: Runtime?,
+                shouldRestore: Bool,
+                shouldClearLoadedPersistence: Bool
+            ) in
+            let shouldClearLoadedPersistence = state.loadedModelId != modelId
+            let runtime = state.loadedModelId == modelId ? nil : state.runtime
+            if runtime != nil {
+                state.loadGeneration += 1
+                state.runtime = nil
+                state.loadedModelId = nil
+                state.modelState = .notLoaded
+            }
+            state.selectedModelId = modelId
+            let shouldRestore =
+                state.runtime == nil
+                && state.host.map {
+                    CohereLocalModelAssets(
+                        pluginDataDirectory: $0.pluginDataDirectory,
+                        model: model
+                    ).isInstalled
+                } == true
+            return (
+                state.host,
+                runtime,
+                shouldRestore,
+                shouldClearLoadedPersistence
+            )
+        }
+
+        context.runtime?.server.stop()
+        context.host?.setUserDefault(modelId, forKey: "selectedModel")
+        if context.shouldClearLoadedPersistence {
+            context.host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+        context.host?.notifyCapabilitiesChanged()
+        if context.shouldRestore {
+            Task { [weak self] in
+                await self?.loadModel(allowDownloads: false)
+            }
+        }
+    }
+
+    var supportsTranslation: Bool { false }
+    var supportsStreaming: Bool { false }
+    var supportedLanguages: [String] { Self.supportedLanguageCodes }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt _: String?
+    ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: nil,
+            onProgress: { _ in true }
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt _: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        if translate {
+            throw CohereLocalPluginError.translationUnsupported
+        }
+        guard let cohereLanguage = Self.cohereLanguage(for: language) else {
+            throw CohereLocalPluginError.explicitLanguageRequired(
+                supportedLanguages: Self.supportedLanguageCodes
+            )
+        }
+        guard let runtime = state.withLock({ $0.runtime }) else {
+            throw CohereLocalPluginError.modelNotLoaded
+        }
+
+        guard !audio.samples.isEmpty, !Self.isDigitalSilence(audio.samples) else {
+            return PluginTranscriptionResult(
+                text: "",
+                detectedLanguage: cohereLanguage
+            )
+        }
+
+        return try await PluginLocalInferenceGate.shared.withLock {
+            try Task.checkCancellation()
+            let _ = onProgress("Running Cohere locally with Metal…")
+            let result = try await runtime.server.transcribe(
+                audio: audio,
+                language: cohereLanguage
+            )
+            let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let _ = onProgress(text)
+            return PluginTranscriptionResult(
+                text: text,
+                detectedLanguage: result.detectedLanguage ?? cohereLanguage,
+                segments: result.segments
+            )
+        }
+    }
+
+    // MARK: - Model Management
+
+    func loadModel(allowDownloads: Bool = true) async {
+        guard let context = beginModelLoad() else { return }
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: context.host.pluginDataDirectory,
+            model: context.model
+        )
+
+        do {
+            if !assets.isInstalled {
+                guard allowDownloads else {
+                    throw CohereLocalPluginError.modelNotDownloaded
+                }
+                try await assets.download(bearerToken: context.huggingFaceToken) { [weak self] fraction in
+                    self?.updateDownloadProgress(
+                        fraction,
+                        generation: context.generation
+                    )
+                }
+            }
+
+            try Task.checkCancellation()
+            guard transitionToPreparing(generation: context.generation) else { return }
+
+            let runtime = try await PluginLocalInferenceGate.shared.withLock {
+                try Task.checkCancellation()
+                let server = CrispAsrServer()
+                try await server.start(assets: assets)
+                return Runtime(server: server)
+            }
+
+            let didInstall = state.withLock { state -> Bool in
+                guard state.loadGeneration == context.generation else { return false }
+                state.runtime = runtime
+                state.loadedModelId = context.model.id
+                state.selectedModelId = context.model.id
+                state.modelState = .ready
+                return true
+            }
+            guard didInstall else { return }
+
+            context.host.setUserDefault(context.model.id, forKey: "selectedModel")
+            context.host.setUserDefault(context.model.id, forKey: "loadedModel")
+            context.host.notifyCapabilitiesChanged()
+        } catch is CancellationError {
+            finishModelLoad(
+                generation: context.generation,
+                state: .notLoaded,
+                host: context.host
+            )
+        } catch {
+            finishModelLoad(
+                generation: context.generation,
+                state: .error(error.localizedDescription),
+                host: context.host
+            )
+        }
+    }
+
+    func restoreLoadedModel(allowDownloads: Bool = false) async {
+        let context = state.withLock { state in
+            let loadedModelId = state.host?.userDefault(forKey: "loadedModel") as? String
+            return (
+                host: state.host,
+                loadedModelId: Self.model(for: loadedModelId)?.id
+            )
+        }
+        guard context.host != nil, let loadedModelId = context.loadedModelId else { return }
+        state.withLock { $0.selectedModelId = loadedModelId }
+        await loadModel(allowDownloads: allowDownloads)
+    }
+
+    func unloadModel(clearPersistence: Bool = true) {
+        let context = state.withLock { state -> (host: (any HostServices)?, runtime: Runtime?) in
+            let runtime = state.runtime
+            state.loadGeneration += 1
+            state.runtime = nil
+            state.loadedModelId = nil
+            state.modelState = .notLoaded
+            return (state.host, runtime)
+        }
+        context.runtime?.server.stop()
+        if clearPersistence {
+            context.host?.setUserDefault(nil, forKey: "loadedModel")
+        }
+        context.host?.notifyCapabilitiesChanged()
+    }
+
+    func deleteDownloadedModel(_ modelId: String) async throws {
+        guard let model = Self.model(for: modelId) else { return }
+        let host = state.withLock { $0.host }
+        guard let host else { return }
+
+        if state.withLock({ $0.loadedModelId == modelId }) {
+            unloadModel(clearPersistence: true)
+        }
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: model
+        )
+        try assets.deleteModelFiles(allModels: Self.models)
+        let fallbackModel = Self.models.first { candidate in
+            CohereLocalModelAssets(
+                pluginDataDirectory: host.pluginDataDirectory,
+                model: candidate
+            ).isInstalled
+        } ?? Self.fastModel
+
+        state.withLock { state in
+            if state.selectedModelId == modelId {
+                state.selectedModelId = fallbackModel.id
+                state.modelState = .notLoaded
+            }
+        }
+        if selectedModelId == fallbackModel.id {
+            host.setUserDefault(fallbackModel.id, forKey: "selectedModel")
+        }
+        host.notifyCapabilitiesChanged()
+    }
+
+    @objc func triggerAutoUnload() {
+        unloadModel(clearPersistence: false)
+    }
+
+    @objc func triggerRestoreModel() {
+        Task { [weak self] in
+            await self?.restoreLoadedModel(allowDownloads: false)
+        }
+    }
+
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        guard modelId == nil || modelId.map(String.init).flatMap(Self.model(for:)) != nil else {
+            return
+        }
+        if let modelId = modelId.map(String.init) {
+            state.withLock { $0.selectedModelId = modelId }
+        }
+        triggerRestoreModel()
+    }
+
+    private func beginModelLoad() -> (
+        host: any HostServices,
+        model: CohereLocalModelDefinition,
+        generation: Int,
+        huggingFaceToken: String?
+    )? {
+        state.withLock { state in
+            guard let host = state.host else { return nil }
+            guard let model = Self.model(for: state.selectedModelId) else { return nil }
+            guard state.runtime == nil else {
+                state.modelState = .ready
+                return nil
+            }
+            switch state.modelState {
+            case .downloading, .preparing:
+                return nil
+            case .notLoaded, .ready, .error:
+                break
+            }
+
+            state.loadGeneration += 1
+            let assets = CohereLocalModelAssets(
+                pluginDataDirectory: host.pluginDataDirectory,
+                model: model
+            )
+            state.modelState = assets.isInstalled ? .preparing : .downloading(progress: 0)
+            return (host, model, state.loadGeneration, state.huggingFaceToken)
+        }
+    }
+
+    private func updateDownloadProgress(_ fraction: Double, generation: Int) {
+        state.withLock { state in
+            guard state.loadGeneration == generation else { return }
+            state.modelState = .downloading(progress: min(max(fraction, 0), 1))
+        }
+    }
+
+    private func transitionToPreparing(generation: Int) -> Bool {
+        state.withLock { state in
+            guard state.loadGeneration == generation else { return false }
+            state.modelState = .preparing
+            return true
+        }
+    }
+
+    private func finishModelLoad(
+        generation: Int,
+        state newState: CohereLocalModelState,
+        host: any HostServices
+    ) {
+        let didFinish = state.withLock { state -> Bool in
+            guard state.loadGeneration == generation else { return false }
+            state.runtime = nil
+            state.loadedModelId = nil
+            state.modelState = newState
+            return true
+        }
+        if didFinish {
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    // MARK: - Settings
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .downloading(let progress):
+            return PluginSettingsActivity(
+                message: "Downloading Cohere model",
+                progress: progress
+            )
+        case .preparing:
+            return PluginSettingsActivity(message: "Starting and warming up Cohere with Metal")
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
+
+    var modelState: CohereLocalModelState {
+        state.withLock { $0.modelState }
+    }
+
+    var huggingFaceToken: String? {
+        state.withLock { $0.huggingFaceToken }
+    }
+
+    func setHuggingFaceToken(_ token: String) {
+        let host = state.withLock { $0.host }
+        let savedToken = PluginHuggingFaceTokenHelper.saveToken(token, to: host)
+        state.withLock { $0.huggingFaceToken = savedToken }
+    }
+
+    func clearHuggingFaceToken() {
+        let host = state.withLock { $0.host }
+        PluginHuggingFaceTokenHelper.clearToken(from: host)
+        state.withLock { $0.huggingFaceToken = nil }
+    }
+
+    func validateHuggingFaceToken(
+        _ token: String,
+        dataFetcher: @escaping @Sendable (URLRequest) async throws -> (Data, URLResponse)
+            = PluginHTTPClient.data
+    ) async -> Bool {
+        await PluginHuggingFaceTokenHelper.validateToken(
+            token,
+            dataFetcher: dataFetcher
+        )
+    }
+
+    var isModelDownloaded: Bool {
+        state.withLock { state in
+            guard let model = Self.model(for: state.selectedModelId) else { return false }
+            return state.host.map {
+                CohereLocalModelAssets(
+                    pluginDataDirectory: $0.pluginDataDirectory,
+                    model: model
+                ).isInstalled
+            } ?? false
+        }
+    }
+
+    var selectedModelDefinition: CohereLocalModelDefinition {
+        state.withLock { Self.model(for: $0.selectedModelId) ?? Self.fastModel }
+    }
+
+    var canDismissSettingsAfterSetup: Bool {
+        if case .ready = modelState {
+            return true
+        }
+        return false
+    }
+
+    var settingsViewManagesScrolling: Bool { true }
+    var preferredSettingsWindowSize: CGSize? { CGSize(width: 620, height: 650) }
+    var minimumSettingsWindowSize: CGSize? { CGSize(width: 520, height: 560) }
+
+    @MainActor
+    var settingsView: AnyView? {
+        AnyView(CohereLocalSettingsView(plugin: self))
+    }
+
+    // MARK: - Language and VAD Helpers
+
+    static func normalizedLanguageCode(for language: String?) -> String? {
+        guard let language else { return nil }
+        let normalized = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+        guard !normalized.isEmpty, normalized != "auto", normalized != "und" else {
+            return nil
+        }
+
+        let baseCode = normalized.split(separator: "-", omittingEmptySubsequences: true)
+            .first
+            .map(String.init)
+        let canonicalCode = baseCode == "cmn" ? "zh" : baseCode
+        guard let canonicalCode, supportedLanguageCodes.contains(canonicalCode) else {
+            return nil
+        }
+        return canonicalCode
+    }
+
+    static func cohereLanguage(for language: String?) -> String? {
+        normalizedLanguageCode(for: language)
+    }
+
+    static func model(for id: String?) -> CohereLocalModelDefinition? {
+        models.first { $0.id == id }
+    }
+
+    static func isDigitalSilence(_ samples: [Float]) -> Bool {
+        samples.allSatisfy { abs($0) <= 0.000_001 }
+    }
+
+}
+
+// MARK: - Model Assets
+
+struct CohereLocalModelDefinition: Sendable, Equatable {
+    let id: String
+    let displayName: String
+    let sizeDescription: String
+    let ramRequirement: String
+    let detail: String
+    let fileName: String
+    let fileSize: Int64
+    let sha256: String
+}
+
+enum CohereLocalModelState: Sendable, Equatable {
+    case notLoaded
+    case downloading(progress: Double)
+    case preparing
+    case ready
+    case error(String)
+}
+
+enum CohereLocalPluginError: LocalizedError, Sendable {
+    case explicitLanguageRequired(supportedLanguages: [String])
+    case translationUnsupported
+    case modelNotDownloaded
+    case modelNotLoaded
+    case invalidRepositoryIdentifier
+    case incompleteModelDownload
+    case runtimeDownloadFailed
+    case invalidRuntimeArchive
+    case runtimeExtractionFailed(String)
+    case assetVerificationFailed(String)
+    case invalidLocalServerURL
+    case localPortReservationFailed
+    case runtimeExited(String)
+    case runtimeStartupTimedOut(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .explicitLanguageRequired(let supportedLanguages):
+            return "Cohere Transcribe requires an explicit supported language: \(supportedLanguages.joined(separator: ", ")). Automatic language detection is not available."
+        case .translationUnsupported:
+            return "Cohere Transcribe does not support translation."
+        case .modelNotDownloaded:
+            return "The Cohere Transcribe model is not downloaded."
+        case .modelNotLoaded:
+            return "The Cohere Transcribe model is not loaded. Open the plugin settings and load it first."
+        case .invalidRepositoryIdentifier:
+            return "The pinned Cohere model repository identifier is invalid."
+        case .incompleteModelDownload:
+            return "The Cohere model download completed without all required model files."
+        case .runtimeDownloadFailed:
+            return "The CrispASR runtime download failed."
+        case .invalidRuntimeArchive:
+            return "The verified CrispASR runtime archive is incomplete."
+        case .runtimeExtractionFailed(let message):
+            return "The CrispASR runtime could not be extracted: \(message)"
+        case .assetVerificationFailed(let fileName):
+            return "Cohere asset verification failed for \(fileName)."
+        case .invalidLocalServerURL:
+            return "The local CrispASR server URL is invalid."
+        case .localPortReservationFailed:
+            return "TypeWhisper could not reserve a local port for Cohere Transcribe."
+        case .runtimeExited(let output):
+            return "CrispASR exited while starting.\(output.isEmpty ? "" : "\n\(output)")"
+        case .runtimeStartupTimedOut(let output):
+            return "CrispASR did not become ready within five minutes.\(output.isEmpty ? "" : "\n\(output)")"
+        }
+    }
+}
+
+// MARK: - Settings View
+
+@MainActor
+private struct CohereLocalSettingsView: View {
+    let plugin: CohereLocalPlugin
+
+    private let bundle = Bundle(for: CohereLocalPlugin.self)
+    private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
+    private let cohereModelURL = URL(
+        string: "https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF"
+    )!
+    private let crispAsrURL = URL(
+        string: "https://github.com/CrispStrobe/CrispASR/tree/v0.8.24"
+    )!
+    private let vadModelURL = URL(
+        string: "https://huggingface.co/ggml-org/whisper-vad"
+    )!
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.pluginSettingsClose) private var closeSettings
+    @State private var modelState: CohereLocalModelState = .notLoaded
+    @State private var selectedModelId = CohereLocalPlugin.fastModel.id
+    @State private var isDownloaded = false
+    @State private var showDeleteConfirmation = false
+    @State private var huggingFaceTokenInput = ""
+    @State private var showHuggingFaceToken = false
+    @State private var isValidatingHuggingFaceToken = false
+    @State private var huggingFaceTokenValidationResult: Bool?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    header
+                    huggingFaceTokenSection
+                    modelCard
+                    capabilityNotes
+                }
+                .padding(24)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(String(localized: "Done", bundle: bundle)) {
+                    if let closeSettings {
+                        closeSettings()
+                    } else {
+                        dismiss()
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(16)
+        }
+        .onAppear {
+            refresh()
+            huggingFaceTokenInput = plugin.huggingFaceToken ?? ""
+        }
+        .onReceive(pollTimer) { _ in refresh() }
+        .onChange(of: huggingFaceTokenInput) { _, newValue in
+            let normalized = PluginHuggingFaceTokenHelper.normalizedToken(newValue)
+            if normalized != plugin.huggingFaceToken {
+                huggingFaceTokenValidationResult = nil
+            }
+        }
+        .alert(
+            String(localized: "Remove downloaded model?", bundle: bundle),
+            isPresented: $showDeleteConfirmation
+        ) {
+            Button(String(localized: "Cancel", bundle: bundle), role: .cancel) {}
+            Button(String(localized: "Remove Model", bundle: bundle), role: .destructive) {
+                Task {
+                    try? await plugin.deleteDownloadedModel(selectedModelId)
+                    refresh()
+                }
+            }
+        } message: {
+            Text(
+                "This removes the selected Cohere model. Shared runtime files remain while another variant is installed.",
+                bundle: bundle
+            )
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: "waveform.badge.mic")
+                    .font(.title2)
+                    .foregroundStyle(.tint)
+                Text("Cohere Transcribe (Local)", bundle: bundle)
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                Spacer()
+                Text("LOCAL · BATCH", bundle: bundle)
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(.quaternary, in: Capsule())
+            }
+
+            Text(
+                "A private on-device GGUF and Metal provider for Cohere Transcribe 03-2026. Audio stays on this Mac.",
+                bundle: bundle
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    private var modelCard: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 14) {
+                Picker(
+                    String(localized: "Model", bundle: bundle),
+                    selection: $selectedModelId
+                ) {
+                    ForEach(CohereLocalPlugin.models, id: \.id) { model in
+                        Text(model.displayName).tag(model.id)
+                    }
+                }
+                .onChange(of: selectedModelId) { _, newValue in
+                    guard newValue != plugin.selectedModelId else { return }
+                    plugin.selectModel(newValue)
+                    refresh()
+                }
+
+                HStack(alignment: .top) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(selectedModel.displayName)
+                            .font(.headline)
+                        Text(
+                            "\(selectedModel.sizeDescription) · \(selectedModel.ramRequirement)"
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        Text(selectedModel.detail)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    statusLabel
+                }
+
+                if case .downloading(let progress) = modelState {
+                    VStack(alignment: .leading, spacing: 5) {
+                        ProgressView(value: progress)
+                        Text("\(Int(progress * 100))%")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                } else if case .preparing = modelState {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(
+                            "Starting CrispASR with Metal and warming up the model. Dictation is ready when this finishes.",
+                            bundle: bundle
+                        )
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    }
+                } else if case .error(let message) = modelState {
+                    Text(message)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .textSelection(.enabled)
+                }
+
+                HStack {
+                    primaryModelButton
+                    if isDownloaded, !isBusy {
+                        Button(String(localized: "Remove Model", bundle: bundle), role: .destructive) {
+                            showDeleteConfirmation = true
+                        }
+                    }
+                }
+            }
+            .padding(4)
+        }
+    }
+
+    private var huggingFaceTokenSection: some View {
+        GroupBox {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Hugging Face Token", bundle: bundle)
+                    .font(.headline)
+
+                Text(
+                    "Optional. Increases download rate limits and may speed up the model download. The token is stored securely in Keychain.",
+                    bundle: bundle
+                )
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+                HStack {
+                    if showHuggingFaceToken {
+                        TextField("hf_...", text: $huggingFaceTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    } else {
+                        SecureField("hf_...", text: $huggingFaceTokenInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showHuggingFaceToken.toggle()
+                    } label: {
+                        Image(systemName: showHuggingFaceToken ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.huggingFaceToken != nil {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            huggingFaceTokenInput = ""
+                            huggingFaceTokenValidationResult = nil
+                            plugin.clearHuggingFaceToken()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Button(String(localized: "Save", bundle: bundle)) {
+                        validateAndSaveHuggingFaceToken()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                    .disabled(
+                        PluginHuggingFaceTokenHelper.normalizedToken(huggingFaceTokenInput) == nil
+                            || isValidatingHuggingFaceToken
+                    )
+                }
+
+                if isValidatingHuggingFaceToken {
+                    HStack(spacing: 5) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("Validating token…", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let huggingFaceTokenValidationResult {
+                    Label(
+                        huggingFaceTokenValidationResult
+                            ? String(localized: "Valid Hugging Face Token", bundle: bundle)
+                            : String(localized: "Invalid Hugging Face Token", bundle: bundle),
+                        systemImage: huggingFaceTokenValidationResult
+                            ? "checkmark.circle.fill"
+                            : "xmark.circle.fill"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(huggingFaceTokenValidationResult ? .green : .red)
+                }
+            }
+            .padding(4)
+        }
+    }
+
+    @ViewBuilder
+    private var statusLabel: some View {
+        switch modelState {
+        case .ready:
+            Label(String(localized: "Ready", bundle: bundle), systemImage: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+        case .downloading:
+            Label(String(localized: "Downloading", bundle: bundle), systemImage: "arrow.down.circle")
+                .foregroundStyle(.secondary)
+        case .preparing:
+            Label(String(localized: "Preparing", bundle: bundle), systemImage: "gearshape.2")
+                .foregroundStyle(.secondary)
+        case .error:
+            Label(String(localized: "Error", bundle: bundle), systemImage: "exclamationmark.triangle.fill")
+                .foregroundStyle(.red)
+        case .notLoaded:
+            Label(
+                String(localized: isDownloaded ? "Downloaded" : "Not Downloaded", bundle: bundle),
+                systemImage: isDownloaded ? "internaldrive" : "icloud.and.arrow.down"
+            )
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var primaryModelButton: some View {
+        switch modelState {
+        case .ready:
+            Button(String(localized: "Unload", bundle: bundle)) {
+                plugin.unloadModel()
+                refresh()
+            }
+            .buttonStyle(.bordered)
+        case .downloading, .preparing:
+            Button(String(localized: "Working…", bundle: bundle)) {}
+                .buttonStyle(.borderedProminent)
+                .disabled(true)
+        case .notLoaded, .error:
+            Button(
+                String(localized: isDownloaded ? "Load" : "Download & Load", bundle: bundle)
+            ) {
+                Task {
+                    await plugin.loadModel()
+                    refresh()
+                }
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var capabilityNotes: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Capabilities and limits", bundle: bundle)
+                .font(.headline)
+
+            capabilityRow(
+                icon: "globe",
+                text: String(
+                    localized: "14 languages with explicit selection: English, French, German, Spanish, Italian, Portuguese, Dutch, Polish, Greek, Arabic, Japanese, Chinese, Vietnamese, and Korean.",
+                    bundle: bundle
+                )
+            )
+            capabilityRow(
+                icon: "waveform.path",
+                text: String(
+                    localized: "Voice activity detection runs before every transcription to suppress silence and low-noise hallucinations.",
+                    bundle: bundle
+                )
+            )
+            capabilityRow(
+                icon: "exclamationmark.circle",
+                text: String(
+                    localized: "No automatic language detection, streaming, diarization, translation, or dictionary boosting.",
+                    bundle: bundle
+                )
+            )
+            capabilityRow(
+                icon: "memorychip",
+                text: String(
+                    localized: "Choose Compact Q4_K for the smallest download, Fast Q5_0 for the recommended default, Q6_K for higher numeric precision, or experimental Q8_0 for maximum numeric precision. Only the selected model is loaded.",
+                    bundle: bundle
+                )
+            )
+            capabilityRow(
+                icon: "hourglass",
+                text: String(
+                    localized: "The model stays resident while loaded. Metal is warmed up before the provider becomes ready, keeping the first transcription responsive.",
+                    bundle: bundle
+                )
+            )
+
+            Divider()
+
+            Text(
+                "Model weights are downloaded from a pinned Apache-2.0 GGUF revision. CrispASR and the VAD model are MIT-licensed.",
+                bundle: bundle
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            HStack(spacing: 14) {
+                Link(
+                    String(localized: "Cohere model license", bundle: bundle),
+                    destination: cohereModelURL
+                )
+                Link(
+                    String(localized: "CrispASR license and notices", bundle: bundle),
+                    destination: crispAsrURL
+                )
+                Link(
+                    String(localized: "VAD model license", bundle: bundle),
+                    destination: vadModelURL
+                )
+            }
+            .font(.caption)
+        }
+    }
+
+    private func capabilityRow(icon: String, text: String) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .frame(width: 18)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var isBusy: Bool {
+        switch modelState {
+        case .downloading, .preparing:
+            return true
+        case .notLoaded, .ready, .error:
+            return false
+        }
+    }
+
+    private var selectedModel: CohereLocalModelDefinition {
+        CohereLocalPlugin.model(for: selectedModelId) ?? CohereLocalPlugin.fastModel
+    }
+
+    private func refresh() {
+        modelState = plugin.modelState
+        selectedModelId = plugin.selectedModelId ?? CohereLocalPlugin.fastModel.id
+        isDownloaded = plugin.isModelDownloaded
+    }
+
+    private func validateAndSaveHuggingFaceToken() {
+        guard let token = PluginHuggingFaceTokenHelper.normalizedToken(
+            huggingFaceTokenInput
+        ) else {
+            huggingFaceTokenValidationResult = false
+            return
+        }
+
+        isValidatingHuggingFaceToken = true
+        huggingFaceTokenValidationResult = nil
+        Task {
+            let isValid = await plugin.validateHuggingFaceToken(token)
+            isValidatingHuggingFaceToken = false
+            huggingFaceTokenValidationResult = isValid
+            if isValid {
+                plugin.setHuggingFaceToken(token)
+                huggingFaceTokenInput = token
+            }
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -180,7 +180,6 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
                 host: (any HostServices)?,
                 runtime: Runtime?,
                 startingServer: CrispAsrServer?,
-                shouldRestore: Bool,
                 shouldClearLoadedPersistence: Bool
             ) in
             let shouldClearLoadedPersistence = state.loadedModelId != modelId
@@ -197,32 +196,33 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
                 state.modelState = .notLoaded
             }
             state.selectedModelId = modelId
-            let shouldRestore =
-                state.runtime == nil
-                && state.startingServer == nil
-                && state.host.map {
-                    CohereLocalModelAssets(
-                        pluginDataDirectory: $0.pluginDataDirectory,
-                        model: model
-                    ).isInstalled
-                } == true
             return (
                 state.host,
                 runtime,
                 startingServer,
-                shouldRestore,
                 shouldClearLoadedPersistence
             )
         }
 
         context.runtime?.server.stop()
         context.startingServer?.stop()
+        let isInstalled = context.host.map {
+            CohereLocalModelAssets(
+                pluginDataDirectory: $0.pluginDataDirectory,
+                model: model
+            ).isInstalled
+        } == true
+        let shouldRestore = isInstalled && state.withLock {
+            $0.selectedModelId == modelId
+                && $0.runtime == nil
+                && $0.startingServer == nil
+        }
         context.host?.setUserDefault(modelId, forKey: "selectedModel")
         if context.shouldClearLoadedPersistence {
             context.host?.setUserDefault(nil, forKey: "loadedModel")
         }
         context.host?.notifyCapabilitiesChanged()
-        if context.shouldRestore {
+        if shouldRestore {
             Task { [weak self] in
                 await self?.loadModel(allowDownloads: false)
             }
@@ -377,14 +377,12 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     }
 
     func restoreLoadedModel(allowDownloads: Bool = false) async {
-        let context = state.withLock { state in
-            let loadedModelId = state.host?.userDefault(forKey: "loadedModel") as? String
-            return (
-                host: state.host,
-                loadedModelId: Self.model(for: loadedModelId)?.id
-            )
+        let host = state.withLock { $0.host }
+        let persistedModelId = host?.userDefault(forKey: "loadedModel") as? String
+        guard host != nil,
+              let loadedModelId = Self.model(for: persistedModelId)?.id else {
+            return
         }
-        guard context.host != nil, let loadedModelId = context.loadedModelId else { return }
         state.withLock { $0.selectedModelId = loadedModelId }
         await loadModel(allowDownloads: allowDownloads)
     }
@@ -472,9 +470,34 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
         generation: Int,
         huggingFaceToken: String?
     )? {
-        state.withLock { state in
-            guard let host = state.host else { return nil }
-            guard let model = Self.model(for: state.selectedModelId) else { return nil }
+        let snapshot = state.withLock {
+            (
+                host: $0.host,
+                selectedModelId: $0.selectedModelId,
+                generation: $0.loadGeneration
+            )
+        }
+        guard let host = snapshot.host,
+              let model = Self.model(for: snapshot.selectedModelId) else {
+            return nil
+        }
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: model
+        )
+        let isInstalled = assets.isInstalled
+
+        return state.withLock { state -> (
+            host: any HostServices,
+            model: CohereLocalModelDefinition,
+            generation: Int,
+            huggingFaceToken: String?
+        )? in
+            guard state.host != nil,
+                  state.selectedModelId == model.id,
+                  state.loadGeneration == snapshot.generation else {
+                return nil
+            }
             guard state.runtime == nil else {
                 state.modelState = .ready
                 return nil
@@ -487,11 +510,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             }
 
             state.loadGeneration += 1
-            let assets = CohereLocalModelAssets(
-                pluginDataDirectory: host.pluginDataDirectory,
-                model: model
-            )
-            state.modelState = assets.isInstalled ? .preparing : .downloading(progress: 0)
+            state.modelState = isInstalled ? .preparing : .downloading(progress: 0)
             return (host, model, state.loadGeneration, state.huggingFaceToken)
         }
     }
@@ -579,15 +598,17 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     }
 
     var isModelDownloaded: Bool {
-        state.withLock { state in
-            guard let model = Self.model(for: state.selectedModelId) else { return false }
-            return state.host.map {
-                CohereLocalModelAssets(
-                    pluginDataDirectory: $0.pluginDataDirectory,
-                    model: model
-                ).isInstalled
-            } ?? false
+        let snapshot = state.withLock {
+            (host: $0.host, selectedModelId: $0.selectedModelId)
         }
+        guard let host = snapshot.host,
+              let model = Self.model(for: snapshot.selectedModelId) else {
+            return false
+        }
+        return CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: model
+        ).isInstalled
     }
 
     var selectedModelDefinition: CohereLocalModelDefinition {
@@ -726,10 +747,10 @@ private struct CohereLocalSettingsView: View {
     private let bundle = Bundle(for: CohereLocalPlugin.self)
     private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
     private let cohereModelURL = URL(
-        string: "https://huggingface.co/cstr/cohere-transcribe-03-2026-GGUF"
+        string: "https://huggingface.co/\(CohereLocalModelAssets.modelRepositoryId)"
     )!
     private let crispAsrURL = URL(
-        string: "https://github.com/CrispStrobe/CrispASR/tree/v0.8.24"
+        string: "https://github.com/CrispStrobe/CrispASR/tree/v\(CohereLocalModelAssets.crispAsrVersion)"
     )!
     private let vadModelURL = URL(
         string: "https://huggingface.co/ggml-org/whisper-vad"

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
@@ -1,0 +1,303 @@
+import Darwin
+import Foundation
+import TypeWhisperPluginSDK
+import os
+
+final class CrispAsrServer: @unchecked Sendable {
+    private struct State {
+        var process: Process?
+        var baseURL: String?
+        var apiKey: String?
+        var modelId: String?
+        var outputTail = ""
+    }
+
+    private static let startupTimeout: TimeInterval = 300
+    private static let shutdownTimeout: TimeInterval = 10
+    private static let logger = Logger(
+        subsystem: CohereLocalPlugin.pluginId,
+        category: "CrispASR"
+    )
+    private static let supervisorScript = """
+        parent_pid="$1"
+        shift
+        "$@" &
+        child_pid=$!
+
+        terminate_child() {
+          trap - TERM INT
+          if kill -0 "$child_pid" 2>/dev/null; then
+            kill -TERM "$child_pid" 2>/dev/null || true
+            attempt=0
+            while kill -0 "$child_pid" 2>/dev/null && [ "$attempt" -lt 100 ]; do
+              sleep 0.05
+              attempt=$((attempt + 1))
+            done
+            if kill -0 "$child_pid" 2>/dev/null; then
+              kill -KILL "$child_pid" 2>/dev/null || true
+            fi
+          fi
+          wait "$child_pid" 2>/dev/null || true
+        }
+
+        trap 'terminate_child; exit 143' TERM INT
+        while kill -0 "$parent_pid" 2>/dev/null && kill -0 "$child_pid" 2>/dev/null; do
+          sleep 0.25
+        done
+
+        if ! kill -0 "$parent_pid" 2>/dev/null; then
+          terminate_child
+          exit 0
+        fi
+
+        wait "$child_pid"
+        status=$?
+        trap - TERM INT
+        exit "$status"
+        """
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    var isRunning: Bool {
+        state.withLock { state in
+            state.process.map { !$0.isRunning ? false : true } == true
+                && state.baseURL != nil
+        }
+    }
+
+    func start(assets: CohereLocalModelAssets) async throws {
+        stop()
+
+        let port = try Self.reserveLoopbackPort()
+        let apiKey = UUID().uuidString.replacingOccurrences(of: "-", with: "")
+            + UUID().uuidString.replacingOccurrences(of: "-", with: "")
+        let baseURL = "http://127.0.0.1:\(port)"
+        let runtimeArguments = [
+            "--server",
+            "--backend", "cohere",
+            "--model", assets.modelFileURL.path,
+            "--host", "127.0.0.1",
+            "--port", String(port),
+            "--language", "en",
+            "--vad",
+            "--vad-model", assets.vadModelURL.path,
+            "--strict-pipeline",
+            "--require-vad",
+            "--threads", String(Self.recommendedThreadCount),
+            "--gpu-backend", "metal",
+        ]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CRISPASR_API_KEYS"] = apiKey
+        environment["CRISPASR_CACHE_DIR"] = assets.cacheDirectory.path
+        let process = Self.makeSupervisedProcess(
+            executableURL: assets.runtimeExecutableURL,
+            arguments: runtimeArguments,
+            currentDirectoryURL: assets.runtimeDirectory,
+            environment: environment
+        )
+
+        let outputPipe = Pipe()
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+        outputPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let text = String(data: data, encoding: .utf8) else { return }
+            self?.captureOutput(text)
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: assets.cacheDirectory,
+                withIntermediateDirectories: true
+            )
+            try process.run()
+            state.withLock { state in
+                state.process = process
+                state.baseURL = baseURL
+                state.apiKey = apiKey
+                state.modelId = assets.model.id
+                state.outputTail = ""
+            }
+            try await waitUntilReady(
+                process: process,
+                baseURL: baseURL
+            )
+            Self.logger.info(
+                "CrispASR \(CohereLocalModelAssets.crispAsrVersion, privacy: .public) is ready on loopback with Metal"
+            )
+        } catch {
+            outputPipe.fileHandleForReading.readabilityHandler = nil
+            stop()
+            throw error
+        }
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String
+    ) async throws -> PluginTranscriptionResult {
+        let context = state.withLock { state in
+            (
+                process: state.process,
+                baseURL: state.baseURL,
+                apiKey: state.apiKey,
+                modelId: state.modelId
+            )
+        }
+        guard let process = context.process,
+              process.isRunning,
+              let baseURL = context.baseURL,
+              let apiKey = context.apiKey,
+              let modelId = context.modelId else {
+            throw CohereLocalPluginError.modelNotLoaded
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(
+            baseURL: baseURL,
+            responseFormat: "verbose_json"
+        )
+        return try await helper.transcribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelId,
+            language: language,
+            translate: false,
+            prompt: nil,
+            requestTimeout: 600
+        )
+    }
+
+    func stop() {
+        let process = state.withLock { state -> Process? in
+            let process = state.process
+            state.process = nil
+            state.baseURL = nil
+            state.apiKey = nil
+            state.modelId = nil
+            return process
+        }
+        guard let process else { return }
+
+        if let pipe = process.standardOutput as? Pipe {
+            pipe.fileHandleForReading.readabilityHandler = nil
+        }
+        guard process.isRunning else { return }
+
+        process.terminate()
+        let deadline = Date().addingTimeInterval(Self.shutdownTimeout)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            kill(process.processIdentifier, SIGKILL)
+        }
+    }
+
+    private func waitUntilReady(
+        process: Process,
+        baseURL: String
+    ) async throws {
+        guard let healthURL = URL(string: "\(baseURL)/health") else {
+            throw CohereLocalPluginError.invalidLocalServerURL
+        }
+
+        let deadline = Date().addingTimeInterval(Self.startupTimeout)
+        while Date() < deadline {
+            try Task.checkCancellation()
+            guard process.isRunning else {
+                throw CohereLocalPluginError.runtimeExited(outputTail)
+            }
+
+            var request = URLRequest(url: healthURL)
+            request.timeoutInterval = 2
+            if let (_, response) = try? await URLSession.shared.data(for: request),
+               let httpResponse = response as? HTTPURLResponse,
+               httpResponse.statusCode == 200 {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        throw CohereLocalPluginError.runtimeStartupTimedOut(outputTail)
+    }
+
+    private var outputTail: String {
+        state.withLock { $0.outputTail }
+    }
+
+    private func captureOutput(_ text: String) {
+        state.withLock { state in
+            state.outputTail.append(text)
+            if state.outputTail.count > 12_000 {
+                state.outputTail.removeFirst(state.outputTail.count - 12_000)
+            }
+        }
+        for line in text.split(whereSeparator: \.isNewline) {
+            Self.logger.debug("\(String(line), privacy: .public)")
+        }
+    }
+
+    private static var recommendedThreadCount: Int {
+        max(1, min(8, ProcessInfo.processInfo.activeProcessorCount - 2))
+    }
+
+    static func makeSupervisedProcess(
+        executableURL: URL,
+        arguments: [String],
+        currentDirectoryURL: URL?,
+        environment: [String: String],
+        parentProcessIdentifier: pid_t = getpid()
+    ) -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.currentDirectoryURL = currentDirectoryURL
+        process.arguments = [
+            "-c",
+            supervisorScript,
+            "typewhisper-crispasr-supervisor",
+            String(parentProcessIdentifier),
+            executableURL.path,
+        ] + arguments
+        process.environment = environment
+        return process
+    }
+
+    private static func reserveLoopbackPort() throws -> UInt16 {
+        let descriptor = socket(AF_INET, SOCK_STREAM, 0)
+        guard descriptor >= 0 else {
+            throw CohereLocalPluginError.localPortReservationFailed
+        }
+        defer { close(descriptor) }
+
+        var address = sockaddr_in()
+        address.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        address.sin_family = sa_family_t(AF_INET)
+        address.sin_port = in_port_t(0)
+        address.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                bind(
+                    descriptor,
+                    socketAddress,
+                    socklen_t(MemoryLayout<sockaddr_in>.size)
+                )
+            }
+        }
+        guard bindResult == 0 else {
+            throw CohereLocalPluginError.localPortReservationFailed
+        }
+
+        var boundAddress = sockaddr_in()
+        var boundAddressLength = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &boundAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                getsockname(descriptor, socketAddress, &boundAddressLength)
+            }
+        }
+        guard nameResult == 0 else {
+            throw CohereLocalPluginError.localPortReservationFailed
+        }
+        return UInt16(bigEndian: boundAddress.sin_port)
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
@@ -14,6 +14,7 @@ final class CrispAsrServer: @unchecked Sendable {
 
     private static let startupTimeout: TimeInterval = 300
     private static let shutdownTimeout: TimeInterval = 10
+    private static let portBindingAttemptLimit = 3
     private static let logger = Logger(
         subsystem: CohereLocalPlugin.pluginId,
         category: "CrispASR"
@@ -66,6 +67,23 @@ final class CrispAsrServer: @unchecked Sendable {
     }
 
     func start(assets: CohereLocalModelAssets) async throws {
+        for attempt in 1...Self.portBindingAttemptLimit {
+            do {
+                try await startOnce(assets: assets)
+                return
+            } catch {
+                guard attempt < Self.portBindingAttemptLimit,
+                      Self.isPortBindingFailure(error) else {
+                    throw error
+                }
+                Self.logger.warning(
+                    "CrispASR loopback port was claimed before startup; retrying with a new port"
+                )
+            }
+        }
+    }
+
+    private func startOnce(assets: CohereLocalModelAssets) async throws {
         stop()
 
         let port = try Self.reserveLoopbackPort()
@@ -131,6 +149,16 @@ final class CrispAsrServer: @unchecked Sendable {
             stop()
             throw error
         }
+    }
+
+    static func isPortBindingFailure(_ error: Error) -> Bool {
+        guard case CohereLocalPluginError.runtimeExited(let output) = error else {
+            return false
+        }
+        let normalized = output.lowercased()
+        return normalized.contains("address already in use")
+            || normalized.contains("failed to bind")
+            || normalized.contains("bind() failed")
     }
 
     func transcribe(

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
@@ -11,12 +11,12 @@
         }
       }
     },
-    "A private on-device Core ML provider for Cohere Transcribe 03-2026. Audio stays on this Mac." : {
+    "A private on-device GGUF and Metal provider for Cohere Transcribe 03-2026. Audio stays on this Mac." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ein privater Core-ML-Provider auf dem Gerät für Cohere Transcribe 03-2026. Audio bleibt auf diesem Mac."
+            "value" : "Ein privater GGUF- und Metal-Provider auf dem Gerät für Cohere Transcribe 03-2026. Audio bleibt auf diesem Mac."
           }
         }
       }
@@ -211,12 +211,12 @@
         }
       }
     },
-    "Preparing Core ML models. The first load can take several minutes." : {
+    "Starting CrispASR with Metal and warming up the model. Dictation is ready when this finishes." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Core-ML-Modelle werden vorbereitet. Das erste Laden kann mehrere Minuten dauern."
+            "value" : "CrispASR wird mit Metal gestartet und das Modell wird aufgewärmt. Nach Abschluss ist die Diktierfunktion bereit."
           }
         }
       }
@@ -271,12 +271,12 @@
         }
       }
     },
-    "The first transcription after loading can take several minutes while Core ML prepares the Neural Engine. Later transcriptions are much faster." : {
+    "The model stays resident while loaded. Metal is warmed up before the provider becomes ready, keeping the first transcription responsive." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die erste Transkription nach dem Laden kann mehrere Minuten dauern, während Core ML die Neural Engine vorbereitet. Spätere Transkriptionen sind deutlich schneller."
+            "value" : "Das Modell bleibt geladen im Arbeitsspeicher. Metal wird aufgewärmt, bevor der Provider bereit ist, damit die erste Transkription schnell reagiert."
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
@@ -1,0 +1,366 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "14 languages with explicit selection: English, French, German, Spanish, Italian, Portuguese, Dutch, Polish, Greek, Arabic, Japanese, Chinese, Vietnamese, and Korean." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "14 Sprachen mit expliziter Auswahl: Englisch, Französisch, Deutsch, Spanisch, Italienisch, Portugiesisch, Niederländisch, Polnisch, Griechisch, Arabisch, Japanisch, Chinesisch, Vietnamesisch und Koreanisch."
+          }
+        }
+      }
+    },
+    "A private on-device Core ML provider for Cohere Transcribe 03-2026. Audio stays on this Mac." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ein privater Core-ML-Provider auf dem Gerät für Cohere Transcribe 03-2026. Audio bleibt auf diesem Mac."
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Abbrechen"
+          }
+        }
+      }
+    },
+    "Capabilities and limits" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funktionen und Einschränkungen"
+          }
+        }
+      }
+    },
+    "Cohere model license" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere-Modelllizenz"
+          }
+        }
+      }
+    },
+    "Cohere Transcribe (Local)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere Transcribe (Lokal)"
+          }
+        }
+      }
+    },
+    "CrispASR license and notices" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrispASR-Lizenz und Hinweise"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        }
+      }
+    },
+    "Download & Load" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Herunterladen & Laden"
+          }
+        }
+      }
+    },
+    "Downloaded" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladen"
+          }
+        }
+      }
+    },
+    "Downloading" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird heruntergeladen"
+          }
+        }
+      }
+    },
+    "Error" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fehler"
+          }
+        }
+      }
+    },
+    "Hugging Face Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hugging-Face-Token"
+          }
+        }
+      }
+    },
+    "Invalid Hugging Face Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ungültiger Hugging-Face-Token"
+          }
+        }
+      }
+    },
+    "Load" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laden"
+          }
+        }
+      }
+    },
+    "LOCAL · BATCH" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LOKAL · BATCH"
+          }
+        }
+      }
+    },
+    "No automatic language detection, streaming, timestamps, diarization, translation, or dictionary boosting." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine automatische Spracherkennung, kein Streaming, keine Zeitstempel, Diarisierung, Übersetzung oder Wörterbuchverstärkung."
+          }
+        }
+      }
+    },
+    "Model weights are downloaded from a pinned Apache-2.0 GGUF revision. CrispASR and the VAD model are MIT-licensed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Modellgewichte werden aus einer festgeschriebenen Apache-2.0-GGUF-Revision geladen. CrispASR und das VAD-Modell stehen unter der MIT-Lizenz."
+          }
+        }
+      }
+    },
+    "Not Downloaded" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nicht heruntergeladen"
+          }
+        }
+      }
+    },
+    "Optional. Increases download rate limits and may speed up the model download. The token is stored securely in Keychain." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Optional. Erhöht die Download-Limits und kann den Modelldownload beschleunigen. Der Token wird sicher im Schlüsselbund gespeichert."
+          }
+        }
+      }
+    },
+    "Preparing" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wird vorbereitet"
+          }
+        }
+      }
+    },
+    "Preparing Core ML models. The first load can take several minutes." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Core-ML-Modelle werden vorbereitet. Das erste Laden kann mehrere Minuten dauern."
+          }
+        }
+      }
+    },
+    "Ready" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bereit"
+          }
+        }
+      }
+    },
+    "Remove" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entfernen"
+          }
+        }
+      }
+    },
+    "Remove downloaded model?" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heruntergeladenes Modell entfernen?"
+          }
+        }
+      }
+    },
+    "Remove Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell entfernen"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speichern"
+          }
+        }
+      }
+    },
+    "The first transcription after loading can take several minutes while Core ML prepares the Neural Engine. Later transcriptions are much faster." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die erste Transkription nach dem Laden kann mehrere Minuten dauern, während Core ML die Neural Engine vorbereitet. Spätere Transkriptionen sind deutlich schneller."
+          }
+        }
+      }
+    },
+    "This removes the Cohere model and its local VAD files. You can download them again later." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dadurch werden das Cohere-Modell und seine lokalen VAD-Dateien entfernt. Du kannst sie später erneut herunterladen."
+          }
+        }
+      }
+    },
+    "This test provider has a much larger memory footprint than Parakeet and unloads through TypeWhisper's model lifecycle." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dieser Test-Provider benötigt deutlich mehr Arbeitsspeicher als Parakeet und wird über den Modell-Lebenszyklus von TypeWhisper entladen."
+          }
+        }
+      }
+    },
+    "Unload" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entladen"
+          }
+        }
+      }
+    },
+    "Valid Hugging Face Token" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gültiger Hugging-Face-Token"
+          }
+        }
+      }
+    },
+    "Validating token…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Token wird geprüft …"
+          }
+        }
+      }
+    },
+    "VAD model license" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VAD-Modelllizenz"
+          }
+        }
+      }
+    },
+    "Voice activity detection runs before every transcription to suppress silence and low-noise hallucinations." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vor jeder Transkription läuft eine Sprachaktivitätserkennung, um Halluzinationen bei Stille und leisem Rauschen zu unterdrücken."
+          }
+        }
+      }
+    },
+    "Working…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In Arbeit …"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -1,0 +1,336 @@
+import Darwin
+import TypeWhisperPluginSDK
+import TypeWhisperPluginSDKTesting
+import XCTest
+
+@testable import CohereLocalPlugin
+
+final class CohereLocalPluginTests: XCTestCase {
+    private actor RequestRecorder {
+        private var request: URLRequest?
+
+        func set(_ request: URLRequest) {
+            self.request = request
+        }
+
+        func get() -> URLRequest? {
+            request
+        }
+    }
+
+    func testPluginIdentityAndCapabilities() {
+        let plugin = CohereLocalPlugin()
+
+        XCTAssertEqual(CohereLocalPlugin.pluginId, "com.typewhisper.cohere-transcribe")
+        XCTAssertEqual(plugin.providerId, "cohere-transcribe")
+        XCTAssertEqual(plugin.providerDisplayName, "Cohere Transcribe (Local)")
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .unsupported)
+    }
+
+    func testSupportedLanguagesMatchCohereGGUFPipeline() {
+        XCTAssertEqual(
+            CohereLocalPlugin.supportedLanguageCodes,
+            [
+                "en", "fr", "de", "es", "it", "pt", "nl",
+                "pl", "el", "ar", "ja", "zh", "vi", "ko",
+            ]
+        )
+        XCTAssertEqual(CohereLocalPlugin.supportedLanguageCodes.count, 14)
+    }
+
+    func testLanguageNormalizationAcceptsRegionAndChineseAliases() {
+        XCTAssertEqual(CohereLocalPlugin.normalizedLanguageCode(for: "de-DE"), "de")
+        XCTAssertEqual(CohereLocalPlugin.normalizedLanguageCode(for: "pt_BR"), "pt")
+        XCTAssertEqual(CohereLocalPlugin.normalizedLanguageCode(for: "zh-Hans"), "zh")
+        XCTAssertEqual(CohereLocalPlugin.normalizedLanguageCode(for: "cmn_Hans_CN"), "zh")
+    }
+
+    func testLanguageNormalizationRejectsAutoRussianAndHindi() {
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: nil))
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: ""))
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: "auto"))
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: "und"))
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: "ru"))
+        XCTAssertNil(CohereLocalPlugin.normalizedLanguageCode(for: "hi"))
+    }
+
+    func testDigitalSilenceGuard() {
+        XCTAssertTrue(CohereLocalPlugin.isDigitalSilence([]))
+        XCTAssertTrue(CohereLocalPlugin.isDigitalSilence(Array(repeating: 0, count: 16_000)))
+        XCTAssertFalse(CohereLocalPlugin.isDigitalSilence([0, 0.001, 0]))
+    }
+
+    func testRuntimeSupervisorStopsChildWhenHostProcessDisappears() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cohere-runtime-supervisor-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+
+        let childPIDFile = temporaryDirectory.appendingPathComponent("child.pid")
+        let temporaryParent = Process()
+        temporaryParent.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        temporaryParent.arguments = ["1"]
+        try temporaryParent.run()
+
+        let process = CrispAsrServer.makeSupervisedProcess(
+            executableURL: URL(fileURLWithPath: "/bin/sh"),
+            arguments: [
+                "-c",
+                "echo $$ > \"$1\"; exec /bin/sleep 60",
+                "cohere-runtime-child",
+                childPIDFile.path,
+            ],
+            currentDirectoryURL: temporaryDirectory,
+            environment: ProcessInfo.processInfo.environment,
+            parentProcessIdentifier: temporaryParent.processIdentifier
+        )
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+
+        try process.run()
+        let deadline = Date().addingTimeInterval(5)
+        while process.isRunning, Date() < deadline {
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        if process.isRunning {
+            process.terminate()
+        }
+
+        XCTAssertFalse(process.isRunning)
+        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let childPID = try XCTUnwrap(pid_t(childPIDText))
+        XCTAssertEqual(kill(childPID, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+    }
+
+    func testDownloadedModelRequiresEveryPinnedAsset() throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.fastModel
+        )
+        XCTAssertFalse(assets.isInstalled)
+
+        for relativePath in [CohereLocalPlugin.fastModel.fileName]
+            + CohereLocalModelAssets.sharedRequiredRelativePaths {
+            let url = assets.rootDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("test".utf8).write(to: url)
+        }
+
+        XCTAssertTrue(assets.isInstalled)
+
+        try FileManager.default.removeItem(
+            at: assets.runtimeLibraryURL
+        )
+        XCTAssertFalse(assets.isInstalled)
+    }
+
+    func testDownloadedModelCatalogAndDeletion() async throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.fastModel
+        )
+
+        for relativePath in [CohereLocalPlugin.fastModel.fileName]
+            + CohereLocalModelAssets.sharedRequiredRelativePaths {
+            let url = assets.rootDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("test".utf8).write(to: url)
+        }
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [CohereLocalPlugin.fastModel.id])
+
+        try await plugin.deleteDownloadedModel(CohereLocalPlugin.fastModel.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: assets.rootDirectory.path))
+        XCTAssertTrue(plugin.downloadedModels.isEmpty)
+        XCTAssertEqual(plugin.selectedModelId, CohereLocalPlugin.fastModel.id)
+        XCTAssertEqual(
+            host.userDefault(forKey: "selectedModel") as? String,
+            CohereLocalPlugin.fastModel.id
+        )
+        XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+    }
+
+    func testCatalogOffersAllQuantizationModels() throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.availableModels.map(\.id), CohereLocalPlugin.models.map(\.id))
+        XCTAssertEqual(plugin.selectedModelId, CohereLocalPlugin.fastModel.id)
+
+        plugin.selectModel(CohereLocalPlugin.compactModel.id)
+
+        XCTAssertEqual(plugin.selectedModelId, CohereLocalPlugin.compactModel.id)
+        XCTAssertEqual(
+            host.userDefault(forKey: "selectedModel") as? String,
+            CohereLocalPlugin.compactModel.id
+        )
+    }
+
+    func testDeletingOneVariantPreservesOtherModelAndSharedRuntime() async throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+        let fastAssets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.fastModel
+        )
+        let compactAssets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.compactModel
+        )
+
+        for relativePath in CohereLocalModelAssets.sharedRequiredRelativePaths {
+            let url = fastAssets.rootDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("test".utf8).write(to: url)
+        }
+        try Data("fast".utf8).write(to: fastAssets.modelFileURL)
+        try Data("compact".utf8).write(to: compactAssets.modelFileURL)
+        XCTAssertTrue(fastAssets.isInstalled)
+        XCTAssertTrue(compactAssets.isInstalled)
+
+        try await plugin.deleteDownloadedModel(CohereLocalPlugin.compactModel.id)
+
+        XCTAssertTrue(fastAssets.isInstalled)
+        XCTAssertFalse(compactAssets.isInstalled)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fastAssets.runtimeExecutableURL.path))
+    }
+
+    func testPassiveRestorePolicyIsDeclaredForExternalPlugin() throws {
+        let plugin = CohereLocalPlugin()
+        let lifecycleAwarePlugin: any HostModelLifecyclePolicyAwarePlugin = plugin
+        XCTAssertEqual(type(of: lifecycleAwarePlugin).pluginId, CohereLocalPlugin.pluginId)
+
+        let host = try PluginTestHostServices(
+            defaults: ["loadedModel": CohereLocalPlugin.fastModel.id],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        plugin.activate(host: host)
+
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+    }
+
+    func testPinnedModelRevisionAndFiles() {
+        XCTAssertEqual(
+            CohereLocalModelAssets.modelRevision,
+            "2242638d5dfecc6f1dbe6c3a8713b97deb2e150f"
+        )
+        XCTAssertEqual(CohereLocalPlugin.models.map(\.id), [
+            "cohere-transcribe-03-2026-q4_k",
+            "cohere-transcribe-03-2026-q5_0",
+            "cohere-transcribe-03-2026-q6_k",
+            "cohere-transcribe-03-2026-q8_0",
+        ])
+        XCTAssertEqual(
+            CohereLocalPlugin.compactModel.sha256,
+            "2931fc0ac6d6708eef5389aadf1ebd5eec7b8e764bac385be585e910c0e7b410"
+        )
+        XCTAssertEqual(
+            CohereLocalPlugin.fastModel.sha256,
+            "a09696c5cc2ed5052bf290c4f2beb35abc69c0d6986842042d92bebb22c9184e"
+        )
+        XCTAssertEqual(
+            CohereLocalPlugin.q6Model.sha256,
+            "0ad2634e0ba34efa38a47d4fd4cf34d7a2d738d8486d83b8d5a178f823109c52"
+        )
+        XCTAssertEqual(
+            CohereLocalPlugin.q8Model.sha256,
+            "c8620cb182a7c04e311e6c24e478b94f7ecd7f1b5230bf39fffa8daf94644f51"
+        )
+        XCTAssertEqual(
+            CohereLocalModelAssets.vadRevision,
+            "9ffd54a1e1ee413ddf265af9913beaf518d1639b"
+        )
+        XCTAssertEqual(
+            CohereLocalModelAssets.runtimeArchiveSHA256,
+            "78397afd5aef2dbd6fa73f8d60800dd4d5725589fb4b04800efd2fb3ff88930c"
+        )
+        XCTAssertEqual(CohereLocalModelAssets.crispAsrVersion, "0.8.24")
+    }
+
+    func testLoadsStoredHuggingFaceTokenOnActivation() throws {
+        let host = try PluginTestHostServices(
+            secrets: [PluginHuggingFaceTokenHelper.storageKey: "hf_cohere_saved"],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        let plugin = CohereLocalPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.huggingFaceToken, "hf_cohere_saved")
+    }
+
+    func testStoresAndClearsHuggingFaceTokenSecret() throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+
+        plugin.setHuggingFaceToken("  hf_cohere_saved  ")
+        XCTAssertEqual(plugin.huggingFaceToken, "hf_cohere_saved")
+        XCTAssertEqual(
+            host.loadSecret(key: PluginHuggingFaceTokenHelper.storageKey),
+            "hf_cohere_saved"
+        )
+
+        plugin.clearHuggingFaceToken()
+        XCTAssertNil(plugin.huggingFaceToken)
+        XCTAssertEqual(
+            host.loadSecret(key: PluginHuggingFaceTokenHelper.storageKey),
+            ""
+        )
+    }
+
+    func testValidatesHuggingFaceTokenAgainstWhoAmIEndpoint() async throws {
+        let plugin = CohereLocalPlugin()
+        let requestRecorder = RequestRecorder()
+
+        let isValid = await plugin.validateHuggingFaceToken("hf_cohere_test") { request in
+            await requestRecorder.set(request)
+            let response = HTTPURLResponse(
+                url: try XCTUnwrap(request.url),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            )!
+            return (Data(#"{"name":"typewhisper","type":"user"}"#.utf8), response)
+        }
+
+        XCTAssertTrue(isValid)
+        let recordedRequest = await requestRecorder.get()
+        let request = try XCTUnwrap(recordedRequest)
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer hf_cohere_test"
+        )
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://huggingface.co/api/whoami-v2"
+        )
+        XCTAssertEqual(request.httpMethod, "GET")
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -111,6 +111,60 @@ final class CohereLocalPluginTests: XCTestCase {
         XCTAssertEqual(errno, ESRCH)
     }
 
+    func testSelectingAnotherModelStopsServerThatIsStillStarting() async throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.fastModel
+        )
+        for relativePath in [CohereLocalPlugin.fastModel.fileName]
+            + CohereLocalModelAssets.sharedRequiredRelativePaths {
+            let url = assets.rootDirectory.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("test".utf8).write(to: url)
+        }
+
+        let childPIDFile = assets.cacheDirectory.appendingPathComponent("test-child.pid")
+        let runtimeScript = """
+            #!/bin/sh
+            echo $$ > "$CRISPASR_CACHE_DIR/test-child.pid"
+            exec /bin/sleep 60
+            """
+        try Data(runtimeScript.utf8).write(to: assets.runtimeExecutableURL)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: assets.runtimeExecutableURL.path
+        )
+
+        let loadTask = Task {
+            await plugin.loadModel(allowDownloads: false)
+        }
+        let startupDeadline = Date().addingTimeInterval(5)
+        while !FileManager.default.fileExists(atPath: childPIDFile.path),
+              Date() < startupDeadline {
+            try await Task.sleep(for: .milliseconds(50))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: childPIDFile.path))
+
+        plugin.selectModel(CohereLocalPlugin.compactModel.id)
+        await loadTask.value
+
+        XCTAssertEqual(plugin.selectedModelId, CohereLocalPlugin.compactModel.id)
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        let childPIDText = try String(contentsOf: childPIDFile, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let childPID = try XCTUnwrap(pid_t(childPIDText))
+        XCTAssertEqual(kill(childPID, 0), -1)
+        XCTAssertEqual(errno, ESRCH)
+    }
+
     func testDownloadedModelRequiresEveryPinnedAsset() throws {
         let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
         let assets = CohereLocalModelAssets(

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -111,6 +111,24 @@ final class CohereLocalPluginTests: XCTestCase {
         XCTAssertEqual(errno, ESRCH)
     }
 
+    func testPortBindingFailureDetectionOnlyRetriesAddressConflicts() {
+        XCTAssertTrue(
+            CrispAsrServer.isPortBindingFailure(
+                CohereLocalPluginError.runtimeExited("bind() failed: Address already in use")
+            )
+        )
+        XCTAssertFalse(
+            CrispAsrServer.isPortBindingFailure(
+                CohereLocalPluginError.runtimeExited("Model file is invalid")
+            )
+        )
+        XCTAssertFalse(
+            CrispAsrServer.isPortBindingFailure(
+                CohereLocalPluginError.runtimeStartupTimedOut("")
+            )
+        )
+    }
+
     func testSelectingAnotherModelStopsServerThatIsStillStarting() async throws {
         let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
         let plugin = CohereLocalPlugin()
@@ -189,6 +207,32 @@ final class CohereLocalPluginTests: XCTestCase {
             at: assets.runtimeLibraryURL
         )
         XCTAssertFalse(assets.isInstalled)
+    }
+
+    func testLegacySharedModelDirectoryMigratesToNeutralDirectory() throws {
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let assets = CohereLocalModelAssets(
+            pluginDataDirectory: host.pluginDataDirectory,
+            model: CohereLocalPlugin.fastModel
+        )
+        try FileManager.default.createDirectory(
+            at: assets.legacyRootDirectory,
+            withIntermediateDirectories: true
+        )
+        let legacyMarker = assets.legacyRootDirectory.appendingPathComponent("marker")
+        try Data("legacy".utf8).write(to: legacyMarker)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: assets.rootDirectory.path))
+        XCTAssertFalse(assets.isInstalled)
+
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: assets.rootDirectory.appendingPathComponent("marker").path
+            )
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: assets.legacyRootDirectory.path)
+        )
     }
 
     func testDownloadedModelCatalogAndDeletion() async throws {

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
@@ -1,0 +1,21 @@
+{
+    "id": "com.typewhisper.cohere-transcribe",
+    "name": "Cohere Transcribe (Local)",
+    "version": "0.1.0",
+    "minHostVersion": "1.5.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "supportedArchitectures": [
+        "arm64"
+    ],
+    "author": "TypeWhisper",
+    "description": "Local GGUF and Metal speech-to-text powered by Cohere Transcribe 03-2026. Q4_K, Q5_0, Q6_K, and Q8_0 models for 14 explicitly selected languages.",
+    "descriptions": {
+        "de": "Lokale GGUF- und Metal-Spracherkennung mit Cohere Transcribe 03-2026. Q4_K-, Q5_0-, Q6_K- und Q8_0-Modelle für 14 explizit ausgewählte Sprachen.",
+        "ja": "Cohere Transcribe 03-2026を使用するローカルGGUF・Metal音声認識。Q4_K、Q5_0、Q6_K、Q8_0モデルと明示的に選択した14言語に対応します。"
+    },
+    "category": "transcription",
+    "iconSystemName": "waveform.badge.mic",
+    "principalClass": "CohereLocalPlugin",
+    "detailsURL": "https://github.com/TypeWhisper/typewhisper-mac/issues/1031"
+}


### PR DESCRIPTION
## Summary

- add `Cohere Transcribe (Local)` as a separate arm64, batch-only transcription plugin alongside Parakeet and the existing Cohere cloud provider
- use the pinned Cohere GGUF models through CrispASR/Metal with mandatory Silero VAD
- offer Q4_K, Q5_0, Q6_K, and Q8_0, with Q5_0 as the recommended default and only one variant loaded at a time
- support the model’s 14 explicit languages, optional Hugging Face authentication, download/checksum/delete management, and automatic runtime unloading
- supervise the persistent CrispASR process so it exits when TypeWhisper exits, including after abnormal host termination
- add the release-workflow target mapping for the official plugin artifact

## Issue context

#1031 originally evaluated Cohere’s Core ML conversion against Parakeet. The expanded benchmark established strong language-specific value but also showed unacceptable first-run time and memory for the Core ML path. The implementation therefore follows the newer GGUF/Metal prototype documented in the issue update while preserving the same product boundary: Cohere is an optional local provider, not a universal Parakeet replacement.

The integrated plugin keeps unsupported capabilities explicit: no streaming, automatic language detection, timestamps, diarization, translation, or dictionary boosting. Russian and Indian languages such as Hindi are not advertised because they are not among this model’s 14 supported languages.

## Quantization benchmark

Directional selection run on an M1 Pro with 16 GiB, using the same first five FLEURS clips in 13 languages (65 clips per variant):

| Quantization | Model size | Wall time | Peak RSS | Macro primary error |
|---|---:|---:|---:|---:|
| Q4_K | 1.51 GB | 50.77 s | 1.52 GiB | 7.99% |
| Q5_0 (default) | 1.74 GB | **44.00 s** | 1.86 GiB | **7.60%** |
| Q6_K | 1.98 GB | 44.04 s | 1.97 GiB | 7.79% |
| Q8_0 | 2.42 GB | 49.21 s | 2.37 GiB | 7.70% |

Q4_K remains a credible compact option, Q5_0 provides the best measured balance, and Q6_K/Q8_0 remain explicit choices without claiming a universal quality improvement. The persistent runtime transcribed the 17.94-second German smoke clip in approximately 0.75–1.20 seconds after startup. Integrated VAD returned empty text for one-second silence, five-second silence, and low white noise.

Full 13-language Cohere-versus-Parakeet tables, methodology, negative tests, and the Core ML/GGUF startup comparison remain in #1031.

## Distribution and licensing

Model and runtime assets are downloaded after installation and pinned by revision/checksum; they are not embedded in the plugin bundle. The settings surface links to the Cohere GGUF model, CrispASR, and VAD sources and identify the upstream licenses: Apache-2.0 for the model weights and MIT for CrispASR/VAD.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK`
- `swift test --package-path TypeWhisperPluginSDK --filter CohereLocalPluginTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run --enable-plugin com.typewhisper.cohere-transcribe CohereLocalPlugin /Users/marco/.codex/worktrees/d685/typewhisper-mac`
- `xcodebuild -project TypeWhisper.xcodeproj -target CohereLocalPlugin -configuration Release SYMROOT="$(mktemp -d)" CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=0.1.0 build`
- verify the loaded Q6_K runtime reports `{"status":"ok","backend":"cohere"}`, then quit TypeWhisper and confirm the app, supervisor, and CrispASR child processes all exit

Closes #1031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Cohere Transcribe (Local)** for on-device transcription with selectable model quality options and local model downloading/installing.
  * Added model lifecycle management (download, select, load/restore, unload, delete) with status/progress reporting.
  * Added optional **Hugging Face token** storage and validation.
  * Added plugin metadata and **German/Japanese localization**.
* **Bug Fixes**
  * Updated the plugin release workflow to correctly package the Cohere Transcribe plugin.
* **Tests**
  * Added automated tests covering model asset verification, language handling, token validation, runtime lifecycle, and model management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->