### PR TITLE
Add optional API version to OpenAI-compatible profiles

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -17,6 +17,22 @@
         }
       }
     },
+    "API Version": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Version"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIバージョン"
+          }
+        }
+      }
+    },
     "API keys are stored securely in the Keychain": {
       "localizations": {
         "de": {
@@ -29,6 +45,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "APIキーはセキュアにキーチェーンに保存されます"
+          }
+        }
+      }
+    },
+    "Azure OpenAI and Microsoft Foundry may require an API version such as preview for audio transcription. Leave blank for standard OpenAI-compatible servers.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azure OpenAI und Microsoft Foundry benötigen für die Audiotranskription möglicherweise eine API-Version wie preview. Für standardmäßige OpenAI-kompatible Server leer lassen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Azure OpenAI および Microsoft Foundry では、音声文字起こしに preview などの API バージョンが必要な場合があります。標準の OpenAI 互換サーバーでは空欄のままにしてください。"
           }
         }
       }
@@ -211,6 +243,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "OllamaやLM Studioなどのローカルサーバー用にオプションで使用可能"
+          }
+        }
+      }
+    },
+    "Optional, e.g. preview": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional, z. B. preview"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "任意（例: preview）"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -493,16 +493,30 @@ final class OpenAICompatiblePlugin: NSObject,
             throw PluginTranscriptionError.noModelSelected
         }
 
-        return try await helper.transcribeCompressedAudioWithWavFallback(
-            audio: audio,
-            apiKey: apiKey(for: profileId) ?? "",
-            modelName: modelId,
-            language: language,
-            translate: translate,
-            prompt: prompt,
-            requestTimeout: Self.transcriptionRequestTimeout,
-            apiVersion: profile.apiVersion
-        )
+        let apiKey = apiKey(for: profileId) ?? ""
+        if profile.apiVersion.isEmpty {
+            return try await helper.transcribeCompressedAudioWithWavFallback(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelId,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                requestTimeout: Self.transcriptionRequestTimeout
+            )
+        }
+
+        return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            try await self.performVersionedTranscriptionRequest(
+                profile: profile,
+                uploadFile: uploadFile,
+                apiKey: apiKey,
+                modelName: modelId,
+                language: language,
+                translate: translate,
+                prompt: prompt
+            )
+        }
     }
 
     func process(
@@ -899,6 +913,93 @@ final class OpenAICompatiblePlugin: NSObject,
         }
 
         return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func performVersionedTranscriptionRequest(
+        profile: OpenAICompatibleProfile,
+        uploadFile: PluginAudioUploadFile,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        let path = translate ? "/v1/audio/translations" : "/v1/audio/transcriptions"
+        guard let url = Self.requestURL(
+            baseURL: profile.baseURL,
+            path: path,
+            apiVersion: profile.apiVersion
+        ) else {
+            throw PluginTranscriptionError.apiError("Invalid URL: \(profile.baseURL)\(path)")
+        }
+
+        let boundary = UUID().uuidString
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("******", forHTTPHeaderField: "Authorization")
+        request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = Self.transcriptionRequestTimeout
+
+        var body = Data()
+        body.append("--\(boundary)\r\n".data(using: .utf8)!)
+        body.append(
+            "Content-Disposition: form-data; name=\"file\"; filename=\"\(uploadFile.filename)\"\r\n"
+                .data(using: .utf8)!
+        )
+        body.append("Content-Type: \(uploadFile.contentType)\r\n\r\n".data(using: .utf8)!)
+        body.append(uploadFile.data)
+        body.append("\r\n".data(using: .utf8)!)
+        Self.appendMultipartField(to: &body, boundary: boundary, name: "model", value: modelName)
+        Self.appendMultipartField(to: &body, boundary: boundary, name: "response_format", value: "json")
+        if !translate, let language, !language.isEmpty {
+            Self.appendMultipartField(to: &body, boundary: boundary, name: "language", value: language)
+        }
+        if let prompt, !prompt.isEmpty {
+            Self.appendMultipartField(to: &body, boundary: boundary, name: "prompt", value: prompt)
+        }
+        body.append("--\(boundary)--\r\n".data(using: .utf8)!)
+        request.httpBody = body
+
+        let (responseData, response) = try await PluginHTTPClient.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401:
+            throw PluginTranscriptionError.invalidApiKey
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        default:
+            let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
+        }
+
+        struct Response: Decodable {
+            let text: String
+            let language: String?
+        }
+        do {
+            let decoded = try JSONDecoder().decode(Response.self, from: responseData)
+            return PluginTranscriptionResult(text: decoded.text, detectedLanguage: decoded.language)
+        } catch {
+            throw PluginTranscriptionError.apiError("Failed to parse response: \(error.localizedDescription)")
+        }
+    }
+
+    private static func appendMultipartField(
+        to data: inout Data,
+        boundary: String,
+        name: String,
+        value: String
+    ) {
+        data.append("--\(boundary)\r\n".data(using: .utf8)!)
+        data.append("Content-Disposition: form-data; name=\"\(name)\"\r\n\r\n".data(using: .utf8)!)
+        data.append("\(value)\r\n".data(using: .utf8)!)
     }
 
     private static func chatErrorMessage(from data: Data, statusCode: Int) -> String {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -563,6 +563,11 @@ final class OpenAICompatiblePlugin: NSObject,
         if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
+        if let apiKey = apiKey(for: profileId),
+           !apiKey.isEmpty,
+           Self.isAzureOpenAIEndpoint(request.url) {
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
         request.timeoutInterval = 10
 
         do {
@@ -598,6 +603,11 @@ final class OpenAICompatiblePlugin: NSObject,
         if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
+        if let apiKey = apiKey(for: profileId),
+           !apiKey.isEmpty,
+           Self.isAzureOpenAIEndpoint(request.url) {
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
         request.timeoutInterval = 10
 
         do {
@@ -632,6 +642,11 @@ final class OpenAICompatiblePlugin: NSObject,
             return match.id
         }
         return trimmed
+    }
+
+    private nonisolated static func isAzureOpenAIEndpoint(_ url: URL?) -> Bool {
+        guard let host = url?.host?.lowercased() else { return false }
+        return host.hasSuffix(".openai.azure.com") || host.hasSuffix(".services.ai.azure.com")
     }
 
     private func providerTemperatureDirective(for profileId: String) -> PluginLLMTemperatureDirective {
@@ -883,6 +898,9 @@ final class OpenAICompatiblePlugin: NSObject,
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        if Self.isAzureOpenAIEndpoint(request.url), !apiKey.isEmpty {
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = requestTimeout
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
@@ -937,6 +955,9 @@ final class OpenAICompatiblePlugin: NSObject,
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("******", forHTTPHeaderField: "Authorization")
+        if Self.isAzureOpenAIEndpoint(request.url), !apiKey.isEmpty {
+            request.setValue(apiKey, forHTTPHeaderField: "api-key")
+        }
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = Self.transcriptionRequestTimeout
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -506,6 +506,8 @@ final class OpenAICompatiblePlugin: NSObject,
             )
         }
 
+        // TypeWhisper 1.6 RC1 does not export the SDK's apiVersion overload.
+        // Keep this JSON request path in the plugin until that host is no longer supported.
         return try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
             try await self.performVersionedTranscriptionRequest(
                 profile: profile,
@@ -560,14 +562,7 @@ final class OpenAICompatiblePlugin: NSObject,
               ) else { return [] }
 
         var request = URLRequest(url: url)
-        if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-        if let apiKey = apiKey(for: profileId),
-           !apiKey.isEmpty,
-           Self.isAzureOpenAIEndpoint(request.url) {
-            request.setValue(apiKey, forHTTPHeaderField: "api-key")
-        }
+        applyAuthentication(to: &request, profileId: profileId)
         request.timeoutInterval = 10
 
         do {
@@ -600,14 +595,7 @@ final class OpenAICompatiblePlugin: NSObject,
               ) else { return false }
 
         var request = URLRequest(url: url)
-        if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
-            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        }
-        if let apiKey = apiKey(for: profileId),
-           !apiKey.isEmpty,
-           Self.isAzureOpenAIEndpoint(request.url) {
-            request.setValue(apiKey, forHTTPHeaderField: "api-key")
-        }
+        applyAuthentication(to: &request, profileId: profileId)
         request.timeoutInterval = 10
 
         do {
@@ -646,7 +634,24 @@ final class OpenAICompatiblePlugin: NSObject,
 
     private nonisolated static func isAzureOpenAIEndpoint(_ url: URL?) -> Bool {
         guard let host = url?.host?.lowercased() else { return false }
-        return host.hasSuffix(".openai.azure.com") || host.hasSuffix(".services.ai.azure.com")
+        return host.hasSuffix(".openai.azure.com")
+            || host.hasSuffix(".openai.azure.us")
+            || host.hasSuffix(".services.ai.azure.com")
+    }
+
+    private func applyAuthentication(to request: inout URLRequest, profileId: String) {
+        guard let apiKey = apiKey(for: profileId) else { return }
+        Self.applyAuthentication(to: &request, apiKey: apiKey)
+    }
+
+    private nonisolated static func applyAuthentication(to request: inout URLRequest, apiKey: String) {
+        let trimmedKey = apiKey.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+        let authorizationHeader = "Authorization"
+        request.setValue("Bearer " + trimmedKey, forHTTPHeaderField: authorizationHeader)
+        if isAzureOpenAIEndpoint(request.url) {
+            request.setValue(trimmedKey, forHTTPHeaderField: "api-key")
+        }
     }
 
     private func providerTemperatureDirective(for profileId: String) -> PluginLLMTemperatureDirective {
@@ -897,10 +902,7 @@ final class OpenAICompatiblePlugin: NSObject,
 
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        if Self.isAzureOpenAIEndpoint(request.url), !apiKey.isEmpty {
-            request.setValue(apiKey, forHTTPHeaderField: "api-key")
-        }
+        Self.applyAuthentication(to: &request, apiKey: apiKey)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = requestTimeout
         request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
@@ -954,10 +956,7 @@ final class OpenAICompatiblePlugin: NSObject,
         let boundary = UUID().uuidString
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
-        request.setValue("******", forHTTPHeaderField: "Authorization")
-        if Self.isAzureOpenAIEndpoint(request.url), !apiKey.isEmpty {
-            request.setValue(apiKey, forHTTPHeaderField: "api-key")
-        }
+        Self.applyAuthentication(to: &request, apiKey: apiKey)
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         request.timeoutInterval = Self.transcriptionRequestTimeout
 
@@ -1000,13 +999,26 @@ final class OpenAICompatiblePlugin: NSObject,
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
+        struct Segment: Decodable {
+            let start: Double
+            let end: Double
+            let text: String
+        }
         struct Response: Decodable {
             let text: String
             let language: String?
+            let segments: [Segment]?
         }
         do {
             let decoded = try JSONDecoder().decode(Response.self, from: responseData)
-            return PluginTranscriptionResult(text: decoded.text, detectedLanguage: decoded.language)
+            let segments = (decoded.segments ?? []).map {
+                PluginTranscriptionSegment(text: $0.text, start: $0.start, end: $0.end)
+            }
+            return PluginTranscriptionResult(
+                text: decoded.text,
+                detectedLanguage: decoded.language,
+                segments: segments
+            )
         } catch {
             throw PluginTranscriptionError.apiError("Failed to parse response: \(error.localizedDescription)")
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -339,7 +339,7 @@ final class OpenAICompatiblePlugin: NSObject,
 
     func setApiVersion(_ apiVersion: String, for profileId: String) {
         updateProfile(profileId) { profile in
-            profile.apiVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+            profile.apiVersion = Self.normalizedAPIVersion(apiVersion)
         }
     }
 
@@ -694,7 +694,9 @@ final class OpenAICompatiblePlugin: NSObject,
         return [
             .defaultProfile(
                 baseURL: Self.normalizedBaseURL(host.userDefault(forKey: "baseURL") as? String ?? ""),
-                apiVersion: host.userDefault(forKey: "apiVersion") as? String ?? "",
+                apiVersion: Self.normalizedAPIVersion(
+                    host.userDefault(forKey: "apiVersion") as? String ?? ""
+                ),
                 selectedModelId: host.userDefault(forKey: "selectedModel") as? String ?? "",
                 selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? "",
                 llmTemperatureModeRaw: host.userDefault(forKey: "llmTemperatureMode") as? String
@@ -721,7 +723,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 profile.name = profile.isDefault ? OpenAICompatibleProfile.defaultName : "Custom Server"
             }
             profile.baseURL = Self.normalizedBaseURL(profile.baseURL)
-            profile.apiVersion = profile.apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+            profile.apiVersion = Self.normalizedAPIVersion(profile.apiVersion)
             seenIds.insert(profile.id)
             result.append(profile)
         }
@@ -730,7 +732,9 @@ final class OpenAICompatiblePlugin: NSObject,
             result.insert(
                 .defaultProfile(
                     baseURL: Self.normalizedBaseURL(host.userDefault(forKey: "baseURL") as? String ?? ""),
-                    apiVersion: host.userDefault(forKey: "apiVersion") as? String ?? "",
+                    apiVersion: Self.normalizedAPIVersion(
+                        host.userDefault(forKey: "apiVersion") as? String ?? ""
+                    ),
                     selectedModelId: host.userDefault(forKey: "selectedModel") as? String ?? "",
                     selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? ""
                 ),
@@ -1083,6 +1087,10 @@ final class OpenAICompatiblePlugin: NSObject,
         return components.string ?? trimmed
     }
 
+    private static func normalizedAPIVersion(_ apiVersion: String) -> String {
+        apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     private static func requestURL(baseURL: String, path: String, apiVersion: String) -> URL? {
         guard var components = URLComponents(string: baseURL) else { return nil }
         let basePath = components.percentEncodedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
@@ -1091,7 +1099,7 @@ final class OpenAICompatiblePlugin: NSObject,
             .filter { !$0.isEmpty }
             .joined(separator: "/")
 
-        let trimmedVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedVersion = normalizedAPIVersion(apiVersion)
         if !trimmedVersion.isEmpty {
             var queryItems = components.queryItems ?? []
             queryItems.removeAll { $0.name.caseInsensitiveCompare("api-version") == .orderedSame }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -11,6 +11,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var id: String
     var name: String
     var baseURL: String
+    var apiVersion: String
     var selectedModelId: String
     var selectedLLMModelId: String
     var llmTemperatureModeRaw: String
@@ -27,6 +28,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         case id
         case name
         case baseURL
+        case apiVersion
         case selectedModelId
         case selectedLLMModelId
         case llmTemperatureModeRaw
@@ -40,6 +42,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         id: String,
         name: String,
         baseURL: String = "",
+        apiVersion: String = "",
         selectedModelId: String = "",
         selectedLLMModelId: String = "",
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
@@ -51,6 +54,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.id = id
         self.name = name
         self.baseURL = baseURL
+        self.apiVersion = apiVersion
         self.selectedModelId = selectedModelId
         self.selectedLLMModelId = selectedLLMModelId
         self.llmTemperatureModeRaw = llmTemperatureModeRaw
@@ -65,6 +69,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         id = try container.decode(String.self, forKey: .id)
         name = try container.decode(String.self, forKey: .name)
         baseURL = try container.decode(String.self, forKey: .baseURL)
+        apiVersion = try container.decodeIfPresent(String.self, forKey: .apiVersion) ?? ""
         selectedModelId = try container.decode(String.self, forKey: .selectedModelId)
         selectedLLMModelId = try container.decode(String.self, forKey: .selectedLLMModelId)
         llmTemperatureModeRaw = try container.decode(String.self, forKey: .llmTemperatureModeRaw)
@@ -90,6 +95,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
 
     static func defaultProfile(
         baseURL: String = "",
+        apiVersion: String = "",
         selectedModelId: String = "",
         selectedLLMModelId: String = "",
         llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue,
@@ -102,6 +108,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             id: defaultId,
             name: defaultName,
             baseURL: baseURL,
+            apiVersion: apiVersion,
             selectedModelId: selectedModelId,
             selectedLLMModelId: selectedLLMModelId,
             llmTemperatureModeRaw: llmTemperatureModeRaw,
@@ -330,6 +337,12 @@ final class OpenAICompatiblePlugin: NSObject,
         }
     }
 
+    func setApiVersion(_ apiVersion: String, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.apiVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
     func setApiKey(_ key: String) {
         setApiKey(key, for: OpenAICompatibleProfile.defaultId)
     }
@@ -487,7 +500,8 @@ final class OpenAICompatiblePlugin: NSObject,
             language: language,
             translate: translate,
             prompt: prompt,
-            requestTimeout: Self.transcriptionRequestTimeout
+            requestTimeout: Self.transcriptionRequestTimeout,
+            apiVersion: profile.apiVersion
         )
     }
 
@@ -513,7 +527,8 @@ final class OpenAICompatiblePlugin: NSObject,
             userText: userText,
             temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),
             requestTimeout: profile.resolvedChatRequestTimeout,
-            thinkingEnabled: profile.thinkingEnabled
+            thinkingEnabled: profile.thinkingEnabled,
+            apiVersion: profile.apiVersion
         )
     }
 
@@ -524,7 +539,11 @@ final class OpenAICompatiblePlugin: NSObject,
     func fetchModels(for profileId: String) async -> [FetchedModel] {
         guard let profile = profile(for: profileId),
               !profile.baseURL.isEmpty,
-              let url = URL(string: "\(profile.baseURL)/v1/models") else { return [] }
+              let url = Self.requestURL(
+                baseURL: profile.baseURL,
+                path: "/v1/models",
+                apiVersion: profile.apiVersion
+              ) else { return [] }
 
         var request = URLRequest(url: url)
         if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
@@ -555,7 +574,11 @@ final class OpenAICompatiblePlugin: NSObject,
     func validateConnection(for profileId: String) async -> Bool {
         guard let profile = profile(for: profileId),
               !profile.baseURL.isEmpty,
-              let url = URL(string: "\(profile.baseURL)/v1/models") else { return false }
+              let url = Self.requestURL(
+                baseURL: profile.baseURL,
+                path: "/v1/models",
+                apiVersion: profile.apiVersion
+              ) else { return false }
 
         var request = URLRequest(url: url)
         if let apiKey = apiKey(for: profileId), !apiKey.isEmpty {
@@ -637,6 +660,7 @@ final class OpenAICompatiblePlugin: NSObject,
         return [
             .defaultProfile(
                 baseURL: Self.normalizedBaseURL(host.userDefault(forKey: "baseURL") as? String ?? ""),
+                apiVersion: host.userDefault(forKey: "apiVersion") as? String ?? "",
                 selectedModelId: host.userDefault(forKey: "selectedModel") as? String ?? "",
                 selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? "",
                 llmTemperatureModeRaw: host.userDefault(forKey: "llmTemperatureMode") as? String
@@ -663,6 +687,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 profile.name = profile.isDefault ? OpenAICompatibleProfile.defaultName : "Custom Server"
             }
             profile.baseURL = Self.normalizedBaseURL(profile.baseURL)
+            profile.apiVersion = profile.apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
             seenIds.insert(profile.id)
             result.append(profile)
         }
@@ -671,6 +696,7 @@ final class OpenAICompatiblePlugin: NSObject,
             result.insert(
                 .defaultProfile(
                     baseURL: Self.normalizedBaseURL(host.userDefault(forKey: "baseURL") as? String ?? ""),
+                    apiVersion: host.userDefault(forKey: "apiVersion") as? String ?? "",
                     selectedModelId: host.userDefault(forKey: "selectedModel") as? String ?? "",
                     selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? ""
                 ),
@@ -702,6 +728,7 @@ final class OpenAICompatiblePlugin: NSObject,
         guard let defaultProfile = profiles.first(where: \.isDefault) else { return }
 
         host.setUserDefault(defaultProfile.baseURL, forKey: "baseURL")
+        host.setUserDefault(defaultProfile.apiVersion, forKey: "apiVersion")
         host.setUserDefault(defaultProfile.selectedModelId, forKey: "selectedModel")
         host.setUserDefault(defaultProfile.selectedLLMModelId, forKey: "selectedLLMModel")
         host.setUserDefault(defaultProfile.llmTemperatureModeRaw, forKey: "llmTemperatureMode")
@@ -770,11 +797,12 @@ final class OpenAICompatiblePlugin: NSObject,
         userText: String,
         temperature: Double?,
         requestTimeout: TimeInterval,
-        thinkingEnabled: Bool
+        thinkingEnabled: Bool,
+        apiVersion: String
     ) async throws -> String {
-        let endpoint = "\(baseURL)/v1/chat/completions"
-        guard let url = URL(string: endpoint) else {
-            throw PluginChatError.apiError("Invalid URL: \(endpoint)")
+        let path = "/v1/chat/completions"
+        guard let url = Self.requestURL(baseURL: baseURL, path: path, apiVersion: apiVersion) else {
+            throw PluginChatError.apiError("Invalid URL: \(baseURL)\(path)")
         }
 
         let outputTokenParameter = OutputTokenParameter.maxTokens
@@ -907,14 +935,36 @@ final class OpenAICompatiblePlugin: NSObject,
     }
 
     private static func normalizedBaseURL(_ url: String) -> String {
-        var normalized = url.trimmingCharacters(in: .whitespacesAndNewlines)
-        while normalized.hasSuffix("/") {
-            normalized = String(normalized.dropLast())
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard var components = URLComponents(string: trimmed) else { return trimmed }
+
+        var path = components.percentEncodedPath
+        while path.hasSuffix("/") {
+            path.removeLast()
         }
-        if normalized.hasSuffix("/v1") {
-            normalized = String(normalized.dropLast(3))
+        if path.hasSuffix("/v1") {
+            path.removeLast(3)
         }
-        return normalized
+        components.percentEncodedPath = path
+        return components.string ?? trimmed
+    }
+
+    private static func requestURL(baseURL: String, path: String, apiVersion: String) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        let basePath = components.percentEncodedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let requestPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.percentEncodedPath = "/" + [basePath, requestPath]
+            .filter { !$0.isEmpty }
+            .joined(separator: "/")
+
+        let trimmedVersion = apiVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedVersion.isEmpty {
+            var queryItems = components.queryItems ?? []
+            queryItems.removeAll { $0.name.caseInsensitiveCompare("api-version") == .orderedSame }
+            queryItems.append(URLQueryItem(name: "api-version", value: trimmedVersion))
+            components.queryItems = queryItems
+        }
+        return components.url
     }
 }
 
@@ -1033,6 +1083,7 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var selectedProfileId = OpenAICompatibleProfile.defaultId
     @State private var nameInput = ""
     @State private var baseURLInput = ""
+    @State private var apiVersionInput = ""
     @State private var apiKeyInput = ""
     @State private var showApiKey = false
     @State private var isTesting = false
@@ -1185,6 +1236,26 @@ private struct OpenAICompatibleSettingsView: View {
                 )
                 .textFieldStyle(.roundedBorder)
                 .font(.system(.body, design: .monospaced))
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Version", bundle: bundle)
+                    .font(.headline)
+
+                TextField(
+                    String(localized: "Optional, e.g. preview", bundle: bundle),
+                    text: $apiVersionInput
+                )
+                .textFieldStyle(.roundedBorder)
+                .font(.system(.body, design: .monospaced))
+                .onSubmit(saveApiVersion)
+                .onChange(of: apiVersionInput) {
+                    saveApiVersion()
+                }
+
+                Text("Azure OpenAI and Microsoft Foundry may require an API version such as preview for audio transcription. Leave blank for standard OpenAI-compatible servers.", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             VStack(alignment: .leading, spacing: 8) {
@@ -1472,6 +1543,7 @@ private struct OpenAICompatibleSettingsView: View {
 
         nameInput = profile.displayName
         baseURLInput = profile.baseURL
+        apiVersionInput = profile.apiVersion
         apiKeyInput = plugin.apiKey(for: profile.id) ?? ""
         selectedTranscriptionModel = profile.selectedModelId
         selectedLLMModel = profile.selectedLLMModelId
@@ -1498,6 +1570,14 @@ private struct OpenAICompatibleSettingsView: View {
         }
     }
 
+    private func saveApiVersion() {
+        guard let selectedProfile else { return }
+        let trimmed = apiVersionInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed != selectedProfile.apiVersion else { return }
+        plugin.setApiVersion(trimmed, for: selectedProfile.id)
+        reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+    }
+
     private func saveProfileName() {
         guard let selectedProfile else { return }
         let trimmed = nameInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1509,6 +1589,7 @@ private struct OpenAICompatibleSettingsView: View {
 
     private func saveServerFields(for profileId: String) {
         plugin.setBaseURL(baseURLInput, for: profileId)
+        plugin.setApiVersion(apiVersionInput, for: profileId)
         let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         if !trimmedKey.isEmpty {
             plugin.setApiKey(trimmedKey, for: profileId)

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -383,7 +383,9 @@ final class OpenAICompatiblePluginTests: XCTestCase {
                     )
                 ),
                 .success(
-                    Data(#"{"text":"transcribed"}"#.utf8),
+                    Data(
+                        #"{"text":"transcribed","language":"en","segments":[{"start":0.0,"end":1.0,"text":"transcribed"}]}"#.utf8
+                    ),
                     Self.httpResponse(
                         url: "https://foundry-example.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview",
                         statusCode: 200
@@ -402,7 +404,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         _ = await plugin.fetchModels()
         let isConnected = await plugin.validateConnection()
         XCTAssertTrue(isConnected)
-        _ = try await plugin.transcribe(
+        let transcription = try await plugin.transcribe(
             audio: AudioData(samples: [0, 0, 0], wavData: Data("wav".utf8), duration: 1.0),
             language: nil,
             translate: false,
@@ -412,9 +414,45 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(store.sessions[0].requestedRequests.count, 4)
         for request in store.sessions[0].requestedRequests {
-            XCTAssertNotNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: "Authorization"),
+                "Bearer " + "azure-key"
+            )
             XCTAssertEqual(request.value(forHTTPHeaderField: "api-key"), "azure-key")
         }
+        let segment = try XCTUnwrap(transcription.segments.first)
+        XCTAssertEqual(transcription.segments.count, 1)
+        XCTAssertEqual(segment.text, "transcribed")
+        XCTAssertEqual(segment.start, 0)
+        XCTAssertEqual(segment.end, 1)
+    }
+
+    func testAzureSovereignEndpointUsesAzureAuthenticationHeaders() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://resource.openai.azure.us"],
+            secrets: ["api-key": "sovereign-key"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"data":[]}"#.utf8),
+                    Self.httpResponse(url: "https://resource.openai.azure.us/v1/models", statusCode: 200)
+                )
+            ])
+        }
+
+        _ = await plugin.fetchModels()
+
+        let request = try XCTUnwrap(store.sessions[0].requestedRequests.first)
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer " + "sovereign-key"
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "api-key"), "sovereign-key")
     }
 
     func testTranscribeRetriesWithWavWhenCompatibleServerRejectsM4A() async throws {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -46,6 +46,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let host = try PluginTestHostServices(
             defaults: [
                 "baseURL": "https://legacy.test/v1/",
+                "apiVersion": "preview",
                 "selectedModel": "whisper-legacy",
                 "selectedLLMModel": "chat-legacy",
                 "llmTemperatureMode": PluginLLMTemperatureMode.custom.rawValue,
@@ -63,6 +64,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.id, "openai-compatible")
         XCTAssertEqual(profile.displayName, "OpenAI Compatible")
         XCTAssertEqual(profile.baseURL, "https://legacy.test")
+        XCTAssertEqual(profile.apiVersion, "preview")
         XCTAssertEqual(profile.selectedModelId, "whisper-legacy")
         XCTAssertEqual(profile.selectedLLMModelId, "chat-legacy")
         XCTAssertEqual(profile.llmTemperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
@@ -97,6 +99,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.activate(host: host)
 
         let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+        XCTAssertEqual(profile.apiVersion, "")
         XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.resolvedChatRequestTimeout, 45)
         XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
@@ -162,6 +165,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(models.map(\.id), ["a-model", "z-model"])
         XCTAssertEqual(store.sessions.count, 1)
+        XCTAssertNil(store.sessions[0].requestedRequests.first?.url?.query)
         XCTAssertEqual(
             store.sessions[0].requestedRequests.first?.value(forHTTPHeaderField: "Authorization"),
             "Bearer secret-token"
@@ -187,6 +191,56 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertTrue(result)
         XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/models"])
+        XCTAssertNil(store.sessions[0].requestedRequests.first?.url?.query)
+    }
+
+    func testConfiguredAPIVersionPreservesExistingQueryForModelRequests() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test/openai?tenant=contoso"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setApiVersion(" preview ", for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"data":[{"id":"gpt-live-transcribe"}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/models?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/models?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let models = await plugin.fetchModels()
+        let isConnected = await plugin.validateConnection()
+
+        XCTAssertEqual(models.map(\.id), ["gpt-live-transcribe"])
+        XCTAssertTrue(isConnected)
+        XCTAssertEqual(plugin.profileSnapshot(for: plugin.providerId)?.apiVersion, "preview")
+        XCTAssertEqual(store.sessions[0].requestedRequests.count, 2)
+        for request in store.sessions[0].requestedRequests {
+            let url = try XCTUnwrap(request.url)
+            let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+            XCTAssertEqual(components.path, "/openai/v1/models")
+            XCTAssertEqual(
+                components.queryItems,
+                [
+                    URLQueryItem(name: "tenant", value: "contoso"),
+                    URLQueryItem(name: "api-version", value: "preview"),
+                ]
+            )
+        }
     }
 
     func testTranscribeUsesLongTimeoutForLocalCompatibleServers() async throws {
@@ -214,10 +268,87 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(result.text, "hello")
         XCTAssertEqual(store.sessions[0].requestedPaths, ["/v1/audio/transcriptions"])
+        XCTAssertNil(store.sessions[0].requestedRequests.first?.url?.query)
         XCTAssertEqual(store.sessions[0].requestedRequests.first?.timeoutInterval, 600)
         let body = String(decoding: try XCTUnwrap(store.sessions[0].requestedRequests.first?.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains(#"filename="audio.m4a""#))
         XCTAssertTrue(body.contains("Content-Type: audio/mp4"))
+    }
+
+    func testConfiguredAPIVersionAppliesToTranscriptionTranslationAndChat() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test/openai?tenant=contoso",
+                "selectedModel": "gpt-live-transcribe",
+                "selectedLLMModel": "gpt-chat",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setApiVersion("preview", for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"transcribed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/audio/transcriptions?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"translated"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/audio/translations?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"completed"}}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/chat/completions?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let audio = AudioData(samples: [0, 0, 0], wavData: Data("wav".utf8), duration: 1.0)
+        let transcription = try await plugin.transcribe(
+            audio: audio,
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+        let translation = try await plugin.transcribe(
+            audio: audio,
+            language: nil,
+            translate: true,
+            prompt: nil
+        )
+        let chat = try await plugin.process(systemPrompt: "Fix", userText: "hello", model: nil)
+
+        XCTAssertEqual(transcription.text, "transcribed")
+        XCTAssertEqual(translation.text, "translated")
+        XCTAssertEqual(chat, "completed")
+        XCTAssertEqual(
+            store.sessions[0].requestedRequests.compactMap(\.url).map(\.path),
+            [
+                "/openai/v1/audio/transcriptions",
+                "/openai/v1/audio/translations",
+                "/openai/v1/chat/completions",
+            ]
+        )
+        for url in store.sessions[0].requestedRequests.compactMap(\.url) {
+            XCTAssertEqual(
+                URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+                [
+                    URLQueryItem(name: "tenant", value: "contoso"),
+                    URLQueryItem(name: "api-version", value: "preview"),
+                ]
+            )
+        }
     }
 
     func testTranscribeRetriesWithWavWhenCompatibleServerRejectsM4A() async throws {
@@ -250,6 +381,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(result.text, "fallback hello")
         let requests = store.sessions[0].requestedRequests
+        XCTAssertTrue(requests.allSatisfy { $0.url?.query == nil })
         XCTAssertEqual(requests.count, 2)
         let firstBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
         XCTAssertTrue(firstBody.contains(#"filename="audio.m4a""#))
@@ -394,6 +526,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(defaultResult, "default processed")
         XCTAssertEqual(inceptionResult, "inception processed")
         let requests = store.sessions[0].requestedRequests
+        XCTAssertTrue(requests.allSatisfy { $0.url?.query == nil })
         XCTAssertEqual(requests.map { $0.url?.host }, ["default-llm.test", "inception.test"])
         XCTAssertEqual(
             requests.map { $0.value(forHTTPHeaderField: "Authorization") },

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -46,7 +46,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let host = try PluginTestHostServices(
             defaults: [
                 "baseURL": "https://legacy.test/v1/",
-                "apiVersion": "preview",
+                "apiVersion": " preview\n",
                 "selectedModel": "whisper-legacy",
                 "selectedLLMModel": "chat-legacy",
                 "llmTemperatureMode": PluginLLMTemperatureMode.custom.rawValue,
@@ -73,6 +73,31 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.fetchedModels.map(\.id), ["legacy-model"])
         XCTAssertEqual(plugin.apiKey(for: profile.id), "legacy-token")
         XCTAssertNotNil(host.userDefault(forKey: "profiles") as? Data)
+    }
+
+    func testMissingDefaultProfileRestoresTrimmedLegacyAPIVersion() throws {
+        let savedProfiles = try JSONEncoder().encode([
+            OpenAICompatibleProfile(
+                id: "openai-compatible:custom",
+                name: "Custom Server",
+                baseURL: "https://custom.test",
+                apiVersion: "custom-version"
+            )
+        ])
+        let host = try PluginTestHostServices(
+            defaults: [
+                "profiles": savedProfiles,
+                "baseURL": "https://legacy.test/openai",
+                "apiVersion": " preview\n",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+
+        plugin.activate(host: host)
+
+        let defaultProfile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+        XCTAssertEqual(defaultProfile.apiVersion, "preview")
+        XCTAssertEqual(host.userDefault(forKey: "apiVersion") as? String, "preview")
     }
 
     func testSavedProfilesWithoutThinkingModeDecodeAsDisabled() throws {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -170,6 +170,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
             store.sessions[0].requestedRequests.first?.value(forHTTPHeaderField: "Authorization"),
             "Bearer secret-token"
         )
+        XCTAssertNil(store.sessions[0].requestedRequests.first?.value(forHTTPHeaderField: "api-key"))
     }
 
     func testValidateConnectionReturnsTrueForHTTP200() async throws {
@@ -348,6 +349,71 @@ final class OpenAICompatiblePluginTests: XCTestCase {
                     URLQueryItem(name: "api-version", value: "preview"),
                 ]
             )
+        }
+    }
+
+    func testAzureEndpointsSendAPIKeyHeaderAlongsideBearerAuthentication() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://foundry-example.services.ai.azure.com/openai",
+                "selectedModel": "gpt-transcribe",
+                "selectedLLMModel": "gpt-chat",
+            ],
+            secrets: ["api-key": "azure-key"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setApiVersion("preview", for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"data":[{"id":"gpt-transcribe"}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://foundry-example.services.ai.azure.com/openai/v1/models?api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://foundry-example.services.ai.azure.com/openai/v1/models?api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"transcribed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://foundry-example.services.ai.azure.com/openai/v1/audio/transcriptions?api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"choices":[{"message":{"content":"completed"}}]}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://foundry-example.services.ai.azure.com/openai/v1/chat/completions?api-version=preview",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        _ = await plugin.fetchModels()
+        let isConnected = await plugin.validateConnection()
+        XCTAssertTrue(isConnected)
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: [0, 0, 0], wavData: Data("wav".utf8), duration: 1.0),
+            language: nil,
+            translate: false,
+            prompt: nil
+        )
+        _ = try await plugin.process(systemPrompt: "Fix", userText: "hello", model: nil)
+
+        XCTAssertEqual(store.sessions[0].requestedRequests.count, 4)
+        for request in store.sessions[0].requestedRequests {
+            XCTAssertNotNil(request.value(forHTTPHeaderField: "Authorization"))
+            XCTAssertEqual(request.value(forHTTPHeaderField: "api-key"), "azure-key")
         }
     }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -572,6 +572,28 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         prompt: String?,
         responseFormat: String? = nil
     ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        responseFormat: String? = nil,
+        apiVersion: String?
+    ) async throws -> PluginTranscriptionResult {
         try await performTranscribe(
             audio: audio,
             apiKey: apiKey,
@@ -580,7 +602,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             translate: translate,
             prompt: prompt,
             responseFormat: responseFormat,
-            requestTimeout: Self.defaultRequestTimeout
+            requestTimeout: Self.defaultRequestTimeout,
+            apiVersion: apiVersion
         )
     }
 
@@ -594,6 +617,30 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         requestTimeout: TimeInterval,
         responseFormat: String? = nil
     ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            requestTimeout: requestTimeout,
+            responseFormat: responseFormat,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        apiVersion: String?
+    ) async throws -> PluginTranscriptionResult {
         try await performTranscribe(
             audio: audio,
             apiKey: apiKey,
@@ -602,7 +649,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             translate: translate,
             prompt: prompt,
             responseFormat: responseFormat,
-            requestTimeout: requestTimeout
+            requestTimeout: requestTimeout,
+            apiVersion: apiVersion
         )
     }
 
@@ -615,6 +663,30 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         prompt: String?,
         requestTimeout: TimeInterval,
         responseFormat: String? = nil
+    ) async throws -> PluginTranscriptionResult {
+        try await transcribeCompressedAudio(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            requestTimeout: requestTimeout,
+            responseFormat: responseFormat,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribeCompressedAudio(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        apiVersion: String?
     ) async throws -> PluginTranscriptionResult {
         let uploadAudio = normalizedAudioForUpload(audio)
         let uploadFile: PluginAudioUploadFile
@@ -635,7 +707,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             prompt: prompt,
             responseFormat: responseFormat,
             requestTimeout: requestTimeout,
-            uploadFile: uploadFile
+            uploadFile: uploadFile,
+            apiVersion: apiVersion
         )
     }
 
@@ -649,6 +722,30 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         requestTimeout: TimeInterval,
         responseFormat: String? = nil
     ) async throws -> PluginTranscriptionResult {
+        try await transcribeCompressedAudioWithWavFallback(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            requestTimeout: requestTimeout,
+            responseFormat: responseFormat,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribeCompressedAudioWithWavFallback(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        apiVersion: String?
+    ) async throws -> PluginTranscriptionResult {
         do {
             return try await transcribeCompressedAudio(
                 audio: audio,
@@ -658,7 +755,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
                 translate: translate,
                 prompt: prompt,
                 requestTimeout: requestTimeout,
-                responseFormat: responseFormat
+                responseFormat: responseFormat,
+                apiVersion: apiVersion
             )
         } catch {
             guard PluginAudioUploadEncoder.shouldRetryWithWavUpload(error: error) else {
@@ -673,7 +771,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
                 translate: translate,
                 prompt: prompt,
                 requestTimeout: requestTimeout,
-                responseFormat: responseFormat
+                responseFormat: responseFormat,
+                apiVersion: apiVersion
             )
         }
     }
@@ -689,6 +788,32 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         responseFormat: String? = nil,
         uploadFile: PluginAudioUploadFile
     ) async throws -> PluginTranscriptionResult {
+        try await transcribeWithUploadFallback(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            requestTimeout: requestTimeout,
+            responseFormat: responseFormat,
+            uploadFile: uploadFile,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribeWithUploadFallback(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        uploadFile: PluginAudioUploadFile,
+        apiVersion: String?
+    ) async throws -> PluginTranscriptionResult {
         do {
             return try await performTranscribe(
                 audio: audio,
@@ -699,7 +824,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
                 prompt: prompt,
                 responseFormat: responseFormat,
                 requestTimeout: requestTimeout,
-                uploadFile: uploadFile
+                uploadFile: uploadFile,
+                apiVersion: apiVersion
             )
         } catch {
             guard uploadFile.format != "wav",
@@ -716,7 +842,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
                 prompt: prompt,
                 responseFormat: responseFormat,
                 requestTimeout: requestTimeout,
-                uploadFile: PluginAudioUploadEncoder.wavUpload(from: normalizedAudioForUpload(audio))
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: normalizedAudioForUpload(audio)),
+                apiVersion: apiVersion
             )
         }
     }
@@ -732,6 +859,32 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         responseFormat: String? = nil,
         uploadFile: PluginAudioUploadFile
     ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            requestTimeout: requestTimeout,
+            responseFormat: responseFormat,
+            uploadFile: uploadFile,
+            apiVersion: nil
+        )
+    }
+
+    public func transcribe(
+        audio: AudioData,
+        apiKey: String,
+        modelName: String,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        requestTimeout: TimeInterval,
+        responseFormat: String? = nil,
+        uploadFile: PluginAudioUploadFile,
+        apiVersion: String?
+    ) async throws -> PluginTranscriptionResult {
         try await performTranscribe(
             audio: audio,
             apiKey: apiKey,
@@ -741,7 +894,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             prompt: prompt,
             responseFormat: responseFormat,
             requestTimeout: requestTimeout,
-            uploadFile: uploadFile
+            uploadFile: uploadFile,
+            apiVersion: apiVersion
         )
     }
 
@@ -754,17 +908,12 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         prompt: String?,
         responseFormat: String?,
         requestTimeout: TimeInterval,
-        uploadFile: PluginAudioUploadFile? = nil
+        uploadFile: PluginAudioUploadFile? = nil,
+        apiVersion: String? = nil
     ) async throws -> PluginTranscriptionResult {
-        let endpoint: String
-        if translate {
-            endpoint = "\(baseURL)/v1/audio/translations"
-        } else {
-            endpoint = "\(baseURL)/v1/audio/transcriptions"
-        }
-
-        guard let url = URL(string: endpoint) else {
-            throw PluginTranscriptionError.apiError("Invalid URL: \(endpoint)")
+        let path = translate ? "/v1/audio/translations" : "/v1/audio/transcriptions"
+        guard let url = requestURL(path: path, apiVersion: apiVersion) else {
+            throw PluginTranscriptionError.apiError("Invalid URL: \(baseURL)\(path)")
         }
 
         let boundary = UUID().uuidString
@@ -829,8 +978,12 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
     }
 
     public func validateApiKey(_ apiKey: String) async -> Bool {
+        await validateApiKey(apiKey, apiVersion: nil)
+    }
+
+    public func validateApiKey(_ apiKey: String, apiVersion: String?) async -> Bool {
         guard !apiKey.isEmpty else { return false }
-        guard let url = URL(string: "\(baseURL)/v1/models") else { return false }
+        guard let url = requestURL(path: "/v1/models", apiVersion: apiVersion) else { return false }
 
         var request = URLRequest(url: url)
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
@@ -843,6 +996,24 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         } catch {
             return false
         }
+    }
+
+    private func requestURL(path: String, apiVersion: String?) -> URL? {
+        guard var components = URLComponents(string: baseURL) else { return nil }
+        let basePath = components.percentEncodedPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let requestPath = path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        components.percentEncodedPath = "/" + [basePath, requestPath]
+            .filter { !$0.isEmpty }
+            .joined(separator: "/")
+
+        let trimmedVersion = apiVersion?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !trimmedVersion.isEmpty {
+            var queryItems = components.queryItems ?? []
+            queryItems.removeAll { $0.name.caseInsensitiveCompare("api-version") == .orderedSame }
+            queryItems.append(URLQueryItem(name: "api-version", value: trimmedVersion))
+            components.queryItems = queryItems
+        }
+        return components.url
     }
 
     private struct APISegment: Decodable {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -287,6 +287,42 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         )
     }
 
+    func testTranscribeWithAPIVersionReplacesExistingVersion() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession()
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(
+            baseURL: "https://example.test/openai?api-version=2024-06-01",
+            responseFormat: "json"
+        )
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        _ = try await helper.transcribeCompressedAudioWithWavFallback(
+            audio: audio,
+            apiKey: "test-key",
+            modelName: "gpt-live-transcribe",
+            language: "en",
+            translate: false,
+            prompt: nil,
+            requestTimeout: 600,
+            apiVersion: " preview "
+        )
+
+        let requestURL = try XCTUnwrap(store.sessions.first?.requestedRequests.first?.url)
+        let components = try XCTUnwrap(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        let apiVersionItems = components.queryItems?.filter {
+            $0.name.caseInsensitiveCompare("api-version") == .orderedSame
+        }
+        XCTAssertEqual(apiVersionItems, [URLQueryItem(name: "api-version", value: "preview")])
+    }
+
     func testTranscribeCompressedAudioRejectsEmptySamplesBeforeUpload() async throws {
         let store = OpenAITranscriptionMockSessionStore()
         PluginHTTPClient.configureForTesting { _ in

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -243,6 +243,48 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
 
         XCTAssertEqual(result.text, "ok")
         XCTAssertEqual(store.sessions.first?.requestedRequests.first?.timeoutInterval, 600)
+        XCTAssertNil(store.sessions.first?.requestedRequests.first?.url?.query)
+    }
+
+    func testTranscribeWithAPIVersionPreservesExistingQueryItems() async throws {
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession()
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(
+            baseURL: "https://example.test/openai?tenant=contoso",
+            responseFormat: "json"
+        )
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await helper.transcribeCompressedAudioWithWavFallback(
+            audio: audio,
+            apiKey: "test-key",
+            modelName: "gpt-live-transcribe",
+            language: "en",
+            translate: false,
+            prompt: nil,
+            requestTimeout: 600,
+            apiVersion: " preview "
+        )
+
+        XCTAssertEqual(result.text, "ok")
+        let requestURL = try XCTUnwrap(store.sessions.first?.requestedRequests.first?.url)
+        let components = try XCTUnwrap(URLComponents(url: requestURL, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.path, "/openai/v1/audio/transcriptions")
+        XCTAssertEqual(
+            components.queryItems,
+            [
+                URLQueryItem(name: "tenant", value: "contoso"),
+                URLQueryItem(name: "api-version", value: "preview"),
+            ]
+        )
     }
 
     func testTranscribeCompressedAudioRejectsEmptySamplesBeforeUpload() async throws {


### PR DESCRIPTION
## Summary

- add an optional API Version string to each OpenAI Compatible profile
- preserve existing profiles and default OpenAI-compatible behavior when the field is blank
- append `api-version` with `URLComponents`/`URLQueryItem` across model discovery, connection validation, transcription/translation, and chat completion while preserving existing query items
- send Azure resource keys in the `api-key` header for Azure OpenAI, Azure Government, and Microsoft Foundry hosts while retaining the existing `Authorization` header
- keep the plugin loadable by TypeWhisper 1.6 RC1 by performing versioned audio uploads inside the plugin and preserving the existing host SDK ABI
- preserve transcription segments in the RC1-compatible versioned upload path

## Context

Certain Azure OpenAI and Microsoft Foundry endpoints currently require `api-version=preview` for the batch `/v1/audio/transcriptions` API. The `/v1/models` request can succeed without that query parameter, which produces a misleading **Connected** state followed by a transcription `404 DeploymentNotFound`.

This change lets each profile opt into the required API version without changing requests for standard OpenAI-compatible servers.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests` - 24 passed
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAITranscriptionHelperTests` - 18 passed
- `xcodebuild -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin -configuration Debug -derivedDataPath build-local-debug CODE_SIGNING_ALLOWED=NO build -quiet`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin -configuration Release -derivedDataPath build-local CODE_SIGNING_ALLOWED=NO build -quiet`

These focused commands validate the affected targets directly through the repository package and Xcode project.

## Local validation

- built and ad-hoc signed the OpenAI Compatible plugin as v1.1.7
- installed it into TypeWhisper 1.6 RC1 using the documented local plugin directory workflow
- preserved the existing profile, selected model, and Keychain credential
- set API Version to `preview`
- confirmed **Test Connection: Connected**
- submitted a short WAV through TypeWhisper's local transcription API
- confirmed the request now reaches Azure's preview audio route with Azure API-key authentication and returns Azure `404 DeploymentNotFound`

The remaining failure is deployment-specific: the configured `gpt-live-transcribe` deployment is documented as a realtime-only transcription model, not a batch `/audio/transcriptions` model. End-to-end batch transcription therefore requires a compatible deployment such as `gpt-transcribe`, `gpt-4o-transcribe`, or another model supported by Azure's Audio API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional API version settings for OpenAI-compatible and Azure OpenAI connections.
  - Applied configured API versions across model, chat, transcription, and fallback requests.
  - Improved Azure authentication for supported requests.
  - Preserved existing URL parameters when applying API versions.

- **Localization**
  - Added German and Japanese translations for API version settings and guidance text.

- **Bug Fixes**
  - Improved request URL handling and API-version synchronization across profiles and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->