### PR TITLE
Fix AssemblyAI Universal 3.5 Pro support

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		AA00000000000000000211 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000202 /* Localizable.xcstrings */; };
 		AA00000000000000000212 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000023 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000213 /* AssemblyAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000204 /* AssemblyAIPlugin.swift */; };
+		C31042000000000000000001 /* AssemblyAIModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C31042000000000000000002 /* AssemblyAIModelCatalog.swift */; };
 		AA00000000000000000214 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000205 /* manifest.json */; };
 		AA00000000000000000215 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000206 /* Localizable.xcstrings */; };
 		AA00000000000000000216 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000024 /* TypeWhisperPluginSDK */; };
@@ -809,6 +810,7 @@
 		BB00000000000000000202 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000203 /* AssemblyAIPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AssemblyAIPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000204 /* AssemblyAIPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssemblyAIPlugin.swift; sourceTree = "<group>"; };
+		C31042000000000000000002 /* AssemblyAIModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssemblyAIModelCatalog.swift; sourceTree = "<group>"; };
 		BB00000000000000000205 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000206 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		RESS00000000000000001 /* Reson8Plugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reson8Plugin.swift; sourceTree = "<group>"; };
@@ -1985,6 +1987,7 @@
 			isa = PBXGroup;
 			children = (
 				BB00000000000000000204 /* AssemblyAIPlugin.swift */,
+				C31042000000000000000002 /* AssemblyAIModelCatalog.swift */,
 				BB00000000000000000205 /* manifest.json */,
 				BB00000000000000000206 /* Localizable.xcstrings */,
 			);
@@ -4366,6 +4369,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000213 /* AssemblyAIPlugin.swift in Sources */,
+				C31042000000000000000001 /* AssemblyAIModelCatalog.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -1345,7 +1345,8 @@ final class ModelManagerService: ObservableObject {
         let overrideRestoreId = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
 
         if let cloudModelOverride {
-            _ = await waitForPluginConfigured(plugin, selectedModelId: cloudModelOverride)
+            let selectedModelId = plugin.selectedModelId ?? cloudModelOverride
+            _ = await waitForPluginConfigured(plugin, selectedModelId: selectedModelId)
             return overrideRestoreId
         }
 

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIModelCatalog.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIModelCatalog.swift
@@ -1,0 +1,87 @@
+import TypeWhisperPluginSDK
+
+enum AssemblyAIDictionaryPayload: Sendable, Equatable {
+    case keytermsPrompt
+    case wordBoost(boostParam: String)
+}
+
+enum AssemblyAIStreamingModelConfiguration: Sendable, Equatable {
+    case universal35Pro(
+        speechModelId: String,
+        supportedLanguageCodes: Set<String>
+    )
+    case universal2(
+        englishSpeechModelId: String,
+        multilingualSpeechModelId: String
+    )
+}
+
+struct AssemblyAIModelDefinition: Sendable, Equatable {
+    let id: String
+    let displayName: String
+    let legacyIds: Set<String>
+    let restModelId: String
+    let supportedLanguages: [String]
+    let dictionaryTermsBudget: DictionaryTermsBudget
+    let dictionaryPayload: AssemblyAIDictionaryPayload
+    let streamingConfiguration: AssemblyAIStreamingModelConfiguration
+
+    var modelInfo: PluginModelInfo {
+        PluginModelInfo(id: id, displayName: displayName)
+    }
+}
+
+enum AssemblyAIModelCatalog {
+    private static let universal35ProModelId = "universal-3-5-pro"
+    private static let universal2ModelId = "universal-2"
+    private static let universal35ProLanguages = [
+        "en", "es", "fr", "de", "it", "pt", "tr", "nl", "sv",
+        "no", "da", "fi", "hi", "vi", "ar", "he", "ja", "zh",
+    ]
+    private static let universal2Languages = [
+        "bg", "ca", "cs", "da", "de", "el", "en", "es", "et", "fi",
+        "fr", "hi", "hr", "hu", "id", "it", "ja", "ko", "lt", "lv",
+        "ms", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq",
+        "sr", "sv", "th", "tr", "uk", "vi", "zh",
+    ]
+
+    static let legacyUniversal3ProModelId = "universal-3-pro"
+
+    static let universal35Pro = AssemblyAIModelDefinition(
+        id: universal35ProModelId,
+        displayName: "Universal-3.5 Pro",
+        legacyIds: [legacyUniversal3ProModelId],
+        restModelId: universal35ProModelId,
+        supportedLanguages: universal35ProLanguages,
+        dictionaryTermsBudget: DictionaryTermsBudget(maxTerms: 1_000, maxWordsPerTerm: 6),
+        dictionaryPayload: .keytermsPrompt,
+        streamingConfiguration: .universal35Pro(
+            speechModelId: universal35ProModelId,
+            supportedLanguageCodes: Set(universal35ProLanguages)
+        )
+    )
+
+    static let universal2 = AssemblyAIModelDefinition(
+        id: universal2ModelId,
+        displayName: "Universal-2",
+        legacyIds: [],
+        restModelId: universal2ModelId,
+        supportedLanguages: universal2Languages,
+        dictionaryTermsBudget: DictionaryTermsBudget(maxTerms: 100, maxCharsPerTerm: 50),
+        dictionaryPayload: .wordBoost(boostParam: "high"),
+        streamingConfiguration: .universal2(
+            englishSpeechModelId: "universal-streaming-english",
+            multilingualSpeechModelId: "universal-streaming-multilingual"
+        )
+    )
+
+    static let all = [universal35Pro, universal2]
+    static let defaultModel = universal35Pro
+
+    static func resolve(_ modelId: String?) -> AssemblyAIModelDefinition {
+        guard let modelId else { return defaultModel }
+        return all.first { definition in
+            definition.id == modelId || definition.legacyIds.contains(modelId)
+        } ?? defaultModel
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -56,8 +56,12 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
     func activate(host: HostServices) {
         self.host = host
         _apiKey = host.loadSecret(key: "api-key")
-        _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
-            ?? transcriptionModels.first?.id
+        let storedModelId = host.userDefault(forKey: "selectedModel") as? String
+        let resolvedModel = AssemblyAIModelCatalog.resolve(storedModelId)
+        _selectedModelId = resolvedModel.id
+        if storedModelId != resolvedModel.id {
+            host.setUserDefault(resolvedModel.id, forKey: "selectedModel")
+        }
         _speakerDiarizationEnabled = host.userDefault(forKey: Self.speakerDiarizationEnabledKey) as? Bool ?? false
     }
 
@@ -76,37 +80,28 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
     }
 
     var transcriptionModels: [PluginModelInfo] {
-        [
-            PluginModelInfo(id: "universal-3-pro", displayName: "Universal-3 Pro"),
-            PluginModelInfo(id: "universal-2", displayName: "Universal-2"),
-        ]
+        AssemblyAIModelCatalog.all.map(\.modelInfo)
     }
 
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {
-        _selectedModelId = modelId
-        host?.setUserDefault(modelId, forKey: "selectedModel")
+        let resolvedModel = AssemblyAIModelCatalog.resolve(modelId)
+        _selectedModelId = resolvedModel.id
+        host?.setUserDefault(resolvedModel.id, forKey: "selectedModel")
     }
 
     var supportsTranslation: Bool { false }
     // AssemblyAI's streaming API does not return the speaker metadata preserved by the structured REST path.
     var supportsStreaming: Bool { !_speakerDiarizationEnabled }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
-    var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryTermsBudget(for: _selectedModelId) }
+    var dictionaryTermsBudget: DictionaryTermsBudget {
+        AssemblyAIModelCatalog.resolve(_selectedModelId).dictionaryTermsBudget
+    }
     var isSpeakerDiarizationEnabled: Bool { _speakerDiarizationEnabled }
 
     var supportedLanguages: [String] {
-        if _selectedModelId == "universal-2" {
-            return [
-                "bg", "ca", "cs", "da", "de", "el", "en", "es", "et", "fi",
-                "fr", "hi", "hr", "hu", "id", "it", "ja", "ko", "lt", "lv",
-                "ms", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq",
-                "sr", "sv", "th", "tr", "uk", "vi", "zh",
-            ]
-        }
-        // Universal-3 Pro: 6 languages
-        return ["de", "en", "es", "fr", "it", "pt"]
+        AssemblyAIModelCatalog.resolve(_selectedModelId).supportedLanguages
     }
 
     // MARK: - Transcription (REST Fallback)
@@ -286,13 +281,6 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         return transcriptId
     }
 
-    private static func dictionaryTermsBudget(for modelId: String?) -> DictionaryTermsBudget {
-        if modelId == "universal-3-pro" {
-            return DictionaryTermsBudget(maxTerms: 1_000, maxWordsPerTerm: 6)
-        }
-        return DictionaryTermsBudget(maxTerms: 100, maxCharsPerTerm: 50)
-    }
-
     static func makeSubmitTranscriptionBody(
         audioURL: String,
         modelId: String,
@@ -300,9 +288,10 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         prompt: String?,
         speakerDiarizationEnabled: Bool
     ) -> [String: Any] {
+        let model = AssemblyAIModelCatalog.resolve(modelId)
         var body: [String: Any] = [
             "audio_url": audioURL,
-            "speech_models": [modelId],
+            "speech_models": [model.restModelId],
         ]
 
         if let lang = language, !lang.isEmpty {
@@ -315,22 +304,24 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
             body["speaker_labels"] = true
         }
 
-        applyDictionaryTerms(prompt: prompt, modelId: modelId, to: &body)
+        applyDictionaryTerms(prompt: prompt, modelId: model.id, to: &body)
         return body
     }
 
     static func applyDictionaryTerms(prompt: String?, modelId: String, to body: inout [String: Any]) {
+        let model = AssemblyAIModelCatalog.resolve(modelId)
         let terms = PluginDictionaryTerms.clippedTerms(
             from: PluginDictionaryTerms.terms(fromPrompt: prompt),
-            budget: dictionaryTermsBudget(for: modelId)
+            budget: model.dictionaryTermsBudget
         )
         guard !terms.isEmpty else { return }
 
-        if modelId == "universal-3-pro" {
+        switch model.dictionaryPayload {
+        case .keytermsPrompt:
             body["keyterms_prompt"] = terms
-        } else {
+        case .wordBoost(let boostParam):
             body["word_boost"] = terms
-            body["boost_param"] = "high"
+            body["boost_param"] = boostParam
         }
     }
 
@@ -478,23 +469,12 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        var queryItems = [
-            URLQueryItem(name: "sample_rate", value: "16000"),
-            URLQueryItem(name: "format_turns", value: "true"),
-        ]
-
-        if let lang = language, !lang.isEmpty, lang != "en" {
-            queryItems.append(URLQueryItem(name: "speech_model", value: "universal-streaming-multilingual"))
-        }
-
-        if let keytermsPrompt = streamingKeytermsPromptJSON(from: prompt, modelId: modelId) {
-            queryItems.append(URLQueryItem(name: "keyterms_prompt", value: keytermsPrompt))
-        }
-
-        var components = URLComponents(string: "wss://streaming.assemblyai.com/v3/ws")
-        components?.queryItems = queryItems
-
-        guard let url = components?.url else {
+        let keytermsPrompt = streamingKeytermsPromptJSON(from: prompt, modelId: modelId)
+        guard let url = Self.makeStreamingURL(
+            modelId: modelId,
+            language: language,
+            keytermsPromptJSON: keytermsPrompt
+        ) else {
             throw PluginTranscriptionError.apiError("Invalid streaming URL")
         }
 
@@ -568,10 +548,53 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         return PluginTranscriptionResult(text: finalText, detectedLanguage: language)
     }
 
+    static func makeStreamingURL(
+        modelId: String,
+        language: String?,
+        keytermsPromptJSON: String?
+    ) -> URL? {
+        let model = AssemblyAIModelCatalog.resolve(modelId)
+        let normalizedLanguage = language?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        var queryItems = [URLQueryItem(name: "sample_rate", value: "16000")]
+
+        switch model.streamingConfiguration {
+        case .universal2(let englishSpeechModelId, let multilingualSpeechModelId):
+            let streamingModel = normalizedLanguage == nil
+                || normalizedLanguage?.isEmpty == true
+                || normalizedLanguage == "en"
+                ? englishSpeechModelId
+                : multilingualSpeechModelId
+            queryItems.append(URLQueryItem(name: "speech_model", value: streamingModel))
+            queryItems.append(URLQueryItem(name: "format_turns", value: "true"))
+        case .universal35Pro(let speechModelId, let supportedLanguageCodes):
+            queryItems.append(URLQueryItem(name: "speech_model", value: speechModelId))
+            if let normalizedLanguage,
+               supportedLanguageCodes.contains(normalizedLanguage),
+               let languageCodesJSON = jsonString(from: [normalizedLanguage]) {
+                queryItems.append(URLQueryItem(name: "language_codes", value: languageCodesJSON))
+            }
+        }
+
+        if let keytermsPromptJSON {
+            queryItems.append(URLQueryItem(name: "keyterms_prompt", value: keytermsPromptJSON))
+        }
+
+        var components = URLComponents(string: "wss://streaming.assemblyai.com/v3/ws")
+        components?.queryItems = queryItems
+        return components?.url
+    }
+
+    private static func jsonString(from values: [String]) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: values) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
     private func streamingKeytermsPromptJSON(from prompt: String?, modelId: String) -> String? {
         let rawTerms = PluginDictionaryTerms.clippedTerms(
             from: PluginDictionaryTerms.terms(fromPrompt: prompt),
-            budget: Self.dictionaryTermsBudget(for: modelId)
+            budget: AssemblyAIModelCatalog.resolve(modelId).dictionaryTermsBudget
         )
         guard !rawTerms.isEmpty else { return nil }
 

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/Tests/AssemblyAIPluginTests.swift
@@ -9,6 +9,151 @@ final class AssemblyAIPluginTests: XCTestCase {
         super.tearDown()
     }
 
+    func testStaticModelCatalogHasUniqueIdentifiersAndUniversal35Default() {
+        let models = AssemblyAIModelCatalog.all
+        let canonicalIds = models.map(\.id)
+        let legacyIds = models.flatMap(\.legacyIds)
+
+        XCTAssertEqual(models, [
+            AssemblyAIModelCatalog.universal35Pro,
+            AssemblyAIModelCatalog.universal2,
+        ])
+        XCTAssertEqual(Set(canonicalIds).count, canonicalIds.count)
+        XCTAssertEqual(Set(legacyIds).count, legacyIds.count)
+        XCTAssertTrue(Set(canonicalIds).isDisjoint(with: legacyIds))
+        XCTAssertEqual(AssemblyAIModelCatalog.defaultModel, AssemblyAIModelCatalog.universal35Pro)
+    }
+
+    func testModelCatalogResolvesCanonicalLegacyUnknownEmptyAndMissingIds() {
+        XCTAssertEqual(
+            AssemblyAIModelCatalog.resolve(AssemblyAIModelCatalog.universal35Pro.id),
+            AssemblyAIModelCatalog.universal35Pro
+        )
+        XCTAssertEqual(
+            AssemblyAIModelCatalog.resolve(AssemblyAIModelCatalog.universal2.id),
+            AssemblyAIModelCatalog.universal2
+        )
+        XCTAssertEqual(
+            AssemblyAIModelCatalog.resolve(AssemblyAIModelCatalog.legacyUniversal3ProModelId),
+            AssemblyAIModelCatalog.universal35Pro
+        )
+        XCTAssertEqual(AssemblyAIModelCatalog.resolve("retired-model"), AssemblyAIModelCatalog.universal35Pro)
+        XCTAssertEqual(AssemblyAIModelCatalog.resolve(""), AssemblyAIModelCatalog.universal35Pro)
+        XCTAssertEqual(AssemblyAIModelCatalog.resolve(nil), AssemblyAIModelCatalog.universal35Pro)
+    }
+
+    func testUniversal35ModelDefinitionContainsCompleteMetadata() {
+        let model = AssemblyAIModelCatalog.universal35Pro
+        let expectedLanguages = [
+            "en", "es", "fr", "de", "it", "pt", "tr", "nl", "sv",
+            "no", "da", "fi", "hi", "vi", "ar", "he", "ja", "zh",
+        ]
+
+        XCTAssertEqual(model.displayName, "Universal-3.5 Pro")
+        XCTAssertEqual(model.restModelId, model.id)
+        XCTAssertEqual(model.supportedLanguages, expectedLanguages)
+        XCTAssertEqual(
+            model.dictionaryTermsBudget,
+            DictionaryTermsBudget(maxTerms: 1_000, maxWordsPerTerm: 6)
+        )
+        XCTAssertEqual(model.dictionaryPayload, .keytermsPrompt)
+        XCTAssertEqual(
+            model.streamingConfiguration,
+            .universal35Pro(
+                speechModelId: model.id,
+                supportedLanguageCodes: Set(expectedLanguages)
+            )
+        )
+    }
+
+    func testUniversal2ModelDefinitionContainsCompleteMetadata() {
+        let model = AssemblyAIModelCatalog.universal2
+        let expectedLanguages = [
+            "bg", "ca", "cs", "da", "de", "el", "en", "es", "et", "fi",
+            "fr", "hi", "hr", "hu", "id", "it", "ja", "ko", "lt", "lv",
+            "ms", "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sq",
+            "sr", "sv", "th", "tr", "uk", "vi", "zh",
+        ]
+
+        XCTAssertEqual(model.displayName, "Universal-2")
+        XCTAssertEqual(model.restModelId, model.id)
+        XCTAssertEqual(model.supportedLanguages, expectedLanguages)
+        XCTAssertEqual(
+            model.dictionaryTermsBudget,
+            DictionaryTermsBudget(maxTerms: 100, maxCharsPerTerm: 50)
+        )
+        XCTAssertEqual(model.dictionaryPayload, .wordBoost(boostParam: "high"))
+        XCTAssertEqual(
+            model.streamingConfiguration,
+            .universal2(
+                englishSpeechModelId: "universal-streaming-english",
+                multilingualSpeechModelId: "universal-streaming-multilingual"
+            )
+        )
+    }
+
+    func testDefaultModelCatalogAndLanguagesUseUniversal35Pro() throws {
+        let host = try PluginTestHostServices()
+        let plugin = AssemblyAIPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), [
+            AssemblyAIPlugin.universal35ProModelId,
+            AssemblyAIPlugin.universal2ModelId,
+        ])
+        XCTAssertEqual(plugin.transcriptionModels.map(\.displayName), ["Universal-3.5 Pro", "Universal-2"])
+        XCTAssertEqual(plugin.selectedModelId, AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(plugin.supportedLanguages, [
+            "en", "es", "fr", "de", "it", "pt", "tr", "nl", "sv",
+            "no", "da", "fi", "hi", "vi", "ar", "he", "ja", "zh",
+        ])
+    }
+
+    func testActivationMigratesLegacyAndUnknownModelIds() throws {
+        let legacyHost = try PluginTestHostServices(defaults: [
+            "selectedModel": AssemblyAIPlugin.legacyUniversal3ProModelId,
+        ])
+        let legacyPlugin = AssemblyAIPlugin()
+
+        legacyPlugin.activate(host: legacyHost)
+
+        XCTAssertEqual(legacyPlugin.selectedModelId, AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(
+            legacyHost.userDefault(forKey: "selectedModel") as? String,
+            AssemblyAIPlugin.universal35ProModelId
+        )
+
+        let unknownHost = try PluginTestHostServices(defaults: ["selectedModel": "retired-model"])
+        let unknownPlugin = AssemblyAIPlugin()
+
+        unknownPlugin.activate(host: unknownHost)
+
+        XCTAssertEqual(unknownPlugin.selectedModelId, AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(
+            unknownHost.userDefault(forKey: "selectedModel") as? String,
+            AssemblyAIPlugin.universal35ProModelId
+        )
+    }
+
+    func testSelectModelNormalizesLegacyAndUnknownModelIds() throws {
+        let host = try PluginTestHostServices()
+        let plugin = AssemblyAIPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectModel(AssemblyAIPlugin.legacyUniversal3ProModelId)
+        XCTAssertEqual(plugin.selectedModelId, AssemblyAIPlugin.universal35ProModelId)
+
+        plugin.selectModel("retired-model")
+        XCTAssertEqual(plugin.selectedModelId, AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, AssemblyAIPlugin.universal35ProModelId)
+
+        plugin.selectModel(AssemblyAIPlugin.universal2ModelId)
+        XCTAssertEqual(plugin.selectedModelId, AssemblyAIPlugin.universal2ModelId)
+        XCTAssertTrue(plugin.supportedLanguages.contains("uk"))
+    }
+
     func testSpeakerDiarizationSettingPersistsAndNotifies() throws {
         let host = try PluginTestHostServices()
         let plugin = AssemblyAIPlugin()
@@ -37,7 +182,7 @@ final class AssemblyAIPluginTests: XCTestCase {
     func testSubmitBodyIncludesSpeakerLabelsOnlyWhenEnabled() {
         var disabledBody = AssemblyAIPlugin.makeSubmitTranscriptionBody(
             audioURL: "https://example.test/audio.wav",
-            modelId: "universal-3-pro",
+            modelId: AssemblyAIPlugin.universal35ProModelId,
             language: nil,
             prompt: nil,
             speakerDiarizationEnabled: false
@@ -46,18 +191,124 @@ final class AssemblyAIPluginTests: XCTestCase {
 
         var enabledBody = AssemblyAIPlugin.makeSubmitTranscriptionBody(
             audioURL: "https://example.test/audio.wav",
-            modelId: "universal-3-pro",
+            modelId: AssemblyAIPlugin.universal35ProModelId,
             language: "en",
             prompt: nil,
             speakerDiarizationEnabled: true
         )
         XCTAssertEqual(enabledBody["speaker_labels"] as? Bool, true)
         XCTAssertEqual(enabledBody["language_code"] as? String, "en")
+        XCTAssertEqual(
+            enabledBody["speech_models"] as? [String],
+            [AssemblyAIPlugin.universal35ProModelId]
+        )
 
-        AssemblyAIPlugin.applyDictionaryTerms(prompt: "TypeWhisper", modelId: "universal-3-pro", to: &disabledBody)
-        AssemblyAIPlugin.applyDictionaryTerms(prompt: "TypeWhisper", modelId: "universal-3-pro", to: &enabledBody)
+        AssemblyAIPlugin.applyDictionaryTerms(
+            prompt: "TypeWhisper",
+            modelId: AssemblyAIPlugin.universal35ProModelId,
+            to: &disabledBody
+        )
+        AssemblyAIPlugin.applyDictionaryTerms(
+            prompt: "TypeWhisper",
+            modelId: AssemblyAIPlugin.universal35ProModelId,
+            to: &enabledBody
+        )
         XCTAssertEqual(disabledBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
         XCTAssertEqual(enabledBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
+    }
+
+    func testSubmitBodyCanonicalizesLegacyModelId() {
+        let body = AssemblyAIPlugin.makeSubmitTranscriptionBody(
+            audioURL: "https://example.test/audio.wav",
+            modelId: AssemblyAIPlugin.legacyUniversal3ProModelId,
+            language: nil,
+            prompt: "TypeWhisper",
+            speakerDiarizationEnabled: false
+        )
+
+        XCTAssertEqual(body["speech_models"] as? [String], [AssemblyAIPlugin.universal35ProModelId])
+        XCTAssertEqual(body["keyterms_prompt"] as? [String], ["TypeWhisper"])
+        XCTAssertNil(body["word_boost"])
+    }
+
+    func testUniversal2SubmitBodyUsesWordBoost() {
+        let body = AssemblyAIPlugin.makeSubmitTranscriptionBody(
+            audioURL: "https://example.test/audio.wav",
+            modelId: AssemblyAIPlugin.universal2ModelId,
+            language: "en",
+            prompt: "TypeWhisper",
+            speakerDiarizationEnabled: false
+        )
+
+        XCTAssertEqual(body["speech_models"] as? [String], [AssemblyAIPlugin.universal2ModelId])
+        XCTAssertEqual(body["word_boost"] as? [String], ["TypeWhisper"])
+        XCTAssertEqual(body["boost_param"] as? String, "high")
+        XCTAssertNil(body["keyterms_prompt"])
+    }
+
+    func testUniversal35StreamingURLUsesModelLanguageAndKeyterms() throws {
+        let url = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.universal35ProModelId,
+            language: "DE",
+            keytermsPromptJSON: #"["TypeWhisper"]"#
+        ))
+        let query = Self.queryItems(in: url)
+
+        XCTAssertEqual(query["sample_rate"], "16000")
+        XCTAssertEqual(query["speech_model"], AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertEqual(query["language_codes"], #"["de"]"#)
+        XCTAssertEqual(query["keyterms_prompt"], #"["TypeWhisper"]"#)
+        XCTAssertNil(query["format_turns"])
+    }
+
+    func testUniversal35StreamingURLOmitsUnsupportedOrAutomaticLanguage() throws {
+        let automaticURL = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.universal35ProModelId,
+            language: nil,
+            keytermsPromptJSON: nil
+        ))
+        let unsupportedURL = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.universal35ProModelId,
+            language: "ru",
+            keytermsPromptJSON: nil
+        ))
+
+        XCTAssertNil(Self.queryItems(in: automaticURL)["language_codes"])
+        XCTAssertNil(Self.queryItems(in: unsupportedURL)["language_codes"])
+    }
+
+    func testUniversal2StreamingURLPreservesEnglishAndMultilingualModels() throws {
+        let englishURL = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.universal2ModelId,
+            language: "en",
+            keytermsPromptJSON: nil
+        ))
+        let multilingualURL = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.universal2ModelId,
+            language: "de",
+            keytermsPromptJSON: nil
+        ))
+        let englishQuery = Self.queryItems(in: englishURL)
+        let multilingualQuery = Self.queryItems(in: multilingualURL)
+
+        XCTAssertEqual(englishQuery["speech_model"], "universal-streaming-english")
+        XCTAssertEqual(englishQuery["format_turns"], "true")
+        XCTAssertNil(englishQuery["language_codes"])
+        XCTAssertEqual(multilingualQuery["speech_model"], "universal-streaming-multilingual")
+        XCTAssertEqual(multilingualQuery["format_turns"], "true")
+        XCTAssertNil(multilingualQuery["language_codes"])
+    }
+
+    func testLegacyStreamingModelIdUsesUniversal35Pro() throws {
+        let url = try XCTUnwrap(AssemblyAIPlugin.makeStreamingURL(
+            modelId: AssemblyAIPlugin.legacyUniversal3ProModelId,
+            language: "en",
+            keytermsPromptJSON: nil
+        ))
+        let query = Self.queryItems(in: url)
+
+        XCTAssertEqual(query["speech_model"], AssemblyAIPlugin.universal35ProModelId)
+        XCTAssertNil(query["format_turns"])
     }
 
     func testCompletedResponseBuildsSpeakerLabeledStructuredSegments() {
@@ -164,6 +415,10 @@ final class AssemblyAIPluginTests: XCTestCase {
             JSONSerialization.jsonObject(with: try XCTUnwrap(requests[1].httpBody)) as? [String: Any]
         )
         XCTAssertEqual(submitBody["speaker_labels"] as? Bool, true)
+        XCTAssertEqual(
+            submitBody["speech_models"] as? [String],
+            [AssemblyAIPlugin.universal35ProModelId]
+        )
     }
 
     func testRESTTranscriptionUploadsCompressedM4A() async throws {
@@ -253,6 +508,19 @@ final class AssemblyAIPluginTests: XCTestCase {
         XCTAssertEqual(submitBody["audio_url"] as? String, "https://cdn.example.test/audio.wav")
         XCTAssertEqual(submitBody["language_code"] as? String, "de")
         XCTAssertEqual(submitBody["keyterms_prompt"] as? [String], ["TypeWhisper"])
+        XCTAssertEqual(
+            submitBody["speech_models"] as? [String],
+            [AssemblyAIPlugin.universal35ProModelId]
+        )
+    }
+
+    private static func queryItems(in url: URL) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: (URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: false
+        )?.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
     }
 
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
@@ -263,4 +531,10 @@ final class AssemblyAIPluginTests: XCTestCase {
             headerFields: nil
         )!
     }
+}
+
+private extension AssemblyAIPlugin {
+    static var universal35ProModelId: String { AssemblyAIModelCatalog.universal35Pro.id }
+    static var universal2ModelId: String { AssemblyAIModelCatalog.universal2.id }
+    static var legacyUniversal3ProModelId: String { AssemblyAIModelCatalog.legacyUniversal3ProModelId }
 }

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
-    "version": "1.0.14",
+    "version": "1.1.0",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -153,13 +153,13 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let viewModel = makeViewModel(defaults: defaults)
 
         viewModel.selectedEngine = "assemblyai"
-        viewModel.selectedModel = "universal-3-pro"
+        viewModel.selectedModel = "universal-3-5-pro"
 
         XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine), "assemblyai")
-        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel), "universal-3-pro")
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel), "universal-3-5-pro")
         XCTAssertEqual(UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine), "groq")
         XCTAssertEqual(viewModel.effectiveProviderId, "assemblyai")
-        XCTAssertEqual(viewModel.effectiveModelId, "universal-3-pro")
+        XCTAssertEqual(viewModel.effectiveModelId, "universal-3-5-pro")
     }
 
     func testRecorderSelectionFallsBackToGlobalDefaultWhenUnset() throws {
@@ -556,7 +556,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             }
         )
         viewModel.selectedEngine = "assemblyai"
-        viewModel.selectedModel = "universal-3-pro"
+        viewModel.selectedModel = "universal-3-5-pro"
         viewModel.languageSelection = .exact("de")
         viewModel.selectedTask = .translate
         viewModel.loadRecordings()
@@ -581,7 +581,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(request.language, "de")
         XCTAssertTrue(request.translate)
         XCTAssertTrue(request.prompt?.contains("TypeWhisper") == true)
-        XCTAssertTrue(plugin.selectedModelOverrides.contains("universal-3-pro"))
+        XCTAssertTrue(plugin.selectedModelOverrides.contains("universal-3-5-pro"))
     }
 
     func testRetranscriptionAudioLoadFailurePreservesExistingTranscript() async throws {
@@ -1137,7 +1137,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
                     providerId: "assemblyai",
                     displayName: "AssemblyAI",
                     models: [
-                        PluginModelInfo(id: "universal-3-pro", displayName: "Universal-3 Pro"),
+                        PluginModelInfo(id: "universal-3-5-pro", displayName: "Universal-3.5 Pro"),
                         PluginModelInfo(id: "universal-2", displayName: "Universal-2")
                     ],
                     selectedModelId: "universal-2",

--- a/TypeWhisperTests/ModelManagerLiveSessionModelOverrideTests.swift
+++ b/TypeWhisperTests/ModelManagerLiveSessionModelOverrideTests.swift
@@ -59,6 +59,36 @@ final class ModelManagerLiveSessionModelOverrideTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelId, "alpha")
     }
 
+    func testLiveSessionWaitsForNormalizedModelOverride() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = LiveModelOverrideTranscriptionPlugin(modelAliases: ["legacy-beta": "beta"])
+        let modelManager = installLivePlugin(plugin, appSupportDirectory: appSupportDirectory)
+        modelManager.setPluginRestoreWaitConfigurationForTesting(
+            initialAttempts: 1,
+            busyAttempts: 0,
+            pollInterval: .seconds(1)
+        )
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        let sessionHandle = try await modelManager.createLiveTranscriptionSession(
+            languageSelection: .auto,
+            task: .transcribe,
+            cloudModelOverride: "legacy-beta",
+            onProgress: { _ in true }
+        )
+        let elapsed = start.duration(to: clock.now)
+        let handle = try XCTUnwrap(sessionHandle)
+
+        XCTAssertLessThan(elapsed, .milliseconds(500))
+        XCTAssertEqual(plugin.selectedModelId, "beta")
+
+        await modelManager.cancelLiveTranscriptionSession(handle)
+        XCTAssertEqual(plugin.selectedModelId, "alpha")
+    }
+
     func testLiveSessionForwardsDictionaryTermHints() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -694,8 +724,18 @@ private final class LiveModelOverrideTranscriptionPlugin: NSObject, Transcriptio
         PluginModelInfo(id: "alpha", displayName: "Alpha"),
         PluginModelInfo(id: "beta", displayName: "Beta")
     ]
+    private var modelAliases: [String: String] = [:]
     private var currentModelId: String? = "alpha"
     private(set) var receivedDictionaryHints: [PluginDictionaryTermHint] = []
+
+    required override init() {
+        super.init()
+    }
+
+    convenience init(modelAliases: [String: String]) {
+        self.init()
+        self.modelAliases = modelAliases
+    }
 
     var providerId: String { "mock-live-model-override" }
     var providerDisplayName: String { Self.pluginName }
@@ -711,7 +751,8 @@ private final class LiveModelOverrideTranscriptionPlugin: NSObject, Transcriptio
     func deactivate() {}
 
     func selectModel(_ modelId: String) {
-        currentModelId = models.contains { $0.id == modelId } ? modelId : nil
+        let resolvedModelId = modelAliases[modelId] ?? modelId
+        currentModelId = models.contains { $0.id == resolvedModelId } ? resolvedModelId : nil
     }
 
     func transcribe(

--- a/docs/specs/2026-07-31-assemblyai-model-catalog-design.md
+++ b/docs/specs/2026-07-31-assemblyai-model-catalog-design.md
@@ -1,0 +1,144 @@
+# AssemblyAI Static Model Catalog
+
+## Context
+
+AssemblyAI does not expose a documented model-discovery endpoint comparable to OpenAI's dynamic writing-model catalog. Its transcription models also differ in more than their display names: REST and streaming identifiers, language handling, streaming query parameters, dictionary-term budgets, and dictionary payload fields are model-specific.
+
+The Universal-3.5 Pro fix for issue #1042 currently centralizes model identifiers through helper constants, but the remaining model metadata and branching still live in `AssemblyAIPlugin.swift`. Adding future AssemblyAI models that way would require coordinated edits across the picker, request construction, streaming behavior, and language support.
+
+## Goals
+
+- Keep the AssemblyAI model list static and independent of network discovery.
+- Make each supported model's identifiers and capabilities available from one internal definition.
+- Derive model selection, migration, UI metadata, REST behavior, streaming behavior, language support, and dictionary behavior from the same catalog.
+- Preserve the behavior already implemented and locally validated for issue #1042.
+- Keep legacy and unknown model selections compatible without exposing obsolete identifiers in the picker or outbound requests.
+
+## Non-Goals
+
+- Adding a remote AssemblyAI model-discovery request.
+- Adding or removing supported models.
+- Changing the public TypeWhisper Plugin SDK.
+- Changing Universal-3.5 Pro or Universal-2 request behavior established by issue #1042.
+- Bumping the AssemblyAIPlugin manifest version from `1.0.14`.
+- Committing, pushing, or opening a pull request before the revised local build is tested and explicitly approved by Marco.
+
+## Architecture
+
+Add `TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIModelCatalog.swift` to both the Swift Package target and the AssemblyAIPlugin Xcode target.
+
+The file defines internal, `Sendable` model metadata:
+
+```swift
+struct AssemblyAIModelDefinition: Sendable {
+    let id: String
+    let displayName: String
+    let legacyIds: Set<String>
+    let restModelId: String
+    let supportedLanguages: [String]
+    let dictionaryTermsBudget: DictionaryTermsBudget
+    let dictionaryPayload: AssemblyAIDictionaryPayload
+    let streamingConfiguration: AssemblyAIStreamingModelConfiguration
+}
+```
+
+`AssemblyAIDictionaryPayload` distinguishes the two supported outbound formats:
+
+- `keytermsPrompt` for Universal-3.5 Pro.
+- `wordBoost(boostParam: "high")` for Universal-2.
+
+`AssemblyAIStreamingModelConfiguration` represents the model-specific streaming behavior without constructing URLs itself:
+
+- Universal-3.5 Pro uses `speech_model=universal-3-5-pro`, omits `format_turns`, and may add a single supported normalized language through `language_codes`.
+- Universal-2 chooses `universal-streaming-english` for English or no explicit language, otherwise `universal-streaming-multilingual`, and sets `format_turns=true`.
+
+The catalog exposes:
+
+- `universal35Pro`
+- `universal2`
+- `all`, ordered for picker presentation
+- `defaultModel`, equal to Universal-3.5 Pro
+- `resolve(_:)`, returning Universal-2 for its canonical ID and Universal-3.5 Pro for its canonical ID, `universal-3-pro`, unknown IDs, empty IDs, or `nil`
+
+Within the AssemblyAI plugin implementation, canonical and legacy identifier literals must occur only in the catalog. Catalog-focused migration tests reference those definitions instead of repeating string literals, and other plugin callers compare resolved definitions or their canonical IDs. Host-level fixtures may continue to use canonical public model IDs without exposing the catalog outside the plugin target.
+
+## Plugin Integration
+
+`AssemblyAIPlugin.swift` remains responsible for host lifecycle, HTTP and WebSocket transport, request assembly, response parsing, settings UI, and persistence.
+
+It consumes the catalog as follows:
+
+- `transcriptionModels` maps `AssemblyAIModelCatalog.all` to `PluginModelInfo`.
+- Activation resolves the persisted selection and writes back the canonical ID when the stored value is missing, legacy, empty, or unknown.
+- `selectModel(_:)` resolves every direct, workflow, profile, or API override before storing it.
+- `supportedLanguages` and `dictionaryTermsBudget` come from the resolved selected definition.
+- REST request construction uses `restModelId` and the model's dictionary payload definition.
+- Realtime URL construction uses the model's streaming configuration while retaining URL construction in the plugin helper.
+- Unsupported Universal-3.5 Pro language codes remain omitted from `language_codes`.
+- Realtime response handling remains unchanged and continues to use `end_of_turn` as the final-turn signal.
+
+No transport code, secrets, host service references, mutable state, or UI state belongs in the catalog.
+
+## Compatibility and Failure Behavior
+
+- `universal-3-pro` resolves to Universal-3.5 Pro and is immediately persisted as `universal-3-5-pro`.
+- Unknown, empty, or missing IDs resolve to Universal-3.5 Pro.
+- The picker exposes only Universal-3.5 Pro and Universal-2.
+- Outbound REST and streaming requests never contain a legacy or unknown model ID.
+- Catalog entries must have unique canonical IDs and must not share legacy IDs.
+- If another model is added later, it must supply all required metadata at compile time; there is no partially configured fallback entry.
+
+## Project Integration
+
+Swift Package Manager automatically compiles the new Swift source because the AssemblyAIPlugin target includes the plugin directory and excludes only `Tests`.
+
+The checked-in `TypeWhisper.xcodeproj/project.pbxproj` must explicitly add `AssemblyAIModelCatalog.swift` to the AssemblyAIPlugin group and its Sources build phase. No project regeneration or unrelated project-file rewrite is required.
+
+## Tests
+
+Extend `AssemblyAIPluginTests.swift` with catalog-focused coverage:
+
+1. `all` contains exactly Universal-3.5 Pro followed by Universal-2.
+2. Canonical IDs are unique and legacy IDs do not collide.
+3. `defaultModel` is Universal-3.5 Pro.
+4. Canonical, legacy, unknown, empty, and missing selections resolve as specified.
+5. Each definition exposes the expected display name, language list, REST ID, streaming configuration, dictionary budget, and dictionary payload.
+6. Existing activation and `selectModel(_:)` migration tests still prove canonical persistence.
+7. Existing REST tests still prove canonical `speech_models`, `keyterms_prompt`, and `word_boost` behavior.
+8. Existing realtime URL tests still prove Universal-3.5 Pro language bias, omitted `format_turns`, Universal-2 English/multilingual routing, and legacy normalization.
+9. The existing ModelManager normalized-override regression remains unchanged and passing.
+
+After implementation, run:
+
+```bash
+swift test --package-path TypeWhisperPluginSDK --filter AssemblyAIPluginTests
+
+xcodebuild test \
+  -project TypeWhisper.xcodeproj \
+  -scheme TypeWhisper \
+  -destination 'platform=macOS' \
+  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests \
+  -only-testing:TypeWhisperTests/ModelManagerLiveSessionModelOverrideTests \
+  CODE_SIGNING_ALLOWED=NO
+
+rg -n '"universal-3-pro"' \
+  TypeWhisper \
+  TypeWhisperTests \
+  TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin
+
+./scripts/pr-preflight.sh origin/main
+```
+
+The `rg` result must contain exactly the catalog's legacy constant; migration tests reference that constant symbolically.
+
+## Local Acceptance Gate
+
+Because this refactor changes the already installed fix, it starts a new local approval round:
+
+1. Keep all product and project-file changes uncommitted.
+2. Run the complete verification commands above.
+3. Rebuild the stable TypeWhisper-Dev app.
+4. Rebuild and install AssemblyAIPlugin from the same uncommitted worktree.
+5. Verify valid Apple Development signatures, the expected App Group, installed plugin version `1.0.14`, and a running Dev app using the installed bundle.
+6. Report automated evidence and any missing real-provider evidence.
+7. Stop for Marco's personal test and explicit approval before any commit, push, branch rename, or pull request.


### PR DESCRIPTION
## Context

AssemblyAI's current Universal-3.5 Pro model uses the `universal-3-5-pro` identifier, while the plugin still exposed and submitted the retired `universal-3-pro` identifier. This caused both pre-recorded and streaming requests to use an unsupported model and could also make normalized workflow/profile overrides time out in the host.

Closes #1042

## Changes

- replace the retired Universal-3 Pro catalog entry with Universal-3.5 Pro and make it the default
- centralize AssemblyAI model IDs, display names, legacy aliases, languages, dictionary budgets, REST mappings, and streaming behavior in a static model catalog
- migrate stored, workflow, profile, and API overrides from `universal-3-pro` to `universal-3-5-pro`
- submit `speech_models=["universal-3-5-pro"]` for pre-recorded transcription
- use `speech_model=universal-3-5-pro` for streaming, omit `format_turns`, and send supported explicit languages through `language_codes`
- preserve the Universal-2 English and multilingual streaming paths with `format_turns=true`
- wait for the model ID actually accepted by a cloud plugin after normalized overrides
- update AssemblyAI fixtures and add coverage for migration, model metadata, REST payloads, dictionary terms, and all streaming mappings
- bump AssemblyAIPlugin from `1.0.14` to `1.1.0` so the fix can be published directly through the manual plugin release workflow after merge

## Impact

Existing Universal-3 Pro selections migrate automatically to Universal-3.5 Pro. Unknown AssemblyAI model IDs also fall back to Universal-3.5 Pro. Universal-2 behavior remains available and unchanged.

This PR updates the plugin manifest to `1.1.0`, allowing the merged fix to be released without a separate version-only pull request.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter AssemblyAIPluginTests`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/ModelManagerLiveSessionModelOverrideTests`
- [x] `rg -n '"universal-3-pro"' TypeWhisper TypeWhisperTests TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin` (only the legacy migration constant remains)
- [x] `./scripts/pr-preflight.sh origin/main`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run AssemblyAIPlugin /Users/marco/.t3/worktrees/typewhisper-mac/t3code-b3955698`
- [x] `plutil -extract version raw -o - '/Users/marco/Library/Application Support/TypeWhisper-Dev/Plugins/AssemblyAIPlugin.bundle/Contents/Resources/manifest.json'` returns `1.1.0`
- [x] Manual TypeWhisper-Dev smoke for Universal-3.5 Pro REST/realtime and Universal-2 realtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AssemblyAI Universal-3.5 Pro and Universal-2 models.
  * Model settings now provide appropriate language support, streaming behavior, transcription options, and dictionary limits.
  * Added compatibility for legacy model selections, with automatic normalization to current model identifiers.
  * Updated the AssemblyAI plugin to version 1.1.0.

* **Bug Fixes**
  * Improved model selection during live sessions and transcription retries.
  * Ensured selected models are correctly restored when sessions are canceled or completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->