### PR TITLE
Prepare TypeWhisper 1.6.0 RC1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -418,8 +418,37 @@ jobs:
               gh release edit "$TAG" --draft=false
             fi
           elif [ "$EXISTING_DRAFT" = "false" ]; then
-            echo "Published release found for $TAG. Uploading assets..."
-            gh release upload "$TAG" "$ASSET_DMG" "$ASSET_ZIP" --clobber
+            echo "Published release found for $TAG. Verifying immutable assets..."
+
+            verify_or_upload_published_asset() {
+              local asset_path="$1"
+              local asset_name
+              local local_digest
+              local remote_digest
+
+              asset_name=$(basename "$asset_path")
+              local_digest="sha256:$(shasum -a 256 "$asset_path" | awk '{print $1}')"
+              remote_digest=$(
+                gh release view "$TAG" --json assets \
+                  --jq ".assets[] | select(.name == \"$asset_name\") | .digest // \"MISSING_DIGEST\""
+              )
+
+              if [ -z "$remote_digest" ]; then
+                echo "Published release is missing $asset_name. Uploading it without replacing existing assets..."
+                gh release upload "$TAG" "$asset_path"
+              elif [ "$remote_digest" = "MISSING_DIGEST" ]; then
+                echo "Published asset $asset_name has no GitHub digest; refusing to replace it" >&2
+                exit 1
+              elif [ "$remote_digest" = "$local_digest" ]; then
+                echo "Published asset $asset_name already matches $local_digest"
+              else
+                echo "Published asset $asset_name has digest $remote_digest, expected $local_digest; refusing to replace it" >&2
+                exit 1
+              fi
+            }
+
+            verify_or_upload_published_asset "$ASSET_DMG"
+            verify_or_upload_published_asset "$ASSET_ZIP"
             if [ "$IS_PRERELEASE" = "true" ]; then
               gh release edit "$TAG" --prerelease
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,11 @@ jobs:
           SCHEDULED_WITHOUT_ICLOUD: ${{ vars.MACOS_SCHEDULED_WITHOUT_ICLOUD }}
         run: |
           WITHOUT_ICLOUD="false"
-          if [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ] ||
+          # Tagged app releases remain on the proven no-iCloud distribution path
+          # until the production container and Developer ID profile are approved.
+          # Scheduled and manually dispatched builds retain their existing controls.
+          if [ "$EVENT_NAME" = "push" ] ||
+            [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ] ||
             { [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULED_WITHOUT_ICLOUD" = "true" ]; }; then
             WITHOUT_ICLOUD="true"
           fi

--- a/docs/release-notes/1.6.0-rc1.md
+++ b/docs/release-notes/1.6.0-rc1.md
@@ -38,4 +38,5 @@ TypeWhisper `1.6.0-rc1` opens the `1.6` release-candidate line with a more produ
 - Verify both an upgrade from `1.5.1` and a clean installation, including permissions, first dictation, and preservation of user data and update-channel selection.
 - Exercise AirPods, Bluetooth, clamshell, virtual-input, and built-in microphone routes across dictation and Recorder sessions.
 - Smoke-test dictation, text insertion, file transcription and export, workflows, History, the local HTTP API, and the CLI.
+- Verify that the tagged RC1 build hides automatic private iCloud sync while preserving user-selected Cloud Folder Sync.
 - Verify Dictionary search, correction training, per-term CTC, Backup & Restore, Statistics, indicators, models, bundled integrations, community plugins, and the Release Candidate update channel.

--- a/docs/release-notes/1.6.0-rc1.md
+++ b/docs/release-notes/1.6.0-rc1.md
@@ -1,0 +1,41 @@
+TypeWhisper `1.6.0-rc1` opens the `1.6` release-candidate line with a more productive settings experience, new statistics and backup tools, and a broad reliability pass across dictation, audio routing, workflows, integrations, and local models.
+
+## Highlights
+
+- Unified the visual language across Settings, including dashboards, forms, collections, workspaces, and advanced tool pages.
+- Added a Statistics view for privacy-friendly aggregate usage insights.
+- Added Backup & Restore for portable workflows, dictionary entries, snippets, profiles, prompt actions, hotkeys, installed community plugins, transcription history text, update-channel selection, and supported preferences.
+- Regrouped the menu bar for faster access and now shows the active transcription provider alongside the selected model.
+
+## Dictation Reliability
+
+- Added an ordered microphone priority list and improved recovery for AirPods, Bluetooth system-default input, clamshell changes, and FaceTime built-in microphone capture.
+- Reduced startup and dictation latency while keeping recording and model preparation responsive.
+- Fixed indicator placement, dismissal, fullscreen visibility, feedback interaction, countdown progress, and optional screen-capture visibility.
+- Improved contextual insertion for Firefox, CJK text, trailing spaces, secure-input situations, and target-app correction learning.
+
+## Dictionary & Workflows
+
+- Added dictionary search, safe reset actions, grouped correction variants, clearer learned-correction visibility, and a guided microphone correction trainer.
+- Applied dictionary corrections to file transcription and connected per-term CTC tuning to Parakeet.
+- Added ordered global LLM provider and model fallbacks while keeping explicit workflow providers strict.
+- Added explicit workflow dictation through the local API and improved webhook and Obsidian workflow configuration.
+
+## Models & Integrations
+
+- Added a live-preview engine override so preview can stay local while final transcription uses the configured dictation engine.
+- Added Soniox live WebSocket transcription and the local Cohere Transcribe integration.
+- Added context-aware OpenAI transcription and dynamic ChatGPT model discovery.
+- Improved MLX model storage, lazy restore, stalled-download recovery, and lifecycle handling across Qwen3, Gemma 4, Granite, Voxtral, Parakeet, and WhisperKit.
+
+## Known Limitation
+
+- Automatic private iCloud sync is disabled in this build while the production container and Developer ID provisioning profile remain unavailable.
+- Cloud Folder Sync through a user-selected iCloud Drive, Dropbox, OneDrive, Syncthing, or custom folder remains available.
+
+## Testing Focus
+
+- Verify both an upgrade from `1.5.1` and a clean installation, including permissions, first dictation, and preservation of user data and update-channel selection.
+- Exercise AirPods, Bluetooth, clamshell, virtual-input, and built-in microphone routes across dictation and Recorder sessions.
+- Smoke-test dictation, text insertion, file transcription and export, workflows, History, the local HTTP API, and the CLI.
+- Verify Dictionary search, correction training, per-term CTC, Backup & Restore, Statistics, indicators, models, bundled integrations, community plugins, and the Release Candidate update channel.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -39,6 +39,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Preserve the `1.x` stability contracts for the HTTP API, CLI, plugin SDK, widgets, and watch folders.
 - Avoid raising plugin `minHostVersion` values to `1.6.0` unless a plugin genuinely requires new host APIs.
 - Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.
+- Keep tagged app releases on the no-iCloud distribution path until the production container and Developer ID provisioning profile are approved and validated. Tag pushes matching `v*` therefore build without automatic private iCloud sync; scheduled builds continue to use `MACOS_SCHEDULED_WITHOUT_ICLOUD`, and manual dispatches continue to use the explicit `without_icloud` input.
 
 ## Stability Contracts for `1.x`
 
@@ -81,6 +82,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - The default channel remains `stable`; `release-candidate` and `daily` exist as Sparkle channels for preview builds.
 - `1.6.0-rc*` and daily builds are distributed as GitHub prereleases, appear in the shared Sparkle appcast only on their own channels, and do not update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
+- Automatic private iCloud sync remains hidden in no-iCloud builds. Enabling it for a future release requires the explicit build flag, an embedded Developer ID provisioning profile, matching signed iCloud entitlements, Sparkle upgrade proof, and a real two-Mac sync validation.
 
 ## Manual Release Validation
 

--- a/docs/specs/2026-08-02-typewhisper-1.6.0-rc1-release-design.md
+++ b/docs/specs/2026-08-02-typewhisper-1.6.0-rc1-release-design.md
@@ -1,0 +1,70 @@
+# TypeWhisper 1.6.0 RC1 Release Design
+
+## Summary
+
+TypeWhisper `1.6.0-rc1` freezes the `1.6` feature set at commit `7e30e7cc967bd355b60c8c64221312d671e6c464`, plus the release preparation changes described here. The candidate is a public GitHub prerelease on the Sparkle `release-candidate` channel. It does not update Homebrew or stable website messaging.
+
+The candidate uses the proven no-iCloud Developer ID distribution path. Automatic private iCloud sync is disabled, while user-selected Cloud Folder Sync remains available. Marco owns a three-day post-publication soak, and Discord is the only active tester-outreach channel.
+
+## Scope
+
+The release includes the complete `main` history through the frozen commit, curated release notes, the no-iCloud tag policy, the release checklist, signed and notarized artifacts, public appcast publication, artifact verification, and a Discord tester call.
+
+The Simplified Chinese localization in PR #1041, the automatic iCloud work in draft PR #1014, unrelated new features, a GitHub Discussion, Homebrew, stable website messaging, and the final `v1.6.0` release are out of scope.
+
+If `main` advances before the preparation branch is created, each additional commit must be reviewed explicitly against this scope. No unrelated commit may be included implicitly.
+
+## Release Preparation
+
+The preparation branch is `seofood/release-1.6.0-rc1`. Its pull request contains this design, the curated `1.6.0-rc1` notes, the release-readiness policy, and the workflow change. The pull request does not auto-close the release checklist issue.
+
+Local validation is:
+
+```bash
+actionlint -shellcheck= .github/workflows/release.yml
+./scripts/pr-preflight.sh origin/main
+```
+
+The exact pull-request head must also pass the release build, app tests, Plugin SDK tests, first-party warning check, CodeQL, PR Guard, and review-thread gates before an exact-head squash merge.
+
+## No-iCloud Tag Policy
+
+All app tag pushes matched by `v*` set `WITHOUT_ICLOUD=true`. Scheduled builds continue to use `MACOS_SCHEDULED_WITHOUT_ICLOUD`. Manual workflow dispatches continue to use the explicit `without_icloud` input. Plugin tags do not match the app release workflow.
+
+This policy remains in force until the production iCloud container and Developer ID provisioning profile are approved. A future activation requires a deliberate workflow change, an embedded profile, matching signed entitlements, Sparkle upgrade proof, and real two-Mac synchronization validation.
+
+## Candidate and Publication
+
+After the preparation pull request is merged, create an English release-checklist issue titled `[Release] TypeWhisper 1.6.0 RC1` with the `area: build & release` label. Record the exact merged `main` commit, `v1.5.1` as the previous stable release, and Marco as test owner.
+
+Create the lightweight tag `v1.6.0-rc1` at that exact commit and push only that tag. The workflow must report `without_icloud=true` before proceeding. It must pass release-tool self-tests, app and Plugin SDK tests, first-party warning checks, an unsigned release build, CLI instrumentation validation, Developer ID and no-iCloud signing checks, app and DMG notarization, stapling, signed app launch, Sparkle signing, GitHub prerelease creation, and canonical appcast publication. Website and Homebrew jobs must be skipped.
+
+## Publication Verification
+
+Publication is complete only when all three evidence layers agree:
+
+1. The GitHub tag targets the approved commit, the release is a published prerelease, and both DMG and ZIP assets exist with the curated notes.
+2. The canonical appcast advertises `1.6.0-rc1` on `release-candidate`, requires macOS 14.0, and contains the exact ZIP URL, signature, and length.
+3. The downloaded ZIP contains a signed and notarized app with `CFBundleShortVersionString=1.6.0`, `TypeWhisperReleaseTag=v1.6.0-rc1`, `TypeWhisperReleaseChannel=release-candidate`, `TypeWhisperICloudEnabled=NO`, the expected numeric build, no iCloud or ubiquity entitlements, and the production App Group.
+
+The Discord announcement is published only after all three layers pass.
+
+## Discord Outreach
+
+The English Discord post identifies RC1 as a public test build rather than a stable release. It links the GitHub release, explains how to select `Settings > About > Update Channel > Release Candidate`, summarizes the productivity and reliability highlights, calls out the disabled automatic iCloud mode, and asks testers to report the exact version, macOS version, hardware, reproduction steps, and diagnostics through the GitHub bug template.
+
+No GitHub Discussion or broader social announcement is created.
+
+## Soak and Failure Policy
+
+Marco validates the published binary through an upgrade from `v1.5.1`, a clean installation, recording and insertion, audio routes, Recorder, file transcription, workflows, History, API and CLI, integrations, Dictionary, models, plugins, indicators, localization, and the update channel.
+
+Data loss, security or signing failures, reproducible crashes, and unusable core paths without an acceptable workaround are P0/P1 failures. They receive the `release-blocker` label and block stable. Any product-code change after RC1 requires at least `v1.6.0-rc2`. P2/P3 issues block only after an explicit severity escalation.
+
+The RC1 tag and announced artifacts are immutable. An infrastructure-only failure may be rerun at the same unchanged tag before publication is complete. If remediation changes tagged workflow or product code, the next candidate is RC2 rather than a moved RC1 tag.
+
+The earliest stable decision is after 72 complete hours without an open P0/P1 blocker and with the core smoke tests complete. Publishing stable `v1.6.0` is outside this design.
+
+## Compatibility
+
+RC1 introduces no new product API, CLI, or Plugin SDK compatibility change. The operational change is limited to the app release workflow: tag pushes matching `v*` use the no-iCloud path. Sparkle remains on the existing release-candidate channel, and `v1.5.1`, Homebrew, and stable website distribution remain unchanged.


### PR DESCRIPTION
## Context

Prepare TypeWhisper 1.6.0 RC1 from the frozen `main` baseline at `7e30e7cc967bd355b60c8c64221312d671e6c464`.

This pull request:
- adds curated RC1 release notes and the approved release design
- keeps tagged app releases on the proven no-iCloud path
- documents the temporary no-iCloud tag policy and future activation gates
- excludes PR #1041, draft PR #1014, automatic private iCloud sync, Homebrew, and stable website messaging

## Release behavior

For app tag push events matched by `v*`, the release workflow now resolves `without_icloud=true`. Scheduled builds continue to use `MACOS_SCHEDULED_WITHOUT_ICLOUD`, and manual workflow dispatches continue to use the explicit input.

## Test plan

- `actionlint -shellcheck= .github/workflows/release.yml`
- `./scripts/pr-preflight.sh origin/main`
- GitHub Build DMG workflow: release build, app tests, Plugin SDK tests, and first-party warning checks
- CodeQL and PR Guard


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added release notes for TypeWhisper 1.6.0 RC1, covering Settings, Statistics, Backup & Restore, dictation reliability, dictionary updates, workflow changes, and integrations.
  - Added release-readiness and release-design guidance covering validation requirements, compatibility, artifact verification, and upgrade criteria.

- **Release Updates**
  - Tagged releases will use the no-iCloud distribution path.
  - Private iCloud sync remains unavailable in this release candidate.
  - TypeWhisper 1.6.0 RC1 will be distributed as a prerelease for testing, with verified download artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->