### PR TITLE
Fix indicator feedback interaction and countdown

### DIFF
--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -3,6 +3,141 @@ import AppKit
 import Combine
 import ApplicationServices
 
+private let indicatorFeedbackClockOrigin = ContinuousClock.now
+
+private func indicatorFeedbackContinuousTime() -> TimeInterval {
+    let elapsed = indicatorFeedbackClockOrigin.duration(to: ContinuousClock.now).components
+    return TimeInterval(elapsed.seconds) + (TimeInterval(elapsed.attoseconds) / 1_000_000_000_000_000_000)
+}
+
+@MainActor
+final class IndicatorFeedbackLifetime: ObservableObject {
+    typealias Now = @MainActor () -> TimeInterval
+    typealias Sleep = @MainActor (Duration) async throws -> Void
+
+    @Published private(set) var remainingFraction: Double = 0
+    @Published private(set) var isPaused = false
+
+    private let tickInterval: Duration
+    private let now: Now
+    private let sleep: Sleep
+    private var tickerTask: Task<Void, Never>?
+    private var totalDuration: TimeInterval = 0
+    private var remainingDuration: TimeInterval = 0
+    private var lastUpdateTime: TimeInterval?
+    private var onExpire: (() -> Void)?
+
+    init(
+        tickInterval: Duration = .milliseconds(33),
+        now: @escaping Now = indicatorFeedbackContinuousTime,
+        sleep: @escaping Sleep = { duration in
+            try await Task.sleep(for: duration)
+        }
+    ) {
+        self.tickInterval = tickInterval
+        self.now = now
+        self.sleep = sleep
+    }
+
+    func start(duration: TimeInterval, onExpire: @escaping () -> Void) {
+        cancel()
+
+        totalDuration = max(0, duration)
+        remainingDuration = totalDuration
+        remainingFraction = totalDuration > 0 ? 1 : 0
+        isPaused = false
+        lastUpdateTime = now()
+        self.onExpire = onExpire
+
+        guard totalDuration > 0 else {
+            expire()
+            return
+        }
+
+        tickerTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let tickInterval = self?.tickInterval,
+                      let sleep = self?.sleep else {
+                    return
+                }
+                do {
+                    try await sleep(tickInterval)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                self?.updateRemainingTime()
+            }
+        }
+    }
+
+    func setHovered(_ hovered: Bool) {
+        guard onExpire != nil, isPaused != hovered else { return }
+
+        if hovered {
+            updateRemainingTime()
+            guard onExpire != nil else { return }
+            isPaused = true
+            lastUpdateTime = nil
+        } else {
+            isPaused = false
+            lastUpdateTime = now()
+        }
+    }
+
+    func cancel() {
+        tickerTask?.cancel()
+        tickerTask = nil
+        totalDuration = 0
+        remainingDuration = 0
+        remainingFraction = 0
+        isPaused = false
+        lastUpdateTime = nil
+        onExpire = nil
+    }
+
+    func finishImmediately() {
+        guard onExpire != nil else {
+            cancel()
+            return
+        }
+        expire()
+    }
+
+    func updateRemainingTime() {
+        guard onExpire != nil,
+              !isPaused,
+              let lastUpdateTime else {
+            return
+        }
+
+        let currentTime = now()
+        let elapsed = max(0, currentTime - lastUpdateTime)
+        self.lastUpdateTime = currentTime
+        remainingDuration = max(0, remainingDuration - elapsed)
+        remainingFraction = totalDuration > 0
+            ? min(max(remainingDuration / totalDuration, 0), 1)
+            : 0
+
+        if remainingDuration <= 0 {
+            expire()
+        }
+    }
+
+    private func expire() {
+        let expiration = onExpire
+        tickerTask?.cancel()
+        tickerTask = nil
+        totalDuration = 0
+        remainingDuration = 0
+        remainingFraction = 0
+        isPaused = false
+        lastUpdateTime = nil
+        onExpire = nil
+        expiration?()
+    }
+}
+
 struct IndicatorPresentationState: Equatable {
     enum Source: Equatable {
         case dictation
@@ -66,6 +201,8 @@ struct IndicatorPresentationData {
     let actionFeedbackIcon: String?
     let actionFeedbackIsError: Bool
     let actionFeedbackUndoTitle: String?
+    let actionFeedbackRemainingFraction: Double?
+    let actionFeedbackIsPaused: Bool
     let externalStreamingDisplayCount: Int
 
     var isRecorder: Bool {
@@ -109,6 +246,11 @@ struct IndicatorPresentationData {
                 actionFeedbackIcon: dictation.actionFeedbackIcon,
                 actionFeedbackIsError: dictation.actionFeedbackIsError,
                 actionFeedbackUndoTitle: dictation.actionFeedbackUndoTitle,
+                actionFeedbackRemainingFraction: presentation.state == .inserting
+                    && dictation.actionFeedbackMessage != nil
+                    ? dictation.actionFeedbackRemainingFraction
+                    : nil,
+                actionFeedbackIsPaused: dictation.actionFeedbackIsPaused,
                 externalStreamingDisplayCount: dictation.externalStreamingDisplayCount
             )
         case .recorder:
@@ -127,6 +269,8 @@ struct IndicatorPresentationData {
                 actionFeedbackIcon: nil,
                 actionFeedbackIsError: false,
                 actionFeedbackUndoTitle: nil,
+                actionFeedbackRemainingFraction: nil,
+                actionFeedbackIsPaused: false,
                 externalStreamingDisplayCount: dictation.externalStreamingDisplayCount
             )
         }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -260,8 +260,11 @@ final class DictationViewModel: ObservableObject {
     @Published var actionFeedbackIcon: String?
     @Published var actionFeedbackIsError: Bool = false
     @Published var actionFeedbackUndoTitle: String?
+    @Published private(set) var actionFeedbackRemainingFraction: Double = 0
+    @Published private(set) var actionFeedbackIsPaused = false
     @Published var activeAppIcon: NSImage?
     private var actionDisplayDuration: TimeInterval = 3.5
+    private let indicatorFeedbackLifetime = IndicatorFeedbackLifetime()
 
     @Published var indicatorStyle: IndicatorStyle {
         didSet { Self.persistIndicatorStyle(indicatorStyle) }
@@ -959,6 +962,20 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func setupBindings() {
+        indicatorFeedbackLifetime.$remainingFraction
+            .removeDuplicates()
+            .sink { [weak self] remainingFraction in
+                self?.actionFeedbackRemainingFraction = remainingFraction
+            }
+            .store(in: &cancellables)
+
+        indicatorFeedbackLifetime.$isPaused
+            .removeDuplicates()
+            .sink { [weak self] isPaused in
+                self?.actionFeedbackIsPaused = isPaused
+            }
+            .store(in: &cancellables)
+
         hotkeyService.onDictationStart = { [weak self] requestTimestamp in
             guard let self else { return }
             logger.info("hotkey→onDictationStart (state=\(String(describing: self.state), privacy: .public))")
@@ -1150,6 +1167,7 @@ final class DictationViewModel: ObservableObject {
         clearPendingUndoActionFeedback()
         insertingResetTask?.cancel()
         insertingResetTask = nil
+        indicatorFeedbackLifetime.cancel()
         clearCancelWarning()
         pendingPushToTalkDiscardMessage = nil
         metadataCaptureTask?.cancel()
@@ -1281,7 +1299,11 @@ final class DictationViewModel: ObservableObject {
         }
 
         if state == .inserting {
-            scheduleInsertingReset(after: .seconds(actionDisplayDuration))
+            if actionFeedbackMessage != nil {
+                indicatorFeedbackLifetime.finishImmediately()
+            } else {
+                scheduleInsertingReset(after: .seconds(actionDisplayDuration))
+            }
         }
     }
 
@@ -1969,8 +1991,11 @@ final class DictationViewModel: ObservableObject {
                 lastTranscriptionLanguage = detectedLang
 
                 state = .inserting
-                let resetDelay: Duration = actionFeedbackMessage != nil ? .seconds(actionDisplayDuration) : .seconds(1.5)
-                scheduleInsertingReset(after: resetDelay)
+                if actionFeedbackMessage != nil {
+                    startActionFeedbackLifetime(duration: actionDisplayDuration)
+                } else {
+                    scheduleInsertingReset(after: .seconds(1.5))
+                }
             } catch {
                 guard !Task.isCancelled else { return }
                 audioRecordingService.preserveActiveRecoveryRecording()
@@ -2152,6 +2177,7 @@ final class DictationViewModel: ObservableObject {
         errorResetTask?.cancel()
         insertingResetTask?.cancel()
         insertingResetTask = nil
+        indicatorFeedbackLifetime.cancel()
         stopFinalizationTask?.cancel()
         stopFinalizationTask = nil
         transcriptionTask?.cancel()
@@ -2799,7 +2825,27 @@ final class DictationViewModel: ObservableObject {
             errorLogService.addEntry(message: message, category: errorCategory)
         }
 
-        scheduleInsertingReset(after: .seconds(duration))
+        startActionFeedbackLifetime(duration: duration)
+    }
+
+    func setActionFeedbackHovered(_ hovered: Bool) {
+        guard state == .inserting, actionFeedbackMessage != nil else {
+            indicatorFeedbackLifetime.setHovered(false)
+            return
+        }
+        indicatorFeedbackLifetime.setHovered(hovered)
+    }
+
+    private func startActionFeedbackLifetime(duration: TimeInterval) {
+        insertingResetTask?.cancel()
+        insertingResetTask = nil
+        let shouldRemainPaused = indicatorFeedbackLifetime.isPaused
+        indicatorFeedbackLifetime.start(duration: duration) { [weak self] in
+            self?.resetDictationState()
+        }
+        if shouldRemainPaused {
+            indicatorFeedbackLifetime.setHovered(true)
+        }
     }
 
     private func scheduleInsertingReset(after delay: Duration) {

--- a/TypeWhisper/Views/MinimalIndicatorPanel.swift
+++ b/TypeWhisper/Views/MinimalIndicatorPanel.swift
@@ -8,17 +8,43 @@ private class MinimalFirstMouseHostingView<Content: View>: NSHostingView<Content
 
 /// Floating panel for the compact minimal indicator mode.
 class MinimalIndicatorPanel: NSPanel {
-    private static let panelWidth: CGFloat = 420
-    private static let panelHeight: CGFloat = 160
-
     private let screenResolver: IndicatorScreenResolver
+    private let displayModeProvider: () -> NotchIndicatorDisplay
+    private let overlayPositionProvider: () -> OverlayPosition
+    private let indicatorVisibleInScreenCapturesProvider: () -> Bool
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
+    private var isFeedbackInteractive = false
 
-    init(screenResolver: IndicatorScreenResolver) {
+    convenience init(screenResolver: IndicatorScreenResolver) {
+        self.init(
+            screenResolver: screenResolver,
+            displayModeProvider: { DictationViewModel.shared.notchIndicatorDisplay },
+            overlayPositionProvider: { DictationViewModel.shared.overlayPosition },
+            indicatorVisibleInScreenCapturesProvider: {
+                DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            },
+            content: { MinimalIndicatorView() }
+        )
+    }
+
+    init<Content: View>(
+        screenResolver: IndicatorScreenResolver,
+        displayModeProvider: @escaping () -> NotchIndicatorDisplay,
+        overlayPositionProvider: @escaping () -> OverlayPosition,
+        indicatorVisibleInScreenCapturesProvider: @escaping () -> Bool = { true },
+        @ViewBuilder content: () -> Content
+    ) {
         self.screenResolver = screenResolver
+        self.displayModeProvider = displayModeProvider
+        self.overlayPositionProvider = overlayPositionProvider
+        self.indicatorVisibleInScreenCapturesProvider = indicatorVisibleInScreenCapturesProvider
+        let initialSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .minimal,
+            isFeedbackInteractive: false
+        )
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -34,12 +60,12 @@ class MinimalIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            displayMode: displayModeProvider(),
             windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
-            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
 
-        let hostingView = MinimalFirstMouseHostingView(rootView: MinimalIndicatorView())
+        let hostingView = MinimalFirstMouseHostingView(rootView: content())
         hostingView.sizingOptions = []
         contentView = hostingView
     }
@@ -100,10 +126,15 @@ class MinimalIndicatorPanel: NSPanel {
             }
             .store(in: &cancellables)
 
-        vm.$actionFeedbackUndoTitle
+        Publishers.CombineLatest(vm.$state, vm.$actionFeedbackMessage)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] undoTitle in
-                self?.ignoresMouseEvents = undoTitle == nil
+            .sink { [weak self] state, message in
+                self?.updateFeedbackInteraction(
+                    isInteractive: IndicatorFeedbackPanelLayout.isInteractive(
+                        state: state,
+                        message: message
+                    )
+                )
             }
             .store(in: &cancellables)
     }
@@ -140,7 +171,7 @@ class MinimalIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        let overlayPosition = DictationViewModel.shared.overlayPosition
+        let overlayPosition = overlayPositionProvider()
         let placement: IndicatorPlacement = overlayPosition == .top ? .notchStrip : .nonNotchArea
         if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: placement) {
             suppressForForeignFullscreen()
@@ -148,22 +179,24 @@ class MinimalIndicatorPanel: NSPanel {
         }
 
         let screenFrame = screen.visibleFrame
-        let x = screenFrame.midX - Self.panelWidth / 2
+        let panelSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .minimal,
+            isFeedbackInteractive: isFeedbackInteractive
+        )
+        let panelFrame = IndicatorFeedbackPanelLayout.panelFrame(
+            for: .minimal,
+            size: panelSize,
+            in: screenFrame,
+            overlayPosition: overlayPosition
+        )
 
-        let y: CGFloat
-        switch overlayPosition {
-        case .bottom:
-            y = screenFrame.origin.y + 20
-        case .top:
-            y = screenFrame.origin.y + screenFrame.height - Self.panelHeight - 20
-        }
-
-        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
+        setFrame(panelFrame, display: true)
+        ignoresMouseEvents = !isFeedbackInteractive
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            displayMode: displayModeProvider(),
             windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
-            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
     }
 
@@ -173,18 +206,30 @@ class MinimalIndicatorPanel: NSPanel {
     }
 
     private func resolveScreen() -> NSScreen {
-        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+        screenResolver.resolveScreen(for: displayModeProvider())
     }
 
     func refreshPlacementForActiveContextChange() {
         guard isVisible else { return }
-        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+        if displayModeProvider() == .activeScreen {
             cachedScreen = nil
         }
         show()
     }
 
+    func updateFeedbackInteraction(isInteractive: Bool) {
+        if !isInteractive {
+            ignoresMouseEvents = true
+        }
+        guard isFeedbackInteractive != isInteractive else { return }
+        isFeedbackInteractive = isInteractive
+        if isVisible {
+            show()
+        }
+    }
+
     func dismiss() {
+        ignoresMouseEvents = true
         cachedScreen = nil
         orderOut(nil)
     }

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -10,7 +10,7 @@ struct MinimalIndicatorView: View {
     private let idleWidth: CGFloat = 42
     private let processingWidth: CGFloat = 76
     private let insertingWidth: CGFloat = 44
-    private let messageWidth: CGFloat = 360
+    private let messageWidth = IndicatorFeedbackPanelLayout.minimalFeedbackWidth
 
     private var presentation: IndicatorPresentationData {
         IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
@@ -132,20 +132,28 @@ struct MinimalIndicatorView: View {
     }
 
     private var content: some View {
-        HStack(spacing: 8) {
-            if let message = errorMessage {
-                compactMessage(
-                    text: message,
-                    icon: "xmark.circle.fill",
-                    iconColor: .red
-                )
-            } else if let message = cancelWarningMessage {
-                compactMessage(
-                    text: message,
-                    icon: "exclamationmark.triangle.fill",
-                    iconColor: .yellow
-                )
-            } else if let message = actionFeedbackMessage {
+        contentBody
+            .background(.black.opacity(0.84), in: Capsule())
+            .overlay(
+                Capsule()
+                    .stroke(strokeColor, lineWidth: 1)
+            )
+            .clipShape(Capsule())
+            .shadow(color: shadowColor, radius: 10, y: 4)
+    }
+
+    @ViewBuilder
+    private var contentBody: some View {
+        if let message = actionFeedbackMessage {
+            VStack(spacing: 0) {
+                if let remainingFraction = presentation.actionFeedbackRemainingFraction {
+                    IndicatorFeedbackProgressBar(remainingFraction: remainingFraction)
+                } else {
+                    Color.clear
+                        .frame(height: 2)
+                        .accessibilityHidden(true)
+                }
+
                 compactMessage(
                     text: message,
                     icon: presentation.actionFeedbackIcon ?? (presentation.actionFeedbackIsError ? "xmark.circle.fill" : "checkmark.circle.fill"),
@@ -155,18 +163,35 @@ struct MinimalIndicatorView: View {
                         viewModel.undoActionFeedback()
                     }
                 )
-            } else {
-                compactStatus
+                .padding(.horizontal, 14)
+                .frame(maxHeight: .infinity)
             }
+            .frame(height: IndicatorFeedbackPanelLayout.feedbackBodyHeight)
+            .contentShape(Rectangle())
+            .onHover { hovered in
+                viewModel.setActionFeedbackHovered(hovered)
+            }
+        } else {
+            HStack(spacing: 8) {
+                if let message = errorMessage {
+                    compactMessage(
+                        text: message,
+                        icon: "xmark.circle.fill",
+                        iconColor: .red
+                    )
+                } else if let message = cancelWarningMessage {
+                    compactMessage(
+                        text: message,
+                        icon: "exclamationmark.triangle.fill",
+                        iconColor: .yellow
+                    )
+                } else {
+                    compactStatus
+                }
+            }
+            .padding(.horizontal, showsExpandedMessage ? 14 : 12)
+            .padding(.vertical, showsExpandedMessage ? 9 : 10)
         }
-        .padding(.horizontal, showsExpandedMessage ? 14 : 12)
-        .padding(.vertical, showsExpandedMessage ? 9 : 10)
-        .background(.black.opacity(0.84), in: Capsule())
-        .overlay(
-            Capsule()
-                .stroke(strokeColor, lineWidth: 1)
-        )
-        .shadow(color: shadowColor, radius: 10, y: 4)
     }
 
     @ViewBuilder

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -1,5 +1,22 @@
 import SwiftUI
 
+struct MinimalIndicatorFeedbackProgress: View {
+    let remainingFraction: Double?
+
+    var body: some View {
+        Group {
+            if let remainingFraction {
+                IndicatorFeedbackProgressBar(remainingFraction: remainingFraction)
+            } else {
+                Color.clear
+                    .frame(height: 2)
+                    .accessibilityHidden(true)
+            }
+        }
+        .padding(.horizontal, IndicatorFeedbackPanelLayout.minimalFeedbackProgressHorizontalInset)
+    }
+}
+
 /// Compact floating indicator for power users who only want essential status.
 struct MinimalIndicatorView: View {
     @ObservedObject private var viewModel = DictationViewModel.shared
@@ -146,13 +163,9 @@ struct MinimalIndicatorView: View {
     private var contentBody: some View {
         if let message = actionFeedbackMessage {
             VStack(spacing: 0) {
-                if let remainingFraction = presentation.actionFeedbackRemainingFraction {
-                    IndicatorFeedbackProgressBar(remainingFraction: remainingFraction)
-                } else {
-                    Color.clear
-                        .frame(height: 2)
-                        .accessibilityHidden(true)
-                }
+                MinimalIndicatorFeedbackProgress(
+                    remainingFraction: presentation.actionFeedbackRemainingFraction
+                )
 
                 compactMessage(
                     text: message,

--- a/TypeWhisper/Views/NotchIndicatorLayout.swift
+++ b/TypeWhisper/Views/NotchIndicatorLayout.swift
@@ -1,5 +1,77 @@
 import AppKit
 
+enum IndicatorFeedbackPanelLayout {
+    static let feedbackWidth: CGFloat = 340
+    static let minimalFeedbackWidth: CGFloat = 360
+    static let feedbackBodyHeight: CGFloat = 52
+    static let overlayStatusHeight: CGFloat = 48
+    static let screenEdgeInset: CGFloat = 20
+
+    static func isInteractive(
+        state: DictationViewModel.State,
+        message: String?
+    ) -> Bool {
+        state == .inserting && message != nil
+    }
+
+    static func panelSize(
+        for style: IndicatorStyle,
+        isFeedbackInteractive: Bool,
+        notchClosedWidth: CGFloat = 0,
+        notchClosedHeight: CGFloat = NotchIndicatorLayout.notchedClosedHeight
+    ) -> CGSize {
+        guard isFeedbackInteractive else {
+            switch style {
+            case .notch:
+                return CGSize(width: 500, height: 500)
+            case .overlay:
+                return CGSize(width: 500, height: 300)
+            case .minimal:
+                return CGSize(width: 420, height: 160)
+            }
+        }
+
+        switch style {
+        case .notch:
+            return CGSize(
+                width: max(notchClosedWidth, feedbackWidth),
+                height: notchClosedHeight + feedbackBodyHeight
+            )
+        case .overlay:
+            return CGSize(
+                width: feedbackWidth,
+                height: overlayStatusHeight + feedbackBodyHeight
+            )
+        case .minimal:
+            return CGSize(width: minimalFeedbackWidth, height: feedbackBodyHeight)
+        }
+    }
+
+    static func panelFrame(
+        for style: IndicatorStyle,
+        size: CGSize,
+        in screenFrame: CGRect,
+        overlayPosition: OverlayPosition = .top
+    ) -> CGRect {
+        let x = screenFrame.midX - (size.width / 2)
+        let y: CGFloat
+
+        switch style {
+        case .notch:
+            y = screenFrame.maxY - size.height
+        case .overlay, .minimal:
+            switch overlayPosition {
+            case .bottom:
+                y = screenFrame.minY + screenEdgeInset
+            case .top:
+                y = screenFrame.maxY - size.height - screenEdgeInset
+            }
+        }
+
+        return CGRect(origin: CGPoint(x: x, y: y), size: size)
+    }
+}
+
 enum NotchExpansionMode {
     case closed
     case transcript
@@ -149,7 +221,7 @@ enum NotchIndicatorLayout {
         case .transcript:
             return max(closedWidth, 400)
         case .feedback:
-            return max(closedWidth, 340)
+            return max(closedWidth, IndicatorFeedbackPanelLayout.feedbackWidth)
         case .processing:
             return closedWidth + 80
         }

--- a/TypeWhisper/Views/NotchIndicatorLayout.swift
+++ b/TypeWhisper/Views/NotchIndicatorLayout.swift
@@ -4,6 +4,7 @@ enum IndicatorFeedbackPanelLayout {
     static let feedbackWidth: CGFloat = 340
     static let minimalFeedbackWidth: CGFloat = 360
     static let feedbackBodyHeight: CGFloat = 52
+    static let minimalFeedbackProgressHorizontalInset: CGFloat = feedbackBodyHeight / 2
     static let overlayStatusHeight: CGFloat = 48
     static let screenEdgeInset: CGFloat = 20
 

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -34,9 +34,6 @@ private class FirstMouseHostingView<Content: View>: NSHostingView<Content> {
 /// Panel that visually extends the MacBook notch, centered over the hardware notch.
 /// Only shown on displays with a hardware notch - hidden on non-notch displays regardless of settings.
 class NotchIndicatorPanel: NSPanel {
-    /// Large enough to accommodate the expanded (open) state. SwiftUI clips the visible area.
-    private static let panelWidth: CGFloat = 500
-    private static let panelHeight: CGFloat = 500
     private static let presentationAnimationDuration: Duration = .milliseconds(220)
 
     private let screenResolver: IndicatorScreenResolver
@@ -47,6 +44,7 @@ class NotchIndicatorPanel: NSPanel {
     private var cachedScreen: NSScreen?
     private var showTask: Task<Void, Never>?
     private var dismissTask: Task<Void, Never>?
+    private var isFeedbackInteractive = false
 
     convenience init(screenResolver: IndicatorScreenResolver) {
         self.init(
@@ -68,8 +66,12 @@ class NotchIndicatorPanel: NSPanel {
         self.screenResolver = screenResolver
         self.displayModeProvider = displayModeProvider
         self.indicatorVisibleInScreenCapturesProvider = indicatorVisibleInScreenCapturesProvider
+        let initialSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .notch,
+            isFeedbackInteractive: false
+        )
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -143,10 +145,15 @@ class NotchIndicatorPanel: NSPanel {
             }
             .store(in: &cancellables)
 
-        vm.$actionFeedbackUndoTitle
+        Publishers.CombineLatest(vm.$state, vm.$actionFeedbackMessage)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] undoTitle in
-                self?.ignoresMouseEvents = undoTitle == nil
+            .sink { [weak self] state, message in
+                self?.updateFeedbackInteraction(
+                    isInteractive: IndicatorFeedbackPanelLayout.isInteractive(
+                        state: state,
+                        message: message
+                    )
+                )
             }
             .store(in: &cancellables)
     }
@@ -215,10 +222,24 @@ class NotchIndicatorPanel: NSPanel {
         notchGeometry.update(for: screen)
 
         let screenFrame = screen.frame
-        let x = screenFrame.midX - Self.panelWidth / 2
-        let y = screenFrame.origin.y + screenFrame.height - Self.panelHeight
+        let closedWidth = NotchIndicatorLayout.closedWidth(
+            hasNotch: notchGeometry.hasNotch,
+            notchWidth: notchGeometry.notchWidth
+        )
+        let panelSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .notch,
+            isFeedbackInteractive: isFeedbackInteractive,
+            notchClosedWidth: closedWidth,
+            notchClosedHeight: notchGeometry.notchHeight
+        )
+        let panelFrame = IndicatorFeedbackPanelLayout.panelFrame(
+            for: .notch,
+            size: panelSize,
+            in: screenFrame
+        )
 
-        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
+        setFrame(panelFrame, display: true)
+        ignoresMouseEvents = !isFeedbackInteractive
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
             displayMode: displayModeProvider(),
@@ -239,7 +260,19 @@ class NotchIndicatorPanel: NSPanel {
         placePanel()
     }
 
+    func updateFeedbackInteraction(isInteractive: Bool) {
+        if !isInteractive {
+            ignoresMouseEvents = true
+        }
+        guard isFeedbackInteractive != isInteractive else { return }
+        isFeedbackInteractive = isInteractive
+        if isVisible {
+            show()
+        }
+    }
+
     func dismiss() {
+        ignoresMouseEvents = true
         cachedScreen = nil
         showTask?.cancel()
         showTask = nil

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -15,7 +15,7 @@ struct NotchIndicatorView: View {
     private let contentPadding: CGFloat = 28
     private let sizing: IndicatorSizing = .notch
     private let processingBodyHeight: CGFloat = 28
-    private let feedbackBodyHeight: CGFloat = 52
+    private let feedbackBodyHeight = IndicatorFeedbackPanelLayout.feedbackBodyHeight
 
     private var presentation: IndicatorPresentationData {
         IndicatorPresentationData.make(dictation: viewModel, recorder: recorder)
@@ -157,6 +157,10 @@ struct NotchIndicatorView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .opacity(presentationOpacity)
         .preferredColorScheme(.dark)
+        .onHover { hovered in
+            guard hasActionFeedback else { return }
+            viewModel.setActionFeedbackHovered(hovered)
+        }
         .animation(.easeOut(duration: 0.22), value: geometry.isPresented)
         .animation(.easeOut(duration: 0.24), value: currentWidth)
         .animation(.easeOut(duration: 0.24), value: expandedBodyHeight)
@@ -283,7 +287,8 @@ struct NotchIndicatorView: View {
                 actionTitle: presentation.actionFeedbackUndoTitle,
                 onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
                     viewModel.undoActionFeedback()
-                }
+                },
+                remainingFraction: presentation.actionFeedbackRemainingFraction
             )
         } else {
             Color.clear

--- a/TypeWhisper/Views/OverlayIndicatorPanel.swift
+++ b/TypeWhisper/Views/OverlayIndicatorPanel.swift
@@ -8,17 +8,43 @@ private class OverlayFirstMouseHostingView<Content: View>: NSHostingView<Content
 
 /// Floating panel for the Overlay Indicator mode.
 class OverlayIndicatorPanel: NSPanel {
-    private static let panelWidth: CGFloat = 500
-    private static let panelHeight: CGFloat = 300
-
     private let screenResolver: IndicatorScreenResolver
+    private let displayModeProvider: () -> NotchIndicatorDisplay
+    private let overlayPositionProvider: () -> OverlayPosition
+    private let indicatorVisibleInScreenCapturesProvider: () -> Bool
     private var cancellables = Set<AnyCancellable>()
     private var cachedScreen: NSScreen?
+    private var isFeedbackInteractive = false
 
-    init(screenResolver: IndicatorScreenResolver) {
+    convenience init(screenResolver: IndicatorScreenResolver) {
+        self.init(
+            screenResolver: screenResolver,
+            displayModeProvider: { DictationViewModel.shared.notchIndicatorDisplay },
+            overlayPositionProvider: { DictationViewModel.shared.overlayPosition },
+            indicatorVisibleInScreenCapturesProvider: {
+                DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            },
+            content: { OverlayIndicatorView() }
+        )
+    }
+
+    init<Content: View>(
+        screenResolver: IndicatorScreenResolver,
+        displayModeProvider: @escaping () -> NotchIndicatorDisplay,
+        overlayPositionProvider: @escaping () -> OverlayPosition,
+        indicatorVisibleInScreenCapturesProvider: @escaping () -> Bool = { true },
+        @ViewBuilder content: () -> Content
+    ) {
         self.screenResolver = screenResolver
+        self.displayModeProvider = displayModeProvider
+        self.overlayPositionProvider = overlayPositionProvider
+        self.indicatorVisibleInScreenCapturesProvider = indicatorVisibleInScreenCapturesProvider
+        let initialSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .overlay,
+            isFeedbackInteractive: false
+        )
         super.init(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
+            contentRect: NSRect(origin: .zero, size: initialSize),
             styleMask: [.borderless, .nonactivatingPanel, .utilityWindow, .hudWindow],
             backing: .buffered,
             defer: false
@@ -34,12 +60,12 @@ class OverlayIndicatorPanel: NSPanel {
         ignoresMouseEvents = true
         FloatingPanelSpacePolicy.applyIndicatorPolicy(
             to: self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            displayMode: displayModeProvider(),
             windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
-            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
 
-        let hostingView = OverlayFirstMouseHostingView(rootView: OverlayIndicatorView())
+        let hostingView = OverlayFirstMouseHostingView(rootView: content())
         hostingView.sizingOptions = []
         contentView = hostingView
     }
@@ -100,10 +126,15 @@ class OverlayIndicatorPanel: NSPanel {
             }
             .store(in: &cancellables)
 
-        vm.$actionFeedbackUndoTitle
+        Publishers.CombineLatest(vm.$state, vm.$actionFeedbackMessage)
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] undoTitle in
-                self?.ignoresMouseEvents = undoTitle == nil
+            .sink { [weak self] state, message in
+                self?.updateFeedbackInteraction(
+                    isInteractive: IndicatorFeedbackPanelLayout.isInteractive(
+                        state: state,
+                        message: message
+                    )
+                )
             }
             .store(in: &cancellables)
     }
@@ -140,7 +171,7 @@ class OverlayIndicatorPanel: NSPanel {
             cachedScreen = screen
         }
 
-        let overlayPosition = DictationViewModel.shared.overlayPosition
+        let overlayPosition = overlayPositionProvider()
         let placement: IndicatorPlacement = overlayPosition == .top ? .notchStrip : .nonNotchArea
         if IndicatorFullscreenSuppressionPolicy.shouldSuppressIndicator(on: screen, placement: placement) {
             suppressForForeignFullscreen()
@@ -148,23 +179,24 @@ class OverlayIndicatorPanel: NSPanel {
         }
 
         let screenFrame = screen.visibleFrame
-        let x = screenFrame.midX - Self.panelWidth / 2
+        let panelSize = IndicatorFeedbackPanelLayout.panelSize(
+            for: .overlay,
+            isFeedbackInteractive: isFeedbackInteractive
+        )
+        let panelFrame = IndicatorFeedbackPanelLayout.panelFrame(
+            for: .overlay,
+            size: panelSize,
+            in: screenFrame,
+            overlayPosition: overlayPosition
+        )
 
-        let y: CGFloat
-        switch overlayPosition {
-        case .bottom:
-            y = screenFrame.origin.y + 20
-        case .top:
-            // Position below menu bar area, like a taskbar
-            y = screenFrame.origin.y + screenFrame.height - Self.panelHeight - 20
-        }
-
-        setFrame(NSRect(x: x, y: y, width: Self.panelWidth, height: Self.panelHeight), display: true)
+        setFrame(panelFrame, display: true)
+        ignoresMouseEvents = !isFeedbackInteractive
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
-            displayMode: DictationViewModel.shared.notchIndicatorDisplay,
+            displayMode: displayModeProvider(),
             windowLevel: FloatingPanelSpacePolicy.floatingIndicatorWindowLevel,
-            isVisibleInScreenCaptures: DictationViewModel.shared.indicatorVisibleInScreenCaptures
+            isVisibleInScreenCaptures: indicatorVisibleInScreenCapturesProvider()
         )
     }
 
@@ -174,18 +206,30 @@ class OverlayIndicatorPanel: NSPanel {
     }
 
     private func resolveScreen() -> NSScreen {
-        screenResolver.resolveScreen(for: DictationViewModel.shared.notchIndicatorDisplay)
+        screenResolver.resolveScreen(for: displayModeProvider())
     }
 
     func refreshPlacementForActiveContextChange() {
         guard isVisible else { return }
-        if DictationViewModel.shared.notchIndicatorDisplay == .activeScreen {
+        if displayModeProvider() == .activeScreen {
             cachedScreen = nil
         }
         show()
     }
 
+    func updateFeedbackInteraction(isInteractive: Bool) {
+        if !isInteractive {
+            ignoresMouseEvents = true
+        }
+        guard isFeedbackInteractive != isInteractive else { return }
+        isFeedbackInteractive = isInteractive
+        if isVisible {
+            show()
+        }
+    }
+
     func dismiss() {
+        ignoresMouseEvents = true
         cachedScreen = nil
         orderOut(nil)
     }

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -29,6 +29,30 @@ struct OverlayTranscriptPreviewState: Equatable {
     }
 }
 
+struct OverlayIndicatorSurface<Content: View>: View {
+    let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 24, style: .continuous)
+    }
+
+    var body: some View {
+        content
+            .background(.black.opacity(0.85), in: shape)
+            // The hosting panel itself is rectangular. Clip all rendered content,
+            // especially the feedback progress bar, to the visible pill.
+            .clipShape(shape)
+            .overlay(
+                shape
+                    .stroke(Color.white.opacity(0.15), lineWidth: 1)
+            )
+    }
+}
+
 /// Pill-shaped overlay indicator that appears centered on the screen.
 /// Supports top and bottom positioning.
 struct OverlayIndicatorView: View {
@@ -77,9 +101,9 @@ struct OverlayIndicatorView: View {
     }
 
     private var currentWidth: CGFloat {
-        if hasCancelWarning { return max(closedWidth, 340) }
+        if hasCancelWarning { return max(closedWidth, IndicatorFeedbackPanelLayout.feedbackWidth) }
         if transcriptBodyVisible { return max(closedWidth, 400) }
-        if hasActionFeedback { return max(closedWidth, 340) }
+        if hasActionFeedback { return max(closedWidth, IndicatorFeedbackPanelLayout.feedbackWidth) }
         return closedWidth
     }
 
@@ -96,28 +120,29 @@ struct OverlayIndicatorView: View {
     }
 
     var body: some View {
-        VStack(alignment: .center, spacing: 0) {
-            if isTop {
-                statusBar
-                    .frame(height: 48)
-                    .frame(maxWidth: .infinity)
-                expandableContent
-            } else {
-                expandableContent
-                statusBar
-                    .frame(height: 48)
-                    .frame(maxWidth: .infinity)
+        OverlayIndicatorSurface {
+            VStack(alignment: .center, spacing: 0) {
+                if isTop {
+                    statusBar
+                        .frame(height: IndicatorFeedbackPanelLayout.overlayStatusHeight)
+                        .frame(maxWidth: .infinity)
+                    expandableContent
+                } else {
+                    expandableContent
+                    statusBar
+                        .frame(height: IndicatorFeedbackPanelLayout.overlayStatusHeight)
+                        .frame(maxWidth: .infinity)
+                }
             }
+            .frame(width: currentWidth)
         }
-        .frame(width: currentWidth)
-        .background(.black.opacity(0.85), in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .overlay(
-            RoundedRectangle(cornerRadius: 24, style: .continuous)
-                .stroke(Color.white.opacity(0.15), lineWidth: 1)
-        )
         .shadow(color: .black.opacity(0.3), radius: 10, y: 5)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: isTop ? .top : .bottom)
         .preferredColorScheme(.dark)
+        .onHover { hovered in
+            guard hasActionFeedback else { return }
+            viewModel.setActionFeedbackHovered(hovered)
+        }
         .animation(.easeInOut(duration: 0.3), value: textExpanded)
         .animation(.easeInOut(duration: 0.2), value: presentation.state)
         // Matches the ~30 Hz (33ms) level-publish throttle shared by both
@@ -218,7 +243,6 @@ struct OverlayIndicatorView: View {
             }
 
             if hasActionFeedback {
-                Divider().background(Color.white.opacity(0.1))
                 IndicatorActionFeedback(
                     message: presentation.actionFeedbackMessage ?? "",
                     icon: presentation.actionFeedbackIcon,
@@ -228,8 +252,12 @@ struct OverlayIndicatorView: View {
                     actionTitle: presentation.actionFeedbackUndoTitle,
                     onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
                         viewModel.undoActionFeedback()
-                    }
+                    },
+                    remainingFraction: presentation.actionFeedbackRemainingFraction
                 )
+                .overlay(alignment: .top) {
+                    Divider().background(Color.white.opacity(0.1))
+                }
             }
         } else {
             // Bottom position: action feedback on top, text above status bar
@@ -243,9 +271,12 @@ struct OverlayIndicatorView: View {
                     actionTitle: presentation.actionFeedbackUndoTitle,
                     onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
                         viewModel.undoActionFeedback()
-                    }
+                    },
+                    remainingFraction: presentation.actionFeedbackRemainingFraction
                 )
-                Divider().background(Color.white.opacity(0.1))
+                .overlay(alignment: .bottom) {
+                    Divider().background(Color.white.opacity(0.1))
+                }
             }
 
             if hasTranscriptSection {

--- a/TypeWhisper/Views/SharedIndicatorComponents.swift
+++ b/TypeWhisper/Views/SharedIndicatorComponents.swift
@@ -269,6 +269,24 @@ struct IndicatorExpandableText: View {
 
 // MARK: - Action Feedback Banner
 
+struct IndicatorFeedbackProgressBar: View {
+    let remainingFraction: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(Color.white.opacity(0.65))
+                .frame(
+                    width: geometry.size.width * CGFloat(min(max(remainingFraction, 0), 1)),
+                    height: 2
+                )
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(height: 2)
+        .accessibilityHidden(true)
+    }
+}
+
 struct IndicatorActionFeedback: View {
     let message: String
     let icon: String?
@@ -277,33 +295,45 @@ struct IndicatorActionFeedback: View {
     let contentPadding: CGFloat
     var actionTitle: String? = nil
     var onAction: (() -> Void)? = nil
+    var remainingFraction: Double? = nil
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: icon ?? (isError ? "xmark.circle.fill" : "checkmark.circle.fill"))
-                .foregroundStyle(iconColor ?? (isError ? .red : .green))
-                .font(.system(size: 16))
-                .accessibilityHidden(true)
-            Text(message)
-                .font(.system(size: 13, weight: .medium))
-                .foregroundStyle(.white.opacity(0.9))
-                .lineLimit(2)
-
-            if let actionTitle, let onAction {
-                Spacer(minLength: 8)
-                Button(actionTitle, action: onAction)
-                    .buttonStyle(.borderless)
-                    .controlSize(.small)
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(Color.white.opacity(0.12), in: Capsule())
+        VStack(spacing: 0) {
+            if let remainingFraction {
+                IndicatorFeedbackProgressBar(remainingFraction: remainingFraction)
+            } else {
+                Color.clear
+                    .frame(height: 2)
+                    .accessibilityHidden(true)
             }
+
+            HStack(spacing: 8) {
+                Image(systemName: icon ?? (isError ? "xmark.circle.fill" : "checkmark.circle.fill"))
+                    .foregroundStyle(iconColor ?? (isError ? .red : .green))
+                    .font(.system(size: 16))
+                    .accessibilityHidden(true)
+                Text(message)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.9))
+                    .lineLimit(2)
+
+                if let actionTitle, let onAction {
+                    Spacer(minLength: 8)
+                    Button(actionTitle, action: onAction)
+                        .buttonStyle(.borderless)
+                        .controlSize(.small)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.white.opacity(0.12), in: Capsule())
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.horizontal, contentPadding)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 10)
-        .padding(.horizontal, contentPadding)
+        .frame(height: IndicatorFeedbackPanelLayout.feedbackBodyHeight)
         .accessibilityElement(children: actionTitle == nil ? .combine : .contain)
         .accessibilityLabel(message)
     }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1414,6 +1414,40 @@ final class IndicatorPanelInteractionTests: XCTestCase {
         XCTAssertGreaterThan(centerEdgeRed, 0.8)
     }
 
+    func testMinimalSurfaceKeepsProgressVisibleNearExpiration() throws {
+        let width = Int(IndicatorFeedbackPanelLayout.minimalFeedbackWidth)
+        let height = Int(IndicatorFeedbackPanelLayout.feedbackBodyHeight)
+        let renderer = ImageRenderer(
+            content: VStack(spacing: 0) {
+                MinimalIndicatorFeedbackProgress(remainingFraction: 0.02)
+                Color.clear
+            }
+            .frame(width: CGFloat(width), height: CGFloat(height))
+            .background(.black.opacity(0.84), in: Capsule())
+            .clipShape(Capsule())
+        )
+        renderer.proposedSize = ProposedViewSize(
+            width: CGFloat(width),
+            height: CGFloat(height)
+        )
+        renderer.scale = 1
+
+        let image = try XCTUnwrap(renderer.cgImage)
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        let progressX = Int(
+            IndicatorFeedbackPanelLayout.minimalFeedbackProgressHorizontalInset
+        ) + 1
+        let progressColor = try XCTUnwrap(
+            bitmap.colorAt(x: progressX, y: 0)?.usingColorSpace(.deviceRGB)
+        )
+        let outsideColor = try XCTUnwrap(
+            bitmap.colorAt(x: 0, y: 0)?.usingColorSpace(.deviceRGB)
+        )
+
+        XCTAssertGreaterThan(progressColor.redComponent, 0.5)
+        XCTAssertLessThan(outsideColor.alphaComponent, 0.1)
+    }
+
     func testFeedbackFramePreservesStyleAnchor() {
         let screenFrame = CGRect(x: 100, y: 200, width: 1_000, height: 800)
 

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1015,6 +1015,33 @@ final class IndicatorPresentationStateTests: XCTestCase {
             actionFeedbackIcon: nil,
             actionFeedbackIsError: false,
             actionFeedbackUndoTitle: nil,
+            actionFeedbackRemainingFraction: nil,
+            actionFeedbackIsPaused: false,
+            externalStreamingDisplayCount: 0
+        )
+    }
+
+    private func makeFeedbackPresentation(
+        remainingFraction: Double,
+        isPaused: Bool
+    ) -> IndicatorPresentationData {
+        IndicatorPresentationData(
+            source: .dictation,
+            state: .inserting,
+            recordingDuration: 0,
+            audioLevel: 0,
+            partialText: "",
+            activeRuleName: nil,
+            activeAppIcon: nil,
+            isRecordingInputReady: false,
+            cancelWarningMessage: nil,
+            processingPhase: nil,
+            actionFeedbackMessage: "Saved",
+            actionFeedbackIcon: "checkmark.circle.fill",
+            actionFeedbackIsError: false,
+            actionFeedbackUndoTitle: "Undo",
+            actionFeedbackRemainingFraction: remainingFraction,
+            actionFeedbackIsPaused: isPaused,
             externalStreamingDisplayCount: 0
         )
     }
@@ -1109,6 +1136,369 @@ final class IndicatorPresentationStateTests: XCTestCase {
             visibility: .never,
             presentation: preparing
         ))
+    }
+
+    func testFeedbackPresentationCarriesCountdownAndPauseState() {
+        let presentation = makeFeedbackPresentation(
+            remainingFraction: 0.625,
+            isPaused: true
+        )
+
+        XCTAssertEqual(presentation.actionFeedbackRemainingFraction, 0.625)
+        XCTAssertTrue(presentation.actionFeedbackIsPaused)
+    }
+
+    func testRegularRecordingPresentationDoesNotExposeFeedbackCountdown() {
+        XCTAssertNil(
+            makeRecordingPresentation(isInputReady: true)
+                .actionFeedbackRemainingFraction
+        )
+    }
+}
+
+@MainActor
+final class IndicatorFeedbackLifetimeTests: XCTestCase {
+    func testCountdownUsesElapsedContinuousTimeAndExpiresOnce() {
+        let clock = IndicatorFeedbackTestClock(now: 100)
+        var expirationCount = 0
+        let lifetime = makeLifetime(clock: clock)
+        defer { lifetime.cancel() }
+
+        lifetime.start(duration: 10) {
+            expirationCount += 1
+        }
+        XCTAssertEqual(lifetime.remainingFraction, 1)
+
+        clock.now = 102.5
+        lifetime.updateRemainingTime()
+        XCTAssertEqual(lifetime.remainingFraction, 0.75, accuracy: 0.0001)
+
+        clock.now = 110
+        lifetime.updateRemainingTime()
+        lifetime.updateRemainingTime()
+        XCTAssertEqual(lifetime.remainingFraction, 0)
+        XCTAssertEqual(expirationCount, 1)
+    }
+
+    func testHoverPausesAndResumesFromRemainingTime() {
+        let clock = IndicatorFeedbackTestClock()
+        let lifetime = makeLifetime(clock: clock)
+        defer { lifetime.cancel() }
+
+        lifetime.start(duration: 10) {}
+        clock.now = 2
+        lifetime.setHovered(true)
+        lifetime.setHovered(true)
+        XCTAssertTrue(lifetime.isPaused)
+        XCTAssertEqual(lifetime.remainingFraction, 0.8, accuracy: 0.0001)
+
+        clock.now = 8
+        lifetime.updateRemainingTime()
+        XCTAssertEqual(lifetime.remainingFraction, 0.8, accuracy: 0.0001)
+
+        lifetime.setHovered(false)
+        lifetime.setHovered(false)
+        clock.now = 10
+        lifetime.updateRemainingTime()
+        XCTAssertFalse(lifetime.isPaused)
+        XCTAssertEqual(lifetime.remainingFraction, 0.6, accuracy: 0.0001)
+    }
+
+    func testRestartCancelsPreviousExpiration() {
+        let clock = IndicatorFeedbackTestClock()
+        var firstExpirationCount = 0
+        var secondExpirationCount = 0
+        let lifetime = makeLifetime(clock: clock)
+        defer { lifetime.cancel() }
+
+        lifetime.start(duration: 10) {
+            firstExpirationCount += 1
+        }
+        clock.now = 3
+        lifetime.updateRemainingTime()
+
+        lifetime.start(duration: 4) {
+            secondExpirationCount += 1
+        }
+        XCTAssertEqual(lifetime.remainingFraction, 1)
+
+        clock.now = 7
+        lifetime.updateRemainingTime()
+        XCTAssertEqual(firstExpirationCount, 0)
+        XCTAssertEqual(secondExpirationCount, 1)
+    }
+
+    func testCancelPreventsExpiration() {
+        let clock = IndicatorFeedbackTestClock()
+        var expirationCount = 0
+        let lifetime = makeLifetime(clock: clock)
+
+        lifetime.start(duration: 2) {
+            expirationCount += 1
+        }
+        lifetime.cancel()
+        clock.now = 5
+        lifetime.updateRemainingTime()
+
+        XCTAssertEqual(expirationCount, 0)
+        XCTAssertEqual(lifetime.remainingFraction, 0)
+        XCTAssertFalse(lifetime.isPaused)
+    }
+
+    func testFinishImmediatelyOverridesHoverPause() {
+        let clock = IndicatorFeedbackTestClock()
+        var expirationCount = 0
+        let lifetime = makeLifetime(clock: clock)
+        defer { lifetime.cancel() }
+
+        lifetime.start(duration: 12) {
+            expirationCount += 1
+        }
+        clock.now = 1
+        lifetime.setHovered(true)
+        lifetime.finishImmediately()
+        lifetime.finishImmediately()
+
+        XCTAssertEqual(expirationCount, 1)
+        XCTAssertEqual(lifetime.remainingFraction, 0)
+        XCTAssertFalse(lifetime.isPaused)
+    }
+
+    func testKnownFeedbackDurationsRetainTheirOwnCountdownScale() {
+        for duration in [2.5, 3.0, 12.0, 7.25] {
+            let clock = IndicatorFeedbackTestClock()
+            let lifetime = makeLifetime(clock: clock)
+
+            lifetime.start(duration: duration) {}
+            clock.now = duration / 2
+            lifetime.updateRemainingTime()
+
+            XCTAssertEqual(
+                lifetime.remainingFraction,
+                0.5,
+                accuracy: 0.0001,
+                "Unexpected progress for duration \(duration)"
+            )
+            lifetime.cancel()
+        }
+    }
+
+    private func makeLifetime(
+        clock: IndicatorFeedbackTestClock
+    ) -> IndicatorFeedbackLifetime {
+        IndicatorFeedbackLifetime(
+            tickInterval: .seconds(60),
+            now: { clock.now },
+            sleep: { _ in
+                try await Task.sleep(for: .seconds(60))
+            }
+        )
+    }
+}
+
+@MainActor
+private final class IndicatorFeedbackTestClock {
+    var now: TimeInterval
+
+    init(now: TimeInterval = 0) {
+        self.now = now
+    }
+}
+
+@MainActor
+final class IndicatorPanelInteractionTests: XCTestCase {
+    func testOnlyVisibleInsertingFeedbackIsInteractive() {
+        XCTAssertTrue(IndicatorFeedbackPanelLayout.isInteractive(
+            state: .inserting,
+            message: "Saved"
+        ))
+        XCTAssertFalse(IndicatorFeedbackPanelLayout.isInteractive(
+            state: .inserting,
+            message: nil
+        ))
+        XCTAssertFalse(IndicatorFeedbackPanelLayout.isInteractive(
+            state: .recording,
+            message: "Stale"
+        ))
+        XCTAssertFalse(IndicatorFeedbackPanelLayout.isInteractive(
+            state: .processing,
+            message: "Stale"
+        ))
+    }
+
+    func testInteractiveFramesMatchVisibleFeedbackSurfaces() {
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .notch,
+                isFeedbackInteractive: true,
+                notchClosedWidth: 305,
+                notchClosedHeight: 30
+            ),
+            CGSize(width: 340, height: 82)
+        )
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .overlay,
+                isFeedbackInteractive: true
+            ),
+            CGSize(width: 340, height: 100)
+        )
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .minimal,
+                isFeedbackInteractive: true
+            ),
+            CGSize(width: 360, height: 52)
+        )
+
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .notch,
+                isFeedbackInteractive: false
+            ),
+            CGSize(width: 500, height: 500)
+        )
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .overlay,
+                isFeedbackInteractive: false
+            ),
+            CGSize(width: 500, height: 300)
+        )
+        XCTAssertEqual(
+            IndicatorFeedbackPanelLayout.panelSize(
+                for: .minimal,
+                isFeedbackInteractive: false
+            ),
+            CGSize(width: 420, height: 160)
+        )
+    }
+
+    func testOverlaySurfaceClipsFeedbackProgressToRoundedWindow() throws {
+        let width = Int(IndicatorFeedbackPanelLayout.feedbackWidth)
+        let height = Int(
+            IndicatorFeedbackPanelLayout.overlayStatusHeight
+                + IndicatorFeedbackPanelLayout.feedbackBodyHeight
+        )
+        let renderer = ImageRenderer(
+            content: OverlayIndicatorSurface {
+                Color.clear
+                    .frame(width: CGFloat(width), height: CGFloat(height))
+                    .overlay(alignment: .top) {
+                        Color.red.frame(height: 2)
+                    }
+            }
+        )
+        renderer.proposedSize = ProposedViewSize(
+            width: CGFloat(width),
+            height: CGFloat(height)
+        )
+        renderer.scale = 1
+
+        let image = try XCTUnwrap(renderer.cgImage)
+        let bitmap = NSBitmapImageRep(cgImage: image)
+        let leftEdgeRed = try XCTUnwrap([
+            XCTUnwrap(bitmap.colorAt(x: 0, y: 0)),
+            XCTUnwrap(bitmap.colorAt(x: 0, y: height - 1))
+        ]
+        .map(\.redComponent)
+        .max())
+        let centerEdgeRed = try XCTUnwrap([
+            XCTUnwrap(bitmap.colorAt(x: width / 2, y: 0)),
+            XCTUnwrap(bitmap.colorAt(x: width / 2, y: height - 1))
+        ]
+        .map(\.redComponent)
+        .max())
+
+        XCTAssertLessThan(leftEdgeRed, 0.2)
+        XCTAssertGreaterThan(centerEdgeRed, 0.8)
+    }
+
+    func testFeedbackFramePreservesStyleAnchor() {
+        let screenFrame = CGRect(x: 100, y: 200, width: 1_000, height: 800)
+
+        let passiveNotch = frame(for: .notch, interactive: false, in: screenFrame)
+        let feedbackNotch = frame(for: .notch, interactive: true, in: screenFrame)
+        XCTAssertEqual(passiveNotch.maxY, feedbackNotch.maxY)
+        XCTAssertEqual(feedbackNotch.maxY, screenFrame.maxY)
+
+        let passiveTop = frame(for: .overlay, interactive: false, in: screenFrame, position: .top)
+        let feedbackTop = frame(for: .overlay, interactive: true, in: screenFrame, position: .top)
+        XCTAssertEqual(passiveTop.maxY, feedbackTop.maxY)
+        XCTAssertEqual(feedbackTop.maxY, screenFrame.maxY - 20)
+
+        let passiveBottom = frame(for: .minimal, interactive: false, in: screenFrame, position: .bottom)
+        let feedbackBottom = frame(for: .minimal, interactive: true, in: screenFrame, position: .bottom)
+        XCTAssertEqual(passiveBottom.minY, feedbackBottom.minY)
+        XCTAssertEqual(feedbackBottom.minY, screenFrame.minY + 20)
+    }
+
+    func testAllPanelsRemainNonactivatingAndPassiveWhenHidden() throws {
+        guard let screen = NSScreen.screens.first else {
+            throw XCTSkip("Indicator panel tests require an available screen")
+        }
+        let resolver = makeResolver(screen: screen)
+        let notch = NotchIndicatorPanel(
+            screenResolver: resolver,
+            displayModeProvider: { .activeScreen },
+            content: { _ in EmptyView() }
+        )
+        let overlay = OverlayIndicatorPanel(
+            screenResolver: resolver,
+            displayModeProvider: { .activeScreen },
+            overlayPositionProvider: { .top },
+            content: { EmptyView() }
+        )
+        let minimal = MinimalIndicatorPanel(
+            screenResolver: resolver,
+            displayModeProvider: { .activeScreen },
+            overlayPositionProvider: { .top },
+            content: { EmptyView() }
+        )
+        let panels: [NSPanel] = [notch, overlay, minimal]
+        defer { panels.forEach { $0.orderOut(nil) } }
+
+        notch.updateFeedbackInteraction(isInteractive: true)
+        overlay.updateFeedbackInteraction(isInteractive: true)
+        minimal.updateFeedbackInteraction(isInteractive: true)
+
+        for panel in panels {
+            XCTAssertFalse(panel.canBecomeKey)
+            XCTAssertFalse(panel.canBecomeMain)
+            XCTAssertTrue(panel.ignoresMouseEvents)
+        }
+    }
+
+    private func frame(
+        for style: IndicatorStyle,
+        interactive: Bool,
+        in screenFrame: CGRect,
+        position: OverlayPosition = .top
+    ) -> CGRect {
+        let size = IndicatorFeedbackPanelLayout.panelSize(
+            for: style,
+            isFeedbackInteractive: interactive,
+            notchClosedWidth: 305,
+            notchClosedHeight: 30
+        )
+        return IndicatorFeedbackPanelLayout.panelFrame(
+            for: style,
+            size: size,
+            in: screenFrame,
+            overlayPosition: position
+        )
+    }
+
+    private func makeResolver(screen: NSScreen) -> IndicatorScreenResolver {
+        IndicatorScreenResolver(
+            focusedElementPositionProvider: { nil },
+            focusedWindowFrameProvider: { nil },
+            frontmostApplicationProvider: { nil },
+            mouseLocationProvider: { CGPoint(x: screen.frame.midX, y: screen.frame.midY) },
+            screensProvider: { [screen] },
+            mainScreenProvider: { screen },
+            windowFrameProvider: { _ in nil }
+        )
     }
 }
 

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4273,6 +4273,44 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testHoveredFeedbackDoesNotDelayBufferedHotkeyStart() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        var startCount = 0
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            startCount += 1
+        }
+        context.dictationViewModel.requireSecondEscapeToCancelRecording = false
+        context.dictationViewModel.state = .recording
+        context.dictationViewModel.handleCancelHotkey()
+        context.dictationViewModel.setActionFeedbackHovered(true)
+
+        XCTAssertEqual(context.dictationViewModel.state, .inserting)
+        XCTAssertTrue(context.dictationViewModel.actionFeedbackIsPaused)
+
+        context.hotkeyService.onDictationStart?(DispatchTime.now().uptimeNanoseconds)
+
+        for _ in 0..<100 {
+            if context.dictationViewModel.state == .recording { break }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTAssertEqual(context.dictationViewModel.state, .recording)
+        XCTAssertEqual(startCount, 1)
+        XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
+        XCTAssertFalse(context.dictationViewModel.actionFeedbackIsPaused)
+    }
+
+    @MainActor
     func testBufferedHotkeyStartIsCancelledWhenPushToTalkStops() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var dictationContext: DictationContext?


### PR DESCRIPTION
## Summary

- unify timed indicator feedback under an elapsed-time countdown lifecycle with hover pause and resume
- constrain Notch, Overlay, and Minimal feedback panels to their visible interactive surfaces so clicks outside pass through
- clip Overlay feedback and its countdown bar to the popup's rounded shape
- cover feedback lifetime, presentation data, panel interaction, anchoring, and rounded clipping with tests

## Root cause

The transparent indicator panels retained large mouse-active bounds while feedback was visible, so they intercepted clicks outside the visible popup. Overlay feedback used a rounded background without clipping its content, which allowed the countdown bar to extend into the transparent rounded corners.

## User impact

Hover and Undo remain interactive inside feedback popups while Finder, Chrome, Settings, and other windows stay clickable outside them. Existing feedback durations, including dictionary and plugin-specific durations, are preserved.

## Test plan

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/IndicatorFeedbackLifetimeTests -only-testing:TypeWhisperTests/IndicatorPanelInteractionTests -only-testing:TypeWhisperTests/NotchIndicatorPanelLifecycleTests -only-testing:TypeWhisperTests/IndicatorPresentationStateTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

```sh
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/1c9e/typewhisper-mac
```

Manual verification covered the rounded Overlay progress bar and click-through behavior; the result was accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible countdown progress bar for action feedback messages (including remaining-time fraction).
  * Improved feedback UI to pause the countdown while hovered and resume when the pointer leaves.
  * Refreshed feedback panel sizing/positioning for notch, overlay, and minimal modes for more consistent layout.
* **Bug Fixes**
  * More reliable feedback panel mouse interaction and expiration behavior, ensuring dictation resets correctly during hover/cancel flows.
* **Tests**
  * Added UI and integration coverage for countdown/pause behavior, panel interaction, layout rendering, and hover timing around hotkey starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->