### PR TITLE
Complete Cohere German localization

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -11,6 +11,19 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     static let pluginName = "Cohere Transcribe (Local)"
     static let providerIdentifier = "cohere-transcribe"
 
+    static var localizationBundle: Bundle {
+#if SWIFT_PACKAGE
+        .module
+#else
+        Bundle(for: CohereLocalPlugin.self)
+#endif
+    }
+
+    static func localizedString(_ key: String, bundle: Bundle? = nil) -> String {
+        let bundle = bundle ?? localizationBundle
+        return bundle.localizedString(forKey: key, value: key, table: nil)
+    }
+
     static let compactModel = CohereLocalModelDefinition(
         id: "cohere-transcribe-03-2026-q4_k",
         displayName: "Compact (Q4_K · Metal)",
@@ -130,7 +143,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
     // MARK: - TranscriptionEnginePlugin
 
     var providerId: String { Self.providerIdentifier }
-    var providerDisplayName: String { Self.pluginName }
+    var providerDisplayName: String { Self.localizedString(Self.pluginName) }
 
     var isConfigured: Bool {
         state.withLock {
@@ -156,8 +169,8 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             } ?? false
             return PluginModelInfo(
                 id: model.id,
-                displayName: model.displayName,
-                sizeDescription: model.sizeDescription,
+                displayName: Self.localizedString(model.displayName),
+                sizeDescription: Self.localizedString(model.sizeDescription),
                 languageCount: Self.supportedLanguageCodes.count,
                 downloaded: isDownloaded,
                 loaded: snapshot.loadedModelId == model.id
@@ -678,6 +691,10 @@ struct CohereLocalModelDefinition: Sendable, Equatable {
     let fileName: String
     let fileSize: Int64
     let sha256: String
+
+    var localizationKeys: [String] {
+        [displayName, sizeDescription, ramRequirement, detail]
+    }
 }
 
 enum CohereLocalModelState: Sendable, Equatable {
@@ -707,33 +724,66 @@ enum CohereLocalPluginError: LocalizedError, Sendable {
     var errorDescription: String? {
         switch self {
         case .explicitLanguageRequired(let supportedLanguages):
-            return "Cohere Transcribe requires an explicit supported language: \(supportedLanguages.joined(separator: ", ")). Automatic language detection is not available."
+            let message = CohereLocalPlugin.localizedString(
+                "Cohere Transcribe requires an explicitly selected supported language. Automatic language detection is not available. Supported languages:"
+            )
+            return "\(message) \(supportedLanguages.joined(separator: ", "))."
         case .translationUnsupported:
-            return "Cohere Transcribe does not support translation."
+            return CohereLocalPlugin.localizedString(
+                "Cohere Transcribe does not support translation."
+            )
         case .modelNotDownloaded:
-            return "The Cohere Transcribe model is not downloaded."
+            return CohereLocalPlugin.localizedString(
+                "The Cohere Transcribe model is not downloaded."
+            )
         case .modelNotLoaded:
-            return "The Cohere Transcribe model is not loaded. Open the plugin settings and load it first."
+            return CohereLocalPlugin.localizedString(
+                "The Cohere Transcribe model is not loaded. Open the plugin settings and load it first."
+            )
         case .invalidRepositoryIdentifier:
-            return "The pinned Cohere model repository identifier is invalid."
+            return CohereLocalPlugin.localizedString(
+                "The pinned Cohere model repository identifier is invalid."
+            )
         case .incompleteModelDownload:
-            return "The Cohere model download completed without all required model files."
+            return CohereLocalPlugin.localizedString(
+                "The Cohere model download completed without all required model files."
+            )
         case .runtimeDownloadFailed:
-            return "The CrispASR runtime download failed."
+            return CohereLocalPlugin.localizedString(
+                "The CrispASR runtime download failed."
+            )
         case .invalidRuntimeArchive:
-            return "The verified CrispASR runtime archive is incomplete."
+            return CohereLocalPlugin.localizedString(
+                "The verified CrispASR runtime archive is incomplete."
+            )
         case .runtimeExtractionFailed(let message):
-            return "The CrispASR runtime could not be extracted: \(message)"
+            let description = CohereLocalPlugin.localizedString(
+                "The CrispASR runtime could not be extracted."
+            )
+            return "\(description) \(message)"
         case .assetVerificationFailed(let fileName):
-            return "Cohere asset verification failed for \(fileName)."
+            let description = CohereLocalPlugin.localizedString(
+                "Cohere asset verification failed for:"
+            )
+            return "\(description) \(fileName)."
         case .invalidLocalServerURL:
-            return "The local CrispASR server URL is invalid."
+            return CohereLocalPlugin.localizedString(
+                "The local CrispASR server URL is invalid."
+            )
         case .localPortReservationFailed:
-            return "TypeWhisper could not reserve a local port for Cohere Transcribe."
+            return CohereLocalPlugin.localizedString(
+                "TypeWhisper could not reserve a local port for Cohere Transcribe."
+            )
         case .runtimeExited(let output):
-            return "CrispASR exited while starting.\(output.isEmpty ? "" : "\n\(output)")"
+            let description = CohereLocalPlugin.localizedString(
+                "CrispASR exited while starting."
+            )
+            return "\(description)\(output.isEmpty ? "" : "\n\(output)")"
         case .runtimeStartupTimedOut(let output):
-            return "CrispASR did not become ready within five minutes.\(output.isEmpty ? "" : "\n\(output)")"
+            let description = CohereLocalPlugin.localizedString(
+                "CrispASR did not become ready within five minutes."
+            )
+            return "\(description)\(output.isEmpty ? "" : "\n\(output)")"
         }
     }
 }
@@ -744,7 +794,7 @@ enum CohereLocalPluginError: LocalizedError, Sendable {
 private struct CohereLocalSettingsView: View {
     let plugin: CohereLocalPlugin
 
-    private let bundle = Bundle(for: CohereLocalPlugin.self)
+    private let bundle = CohereLocalPlugin.localizationBundle
     private let pollTimer = Timer.publish(every: 0.25, on: .main, in: .common).autoconnect()
     private let cohereModelURL = URL(
         string: "https://huggingface.co/\(CohereLocalModelAssets.modelRepositoryId)"
@@ -860,7 +910,8 @@ private struct CohereLocalSettingsView: View {
                     selection: $selectedModelId
                 ) {
                     ForEach(CohereLocalPlugin.models, id: \.id) { model in
-                        Text(model.displayName).tag(model.id)
+                        Text(CohereLocalPlugin.localizedString(model.displayName, bundle: bundle))
+                            .tag(model.id)
                     }
                 }
                 .onChange(of: selectedModelId) { _, newValue in
@@ -871,14 +922,20 @@ private struct CohereLocalSettingsView: View {
 
                 HStack(alignment: .top) {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(selectedModel.displayName)
+                        Text(CohereLocalPlugin.localizedString(
+                            selectedModel.displayName,
+                            bundle: bundle
+                        ))
                             .font(.headline)
                         Text(
-                            "\(selectedModel.sizeDescription) · \(selectedModel.ramRequirement)"
+                            "\(CohereLocalPlugin.localizedString(selectedModel.sizeDescription, bundle: bundle)) · \(CohereLocalPlugin.localizedString(selectedModel.ramRequirement, bundle: bundle))"
                         )
                         .font(.caption)
                         .foregroundStyle(.secondary)
-                        Text(selectedModel.detail)
+                        Text(CohereLocalPlugin.localizedString(
+                            selectedModel.detail,
+                            bundle: bundle
+                        ))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -1071,7 +1128,7 @@ private struct CohereLocalSettingsView: View {
             capabilityRow(
                 icon: "exclamationmark.circle",
                 text: String(
-                    localized: "No automatic language detection, streaming, diarization, translation, or dictionary boosting.",
+                    localized: "No automatic language detection, streaming, timestamps, diarization, translation, or dictionary boosting.",
                     bundle: bundle
                 )
             )

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -290,7 +290,7 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
 
         return try await PluginLocalInferenceGate.shared.withLock {
             try Task.checkCancellation()
-            let _ = onProgress("Running Cohere locally with Metal…")
+            let _ = onProgress(Self.localizedString("Running Cohere locally with Metal…"))
             let result = try await runtime.server.transcribe(
                 audio: audio,
                 language: cohereLanguage
@@ -569,11 +569,13 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             return nil
         case .downloading(let progress):
             return PluginSettingsActivity(
-                message: "Downloading Cohere model",
+                message: Self.localizedString("Downloading Cohere model"),
                 progress: progress
             )
         case .preparing:
-            return PluginSettingsActivity(message: "Starting and warming up Cohere with Metal")
+            return PluginSettingsActivity(
+                message: Self.localizedString("Starting and warming up Cohere with Metal")
+            )
         case .error(let message):
             return PluginSettingsActivity(message: message, isError: true)
         }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
@@ -281,26 +281,6 @@
         }
       }
     },
-    "This removes the Cohere model and its local VAD files. You can download them again later." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dadurch werden das Cohere-Modell und seine lokalen VAD-Dateien entfernt. Du kannst sie später erneut herunterladen."
-          }
-        }
-      }
-    },
-    "This test provider has a much larger memory footprint than Parakeet and unloads through TypeWhisper's model lifecycle." : {
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dieser Test-Provider benötigt deutlich mehr Arbeitsspeicher als Parakeet und wird über den Modell-Lebenszyklus von TypeWhisper entladen."
-          }
-        }
-      }
-    },
     "Unload" : {
       "localizations" : {
         "de" : {
@@ -347,6 +327,316 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Vor jeder Transkription läuft eine Sprachaktivitätserkennung, um Halluzinationen bei Stille und leisem Rauschen zu unterdrücken."
+          }
+        }
+      }
+    },
+    "1.51 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,51 GB"
+          }
+        }
+      }
+    },
+    "1.74 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,74 GB"
+          }
+        }
+      }
+    },
+    "1.98 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1,98 GB"
+          }
+        }
+      }
+    },
+    "2.42 GB" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2,42 GB"
+          }
+        }
+      }
+    },
+    "8 GB+ Mac" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mac mit mindestens 8 GB"
+          }
+        }
+      }
+    },
+    "16 GB+ recommended" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mindestens 16 GB empfohlen"
+          }
+        }
+      }
+    },
+    "Best tested balance of size, speed, and accuracy" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bestes getestetes Verhältnis von Größe, Geschwindigkeit und Genauigkeit"
+          }
+        }
+      }
+    },
+    "Choose Compact Q4_K for the smallest download, Fast Q5_0 for the recommended default, Q6_K for higher numeric precision, or experimental Q8_0 for maximum numeric precision. Only the selected model is loaded." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wähle Kompakt Q4_K für den kleinsten Download, Schnell Q5_0 als empfohlene Standardeinstellung, Q6_K für höhere numerische Präzision oder das experimentelle Q8_0 für maximale numerische Präzision. Nur das ausgewählte Modell wird geladen."
+          }
+        }
+      }
+    },
+    "Cohere asset verification failed for:" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere-Asset-Überprüfung fehlgeschlagen für:"
+          }
+        }
+      }
+    },
+    "Cohere Transcribe does not support translation." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere Transcribe unterstützt keine Übersetzung."
+          }
+        }
+      }
+    },
+    "Cohere Transcribe requires an explicitly selected supported language. Automatic language detection is not available. Supported languages:" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere Transcribe benötigt eine explizit ausgewählte unterstützte Sprache. Automatische Spracherkennung ist nicht verfügbar. Unterstützte Sprachen:"
+          }
+        }
+      }
+    },
+    "Compact (Q4_K · Metal)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kompakt (Q4_K · Metal)"
+          }
+        }
+      }
+    },
+    "CrispASR did not become ready within five minutes." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrispASR war nicht innerhalb von fünf Minuten bereit."
+          }
+        }
+      }
+    },
+    "CrispASR exited while starting." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CrispASR wurde während des Starts beendet."
+          }
+        }
+      }
+    },
+    "Fast (Q5_0 · Recommended)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schnell (Q5_0 · empfohlen)"
+          }
+        }
+      }
+    },
+    "Higher precision (Q6_K · Metal)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Höhere Präzision (Q6_K · Metal)"
+          }
+        }
+      }
+    },
+    "Intermediate quantization between recommended Q5_0 and Q8_0" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mittlere Quantisierung zwischen dem empfohlenen Q5_0 und Q8_0"
+          }
+        }
+      }
+    },
+    "Largest quantization; no overall accuracy gain measured yet" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Größte Quantisierung; bisher kein allgemeiner Genauigkeitsgewinn gemessen"
+          }
+        }
+      }
+    },
+    "Maximum precision (Q8_0 · Experimental)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maximale Präzision (Q8_0 · experimentell)"
+          }
+        }
+      }
+    },
+    "Model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modell"
+          }
+        }
+      }
+    },
+    "Smallest download and memory footprint" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleinster Download und geringster Speicherbedarf"
+          }
+        }
+      }
+    },
+    "The Cohere model download completed without all required model files." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Der Download des Cohere-Modells wurde abgeschlossen, ohne dass alle erforderlichen Modelldateien vorhanden sind."
+          }
+        }
+      }
+    },
+    "The Cohere Transcribe model is not downloaded." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Cohere-Transcribe-Modell wurde nicht heruntergeladen."
+          }
+        }
+      }
+    },
+    "The Cohere Transcribe model is not loaded. Open the plugin settings and load it first." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Cohere-Transcribe-Modell ist nicht geladen. Öffne die Plugin-Einstellungen und lade es zuerst."
+          }
+        }
+      }
+    },
+    "The CrispASR runtime could not be extracted." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die CrispASR-Laufzeit konnte nicht entpackt werden."
+          }
+        }
+      }
+    },
+    "The CrispASR runtime download failed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die CrispASR-Laufzeit konnte nicht heruntergeladen werden."
+          }
+        }
+      }
+    },
+    "The local CrispASR server URL is invalid." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die URL des lokalen CrispASR-Servers ist ungültig."
+          }
+        }
+      }
+    },
+    "The pinned Cohere model repository identifier is invalid." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Kennung des festgeschriebenen Cohere-Modell-Repositorys ist ungültig."
+          }
+        }
+      }
+    },
+    "The verified CrispASR runtime archive is incomplete." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das überprüfte CrispASR-Laufzeitarchiv ist unvollständig."
+          }
+        }
+      }
+    },
+    "This removes the selected Cohere model. Shared runtime files remain while another variant is installed." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dadurch wird das ausgewählte Cohere-Modell entfernt. Gemeinsam genutzte Laufzeitdateien bleiben erhalten, solange eine andere Variante installiert ist."
+          }
+        }
+      }
+    },
+    "TypeWhisper could not reserve a local port for Cohere Transcribe." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisper konnte keinen lokalen Port für Cohere Transcribe reservieren."
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
@@ -111,6 +111,16 @@
         }
       }
     },
+    "Downloading Cohere model" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere-Modell wird heruntergeladen"
+          }
+        }
+      }
+    },
     "Error" : {
       "localizations" : {
         "de" : {
@@ -227,6 +237,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bereit"
+          }
+        }
+      }
+    },
+    "Running Cohere locally with Metal…" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere läuft lokal mit Metal …"
           }
         }
       }
@@ -637,6 +657,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "TypeWhisper konnte keinen lokalen Port für Cohere Transcribe reservieren."
+          }
+        }
+      }
+    },
+    "Starting and warming up Cohere with Metal" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cohere wird mit Metal gestartet und aufgewärmt"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -1,4 +1,5 @@
 import Darwin
+import Foundation
 import TypeWhisperPluginSDK
 import TypeWhisperPluginSDKTesting
 import XCTest
@@ -23,7 +24,10 @@ final class CohereLocalPluginTests: XCTestCase {
 
         XCTAssertEqual(CohereLocalPlugin.pluginId, "com.typewhisper.cohere-transcribe")
         XCTAssertEqual(plugin.providerId, "cohere-transcribe")
-        XCTAssertEqual(plugin.providerDisplayName, "Cohere Transcribe (Local)")
+        XCTAssertEqual(
+            plugin.providerDisplayName,
+            CohereLocalPlugin.localizedString(CohereLocalPlugin.pluginName)
+        )
         XCTAssertFalse(plugin.supportsStreaming)
         XCTAssertFalse(plugin.supportsTranslation)
         XCTAssertEqual(plugin.dictionaryTermsSupport, .unsupported)
@@ -431,4 +435,66 @@ final class CohereLocalPluginTests: XCTestCase {
         )
         XCTAssertEqual(request.httpMethod, "GET")
     }
+
+    func testGermanLocalizationCoversCurrentSourceAndModelMetadata() throws {
+        let pluginDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: pluginDirectory.appendingPathComponent("CohereLocalPlugin.swift"),
+            encoding: .utf8
+        )
+        let catalogData = try Data(
+            contentsOf: pluginDirectory.appendingPathComponent("Localizable.xcstrings")
+        )
+        let catalog = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: catalogData) as? [String: Any]
+        )
+        let catalogStrings = try XCTUnwrap(catalog["strings"] as? [String: Any])
+
+        var requiredKeys = Set(
+            CohereLocalPlugin.models.flatMap(\.localizationKeys)
+        )
+        requiredKeys.insert(CohereLocalPlugin.pluginName)
+
+        let patterns = [
+            #"String\(localized:\s*"([^"]+)""#,
+            #"Text\(\s*"([^"]+)"\s*,\s*bundle:\s*bundle"#,
+            #"localizedString\(\s*"([^"]+)""#,
+        ]
+        for pattern in patterns {
+            let expression = try NSRegularExpression(pattern: pattern)
+            let range = NSRange(source.startIndex..., in: source)
+            for match in expression.matches(in: source, range: range) {
+                guard let captureRange = Range(match.range(at: 1), in: source) else {
+                    continue
+                }
+                requiredKeys.insert(String(source[captureRange]))
+            }
+        }
+
+        let missingKeys = requiredKeys.filter { catalogStrings[$0] == nil }.sorted()
+        XCTAssertEqual(missingKeys, [], "Missing localization keys: \(missingKeys)")
+
+        let incompleteGermanKeys = requiredKeys.filter { key in
+            guard
+                let entry = catalogStrings[key] as? [String: Any],
+                let localizations = entry["localizations"] as? [String: Any],
+                let german = localizations["de"] as? [String: Any],
+                let stringUnit = german["stringUnit"] as? [String: Any],
+                stringUnit["state"] as? String == "translated",
+                let value = stringUnit["value"] as? String,
+                !value.isEmpty
+            else {
+                return true
+            }
+            return false
+        }.sorted()
+        XCTAssertEqual(
+            incompleteGermanKeys,
+            [],
+            "Missing German translations: \(incompleteGermanKeys)"
+        )
+    }
+
 }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -495,6 +495,19 @@ final class CohereLocalPluginTests: XCTestCase {
             [],
             "Missing German translations: \(incompleteGermanKeys)"
         )
+
+        let directUserFacingLiteralPatterns = [
+            #"onProgress\(\s*""#,
+            #"message:\s*""#,
+        ]
+        for pattern in directUserFacingLiteralPatterns {
+            let expression = try NSRegularExpression(pattern: pattern)
+            let range = NSRange(source.startIndex..., in: source)
+            XCTAssertNil(
+                expression.firstMatch(in: source, range: range),
+                "User-facing status strings must use the plugin localization bundle"
+            )
+        }
     }
 
 }


### PR DESCRIPTION
## Issue context

Cohere Transcribe (Local) v0.1.0 shipped with several English strings still visible when TypeWhisper runs in German. The string catalog reported complete German coverage, but current source keys, dynamic model metadata, and user-facing runtime errors were missing from the catalog.

Closes #1033

## Changes

- Localize the Cohere provider name, model names, sizes, RAM guidance, and model details through the plugin resource bundle.
- Localize current removal, capability, runtime, and error copy in German.
- Remove stale catalog entries and synchronize the catalog with the current UI wording.
- Add a focused regression test that compares source-used keys and dynamic model keys against translated German catalog entries.

## User impact

German Cohere settings no longer fall back to English for model metadata and error states. Technical names and quantization identifiers remain unchanged.

## Test plan

```bash
git diff --check
jq empty TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Localizable.xcstrings
swift test --package-path TypeWhisperPluginSDK
```

Validated locally with 459 passing Plugin SDK tests. The updated development bundle was also built, signed, installed, and launched successfully. This PR does not trigger a Cohere plugin release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added centralized localization for the Cohere Local plugin, updating display names, model details, settings/status messages, and user-facing error text to use translated strings.
  * Improved German translations for download, validation, VAD/license guidance, model/quantization options, and runtime failure messages.
  * Clarified in model removal guidance that only the selected model is removed while shared runtime files remain for other variants.
  * Updated capability guidance to mention timestamps.
* **Tests**
  * Added/expanded checks to ensure all current localization keys have complete German translations and that key UI/status text isn’t left as hardcoded literals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->