### PR TITLE
Prepare MLX storage plugin releases

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.3",
-    "minHostVersion": "1.5.0",
+    "version": "1.1.4",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [
         "arm64"

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.granite",
     "name": "Granite Speech",
-    "version": "1.0.2",
-    "minHostVersion": "1.4.0",
+    "version": "1.0.9",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
-    "version": "1.1.5",
-    "minHostVersion": "1.4.0",
+    "version": "1.1.6",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.voxtral",
     "name": "Voxtral",
-    "version": "1.0.6",
-    "minHostVersion": "1.4.0",
+    "version": "1.0.13",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -104,17 +104,18 @@ final class PluginManifestValidationTests: XCTestCase {
     }
 
     func testMLXStoragePluginReleasesRequireHost16() throws {
-        let manifestPaths = [
-            "TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json",
+        let manifestExpectations = [
+            ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.6"),
+            ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.13"),
+            ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.9"),
+            ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.4"),
         ]
 
-        for relativePath in manifestPaths {
+        for (relativePath, expectedVersion) in manifestExpectations {
             let manifestURL = TestSupport.repoRoot.appendingPathComponent(relativePath)
             let data = try Data(contentsOf: manifestURL)
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+            XCTAssertEqual(manifest.version, expectedVersion, relativePath)
             XCTAssertEqual(manifest.minHostVersion, "1.6.0", relativePath)
         }
     }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -103,28 +103,20 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 
-    func testDownloadedModelManagingPluginReleasesRequireHost14() throws {
+    func testMLXStoragePluginReleasesRequireHost16() throws {
         let manifestPaths = [
             "TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json",
             "TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json",
             "TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json",
+            "TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json",
         ]
 
         for relativePath in manifestPaths {
             let manifestURL = TestSupport.repoRoot.appendingPathComponent(relativePath)
             let data = try Data(contentsOf: manifestURL)
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
-            XCTAssertEqual(manifest.minHostVersion, "1.4.0", relativePath)
+            XCTAssertEqual(manifest.minHostVersion, "1.6.0", relativePath)
         }
-    }
-
-    func testGemma4PluginReleaseRequiresHost15() throws {
-        let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json")
-        let data = try Data(contentsOf: manifestURL)
-        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
-
-        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
     }
 
     func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {


### PR DESCRIPTION
## Context

This is the release-preparation follow-up for #1036 and #1044. The MLX model-storage fix adds a first-party SDK storage component used by Qwen3, Granite, Voxtral, and Gemma 4, so updated standalone plugin releases must require a host that contains that SDK implementation.

## Changes

- bump Qwen3 to 1.1.6
- bump Granite to 1.0.9
- bump Voxtral to 1.0.13
- bump Gemma 4 to 1.1.4
- require TypeWhisper 1.6.0 for all four releases

Granite and Voxtral advance from the latest versions already present in the public registries (1.0.8 and 1.0.12), rather than from their older source-manifest versions.

## Test plan

- [x] `for manifest in TypeWhisperPluginSDK/Plugins/{Qwen3Plugin,GranitePlugin,VoxtralPlugin,Gemma4Plugin}/manifest.json; do jq -e '.version and .minHostVersion == "1.6.0"' "$manifest" >/dev/null; done`
- [x] `./scripts/pr-preflight.sh origin/main` (481 tests passed)

Closes #1036


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Gemma 4, Granite, Qwen3, and Voxtral plugins to newer releases.
  * These updates require host version 1.6.0 or later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->