### PR TITLE
Fix duplicate MLX model storage

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AA9400000000000000000001 /* SettingsVisualComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9400000000000000000001 /* SettingsVisualComponents.swift */; };
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
+		103600000000000000000001 /* MLXPluginModelStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103600000000000000000002 /* MLXPluginModelStorageTests.swift */; };
 		1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */; };
 		1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */; };
 		1F7A2C3D4E5B60718293A4C7 /* PromptActionsViewModelWizardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C7 /* PromptActionsViewModelWizardTests.swift */; };
@@ -914,6 +915,7 @@
 		BB00000000000000000246 /* AccessibilityAnnouncementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAnnouncementService.swift; sourceTree = "<group>"; };
 		BB00000000000000000247 /* SpeechFeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackService.swift; sourceTree = "<group>"; };
 		BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginManifestValidationTests.swift; sourceTree = "<group>"; };
+		103600000000000000000002 /* MLXPluginModelStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MLXPluginModelStorageTests.swift; sourceTree = "<group>"; };
 		BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnippetServiceTests.swift; sourceTree = "<group>"; };
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
 		FEEDFACE00000000000000B1 /* PromptProcessingModelResolutionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptProcessingModelResolutionTests.swift; sourceTree = "<group>"; };
@@ -2413,6 +2415,7 @@
 				C50700000000000000000002 /* MemoryServiceTests.swift */,
 				A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
+				103600000000000000000002 /* MLXPluginModelStorageTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */,
 				B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */,
@@ -4002,6 +4005,7 @@
 				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
 				C42900000000000000000003 /* LiveTranscriptPlugin.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
+				103600000000000000000001 /* MLXPluginModelStorageTests.swift in Sources */,
 				F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,
 				545000000000000000000002 /* SetupWizardRecommendationAvailabilityTests.swift in Sources */,

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -7,7 +7,7 @@ import MLXLMCommon
 import HuggingFace
 import Hub
 import Tokenizers
-import TypeWhisperPluginSDK
+@_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
 import os
 
 private struct Gemma4DownloadProgressReport: Equatable {
@@ -155,7 +155,6 @@ private final class Gemma4DownloadProgressSampler: @unchecked Sendable {
 private struct Gemma4HubDownloader: Downloader {
     let client: HubClient
     let session: URLSession
-    let modelsDirectory: URL
 
     func download(
         id: String,
@@ -168,12 +167,6 @@ private struct Gemma4HubDownloader: Downloader {
             throw Gemma4Plugin.DownloadError.invalidRepositoryID(id)
         }
 
-        let destination = modelsDirectory.appendingPathComponent(id, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: destination.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-
         let progressSampler = Gemma4DownloadProgressSampler(
             session: session,
             progressHandler: progressHandler
@@ -183,7 +176,6 @@ private struct Gemma4HubDownloader: Downloader {
 
         return try await client.downloadSnapshot(
             of: repoID,
-            to: destination,
             revision: revision ?? "main",
             matching: patterns,
             progressHandler: { @MainActor progress in
@@ -254,6 +246,10 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
     private static let loadedModelPreparationProgress = 0.9
     private static let minimumVisibleDownloadProgress = 0.01
     private static let minimumVisibleProgressAdvance = 0.001
+    private static let modelRequirements = PluginHuggingFaceModelStore.Requirements(
+        requiredFiles: ["config.json", "tokenizer.json"],
+        weightFileExtensions: ["safetensors"]
+    )
 
     private enum ModelLoadPhase: Equatable {
         case downloading
@@ -300,24 +296,8 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
         modelsDirectory().appendingPathComponent(repoId, isDirectory: true)
     }
 
-    private func hubCacheDirectory(for repoId: String) -> URL {
-        let cacheName = "models--" + repoId.replacingOccurrences(of: "/", with: "--")
-        return modelsDirectory().appendingPathComponent(cacheName, isDirectory: true)
-    }
-
-    private func hubLockDirectory(for repoId: String) -> URL {
-        let cacheName = "models--" + repoId.replacingOccurrences(of: "/", with: "--")
-        return modelsDirectory()
-            .appendingPathComponent(".locks", isDirectory: true)
-            .appendingPathComponent(cacheName, isDirectory: true)
-    }
-
-    private func modelCacheDirectories(for modelDef: Gemma4ModelDef) -> [URL] {
-        [
-            localModelDirectory(for: modelDef.repoId),
-            hubCacheDirectory(for: modelDef.repoId),
-            hubLockDirectory(for: modelDef.repoId),
-        ]
+    private func modelStore() -> PluginHuggingFaceModelStore {
+        PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory())
     }
     @Published var downloadProgress: Double = 0
 
@@ -335,6 +315,7 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
         if sanitizedSelection != persistedSelection {
             host.setUserDefault(sanitizedSelection, forKey: "selectedLLMModel")
         }
+        cleanupRedundantModelCopies()
 
         let shouldAutoRestoreLoadedModel: Bool
         if host.shouldRestoreLoadedModelsPassively,
@@ -587,11 +568,10 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
     }
 
     func hasCachedModelFiles(_ modelDef: Gemma4ModelDef) -> Bool {
-        modelCacheDirectories(for: modelDef).contains { cacheDir in
-            var isDirectory: ObjCBool = false
-            return FileManager.default.fileExists(atPath: cacheDir.path, isDirectory: &isDirectory)
-                && isDirectory.boolValue
-        }
+        modelStore().hasCachedModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: [localModelDirectory(for: modelDef.repoId)]
+        )
     }
 
     @discardableResult
@@ -618,7 +598,8 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
 
     func loadModel(_ modelDef: Gemma4ModelDef) async throws {
         try Task.checkCancellation()
-        let isAlreadyDownloaded = isModelDownloaded(modelDef)
+        let downloadedDirectory = usableModelDirectory(for: modelDef)
+        let isAlreadyDownloaded = downloadedDirectory != nil
         let loadGeneration = beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
         startModelLoadTimeout(generation: loadGeneration, modelName: modelDef.displayName)
         do {
@@ -639,18 +620,20 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
             )
             let downloader = Gemma4HubDownloader(
                 client: hubClient,
-                session: hubSession,
-                modelsDirectory: modelsDir
+                session: hubSession
             )
-            let configuration = isAlreadyDownloaded
-                ? ModelConfiguration(
-                    directory: localModelDirectory(for: modelDef.repoId),
+            let configuration: ModelConfiguration
+            if let downloadedDirectory {
+                configuration = ModelConfiguration(
+                    directory: downloadedDirectory,
                     extraEOSTokens: ["<turn|>"]
                 )
-                : ModelConfiguration(
+            } else {
+                configuration = ModelConfiguration(
                     id: modelDef.repoId,
                     extraEOSTokens: ["<turn|>"]
                 )
+            }
             let loadTask = Task<ModelContainer, Error> {
                 try await LLMModelFactory.shared.loadContainer(
                     from: downloader,
@@ -731,17 +714,10 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
     }
 
     func deleteModelFiles(_ modelDef: Gemma4ModelDef) throws {
-        let fileManager = FileManager.default
-        for cacheDir in modelCacheDirectories(for: modelDef) {
-            if fileManager.fileExists(atPath: cacheDir.path) {
-                try fileManager.removeItem(at: cacheDir)
-            }
-        }
-
-        let repoNamespaceDir = localModelDirectory(for: modelDef.repoId).deletingLastPathComponent()
-        if (try? fileManager.contentsOfDirectory(atPath: repoNamespaceDir.path).isEmpty) == true {
-            try? fileManager.removeItem(at: repoNamespaceDir)
-        }
+        try modelStore().deleteModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: [localModelDirectory(for: modelDef.repoId)]
+        )
     }
 
     func resetCachedModel(_ modelDef: Gemma4ModelDef) {
@@ -964,44 +940,36 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
     }
 
     private func isUsableDownloadedModel(_ modelDef: Gemma4ModelDef) -> Bool {
-        let repoDir = localModelDirectory(for: modelDef.repoId)
-        return Self.isUsableDownloadedModel(at: repoDir)
+        usableModelDirectory(for: modelDef) != nil
     }
 
     static func isUsableDownloadedModel(at repoDir: URL) -> Bool {
-        let fileManager = FileManager.default
-        var isDirectory: ObjCBool = false
-        guard fileManager.fileExists(atPath: repoDir.path, isDirectory: &isDirectory),
-              isDirectory.boolValue else {
-            return false
-        }
-
-        let requiredRootFiles = [
-            "config.json",
-            "tokenizer.json",
-        ]
-        guard requiredRootFiles.allSatisfy({ fileManager.fileExists(atPath: repoDir.appendingPathComponent($0).path) }) else {
-            return false
-        }
-
-        guard let enumerator = fileManager.enumerator(
-            at: repoDir,
-            includingPropertiesForKeys: [.isRegularFileKey],
-            options: [.skipsHiddenFiles]
-        ) else {
-            return false
-        }
-
-        for case let fileURL as URL in enumerator where fileURL.pathExtension == "safetensors" {
-            return true
-        }
-        return false
+        PluginHuggingFaceModelStore(modelsDirectory: repoDir.deletingLastPathComponent())
+            .isUsableModelDirectory(repoDir, requirements: modelRequirements)
     }
 
     private func removeIncompleteModelIfNeeded(_ modelDef: Gemma4ModelDef) {
-        let repoDir = localModelDirectory(for: modelDef.repoId)
-        guard hasCachedModelFiles(modelDef), !Self.isUsableDownloadedModel(at: repoDir) else { return }
+        guard hasCachedModelFiles(modelDef), !isModelDownloaded(modelDef) else { return }
         try? deleteModelFiles(modelDef)
+    }
+
+    private func usableModelDirectory(for modelDef: Gemma4ModelDef) -> URL? {
+        modelStore().usableModelDirectory(
+            for: modelDef.repoId,
+            legacyDirectories: [localModelDirectory(for: modelDef.repoId)],
+            requirements: Self.modelRequirements
+        )
+    }
+
+    private func cleanupRedundantModelCopies() {
+        let store = modelStore()
+        for modelDef in Self.availableModels {
+            _ = try? store.removeRedundantLegacyDirectories(
+                for: modelDef.repoId,
+                legacyDirectories: [localModelDirectory(for: modelDef.repoId)],
+                requirements: Self.modelRequirements
+            )
+        }
     }
 
     #if DEBUG

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -206,6 +206,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
                         domain: "GranitePlugin",
@@ -218,19 +219,24 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                     bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
                     cache: HubCache(cacheDirectory: modelsDir)
                 )
-                modelDirectory = try await client.downloadSnapshot(
-                    of: repoID,
-                    matching: Self.modelDownloadPatterns
-                )
-                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
-                    modelDirectory,
-                    requirements: Self.modelRequirements
-                ) else {
-                    throw NSError(
-                        domain: "GranitePlugin",
-                        code: 2,
-                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                do {
+                    modelDirectory = try await client.downloadSnapshot(
+                        of: repoID,
+                        matching: Self.modelDownloadPatterns
                     )
+                    guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                        modelDirectory,
+                        requirements: Self.modelRequirements
+                    ) else {
+                        throw NSError(
+                            domain: "GranitePlugin",
+                            code: 2,
+                            userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                        )
+                    }
+                } catch {
+                    removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
+                    throw error
                 }
             }
             let loaded = try await GraniteSpeechModel.fromModelDirectory(modelDirectory)
@@ -295,6 +301,16 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         modelsDirectory
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(modelDef.repoId.replacingOccurrences(of: "/", with: "_"))
+    }
+
+    private func removeIncompleteModelIfNeeded(_ modelDef: GraniteModelDef, modelsDirectory: URL) {
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        let legacyDirectories = [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)]
+        guard usableModelDirectory(for: modelDef, modelsDirectory: modelsDirectory) == nil,
+              store.hasCachedModelFiles(for: modelDef.repoId, legacyDirectories: legacyDirectories) else {
+            return
+        }
+        try? store.deleteModelFiles(for: modelDef.repoId, legacyDirectories: legacyDirectories)
     }
 
     private func cleanupRedundantModelCopies() {

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -4,7 +4,7 @@ import HuggingFace
 import MLX
 import MLXAudioCore
 import MLXAudioSTT
-import TypeWhisperPluginSDK
+@_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
 
 // MARK: - Plugin Entry Point
 
@@ -21,6 +21,12 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     fileprivate var modelState: GraniteModelState = .notLoaded
 
+    private static let modelRequirements = PluginHuggingFaceModelStore.Requirements(
+        requiredFiles: ["config.json", "tokenizer.json"],
+        weightFileExtensions: ["safetensors"]
+    )
+    private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
+
     required override init() {
         super.init()
     }
@@ -30,6 +36,7 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
+        cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
             Task { await restoreLoadedModel(allowDownloads: false) }
@@ -195,9 +202,38 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                 ?? FileManager.default.temporaryDirectory
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
-            let cache = HubCache(cacheDirectory: modelsDir)
-            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
-            let loaded = try await GraniteSpeechModel.fromPretrained(modelDef.repoId, cache: cache)
+            let modelDirectory: URL
+            if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
+                modelDirectory = existing
+            } else {
+                guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
+                    throw NSError(
+                        domain: "GranitePlugin",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelDef.repoId)"]
+                    )
+                }
+                let client = HubClient(
+                    host: HubClient.defaultHost,
+                    bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
+                    cache: HubCache(cacheDirectory: modelsDir)
+                )
+                modelDirectory = try await client.downloadSnapshot(
+                    of: repoID,
+                    matching: Self.modelDownloadPatterns
+                )
+                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                    modelDirectory,
+                    requirements: Self.modelRequirements
+                ) else {
+                    throw NSError(
+                        domain: "GranitePlugin",
+                        code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                    )
+                }
+            }
+            let loaded = try await GraniteSpeechModel.fromModelDirectory(modelDirectory)
 
             model = loaded
             loadedModelId = modelDef.id
@@ -227,13 +263,10 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     fileprivate func deleteModelFiles(_ modelDef: GraniteModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
-        let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
-        let modelDir = modelsDir
-            .appendingPathComponent("mlx-audio")
-            .appendingPathComponent(subdirectory)
-        if FileManager.default.fileExists(atPath: modelDir.path) {
-            try FileManager.default.removeItem(at: modelDir)
-        }
+        try PluginHuggingFaceModelStore(modelsDirectory: modelsDir).deleteModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDir)]
+        )
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -247,14 +280,33 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     private func hasDownloadedModel(_ modelDef: GraniteModelDef) -> Bool {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return false }
-        let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
-        let modelDir = modelsDir
-            .appendingPathComponent("mlx-audio")
-            .appendingPathComponent(subdirectory)
+        return usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) != nil
+    }
 
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: modelDir.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
+    private func usableModelDirectory(for modelDef: GraniteModelDef, modelsDirectory: URL) -> URL? {
+        PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory).usableModelDirectory(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+            requirements: Self.modelRequirements
+        )
+    }
+
+    private func legacyModelDirectory(for modelDef: GraniteModelDef, modelsDirectory: URL) -> URL {
+        modelsDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(modelDef.repoId.replacingOccurrences(of: "/", with: "_"))
+    }
+
+    private func cleanupRedundantModelCopies() {
+        guard let modelsDirectory = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        for modelDef in Self.availableModels {
+            _ = try? store.removeRedundantLegacyDirectories(
+                for: modelDef.repoId,
+                legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+                requirements: Self.modelRequirements
+            )
+        }
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -242,6 +242,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
                         domain: "Qwen3Plugin",
@@ -254,19 +255,24 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
                     bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
                     cache: HubCache(cacheDirectory: modelsDir)
                 )
-                modelDirectory = try await client.downloadSnapshot(
-                    of: repoID,
-                    matching: Self.modelDownloadPatterns
-                )
-                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
-                    modelDirectory,
-                    requirements: Self.modelRequirements
-                ) else {
-                    throw NSError(
-                        domain: "Qwen3Plugin",
-                        code: 2,
-                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                do {
+                    modelDirectory = try await client.downloadSnapshot(
+                        of: repoID,
+                        matching: Self.modelDownloadPatterns
                     )
+                    guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                        modelDirectory,
+                        requirements: Self.modelRequirements
+                    ) else {
+                        throw NSError(
+                            domain: "Qwen3Plugin",
+                            code: 2,
+                            userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                        )
+                    }
+                } catch {
+                    removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
+                    throw error
                 }
             }
             let loaded = try await Qwen3ASRModel.fromModelDirectory(modelDirectory)
@@ -391,6 +397,16 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         modelsDirectory
             .appendingPathComponent("mlx-audio")
             .appendingPathComponent(modelDef.repoId.replacingOccurrences(of: "/", with: "_"))
+    }
+
+    private func removeIncompleteModelIfNeeded(_ modelDef: Qwen3ModelDef, modelsDirectory: URL) {
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        let legacyDirectories = [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)]
+        guard usableModelDirectory(for: modelDef, modelsDirectory: modelsDirectory) == nil,
+              store.hasCachedModelFiles(for: modelDef.repoId, legacyDirectories: legacyDirectories) else {
+            return
+        }
+        try? store.deleteModelFiles(for: modelDef.repoId, legacyDirectories: legacyDirectories)
     }
 
     private func cleanupRedundantModelCopies() {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -3,7 +3,7 @@ import SwiftUI
 import HuggingFace
 import MLX
 import MLXAudioSTT
-import TypeWhisperPluginSDK
+@_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
 
 // MARK: - Plugin Entry Point
 
@@ -37,6 +37,13 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         minChunkDuration: 1.0
     )
 
+    private static let modelRequirements = PluginHuggingFaceModelStore.Requirements(
+        requiredFiles: ["config.json"],
+        alternativeFileGroups: [["tokenizer.json"], ["vocab.json", "merges.txt"]],
+        weightFileExtensions: ["safetensors"]
+    )
+    private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
+
     required override init() {
         super.init()
     }
@@ -45,6 +52,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         self.host = host
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
+        cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
             Task { await restoreLoadedModel(allowDownloads: false) }
@@ -230,9 +238,38 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
                 ?? FileManager.default.temporaryDirectory
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
-            let cache = HubCache(cacheDirectory: modelsDir)
-            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
-            let loaded = try await Qwen3ASRModel.fromPretrained(modelDef.repoId, cache: cache)
+            let modelDirectory: URL
+            if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
+                modelDirectory = existing
+            } else {
+                guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
+                    throw NSError(
+                        domain: "Qwen3Plugin",
+                        code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelDef.repoId)"]
+                    )
+                }
+                let client = HubClient(
+                    host: HubClient.defaultHost,
+                    bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
+                    cache: HubCache(cacheDirectory: modelsDir)
+                )
+                modelDirectory = try await client.downloadSnapshot(
+                    of: repoID,
+                    matching: Self.modelDownloadPatterns
+                )
+                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                    modelDirectory,
+                    requirements: Self.modelRequirements
+                ) else {
+                    throw NSError(
+                        domain: "Qwen3Plugin",
+                        code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                    )
+                }
+            }
+            let loaded = try await Qwen3ASRModel.fromModelDirectory(modelDirectory)
 
             model = loaded
             loadedModelId = modelDef.id
@@ -267,13 +304,10 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     fileprivate func deleteModelFiles(_ modelDef: Qwen3ModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
-        let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
-        let modelDir = modelsDir
-            .appendingPathComponent("mlx-audio")
-            .appendingPathComponent(subdirectory)
-        if FileManager.default.fileExists(atPath: modelDir.path) {
-            try FileManager.default.removeItem(at: modelDir)
-        }
+        try PluginHuggingFaceModelStore(modelsDirectory: modelsDir).deleteModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDir)]
+        )
     }
 
     func restoreLoadedModel(allowDownloads: Bool = false) async {
@@ -342,14 +376,34 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     private func hasDownloadedModel(_ modelDef: Qwen3ModelDef) -> Bool {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return false }
-        let subdirectory = modelDef.repoId.replacingOccurrences(of: "/", with: "_")
-        let modelDir = modelsDir
-            .appendingPathComponent("mlx-audio")
-            .appendingPathComponent(subdirectory)
+        return usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) != nil
+    }
 
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: modelDir.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
+    private func usableModelDirectory(for modelDef: Qwen3ModelDef, modelsDirectory: URL) -> URL? {
+        PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory).usableModelDirectory(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+            requirements: Self.modelRequirements
+        )
+    }
+
+    private func legacyModelDirectory(for modelDef: Qwen3ModelDef, modelsDirectory: URL) -> URL {
+        modelsDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(modelDef.repoId.replacingOccurrences(of: "/", with: "_"))
+    }
+
+    private func cleanupRedundantModelCopies() {
+        guard let modelsDirectory = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        for modelDef in Self.availableModels {
+            _ = try? store.removeRedundantLegacyDirectories(
+                for: modelDef.repoId,
+                legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+                requirements: Self.modelRequirements,
+                reproducibleRelativePaths: ["tokenizer.json"]
+            )
+        }
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -234,15 +234,40 @@ final class Qwen3PluginTests: XCTestCase {
         host.setUserDefault(model.id, forKey: "loadedModel")
 
         let modelDirectory = try makeDownloadedModelDirectory(model, host: host)
+        let canonicalDirectory = try makeCanonicalModelDirectory(model, host: host)
+        let cacheRoot = canonicalDirectory.deletingLastPathComponent().deletingLastPathComponent()
+        let cacheName = "models--" + model.repoId.replacingOccurrences(of: "/", with: "--")
+        let metadataDirectory = host.pluginDataDirectory
+            .appendingPathComponent("models/.metadata/\(cacheName)", isDirectory: true)
+        let lockDirectory = host.pluginDataDirectory
+            .appendingPathComponent("models/.locks/\(cacheName)", isDirectory: true)
+        try write("metadata", to: metadataDirectory.appendingPathComponent("entry"))
+        try write("lock", to: lockDirectory.appendingPathComponent("entry.lock"))
 
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
 
         try await plugin.deleteDownloadedModel(model.id)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: modelDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: cacheRoot.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: metadataDirectory.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: lockDirectory.path))
         XCTAssertNil(plugin.selectedModelId)
         XCTAssertNil(host.userDefault(forKey: "selectedModel"))
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
+    }
+
+    func testCanonicalSnapshotIsRecognizedAndActivationRemovesEquivalentLegacyCopy() throws {
+        let model = try XCTUnwrap(Qwen3Plugin.availableModels.first)
+        let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
+        let legacyDirectory = try makeDownloadedModelDirectory(model, host: host)
+        _ = try makeCanonicalModelDirectory(model, host: host, tokenizerFormat: .vocabAndMerges)
+
+        let plugin = Qwen3Plugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyDirectory.path))
     }
 
     @discardableResult
@@ -255,7 +280,45 @@ final class Qwen3PluginTests: XCTestCase {
             .appendingPathComponent("mlx-audio", isDirectory: true)
             .appendingPathComponent(model.repoId.replacingOccurrences(of: "/", with: "_"), isDirectory: true)
         try FileManager.default.createDirectory(at: modelDirectory, withIntermediateDirectories: true)
-        try Data("partial".utf8).write(to: modelDirectory.appendingPathComponent("model.safetensors"))
+        try write("{}", to: modelDirectory.appendingPathComponent("config.json"))
+        try write("{}", to: modelDirectory.appendingPathComponent("vocab.json"))
+        try write("#version: 0.2\na b", to: modelDirectory.appendingPathComponent("merges.txt"))
+        try write("weights", to: modelDirectory.appendingPathComponent("model.safetensors"))
         return modelDirectory
+    }
+
+    private enum TokenizerFormat {
+        case tokenizerJSON
+        case vocabAndMerges
+    }
+
+    @discardableResult
+    private func makeCanonicalModelDirectory(
+        _ model: Qwen3ModelDef,
+        host: PluginTestHostServices,
+        tokenizerFormat: TokenizerFormat = .tokenizerJSON
+    ) throws -> URL {
+        let commit = String(repeating: "a", count: 40)
+        let cacheName = "models--" + model.repoId.replacingOccurrences(of: "/", with: "--")
+        let repository = host.pluginDataDirectory
+            .appendingPathComponent("models", isDirectory: true)
+            .appendingPathComponent(cacheName, isDirectory: true)
+        let snapshot = repository.appendingPathComponent("snapshots/\(commit)", isDirectory: true)
+        try write(commit + "\n", to: repository.appendingPathComponent("refs/main"))
+        try write("{}", to: snapshot.appendingPathComponent("config.json"))
+        try write("weights", to: snapshot.appendingPathComponent("model.safetensors"))
+        switch tokenizerFormat {
+        case .tokenizerJSON:
+            try write("{}", to: snapshot.appendingPathComponent("tokenizer.json"))
+        case .vocabAndMerges:
+            try write("{}", to: snapshot.appendingPathComponent("vocab.json"))
+            try write("#version: 0.2\na b", to: snapshot.appendingPathComponent("merges.txt"))
+        }
+        return snapshot
+    }
+
+    private func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -4,7 +4,7 @@ import HuggingFace
 import MLX
 import MLXAudioCore
 import MLXAudioSTT
-import TypeWhisperPluginSDK
+@_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
 
 // MARK: - Plugin Entry Point
 
@@ -37,6 +37,12 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         minChunkDuration: 1.0
     )
 
+    private static let modelRequirements = PluginHuggingFaceModelStore.Requirements(
+        requiredFiles: ["config.json", "tekken.json"],
+        weightFileExtensions: ["safetensors"]
+    )
+    private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
+
     required override init() {
         super.init()
     }
@@ -46,6 +52,7 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         _selectedModelId = host.userDefault(forKey: "selectedModel") as? String
             ?? Self.availableModels.first?.id
         _hfToken = PluginHuggingFaceTokenHelper.loadToken(from: host)
+        cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
             Task { await restoreLoadedModel(allowDownloads: false) }
@@ -203,22 +210,37 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                 ?? FileManager.default.temporaryDirectory
             try? FileManager.default.createDirectory(at: modelsDir, withIntermediateDirectories: true)
 
-            let cache = HubCache(cacheDirectory: modelsDir)
-            PluginHuggingFaceTokenHelper.applyTokenToEnvironment(_hfToken)
-            guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
-                throw NSError(
-                    domain: "VoxtralPlugin", code: 1,
-                    userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelDef.repoId)"]
+            let modelDirectory: URL
+            if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
+                modelDirectory = existing
+            } else {
+                guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
+                    throw NSError(
+                        domain: "VoxtralPlugin", code: 1,
+                        userInfo: [NSLocalizedDescriptionKey: "Invalid repository ID: \(modelDef.repoId)"]
+                    )
+                }
+                let client = HubClient(
+                    host: HubClient.defaultHost,
+                    bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
+                    cache: HubCache(cacheDirectory: modelsDir)
                 )
+                modelDirectory = try await client.downloadSnapshot(
+                    of: repoID,
+                    matching: Self.modelDownloadPatterns
+                )
+                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                    modelDirectory,
+                    requirements: Self.modelRequirements
+                ) else {
+                    throw NSError(
+                        domain: "VoxtralPlugin", code: 2,
+                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                    )
+                }
             }
 
-            let modelDir = try await ModelUtils.resolveOrDownloadModel(
-                repoID: repoID,
-                requiredExtension: "safetensors",
-                cache: cache
-            )
-
-            let loaded = try VoxtralRealtimeModel.fromDirectory(modelDir)
+            let loaded = try VoxtralRealtimeModel.fromDirectory(modelDirectory)
 
             model = loaded
             loadedModelId = modelDef.id
@@ -248,14 +270,11 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     fileprivate func deleteModelFiles(_ modelDef: VoxtralModelDef) throws {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
-        let repoDir = modelsDir.appendingPathComponent("huggingface")
-            .appendingPathComponent("hub")
-        // HubCache stores repos under models--org--name pattern
-        let subdirectory = "models--" + modelDef.repoId.replacingOccurrences(of: "/", with: "--")
-        let modelDir = repoDir.appendingPathComponent(subdirectory)
-        if FileManager.default.fileExists(atPath: modelDir.path) {
-            try FileManager.default.removeItem(at: modelDir)
-        }
+        try PluginHuggingFaceModelStore(modelsDirectory: modelsDir).deleteModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDir)],
+            additionalCacheRoots: [historicalCacheRoot(modelsDirectory: modelsDir)]
+        )
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
@@ -269,15 +288,39 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     private func hasDownloadedModel(_ modelDef: VoxtralModelDef) -> Bool {
         guard let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models") else { return false }
-        let repoDir = modelsDir
-            .appendingPathComponent("huggingface")
-            .appendingPathComponent("hub")
-        let subdirectory = "models--" + modelDef.repoId.replacingOccurrences(of: "/", with: "--")
-        let modelDir = repoDir.appendingPathComponent(subdirectory)
+        return usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) != nil
+    }
 
-        var isDirectory: ObjCBool = false
-        return FileManager.default.fileExists(atPath: modelDir.path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
+    private func usableModelDirectory(for modelDef: VoxtralModelDef, modelsDirectory: URL) -> URL? {
+        PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory).usableModelDirectory(
+            for: modelDef.repoId,
+            legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+            requirements: Self.modelRequirements
+        )
+    }
+
+    private func legacyModelDirectory(for modelDef: VoxtralModelDef, modelsDirectory: URL) -> URL {
+        modelsDirectory
+            .appendingPathComponent("mlx-audio")
+            .appendingPathComponent(modelDef.repoId.replacingOccurrences(of: "/", with: "_"))
+    }
+
+    private func historicalCacheRoot(modelsDirectory: URL) -> URL {
+        modelsDirectory
+            .appendingPathComponent("huggingface", isDirectory: true)
+            .appendingPathComponent("hub", isDirectory: true)
+    }
+
+    private func cleanupRedundantModelCopies() {
+        guard let modelsDirectory = host?.pluginDataDirectory.appendingPathComponent("models") else { return }
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        for modelDef in Self.availableModels {
+            _ = try? store.removeRedundantLegacyDirectories(
+                for: modelDef.repoId,
+                legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+                requirements: Self.modelRequirements
+            )
+        }
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -214,6 +214,7 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
                         domain: "VoxtralPlugin", code: 1,
@@ -225,18 +226,23 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
                     bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(_hfToken),
                     cache: HubCache(cacheDirectory: modelsDir)
                 )
-                modelDirectory = try await client.downloadSnapshot(
-                    of: repoID,
-                    matching: Self.modelDownloadPatterns
-                )
-                guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
-                    modelDirectory,
-                    requirements: Self.modelRequirements
-                ) else {
-                    throw NSError(
-                        domain: "VoxtralPlugin", code: 2,
-                        userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                do {
+                    modelDirectory = try await client.downloadSnapshot(
+                        of: repoID,
+                        matching: Self.modelDownloadPatterns
                     )
+                    guard PluginHuggingFaceModelStore(modelsDirectory: modelsDir).isUsableModelDirectory(
+                        modelDirectory,
+                        requirements: Self.modelRequirements
+                    ) else {
+                        throw NSError(
+                            domain: "VoxtralPlugin", code: 2,
+                            userInfo: [NSLocalizedDescriptionKey: "Downloaded model is incomplete: \(modelDef.repoId)"]
+                        )
+                    }
+                } catch {
+                    removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
+                    throw error
                 }
             }
 
@@ -292,9 +298,17 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     }
 
     private func usableModelDirectory(for modelDef: VoxtralModelDef, modelsDirectory: URL) -> URL? {
-        PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory).usableModelDirectory(
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        if let current = store.usableModelDirectory(
             for: modelDef.repoId,
             legacyDirectories: [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)],
+            requirements: Self.modelRequirements
+        ) {
+            return current
+        }
+        return store.snapshotDirectory(
+            for: modelDef.repoId,
+            cacheRoot: historicalCacheRoot(modelsDirectory: modelsDirectory),
             requirements: Self.modelRequirements
         )
     }
@@ -309,6 +323,25 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         modelsDirectory
             .appendingPathComponent("huggingface", isDirectory: true)
             .appendingPathComponent("hub", isDirectory: true)
+    }
+
+    private func removeIncompleteModelIfNeeded(_ modelDef: VoxtralModelDef, modelsDirectory: URL) {
+        let store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+        let legacyDirectories = [legacyModelDirectory(for: modelDef, modelsDirectory: modelsDirectory)]
+        let additionalCacheRoots = [historicalCacheRoot(modelsDirectory: modelsDirectory)]
+        guard usableModelDirectory(for: modelDef, modelsDirectory: modelsDirectory) == nil,
+              store.hasCachedModelFiles(
+                for: modelDef.repoId,
+                legacyDirectories: legacyDirectories,
+                additionalCacheRoots: additionalCacheRoots
+              ) else {
+            return
+        }
+        try? store.deleteModelFiles(
+            for: modelDef.repoId,
+            legacyDirectories: legacyDirectories,
+            additionalCacheRoots: additionalCacheRoots
+        )
     }
 
     private func cleanupRedundantModelCopies() {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHuggingFaceModelStore.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHuggingFaceModelStore.swift
@@ -1,0 +1,352 @@
+import Darwin
+import Foundation
+
+@_spi(FirstPartyPlugins)
+public struct PluginHuggingFaceModelStore: Sendable {
+    public struct Requirements: Sendable {
+        public let requiredFiles: Set<String>
+        public let alternativeFileGroups: [Set<String>]
+        public let weightFileExtensions: Set<String>
+
+        public init(
+            requiredFiles: Set<String>,
+            alternativeFileGroups: [Set<String>] = [],
+            weightFileExtensions: Set<String>
+        ) {
+            self.requiredFiles = requiredFiles
+            self.alternativeFileGroups = alternativeFileGroups
+            self.weightFileExtensions = Set(
+                weightFileExtensions.map { $0.trimmingCharacters(in: CharacterSet(charactersIn: ".")).lowercased() }
+            )
+        }
+    }
+
+    public let modelsDirectory: URL
+
+    public init(modelsDirectory: URL) {
+        self.modelsDirectory = modelsDirectory.standardizedFileURL
+    }
+
+    public func repositoryCacheDirectory(for repositoryID: String, cacheRoot: URL? = nil) -> URL? {
+        guard let cacheName = repositoryCacheName(for: repositoryID) else { return nil }
+        return (cacheRoot ?? modelsDirectory).appendingPathComponent(cacheName, isDirectory: true)
+    }
+
+    public func repositoryMetadataDirectory(for repositoryID: String, cacheRoot: URL? = nil) -> URL? {
+        guard let cacheName = repositoryCacheName(for: repositoryID) else { return nil }
+        return (cacheRoot ?? modelsDirectory)
+            .appendingPathComponent(".metadata", isDirectory: true)
+            .appendingPathComponent(cacheName, isDirectory: true)
+    }
+
+    public func repositoryLockDirectory(for repositoryID: String, cacheRoot: URL? = nil) -> URL? {
+        guard let cacheName = repositoryCacheName(for: repositoryID) else { return nil }
+        return (cacheRoot ?? modelsDirectory)
+            .appendingPathComponent(".locks", isDirectory: true)
+            .appendingPathComponent(cacheName, isDirectory: true)
+    }
+
+    public func snapshotDirectory(
+        for repositoryID: String,
+        revision: String = "main",
+        cacheRoot: URL? = nil,
+        requirements: Requirements
+    ) -> URL? {
+        guard isSafePathComponent(revision),
+              let repositoryDirectory = repositoryCacheDirectory(for: repositoryID, cacheRoot: cacheRoot) else {
+            return nil
+        }
+
+        let refURL = repositoryDirectory
+            .appendingPathComponent("refs", isDirectory: true)
+            .appendingPathComponent(revision, isDirectory: false)
+        guard let refData = try? Data(contentsOf: refURL, options: .mappedIfSafe),
+              refData.count <= 256,
+              let rawRef = String(data: refData, encoding: .utf8) else {
+            return nil
+        }
+
+        let commit = rawRef.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isSafeCommit(commit) else { return nil }
+
+        let snapshot = repositoryDirectory
+            .appendingPathComponent("snapshots", isDirectory: true)
+            .appendingPathComponent(commit, isDirectory: true)
+        return isUsableModelDirectory(snapshot, requirements: requirements) ? snapshot : nil
+    }
+
+    public func usableModelDirectory(
+        for repositoryID: String,
+        revision: String = "main",
+        legacyDirectories: [URL],
+        requirements: Requirements
+    ) -> URL? {
+        if let snapshot = snapshotDirectory(
+            for: repositoryID,
+            revision: revision,
+            requirements: requirements
+        ) {
+            return snapshot
+        }
+
+        return legacyDirectories.first {
+            isPathInsideModelsDirectory($0) && isUsableModelDirectory($0, requirements: requirements)
+        }
+    }
+
+    public func isUsableModelDirectory(_ directory: URL, requirements: Requirements) -> Bool {
+        guard isDirectory(directory),
+              requirements.requiredFiles.allSatisfy({ isNonemptyRegularFile(relativePath: $0, in: directory) }),
+              requirements.alternativeFileGroups.isEmpty
+                || requirements.alternativeFileGroups.contains(where: { group in
+                    group.allSatisfy { isNonemptyRegularFile(relativePath: $0, in: directory) }
+                }),
+              !requirements.weightFileExtensions.isEmpty else {
+            return false
+        }
+
+        guard let enumerator = FileManager.default.enumerator(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return false
+        }
+
+        for case let fileURL as URL in enumerator {
+            let fileExtension = fileURL.pathExtension.lowercased()
+            if requirements.weightFileExtensions.contains(fileExtension), regularFileSize(fileURL) ?? 0 > 0 {
+                return true
+            }
+        }
+        return false
+    }
+
+    @discardableResult
+    public func removeRedundantLegacyDirectories(
+        for repositoryID: String,
+        revision: String = "main",
+        legacyDirectories: [URL],
+        requirements: Requirements,
+        reproducibleRelativePaths: Set<String> = []
+    ) throws -> [URL] {
+        guard let snapshot = snapshotDirectory(
+            for: repositoryID,
+            revision: revision,
+            requirements: requirements
+        ) else {
+            return []
+        }
+
+        var removed: [URL] = []
+        var firstError: Error?
+        for legacyDirectory in legacyDirectories
+        where isPathInsideModelsDirectory(legacyDirectory) && entryExists(legacyDirectory) {
+            guard legacyIsEquivalent(
+                legacyDirectory,
+                to: snapshot,
+                reproducibleRelativePaths: reproducibleRelativePaths
+            ) else {
+                continue
+            }
+
+            do {
+                try FileManager.default.removeItem(at: legacyDirectory)
+                removed.append(legacyDirectory)
+                removeEmptyParents(startingAt: legacyDirectory.deletingLastPathComponent())
+            } catch {
+                if firstError == nil { firstError = error }
+            }
+        }
+
+        if let firstError { throw firstError }
+        return removed
+    }
+
+    public func hasCachedModelFiles(
+        for repositoryID: String,
+        legacyDirectories: [URL],
+        additionalCacheRoots: [URL] = []
+    ) -> Bool {
+        artifactURLs(
+            for: repositoryID,
+            legacyDirectories: legacyDirectories,
+            additionalCacheRoots: additionalCacheRoots
+        ).contains(where: entryExists)
+    }
+
+    public func deleteModelFiles(
+        for repositoryID: String,
+        legacyDirectories: [URL],
+        additionalCacheRoots: [URL] = []
+    ) throws {
+        var firstError: Error?
+        let artifacts = artifactURLs(
+            for: repositoryID,
+            legacyDirectories: legacyDirectories,
+            additionalCacheRoots: additionalCacheRoots
+        )
+
+        for artifact in artifacts where entryExists(artifact) {
+            do {
+                try FileManager.default.removeItem(at: artifact)
+            } catch {
+                if firstError == nil { firstError = error }
+            }
+        }
+
+        for artifact in artifacts {
+            removeEmptyParents(startingAt: artifact.deletingLastPathComponent())
+        }
+
+        if let firstError { throw firstError }
+    }
+
+    private func artifactURLs(
+        for repositoryID: String,
+        legacyDirectories: [URL],
+        additionalCacheRoots: [URL]
+    ) -> [URL] {
+        var urls = legacyDirectories.filter(isPathInsideModelsDirectory)
+        let safeAdditionalRoots = additionalCacheRoots
+            .map(\.standardizedFileURL)
+            .filter(isPathInsideModelsDirectory)
+        for root in [modelsDirectory] + safeAdditionalRoots {
+            if let repository = repositoryCacheDirectory(for: repositoryID, cacheRoot: root) {
+                urls.append(repository)
+            }
+            if let metadata = repositoryMetadataDirectory(for: repositoryID, cacheRoot: root) {
+                urls.append(metadata)
+            }
+            if let locks = repositoryLockDirectory(for: repositoryID, cacheRoot: root) {
+                urls.append(locks)
+            }
+        }
+
+        var seen = Set<String>()
+        return urls.filter { seen.insert($0.standardizedFileURL.path).inserted }
+    }
+
+    private func legacyIsEquivalent(
+        _ legacyDirectory: URL,
+        to snapshot: URL,
+        reproducibleRelativePaths: Set<String>
+    ) -> Bool {
+        guard isDirectory(legacyDirectory),
+              let enumerator = FileManager.default.enumerator(
+                at: legacyDirectory,
+                includingPropertiesForKeys: nil,
+                options: []
+              ) else {
+            return false
+        }
+
+        let normalizedReproduciblePaths = Set(reproducibleRelativePaths.map(normalizedRelativePath))
+        var comparedFile = false
+        for case let legacyFile as URL in enumerator {
+            guard let relativePath = relativePath(of: legacyFile, below: legacyDirectory) else { return false }
+            if relativePath == ".cache" || relativePath.hasPrefix(".cache/") {
+                enumerator.skipDescendants()
+                continue
+            }
+            if normalizedReproduciblePaths.contains(relativePath) {
+                continue
+            }
+            if isDirectory(legacyFile) {
+                continue
+            }
+            guard let legacySize = regularFileSize(legacyFile) else { return false }
+
+            let snapshotFile = snapshot.appendingPathComponent(relativePath, isDirectory: false)
+            guard regularFileSize(snapshotFile) == legacySize else { return false }
+            comparedFile = true
+        }
+        return comparedFile
+    }
+
+    private func repositoryCacheName(for repositoryID: String) -> String? {
+        let components = repositoryID.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        guard components.count >= 2, components.allSatisfy(isSafePathComponent) else { return nil }
+        return "models--" + components.joined(separator: "--")
+    }
+
+    private func isSafePathComponent(_ component: String) -> Bool {
+        !component.isEmpty && component != "." && component != ".."
+            && !component.contains("/") && !component.contains("\\")
+            && !component.unicodeScalars.contains(where: { CharacterSet.controlCharacters.contains($0) })
+    }
+
+    private func isSafeCommit(_ commit: String) -> Bool {
+        commit.utf8.count == 40 && commit.utf8.allSatisfy { byte in
+            (48...57).contains(byte) || (65...70).contains(byte) || (97...102).contains(byte)
+        }
+    }
+
+    private func normalizedRelativePath(_ path: String) -> String {
+        path.split(separator: "/").map(String.init).joined(separator: "/")
+    }
+
+    private func isNonemptyRegularFile(relativePath: String, in directory: URL) -> Bool {
+        let normalized = normalizedRelativePath(relativePath)
+        guard !normalized.isEmpty,
+              !relativePath.hasPrefix("/"),
+              !normalized.split(separator: "/").contains("..") else {
+            return false
+        }
+        return regularFileSize(directory.appendingPathComponent(normalized, isDirectory: false)) ?? 0 > 0
+    }
+
+    private func relativePath(of url: URL, below directory: URL) -> String? {
+        let base = directory.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        let prefix = base.hasSuffix("/") ? base : base + "/"
+        guard path.hasPrefix(prefix) else { return nil }
+        return String(path.dropFirst(prefix.count))
+    }
+
+    private func isPathInsideModelsDirectory(_ url: URL) -> Bool {
+        url.standardizedFileURL.path.hasPrefix(modelsDirectory.path + "/")
+    }
+
+    private func entryExists(_ url: URL) -> Bool {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return false }
+            var info = stat()
+            return lstat(path, &info) == 0
+        }
+    }
+
+    private func isDirectory(_ url: URL) -> Bool {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return false }
+            var info = stat()
+            guard stat(path, &info) == 0 else { return false }
+            return (info.st_mode & S_IFMT) == S_IFDIR
+        }
+    }
+
+    private func regularFileSize(_ url: URL) -> Int64? {
+        url.withUnsafeFileSystemRepresentation { path in
+            guard let path else { return nil }
+            var info = stat()
+            guard stat(path, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else { return nil }
+            return info.st_size
+        }
+    }
+
+    private func removeEmptyParents(startingAt directory: URL) {
+        var current = directory.standardizedFileURL
+        let root = modelsDirectory.standardizedFileURL
+        while current.path != root.path, current.path.hasPrefix(root.path + "/") {
+            guard let contents = try? FileManager.default.contentsOfDirectory(atPath: current.path), contents.isEmpty else {
+                return
+            }
+            do {
+                try FileManager.default.removeItem(at: current)
+            } catch {
+                return
+            }
+            current.deleteLastPathComponent()
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHuggingFaceModelStoreTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHuggingFaceModelStoreTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import XCTest
+@_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
+
+final class PluginHuggingFaceModelStoreTests: XCTestCase {
+    private let repositoryID = "typewhisper/test-model"
+    private let commit = String(repeating: "a", count: 40)
+    private let requirements = PluginHuggingFaceModelStore.Requirements(
+        requiredFiles: ["config.json"],
+        alternativeFileGroups: [["tokenizer.json"], ["vocab.json", "merges.txt"]],
+        weightFileExtensions: ["safetensors"]
+    )
+
+    func testResolvesValidMainSnapshot() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let snapshot = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+
+        XCTAssertEqual(
+            fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements),
+            snapshot
+        )
+    }
+
+    func testRejectsMissingMalformedAndUnsafeRefs() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let repository = try XCTUnwrap(fixture.store.repositoryCacheDirectory(for: repositoryID))
+        try fixture.write("{}", to: repository.appendingPathComponent("snapshots/\(commit)/config.json"))
+        try fixture.write("weights", to: repository.appendingPathComponent("snapshots/\(commit)/model.safetensors"))
+        try fixture.write("{}", to: repository.appendingPathComponent("snapshots/\(commit)/tokenizer.json"))
+
+        XCTAssertNil(fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements))
+
+        for invalidRef in ["short", String(repeating: "g", count: 40), "../\(String(repeating: "a", count: 37))"] {
+            try fixture.write(invalidRef, to: repository.appendingPathComponent("refs/main"))
+            XCTAssertNil(fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements))
+        }
+    }
+
+    func testRejectsMissingRequiredFilesAndEmptyWeights() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let snapshot = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+        try FileManager.default.removeItem(at: snapshot.appendingPathComponent("config.json"))
+
+        XCTAssertNil(fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements))
+
+        try fixture.write("{}", to: snapshot.appendingPathComponent("config.json"))
+        try Data().write(to: snapshot.appendingPathComponent("model.safetensors"))
+        XCTAssertNil(fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements))
+    }
+
+    func testAcceptsAlternativeTokenizerFileGroup() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let snapshot = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+        try FileManager.default.removeItem(at: snapshot.appendingPathComponent("tokenizer.json"))
+        try fixture.write("vocab", to: snapshot.appendingPathComponent("vocab.json"))
+        try fixture.write("merges", to: snapshot.appendingPathComponent("merges.txt"))
+
+        XCTAssertEqual(fixture.store.snapshotDirectory(for: repositoryID, requirements: requirements), snapshot)
+    }
+
+    func testCanonicalSnapshotTakesPrecedenceAndLegacyIsFallback() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let legacy = fixture.modelsDirectory.appendingPathComponent("legacy/model", isDirectory: true)
+        try fixture.createUsableModel(at: legacy, weightContents: "legacy")
+
+        XCTAssertEqual(
+            fixture.store.usableModelDirectory(
+                for: repositoryID,
+                legacyDirectories: [legacy],
+                requirements: requirements
+            ),
+            legacy
+        )
+
+        let snapshot = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+        XCTAssertEqual(
+            fixture.store.usableModelDirectory(
+                for: repositoryID,
+                legacyDirectories: [legacy],
+                requirements: requirements
+            ),
+            snapshot
+        )
+    }
+
+    func testMigrationRemovesOnlyEquivalentLegacyDirectory() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        _ = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+        let equivalent = fixture.modelsDirectory.appendingPathComponent("legacy/equivalent", isDirectory: true)
+        let different = fixture.modelsDirectory.appendingPathComponent("legacy/different", isDirectory: true)
+        try fixture.createUsableModel(at: equivalent)
+        try fixture.createUsableModel(at: different, weightContents: "different-size")
+
+        let removed = try fixture.store.removeRedundantLegacyDirectories(
+            for: repositoryID,
+            legacyDirectories: [equivalent, different],
+            requirements: requirements
+        )
+
+        XCTAssertEqual(removed, [equivalent])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: equivalent.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: different.path))
+    }
+
+    func testMigrationKeepsLegacyForIncompleteSnapshotAndIgnoresReproducibleFile() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let legacy = fixture.modelsDirectory.appendingPathComponent("legacy/model", isDirectory: true)
+        try fixture.createUsableModel(at: legacy)
+        try fixture.write("generated", to: legacy.appendingPathComponent("generated-tokenizer.json"))
+
+        XCTAssertTrue(
+            try fixture.store.removeRedundantLegacyDirectories(
+                for: repositoryID,
+                legacyDirectories: [legacy],
+                requirements: requirements,
+                reproducibleRelativePaths: ["generated-tokenizer.json"]
+            ).isEmpty
+        )
+        XCTAssertTrue(FileManager.default.fileExists(atPath: legacy.path))
+
+        _ = try fixture.createUsableSnapshot(repositoryID: repositoryID, commit: commit)
+        XCTAssertEqual(
+            try fixture.store.removeRedundantLegacyDirectories(
+                for: repositoryID,
+                legacyDirectories: [legacy],
+                requirements: requirements,
+                reproducibleRelativePaths: ["generated-tokenizer.json"]
+            ),
+            [legacy]
+        )
+    }
+
+    func testDeleteRemovesAllModelArtifactsAndPreservesSiblingModel() throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let legacy = fixture.modelsDirectory.appendingPathComponent("mlx-audio/typewhisper_test-model")
+        try fixture.createUsableModel(at: legacy)
+        let repository = try XCTUnwrap(fixture.store.repositoryCacheDirectory(for: repositoryID))
+        let metadata = try XCTUnwrap(fixture.store.repositoryMetadataDirectory(for: repositoryID))
+        let locks = try XCTUnwrap(fixture.store.repositoryLockDirectory(for: repositoryID))
+        let sibling = try XCTUnwrap(fixture.store.repositoryCacheDirectory(for: "typewhisper/sibling"))
+        try fixture.write("repo", to: repository.appendingPathComponent("refs/main"))
+        try fixture.write("metadata", to: metadata.appendingPathComponent("file"))
+        try fixture.write("lock", to: locks.appendingPathComponent("file.lock"))
+        try fixture.write("keep", to: sibling.appendingPathComponent("refs/main"))
+
+        XCTAssertTrue(fixture.store.hasCachedModelFiles(for: repositoryID, legacyDirectories: [legacy]))
+        try fixture.store.deleteModelFiles(
+            for: repositoryID,
+            legacyDirectories: [fixture.modelsDirectory, legacy]
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacy.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repository.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: metadata.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: locks.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: sibling.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.modelsDirectory.path))
+    }
+}
+
+private final class Fixture {
+    let root: URL
+    let modelsDirectory: URL
+    let store: PluginHuggingFaceModelStore
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        modelsDirectory = root.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+        store = PluginHuggingFaceModelStore(modelsDirectory: modelsDirectory)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func createUsableSnapshot(repositoryID: String, commit: String) throws -> URL {
+        let repository = try XCTUnwrap(store.repositoryCacheDirectory(for: repositoryID))
+        let snapshot = repository.appendingPathComponent("snapshots/\(commit)", isDirectory: true)
+        try createUsableModel(at: snapshot)
+        try write(commit + "\n", to: repository.appendingPathComponent("refs/main"))
+        return snapshot
+    }
+
+    func createUsableModel(at directory: URL, weightContents: String = "weights") throws {
+        try write("{}", to: directory.appendingPathComponent("config.json"))
+        try write("{}", to: directory.appendingPathComponent("tokenizer.json"))
+        try write(weightContents, to: directory.appendingPathComponent("model.safetensors"))
+    }
+
+    func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
+    }
+}

--- a/TypeWhisperTests/MLXPluginModelStorageTests.swift
+++ b/TypeWhisperTests/MLXPluginModelStorageTests.swift
@@ -1,0 +1,327 @@
+import Foundation
+import XCTest
+@testable import TypeWhisper
+import TypeWhisperPluginSDK
+
+final class MLXPluginModelStorageTests: XCTestCase {
+    private let commit = String(repeating: "b", count: 40)
+
+    func testModelCatalogsRecognizeLegacyAndCanonicalLayouts() throws {
+        try assertCatalogRecognizesBothLayouts(
+            plugin: Qwen3Plugin(),
+            modelID: Qwen3Plugin.availableModels[0].id,
+            repositoryID: Qwen3Plugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "vocab.json", "merges.txt"]
+        )
+        try assertCatalogRecognizesBothLayouts(
+            plugin: GranitePlugin(),
+            modelID: GranitePlugin.availableModels[0].id,
+            repositoryID: GranitePlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tokenizer.json"]
+        )
+        try assertCatalogRecognizesBothLayouts(
+            plugin: VoxtralPlugin(),
+            modelID: VoxtralPlugin.availableModels[0].id,
+            repositoryID: VoxtralPlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tekken.json"]
+        )
+
+        let gemmaModel = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        let gemmaFixture = try Fixture()
+        defer { gemmaFixture.remove() }
+        let gemmaHost = MockHostServices(pluginDataDirectory: gemmaFixture.root)
+        let gemma = Gemma4Plugin()
+        gemma.activate(host: gemmaHost)
+        let gemmaLegacy = gemmaFixture.legacyDirectory(repositoryID: gemmaModel.repoId, usesMLXAudio: false)
+        try gemmaFixture.writeModel(at: gemmaLegacy, requiredFiles: ["config.json", "tokenizer.json"])
+        XCTAssertEqual(gemma.downloadedModels.map(\.id), [gemmaModel.id])
+        try FileManager.default.removeItem(at: gemmaLegacy)
+        _ = try gemmaFixture.writeSnapshot(
+            repositoryID: gemmaModel.repoId,
+            commit: commit,
+            requiredFiles: ["config.json", "tokenizer.json"]
+        )
+        XCTAssertEqual(gemma.downloadedModels.map(\.id), [gemmaModel.id])
+    }
+
+    func testActivationRemovesVerifiedDuplicateCopiesForAllPlugins() throws {
+        try assertActivationRemovesDuplicate(
+            plugin: Qwen3Plugin(),
+            repositoryID: Qwen3Plugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "vocab.json", "merges.txt"],
+            usesMLXAudio: true
+        )
+        try assertActivationRemovesDuplicate(
+            plugin: GranitePlugin(),
+            repositoryID: GranitePlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tokenizer.json"],
+            usesMLXAudio: true
+        )
+        try assertActivationRemovesDuplicate(
+            plugin: VoxtralPlugin(),
+            repositoryID: VoxtralPlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tekken.json"],
+            usesMLXAudio: true
+        )
+
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        try assertActivationRemovesDuplicate(
+            plugin: Gemma4Plugin(),
+            repositoryID: model.repoId,
+            requiredFiles: ["config.json", "tokenizer.json"],
+            usesMLXAudio: false
+        )
+    }
+
+    func testUIDeletionRemovesLegacyAndCanonicalArtifactsForAllPlugins() async throws {
+        try await assertDeletionRemovesAllArtifacts(
+            plugin: Qwen3Plugin(),
+            modelID: Qwen3Plugin.availableModels[0].id,
+            repositoryID: Qwen3Plugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "vocab.json", "merges.txt"],
+            usesMLXAudio: true
+        )
+        try await assertDeletionRemovesAllArtifacts(
+            plugin: GranitePlugin(),
+            modelID: GranitePlugin.availableModels[0].id,
+            repositoryID: GranitePlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tokenizer.json"],
+            usesMLXAudio: true
+        )
+        try await assertDeletionRemovesAllArtifacts(
+            plugin: VoxtralPlugin(),
+            modelID: VoxtralPlugin.availableModels[0].id,
+            repositoryID: VoxtralPlugin.availableModels[0].repoId,
+            requiredFiles: ["config.json", "tekken.json"],
+            usesMLXAudio: true
+        )
+
+        let model = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        try await assertDeletionRemovesAllArtifacts(
+            plugin: Gemma4Plugin(),
+            modelID: model.id,
+            repositoryID: model.repoId,
+            requiredFiles: ["config.json", "tokenizer.json"],
+            usesMLXAudio: false
+        )
+    }
+
+    func testVoxtralUsesActualCacheRootAndDeletesHistoricalWrongRoot() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let model = VoxtralPlugin.availableModels[0]
+        let plugin = VoxtralPlugin()
+        plugin.activate(host: MockHostServices(pluginDataDirectory: fixture.root))
+        let actualSnapshot = try fixture.writeSnapshot(
+            repositoryID: model.repoId,
+            commit: commit,
+            requiredFiles: ["config.json", "tekken.json"]
+        )
+        let historicalRoot = fixture.modelsDirectory.appendingPathComponent("huggingface/hub", isDirectory: true)
+        let historicalRepository = fixture.repositoryDirectory(repositoryID: model.repoId, cacheRoot: historicalRoot)
+        try fixture.write("historical", to: historicalRepository.appendingPathComponent("refs/main"))
+
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+        try await plugin.deleteDownloadedModel(model.id)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: actualSnapshot.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: historicalRepository.path))
+    }
+
+    func testPassiveOfflineRestoreDoesNotCreateDownloadArtifacts() async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+
+        let qwen = Qwen3Plugin.availableModels[0]
+        let granite = GranitePlugin.availableModels[0]
+        let voxtral = VoxtralPlugin.availableModels[0]
+        let gemma = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
+        Qwen3Plugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("qwen"), defaults: ["loadedModel": qwen.id]))
+        GranitePlugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("granite"), defaults: ["loadedModel": granite.id]))
+        VoxtralPlugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("voxtral"), defaults: ["loadedModel": voxtral.id]))
+        Gemma4Plugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("gemma"), defaults: ["loadedModel": gemma.id]))
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        for pluginRoot in ["qwen", "granite", "voxtral", "gemma"] {
+            let models = fixture.root.appendingPathComponent(pluginRoot).appendingPathComponent("models")
+            XCTAssertFalse(FileManager.default.fileExists(atPath: models.path), "Unexpected cache for \(pluginRoot)")
+        }
+    }
+
+    private func assertCatalogRecognizesBothLayouts<P: PluginDownloadedModelManaging & TranscriptionModelCatalogProviding>(
+        plugin: P,
+        modelID: String,
+        repositoryID: String,
+        requiredFiles: [String]
+    ) throws where P: AnyObject {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let host = MockHostServices(pluginDataDirectory: fixture.root)
+        (plugin as! TypeWhisperPlugin).activate(host: host)
+        let legacy = fixture.legacyDirectory(repositoryID: repositoryID, usesMLXAudio: true)
+        try fixture.writeModel(at: legacy, requiredFiles: requiredFiles)
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [modelID])
+        try FileManager.default.removeItem(at: legacy)
+        _ = try fixture.writeSnapshot(
+            repositoryID: repositoryID,
+            commit: commit,
+            requiredFiles: requiredFiles
+        )
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [modelID])
+    }
+
+    private func assertActivationRemovesDuplicate<P: TypeWhisperPlugin>(
+        plugin: P,
+        repositoryID: String,
+        requiredFiles: [String],
+        usesMLXAudio: Bool
+    ) throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        let legacy = fixture.legacyDirectory(repositoryID: repositoryID, usesMLXAudio: usesMLXAudio)
+        try fixture.writeModel(at: legacy, requiredFiles: requiredFiles)
+        _ = try fixture.writeSnapshot(
+            repositoryID: repositoryID,
+            commit: commit,
+            requiredFiles: requiredFiles
+        )
+
+        plugin.activate(host: MockHostServices(pluginDataDirectory: fixture.root))
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacy.path))
+    }
+
+    private func assertDeletionRemovesAllArtifacts<P: TypeWhisperPlugin & PluginDownloadedModelManaging>(
+        plugin: P,
+        modelID: String,
+        repositoryID: String,
+        requiredFiles: [String],
+        usesMLXAudio: Bool
+    ) async throws {
+        let fixture = try Fixture()
+        defer { fixture.remove() }
+        plugin.activate(host: MockHostServices(pluginDataDirectory: fixture.root))
+        let legacy = fixture.legacyDirectory(repositoryID: repositoryID, usesMLXAudio: usesMLXAudio)
+        try fixture.writeModel(at: legacy, requiredFiles: requiredFiles)
+        let snapshot = try fixture.writeSnapshot(
+            repositoryID: repositoryID,
+            commit: commit,
+            requiredFiles: requiredFiles
+        )
+        let repository = fixture.repositoryDirectory(repositoryID: repositoryID)
+        let metadata = fixture.metadataDirectory(repositoryID: repositoryID)
+        let locks = fixture.lockDirectory(repositoryID: repositoryID)
+        try fixture.write("metadata", to: metadata.appendingPathComponent("entry"))
+        try fixture.write("lock", to: locks.appendingPathComponent("entry.lock"))
+
+        try await plugin.deleteDownloadedModel(modelID)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacy.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: snapshot.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: repository.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: metadata.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: locks.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: fixture.modelsDirectory.path))
+    }
+}
+
+private final class MockEventBus: EventBusProtocol, @unchecked Sendable {
+    func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID { UUID() }
+    func unsubscribe(id: UUID) {}
+}
+
+private final class MockHostServices: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
+    private var defaults: [String: Any]
+
+    let pluginDataDirectory: URL
+    let eventBus: EventBusProtocol = MockEventBus()
+    let activeAppBundleId: String? = nil
+    let activeAppName: String? = nil
+    let availableRuleNames: [String] = []
+    let shouldRestoreLoadedModelsPassively: Bool
+
+    init(
+        pluginDataDirectory: URL,
+        defaults: [String: Any] = [:],
+        shouldRestoreLoadedModelsPassively: Bool = false
+    ) {
+        self.pluginDataDirectory = pluginDataDirectory
+        self.defaults = defaults
+        self.shouldRestoreLoadedModelsPassively = shouldRestoreLoadedModelsPassively
+    }
+
+    func storeSecret(key: String, value: String) throws {}
+    func loadSecret(key: String) -> String? { nil }
+    func userDefault(forKey key: String) -> Any? { defaults[key] }
+    func setUserDefault(_ value: Any?, forKey key: String) { defaults[key] = value }
+    func notifyCapabilitiesChanged() {}
+    func setStreamingDisplayActive(_ active: Bool) {}
+}
+
+private final class Fixture {
+    let root: URL
+    let modelsDirectory: URL
+
+    init() throws {
+        root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        modelsDirectory = root.appendingPathComponent("models", isDirectory: true)
+        try FileManager.default.createDirectory(at: modelsDirectory, withIntermediateDirectories: true)
+    }
+
+    func remove() {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func repositoryDirectory(repositoryID: String, cacheRoot: URL? = nil) -> URL {
+        (cacheRoot ?? modelsDirectory).appendingPathComponent(
+            "models--" + repositoryID.replacingOccurrences(of: "/", with: "--"),
+            isDirectory: true
+        )
+    }
+
+    func metadataDirectory(repositoryID: String) -> URL {
+        modelsDirectory
+            .appendingPathComponent(".metadata", isDirectory: true)
+            .appendingPathComponent("models--" + repositoryID.replacingOccurrences(of: "/", with: "--"))
+    }
+
+    func lockDirectory(repositoryID: String) -> URL {
+        modelsDirectory
+            .appendingPathComponent(".locks", isDirectory: true)
+            .appendingPathComponent("models--" + repositoryID.replacingOccurrences(of: "/", with: "--"))
+    }
+
+    func legacyDirectory(repositoryID: String, usesMLXAudio: Bool) -> URL {
+        if usesMLXAudio {
+            return modelsDirectory
+                .appendingPathComponent("mlx-audio", isDirectory: true)
+                .appendingPathComponent(repositoryID.replacingOccurrences(of: "/", with: "_"), isDirectory: true)
+        }
+        return modelsDirectory.appendingPathComponent(repositoryID, isDirectory: true)
+    }
+
+    func writeSnapshot(
+        repositoryID: String,
+        commit: String,
+        requiredFiles: [String]
+    ) throws -> URL {
+        let repository = repositoryDirectory(repositoryID: repositoryID)
+        let snapshot = repository.appendingPathComponent("snapshots/\(commit)", isDirectory: true)
+        try writeModel(at: snapshot, requiredFiles: requiredFiles)
+        try write(commit + "\n", to: repository.appendingPathComponent("refs/main"))
+        return snapshot
+    }
+
+    func writeModel(at directory: URL, requiredFiles: [String]) throws {
+        for file in requiredFiles {
+            try write(file == "merges.txt" ? "#version: 0.2\na b" : "{}", to: directory.appendingPathComponent(file))
+        }
+        try write("weights", to: directory.appendingPathComponent("model.safetensors"))
+    }
+
+    func write(_ contents: String, to url: URL) throws {
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data(contents.utf8).write(to: url)
+    }
+}

--- a/TypeWhisperTests/MLXPluginModelStorageTests.swift
+++ b/TypeWhisperTests/MLXPluginModelStorageTests.swift
@@ -158,7 +158,7 @@ final class MLXPluginModelStorageTests: XCTestCase {
         let fixture = try Fixture()
         defer { fixture.remove() }
         let host = MockHostServices(pluginDataDirectory: fixture.root)
-        (plugin as! TypeWhisperPlugin).activate(host: host)
+        (plugin as TypeWhisperPlugin).activate(host: host)
         let legacy = fixture.legacyDirectory(repositoryID: repositoryID, usesMLXAudio: true)
         try fixture.writeModel(at: legacy, requiredFiles: requiredFiles)
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [modelID])

--- a/TypeWhisperTests/MLXPluginModelStorageTests.swift
+++ b/TypeWhisperTests/MLXPluginModelStorageTests.swift
@@ -118,14 +118,20 @@ final class MLXPluginModelStorageTests: XCTestCase {
             requiredFiles: ["config.json", "tekken.json"]
         )
         let historicalRoot = fixture.modelsDirectory.appendingPathComponent("huggingface/hub", isDirectory: true)
-        let historicalRepository = fixture.repositoryDirectory(repositoryID: model.repoId, cacheRoot: historicalRoot)
-        try fixture.write("historical", to: historicalRepository.appendingPathComponent("refs/main"))
+        let historicalSnapshot = try fixture.writeSnapshot(
+            repositoryID: model.repoId,
+            commit: commit,
+            requiredFiles: ["config.json", "tekken.json"],
+            cacheRoot: historicalRoot
+        )
 
+        XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
+        try FileManager.default.removeItem(at: fixture.repositoryDirectory(repositoryID: model.repoId))
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [model.id])
         try await plugin.deleteDownloadedModel(model.id)
 
         XCTAssertFalse(FileManager.default.fileExists(atPath: actualSnapshot.path))
-        XCTAssertFalse(FileManager.default.fileExists(atPath: historicalRepository.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: historicalSnapshot.path))
     }
 
     func testPassiveOfflineRestoreDoesNotCreateDownloadArtifacts() async throws {
@@ -136,10 +142,31 @@ final class MLXPluginModelStorageTests: XCTestCase {
         let granite = GranitePlugin.availableModels[0]
         let voxtral = VoxtralPlugin.availableModels[0]
         let gemma = try XCTUnwrap(Gemma4Plugin.modelDefinition(for: "gemma-4-e2b-it-4bit"))
-        Qwen3Plugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("qwen"), defaults: ["loadedModel": qwen.id]))
-        GranitePlugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("granite"), defaults: ["loadedModel": granite.id]))
-        VoxtralPlugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("voxtral"), defaults: ["loadedModel": voxtral.id]))
-        Gemma4Plugin().activate(host: MockHostServices(pluginDataDirectory: fixture.root.appendingPathComponent("gemma"), defaults: ["loadedModel": gemma.id]))
+        let plugins: [(TypeWhisperPlugin, MockHostServices)] = [
+            (Qwen3Plugin(), MockHostServices(
+                pluginDataDirectory: fixture.root.appendingPathComponent("qwen"),
+                defaults: ["loadedModel": qwen.id],
+                shouldRestoreLoadedModelsPassively: true
+            )),
+            (GranitePlugin(), MockHostServices(
+                pluginDataDirectory: fixture.root.appendingPathComponent("granite"),
+                defaults: ["loadedModel": granite.id],
+                shouldRestoreLoadedModelsPassively: true
+            )),
+            (VoxtralPlugin(), MockHostServices(
+                pluginDataDirectory: fixture.root.appendingPathComponent("voxtral"),
+                defaults: ["loadedModel": voxtral.id],
+                shouldRestoreLoadedModelsPassively: true
+            )),
+            (Gemma4Plugin(), MockHostServices(
+                pluginDataDirectory: fixture.root.appendingPathComponent("gemma"),
+                defaults: ["loadedModel": gemma.id],
+                shouldRestoreLoadedModelsPassively: true
+            )),
+        ]
+        for (plugin, host) in plugins {
+            plugin.activate(host: host)
+        }
 
         try await Task.sleep(for: .milliseconds(100))
 
@@ -147,18 +174,19 @@ final class MLXPluginModelStorageTests: XCTestCase {
             let models = fixture.root.appendingPathComponent(pluginRoot).appendingPathComponent("models")
             XCTAssertFalse(FileManager.default.fileExists(atPath: models.path), "Unexpected cache for \(pluginRoot)")
         }
+        withExtendedLifetime(plugins) {}
     }
 
-    private func assertCatalogRecognizesBothLayouts<P: PluginDownloadedModelManaging & TranscriptionModelCatalogProviding>(
+    private func assertCatalogRecognizesBothLayouts<P: TypeWhisperPlugin & PluginDownloadedModelManaging & TranscriptionModelCatalogProviding>(
         plugin: P,
         modelID: String,
         repositoryID: String,
         requiredFiles: [String]
-    ) throws where P: AnyObject {
+    ) throws {
         let fixture = try Fixture()
         defer { fixture.remove() }
         let host = MockHostServices(pluginDataDirectory: fixture.root)
-        (plugin as TypeWhisperPlugin).activate(host: host)
+        plugin.activate(host: host)
         let legacy = fixture.legacyDirectory(repositoryID: repositoryID, usesMLXAudio: true)
         try fixture.writeModel(at: legacy, requiredFiles: requiredFiles)
         XCTAssertEqual(plugin.downloadedModels.map(\.id), [modelID])
@@ -304,9 +332,10 @@ private final class Fixture {
     func writeSnapshot(
         repositoryID: String,
         commit: String,
-        requiredFiles: [String]
+        requiredFiles: [String],
+        cacheRoot: URL? = nil
     ) throws -> URL {
-        let repository = repositoryDirectory(repositoryID: repositoryID)
+        let repository = repositoryDirectory(repositoryID: repositoryID, cacheRoot: cacheRoot)
         let snapshot = repository.appendingPathComponent("snapshots/\(commit)", isDirectory: true)
         try writeModel(at: snapshot, requiredFiles: requiredFiles)
         try write(commit + "\n", to: repository.appendingPathComponent("refs/main"))


### PR DESCRIPTION
## Issue context

Issue #1036 reports that MLX model downloads were materialized twice: once in the canonical Hugging Face blob/snapshot cache and again in a plugin-specific legacy directory. The UI deleted only the legacy copy, leaving the canonical cache behind and consuming several additional gigabytes.

## Root cause

Qwen3, Granite, and Voxtral used MLX Audio helpers that copied a cached Hugging Face snapshot into `models/mlx-audio`. Gemma 4 explicitly passed a second destination to `downloadSnapshot`. Download detection and deletion also used plugin-specific path assumptions, including an incorrect historical Voxtral cache root.

## Changes

- add a first-party SPI model store that validates canonical `refs/main` snapshots, required files, alternative tokenizer layouts, and non-empty weight files
- load Qwen3, Granite, Voxtral, and Gemma 4 directly from the canonical Hugging Face snapshot
- retain safe fallback support for existing legacy model directories
- remove a legacy duplicate on activation only after the canonical snapshot is usable and path/size equivalent
- delete repository blobs/snapshots, metadata, locks, legacy directories, and Voxtral's historical cache path while preserving neighboring models and the shared `models` root
- keep Qwen3's generated `tokenizer.json` reproducible during migration
- preserve Gemma 4 download progress, cancellation, timeout, model selection, and error behavior

## User impact

New downloads store model weights only once. Existing verified duplicates are reclaimed automatically when the corresponding plugin activates. Deleting a model from the UI now removes all model-specific cache artifacts.

## Test plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter PluginHuggingFaceModelStoreTests
swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  -only-testing:TypeWhisperTests/MLXPluginModelStorageTests
./scripts/pr-preflight.sh origin/main
```

Local results:
- model store tests: 8 passed
- Qwen3 plugin tests: 19 passed
- MLX storage app tests: 5 passed
- existing Gemma 4 policy/progress/timeout/cancellation tests: 43 passed
- preflight Plugin SDK suite: 481 passed

MacBook worker validation:
- exact SHA: `3dd5028cebcdfe1e1a458069c4b2fa550d85137a`
- full-profile job: `twx-66a61603f836`
- the Release build passed, including warning and binary instrumentation checks
- the job was cancelled while the app-test phase rebuilt MLX dependencies; the complete remote test gate was intentionally skipped
- the worker lifecycle and duplicate-build issues discovered by this first run were fixed separately in the private worker tooling

Closes #1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added centralized Hugging Face model storage with cache discovery, validation, cleanup, migration, and deletion support.
  - Improved model loading across Gemma, Granite, Qwen3, and Voxtral by reusing valid cached models or downloading verified snapshots.
  - Added clearer handling for invalid repositories and incomplete downloads.
  - Added cleanup of redundant legacy model copies and related cache artifacts.

- **Tests**
  - Expanded coverage for canonical and legacy cache layouts, restoration, deletion, validation, and duplicate cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->