### PR TITLE
Add realtime transcription support to OpenAI Compatible plugin

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		AA00000000000000000183 /* PromptPaletteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000173 /* PromptPaletteHandler.swift */; };
 		AA00000000000000000184 /* DictationSettingsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000174 /* DictationSettingsHandler.swift */; };
 		AA00000000000000000185 /* OpenAICompatiblePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000176 /* OpenAICompatiblePlugin.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* OpenAIRealtimeTranscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E2F3A4B5C60718293A4B5C /* OpenAIRealtimeTranscription.swift */; };
 		AA00000000000000000186 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000177 /* manifest.json */; };
 		AA00000000000000000187 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000178 /* Localizable.xcstrings */; };
 		AA00000000000000000188 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000019 /* TypeWhisperPluginSDK */; };
@@ -779,6 +780,7 @@
 		BB00000000000000000174 /* DictationSettingsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictationSettingsHandler.swift; sourceTree = "<group>"; };
 		BB00000000000000000175 /* OpenAICompatiblePlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenAICompatiblePlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000176 /* OpenAICompatiblePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAICompatiblePlugin.swift; sourceTree = "<group>"; };
+		D1E2F3A4B5C60718293A4B5C /* OpenAIRealtimeTranscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenAIRealtimeTranscription.swift; sourceTree = "<group>"; };
 		BB00000000000000000177 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000178 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000179 /* WidgetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetData.swift; sourceTree = "<group>"; };
@@ -1933,6 +1935,7 @@
 			isa = PBXGroup;
 			children = (
 				BB00000000000000000176 /* OpenAICompatiblePlugin.swift */,
+				D1E2F3A4B5C60718293A4B5C /* OpenAIRealtimeTranscription.swift */,
 				BB00000000000000000177 /* manifest.json */,
 				BB00000000000000000178 /* Localizable.xcstrings */,
 			);
@@ -4336,6 +4339,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000185 /* OpenAICompatiblePlugin.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* OpenAIRealtimeTranscription.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -49,6 +49,38 @@
         }
       }
     },
+    "Auto": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "Auto uses realtime streaming only for known realtime model IDs (gpt-live-transcribe, gpt-realtime-whisper) and batch upload otherwise. Choose Realtime to force streaming for any OpenAI-compatible server that supports the /v1/realtime WebSocket API, including custom deployment aliases (e.g. an Azure OpenAI or Microsoft Foundry gpt-live-transcribe deployment) — some providers, including Azure, require a preview API version for realtime transcription. Choose Batch to always use /v1/audio/transcriptions.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch verwendet Echtzeit-Streaming nur für bekannte Echtzeit-Modell-IDs (gpt-live-transcribe, gpt-realtime-whisper) und ansonsten den Batch-Upload. Wählen Sie Echtzeit, um Streaming für jeden OpenAI-kompatiblen Server zu erzwingen, der die WebSocket-API /v1/realtime unterstützt, einschließlich benutzerdefinierter Bereitstellungsaliase (z. B. eine gpt-live-transcribe-Bereitstellung in Azure OpenAI oder Microsoft Foundry). Einige Anbieter, darunter Azure, erfordern für die Echtzeittranskription eine Vorschau-API-Version. Wählen Sie Batch, um immer /v1/audio/transcriptions zu verwenden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動では、既知のリアルタイムモデル ID（gpt-live-transcribe、gpt-realtime-whisper）のみリアルタイムストリーミングを使用し、それ以外はバッチアップロードを使用します。/v1/realtime WebSocket API をサポートする任意の OpenAI 互換サーバーでストリーミングを強制するには、リアルタイムを選択します。これには、カスタムデプロイ名（Azure OpenAI または Microsoft Foundry の gpt-live-transcribe デプロイなど）も含まれます。Azure など一部のプロバイダーでは、リアルタイム文字起こしにプレビュー API バージョンが必要です。常に /v1/audio/transcriptions を使用するには、バッチを選択します。"
+          }
+        }
+      }
+    },
     "Azure OpenAI and Microsoft Foundry may require an API version such as preview for audio transcription. Leave blank for standard OpenAI-compatible servers.": {
       "localizations": {
         "de": {
@@ -61,6 +93,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "Azure OpenAI および Microsoft Foundry では、音声文字起こしに preview などの API バージョンが必要な場合があります。標準の OpenAI 互換サーバーでは空欄のままにしてください。"
+          }
+        }
+      }
+    },
+    "Batch": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Batch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "バッチ"
           }
         }
       }
@@ -279,6 +327,22 @@
         }
       }
     },
+    "Realtime": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Echtzeit"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リアルタイム"
+          }
+        }
+      }
+    },
     "Remove": {
       "localizations": {
         "de": {
@@ -403,6 +467,22 @@
           "stringUnit": {
             "state": "translated",
             "value": "音声認識モデル"
+          }
+        }
+      }
+    },
+    "Transcription Transport": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こし方式"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -2,6 +2,28 @@ import Foundation
 import SwiftUI
 import TypeWhisperPluginSDK
 
+protocol OpenAICompatibleRealtimeSessionConnecting: Sendable {
+    func connect(
+        request: URLRequest,
+        configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession
+}
+
+private struct DefaultOpenAICompatibleRealtimeSessionConnector: OpenAICompatibleRealtimeSessionConnecting {
+    func connect(
+        request: URLRequest,
+        configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await PluginOpenAIRealtimeTranscriptionSession.connect(
+            request: request,
+            configuration: configuration,
+            onProgress: onProgress
+        )
+    }
+}
+
 // MARK: - Transcription Transport
 
 /// Per-profile transport selection for transcription requests.
@@ -233,6 +255,9 @@ final class OpenAICompatiblePlugin: NSObject,
     private static let profilesKey = "profiles"
     private static let legacyProviderName = "OpenAI Compatible"
     private static let transcriptionRequestTimeout: TimeInterval = 600
+    private static let realtimeAudioChunkSampleCount = 16_000
+    var realtimeSessionConnector: any OpenAICompatibleRealtimeSessionConnecting =
+        DefaultOpenAICompatibleRealtimeSessionConnector()
 
     required override init() {
         super.init()
@@ -640,8 +665,7 @@ final class OpenAICompatiblePlugin: NSObject,
         prompt: String?,
         profileId: String
     ) async throws -> PluginTranscriptionResult {
-        guard let profile = profile(for: profileId),
-              let helper = makeTranscriptionHelper(for: profile) else {
+        guard let profile = profile(for: profileId), !profile.baseURL.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
         let modelId = profile.selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -649,6 +673,34 @@ final class OpenAICompatiblePlugin: NSObject,
             throw PluginTranscriptionError.noModelSelected
         }
 
+        if profile.resolvedTranscriptionTransport() == .realtime {
+            let session = try await createLiveTranscriptionSession(
+                languageSelection: PluginLanguageSelection(requestedLanguage: language),
+                translate: translate,
+                prompt: prompt,
+                dictionaryTermHints: [],
+                onProgress: { _ in true },
+                profileId: profileId
+            )
+            do {
+                for startIndex in stride(
+                    from: audio.samples.startIndex,
+                    to: audio.samples.endIndex,
+                    by: Self.realtimeAudioChunkSampleCount
+                ) {
+                    let endIndex = min(startIndex + Self.realtimeAudioChunkSampleCount, audio.samples.endIndex)
+                    try await session.appendAudio(samples: Array(audio.samples[startIndex..<endIndex]))
+                }
+                return try await session.finish()
+            } catch {
+                await session.cancel()
+                throw error
+            }
+        }
+
+        guard let helper = makeTranscriptionHelper(for: profile) else {
+            throw PluginTranscriptionError.notConfigured
+        }
         let apiKey = apiKey(for: profileId) ?? ""
         if profile.apiVersion.isEmpty {
             return try await helper.transcribeCompressedAudioWithWavFallback(
@@ -752,7 +804,7 @@ final class OpenAICompatiblePlugin: NSObject,
             usesContextAwareHints: usesContextAwareHints
         )
 
-        return try await PluginOpenAIRealtimeTranscriptionSession.connect(
+        return try await realtimeSessionConnector.connect(
             request: request,
             configuration: configuration,
             onProgress: onProgress

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -2,6 +2,66 @@ import Foundation
 import SwiftUI
 import TypeWhisperPluginSDK
 
+// MARK: - Transcription Transport
+
+/// Per-profile transport selection for transcription requests.
+///
+/// `auto` keeps existing batch behavior for every model except a small set of
+/// known realtime-only model IDs (see `OpenAICompatibleRealtimeModel`), which
+/// is the safe default for profiles migrated from before realtime support
+/// existed. `batch` and `realtime` let a user force one transport regardless
+/// of the selected model name, which is required for custom Azure/BYO
+/// deployment aliases that don't match the well-known IDs.
+enum OpenAICompatibleTranscriptTransport: String, Codable, CaseIterable, Sendable {
+    case auto
+    case batch
+    case realtime
+
+    var displayName: String {
+        switch self {
+        case .auto:
+            "Auto"
+        case .batch:
+            "Batch"
+        case .realtime:
+            "Realtime"
+        }
+    }
+}
+
+/// Resolved (non-`auto`) transport for a single transcription request.
+enum OpenAICompatibleResolvedTranscriptionTransport: Sendable, Equatable {
+    case batch
+    case realtime
+}
+
+/// Knowledge about the well-known OpenAI/Azure realtime transcription model
+/// IDs, mirroring the classification `OpenAIPlugin` uses for `gpt-live-transcribe`
+/// (context-aware) and `gpt-realtime-whisper` (legacy). Custom Azure/Foundry
+/// deployment aliases won't match these names, so callers must opt in
+/// explicitly via `OpenAICompatibleTranscriptTransport.realtime`.
+enum OpenAICompatibleRealtimeModel {
+    static let contextAwareModelID = "gpt-live-transcribe"
+    static let legacyModelID = "gpt-realtime-whisper"
+    static let knownRealtimeModelIDs: Set<String> = [contextAwareModelID, legacyModelID]
+
+    static func isKnownRealtimeModelID(_ modelId: String) -> Bool {
+        knownRealtimeModelIDs.contains(normalized(modelId))
+    }
+
+    /// Custom Azure/BYO deployment aliases are assumed to use the modern,
+    /// context-aware realtime transcription protocol (languages/keywords/delay)
+    /// unless the alias itself signals the legacy Whisper-based protocol by
+    /// containing "whisper", matching Azure's own `gpt-realtime-whisper` name.
+    static func usesContextAwareRealtimeHints(modelId: String) -> Bool {
+        !normalized(modelId).contains("whisper")
+    }
+
+    private static func normalized(_ modelId: String) -> String {
+        modelId.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
 // MARK: - Profile Model
 
 struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
@@ -19,6 +79,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var fetchedModels: [FetchedModel]
     var chatRequestTimeoutSeconds: TimeInterval?
     var thinkingEnabled: Bool
+    var transcriptionTransportRaw: String
 
     static let defaultChatRequestTimeout: TimeInterval = 30
     static let minChatRequestTimeout: TimeInterval = 5
@@ -36,6 +97,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         case fetchedModels
         case chatRequestTimeoutSeconds
         case thinkingEnabled
+        case transcriptionTransportRaw
     }
 
     init(
@@ -49,7 +111,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
-        thinkingEnabled: Bool = false
+        thinkingEnabled: Bool = false,
+        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue
     ) {
         self.id = id
         self.name = name
@@ -62,6 +125,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.fetchedModels = fetchedModels
         self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
         self.thinkingEnabled = thinkingEnabled
+        self.transcriptionTransportRaw = transcriptionTransportRaw
     }
 
     init(from decoder: Decoder) throws {
@@ -77,6 +141,11 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         fetchedModels = try container.decode([FetchedModel].self, forKey: .fetchedModels)
         chatRequestTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .chatRequestTimeoutSeconds)
         thinkingEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingEnabled) ?? false
+        // Profiles saved before realtime support existed have no stored value;
+        // default to `auto` so previously-working batch models keep working
+        // and only the known realtime model IDs switch transport.
+        transcriptionTransportRaw = try container.decodeIfPresent(String.self, forKey: .transcriptionTransportRaw)
+            ?? OpenAICompatibleTranscriptTransport.auto.rawValue
     }
 
     var isDefault: Bool { id == Self.defaultId }
@@ -93,6 +162,23 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         return trimmed.isEmpty ? Self.defaultName : trimmed
     }
 
+    var transcriptionTransport: OpenAICompatibleTranscriptTransport {
+        OpenAICompatibleTranscriptTransport(rawValue: transcriptionTransportRaw) ?? .auto
+    }
+
+    /// Resolves the effective (non-`auto`) transport for the currently
+    /// selected transcription model.
+    func resolvedTranscriptionTransport() -> OpenAICompatibleResolvedTranscriptionTransport {
+        switch transcriptionTransport {
+        case .batch:
+            .batch
+        case .realtime:
+            .realtime
+        case .auto:
+            OpenAICompatibleRealtimeModel.isKnownRealtimeModelID(selectedModelId) ? .realtime : .batch
+        }
+    }
+
     static func defaultProfile(
         baseURL: String = "",
         apiVersion: String = "",
@@ -102,7 +188,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
-        thinkingEnabled: Bool = false
+        thinkingEnabled: Bool = false,
+        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue
     ) -> OpenAICompatibleProfile {
         OpenAICompatibleProfile(
             id: defaultId,
@@ -115,7 +202,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             llmTemperatureValue: llmTemperatureValue,
             fetchedModels: fetchedModels,
             chatRequestTimeoutSeconds: chatRequestTimeoutSeconds,
-            thinkingEnabled: thinkingEnabled
+            thinkingEnabled: thinkingEnabled,
+            transcriptionTransportRaw: transcriptionTransportRaw
         )
     }
 }
@@ -132,6 +220,7 @@ final class OpenAICompatiblePlugin: NSObject,
     LLMModelSelectable,
     AdditionalTranscriptionEnginesProviding,
     AdditionalLLMProvidersProviding,
+    LiveLanguageHintDictionaryTermHintTranscriptionCapablePlugin,
     @unchecked Sendable
 {
     static let pluginId = "com.typewhisper.openai-compatible"
@@ -219,6 +308,73 @@ final class OpenAICompatiblePlugin: NSObject,
             language: language,
             translate: translate,
             prompt: prompt,
+            profileId: providerId
+        )
+    }
+
+    var supportsStreaming: Bool {
+        supportsStreaming(for: providerId)
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress,
             profileId: providerId
         )
     }
@@ -521,6 +677,125 @@ final class OpenAICompatiblePlugin: NSObject,
         }
     }
 
+    // MARK: - Realtime Transport
+
+    func transcriptionTransport(for profileId: String) -> OpenAICompatibleTranscriptTransport {
+        profile(for: profileId)?.transcriptionTransport ?? .auto
+    }
+
+    func setTranscriptionTransport(_ transport: OpenAICompatibleTranscriptTransport, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.transcriptionTransportRaw = transport.rawValue
+        }
+    }
+
+    /// Resolves the effective transport for the profile's *currently selected*
+    /// transcription model, applying the `auto` heuristic (known realtime IDs
+    /// use realtime, everything else stays batch) when the profile hasn't
+    /// forced an explicit transport.
+    func resolvedTranscriptionTransport(for profileId: String) -> OpenAICompatibleResolvedTranscriptionTransport {
+        profile(for: profileId)?.resolvedTranscriptionTransport() ?? .batch
+    }
+
+    func supportsStreaming(for profileId: String) -> Bool {
+        resolvedTranscriptionTransport(for: profileId) == .realtime
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool,
+        profileId: String
+    ) async throws -> any LiveTranscriptionSession {
+        guard let profile = profile(for: profileId), !profile.baseURL.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        let modelId = profile.selectedModelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !modelId.isEmpty else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+        guard profile.resolvedTranscriptionTransport() == .realtime else {
+            // Batch-routed models: don't fake streaming with a repeated-REST-upload
+            // loop here. Throwing lets the host fall back to its own generic
+            // polling-based transcript preview loop over the regular `transcribe()`
+            // call, which is exactly the behavior a batch-only model already had.
+            throw PluginTranscriptionError.apiError(
+                "\"\(modelId)\" is routed through batch transcription; live streaming is unavailable for it."
+            )
+        }
+        guard !translate else {
+            throw PluginTranscriptionError.apiError(
+                "Realtime transcription does not support translation. Disable translation or switch to batch transport."
+            )
+        }
+        guard let request = realtimeRequest(for: profile, profileId: profileId) else {
+            throw PluginTranscriptionError.notConfigured
+        }
+
+        let usesContextAwareHints = OpenAICompatibleRealtimeModel.usesContextAwareRealtimeHints(modelId: modelId)
+        let configuration = PluginOpenAIRealtimeTranscriptionConfiguration(
+            modelID: modelId,
+            languageSelection: usesContextAwareHints
+                ? languageSelection
+                : PluginLanguageSelection(
+                    requestedLanguage: PluginOpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(
+                        from: languageSelection
+                    ).first
+                ),
+            prompt: prompt,
+            keywords: usesContextAwareHints
+                ? PluginOpenAIRealtimeTranscriptionConfiguration.normalizedRealtimeKeywords(from: dictionaryTermHints)
+                : [],
+            delay: nil,
+            usesContextAwareHints: usesContextAwareHints
+        )
+
+        return try await PluginOpenAIRealtimeTranscriptionSession.connect(
+            request: request,
+            configuration: configuration,
+            onProgress: onProgress
+        )
+    }
+
+    /// Builds the WebSocket request for the realtime transcription endpoint:
+    /// scheme swapped to ws/wss, the profile's configured base path preserved,
+    /// `/v1/realtime` appended, `intent=transcription` and the configured
+    /// api-version applied without duplicating any existing query items, and
+    /// the same Bearer/api-key authentication used by REST requests.
+    func realtimeRequest(for profile: OpenAICompatibleProfile, profileId: String) -> URLRequest? {
+        guard let url = Self.realtimeRequestURL(baseURL: profile.baseURL, apiVersion: profile.apiVersion) else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        applyAuthentication(to: &request, profileId: profileId)
+        return request
+    }
+
+    static func realtimeRequestURL(baseURL: String, apiVersion: String) -> URL? {
+        guard let restURL = requestURL(baseURL: baseURL, path: "/v1/realtime", apiVersion: apiVersion),
+              var components = URLComponents(url: restURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+
+        switch components.scheme?.lowercased() {
+        case "https":
+            components.scheme = "wss"
+        case "http":
+            components.scheme = "ws"
+        default:
+            break
+        }
+
+        var queryItems = components.queryItems ?? []
+        queryItems.removeAll { $0.name.caseInsensitiveCompare("intent") == .orderedSame }
+        queryItems.append(URLQueryItem(name: "intent", value: "transcription"))
+        components.queryItems = queryItems
+
+        return components.url
+    }
+
     func process(
         systemPrompt: String,
         userText: String,
@@ -541,8 +816,7 @@ final class OpenAICompatiblePlugin: NSObject,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
-            temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),
-            requestTimeout: profile.resolvedChatRequestTimeout,
+            temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),            requestTimeout: profile.resolvedChatRequestTimeout,
             thinkingEnabled: profile.thinkingEnabled,
             apiVersion: profile.apiVersion
         )
@@ -1119,6 +1393,7 @@ private final class OpenAICompatibleProfileRole: NSObject,
     LLMProviderIdentityProviding,
     LLMTemperatureControllableProvider,
     LLMModelSelectable,
+    LiveLanguageHintDictionaryTermHintTranscriptionCapablePlugin,
     @unchecked Sendable
 {
     static let pluginId = OpenAICompatiblePlugin.pluginId
@@ -1164,6 +1439,73 @@ private final class OpenAICompatibleProfileRole: NSObject,
             language: language,
             translate: translate,
             prompt: prompt,
+            profileId: profileId
+        )
+    }
+
+    var supportsStreaming: Bool {
+        plugin.supportsStreaming(for: profileId)
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await plugin.createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress,
             profileId: profileId
         )
     }
@@ -1238,6 +1580,7 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var llmTemperatureValue: Double = 0.3
     @State private var thinkingEnabled = false
     @State private var chatTimeoutInput = ""
+    @State private var transcriptionTransport: OpenAICompatibleTranscriptTransport = .auto
 
     private let bundle = pluginModuleBundle
 
@@ -1488,6 +1831,31 @@ private struct OpenAICompatibleSettingsView: View {
             } else {
                 manualModelSection
             }
+
+            transportSection
+        }
+    }
+
+    private var transportSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Transcription Transport", bundle: bundle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Picker("Transcription Transport", selection: $transcriptionTransport) {
+                Text("Auto", bundle: bundle).tag(OpenAICompatibleTranscriptTransport.auto)
+                Text("Batch", bundle: bundle).tag(OpenAICompatibleTranscriptTransport.batch)
+                Text("Realtime", bundle: bundle).tag(OpenAICompatibleTranscriptTransport.realtime)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .onChange(of: transcriptionTransport) {
+                saveTranscriptionTransport()
+            }
+
+            Text("Auto uses realtime streaming only for known realtime model IDs (gpt-live-transcribe, gpt-realtime-whisper) and batch upload otherwise. Choose Realtime to force streaming for a custom Azure/Microsoft Foundry deployment alias (e.g. a gpt-live-transcribe deployment) — Azure realtime transcription currently requires the preview API version. Choose Batch to always use /v1/audio/transcriptions.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -1695,6 +2063,7 @@ private struct OpenAICompatibleSettingsView: View {
         llmTemperatureValue = profile.llmTemperatureValue
         thinkingEnabled = profile.thinkingEnabled
         chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
+        transcriptionTransport = profile.transcriptionTransport
         connectionResult = nil
     }
 
@@ -1717,6 +2086,13 @@ private struct OpenAICompatibleSettingsView: View {
         let trimmed = apiVersionInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard trimmed != selectedProfile.apiVersion else { return }
         plugin.setApiVersion(trimmed, for: selectedProfile.id)
+        reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+    }
+
+    private func saveTranscriptionTransport() {
+        guard let selectedProfile else { return }
+        guard transcriptionTransport != selectedProfile.transcriptionTransport else { return }
+        plugin.setTranscriptionTransport(transcriptionTransport, for: selectedProfile.id)
         reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
     }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -816,7 +816,9 @@ final class OpenAICompatiblePlugin: NSObject,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
-            temperature: providerTemperatureDirective(for: profileId).resolvedTemperature(applying: temperatureDirective),            requestTimeout: profile.resolvedChatRequestTimeout,
+            temperature: providerTemperatureDirective(for: profileId)
+                .resolvedTemperature(applying: temperatureDirective),
+            requestTimeout: profile.resolvedChatRequestTimeout,
             thinkingEnabled: profile.thinkingEnabled,
             apiVersion: profile.apiVersion
         )

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -1853,7 +1853,7 @@ private struct OpenAICompatibleSettingsView: View {
                 saveTranscriptionTransport()
             }
 
-            Text("Auto uses realtime streaming only for known realtime model IDs (gpt-live-transcribe, gpt-realtime-whisper) and batch upload otherwise. Choose Realtime to force streaming for a custom Azure/Microsoft Foundry deployment alias (e.g. a gpt-live-transcribe deployment) — Azure realtime transcription currently requires the preview API version. Choose Batch to always use /v1/audio/transcriptions.", bundle: bundle)
+            Text("Auto uses realtime streaming only for known realtime model IDs (gpt-live-transcribe, gpt-realtime-whisper) and batch upload otherwise. Choose Realtime to force streaming for any OpenAI-compatible server that supports the /v1/realtime WebSocket API, including custom deployment aliases (e.g. an Azure OpenAI or Microsoft Foundry gpt-live-transcribe deployment) — some providers, including Azure, require a preview API version for realtime transcription. Choose Batch to always use /v1/audio/transcriptions.", bundle: bundle)
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import TypeWhisperPluginSDK
 
 // MARK: - Shared OpenAI-Compatible Realtime Transcription
 
@@ -326,33 +327,43 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
         let urlSession = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
         let webSocketTask = urlSession.webSocketTask(with: request)
         let collector = PluginOpenAIRealtimeTranscriptCollector()
-
-        webSocketTask.resume()
-        try await waitForSocketOpen(openWaiter)
-
-        let receiveTask = Task { [webSocketTask, collector, onProgress] in
-            do {
-                while !Task.isCancelled {
-                    let message = try await webSocketTask.receive()
-                    guard let data = Self.data(from: message) else { continue }
-                    if let text = try await collector.applyEvent(data), !text.isEmpty {
-                        _ = onProgress(text)
-                    }
-                }
-            } catch is CancellationError {
-                return
-            } catch {
-                await collector.recordConnectionFailure(realtimeErrorDescription(error))
-            }
-        }
+        var receiveTask: Task<Void, Never>?
 
         do {
+            webSocketTask.resume()
+            try await waitForSocketOpen(openWaiter)
+
+            receiveTask = Task { [webSocketTask, collector, onProgress] in
+                do {
+                    while !Task.isCancelled {
+                        let message = try await webSocketTask.receive()
+                        guard let data = Self.data(from: message) else { continue }
+                        if let text = try await collector.applyEvent(data), !text.isEmpty {
+                            _ = onProgress(text)
+                        }
+                    }
+                } catch is CancellationError {
+                    return
+                } catch {
+                    await collector.recordConnectionFailure(realtimeErrorDescription(error))
+                }
+            }
+
             try await webSocketTask.send(
                 .string(try jsonString(sessionUpdatePayload(configuration: configuration)))
             )
             try await waitForSessionReady(collector)
+
+            return PluginOpenAIRealtimeTranscriptionSession(
+                urlSession: urlSession,
+                webSocketTask: webSocketTask,
+                receiveTask: receiveTask,
+                collector: collector,
+                language: configuration.fallbackLanguage,
+                onProgress: onProgress
+            )
         } catch {
-            receiveTask.cancel()
+            receiveTask?.cancel()
             webSocketTask.cancel(with: .goingAway, reason: nil)
             urlSession.finishTasksAndInvalidate()
             if let collectorError = await collector.error {
@@ -360,15 +371,6 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
             }
             throw error
         }
-
-        return PluginOpenAIRealtimeTranscriptionSession(
-            urlSession: urlSession,
-            webSocketTask: webSocketTask,
-            receiveTask: receiveTask,
-            collector: collector,
-            language: configuration.fallbackLanguage,
-            onProgress: onProgress
-        )
     }
 
     private static func waitForSessionReady(_ collector: PluginOpenAIRealtimeTranscriptCollector) async throws {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
@@ -2,15 +2,12 @@ import Foundation
 import os
 import TypeWhisperPluginSDK
 
-// MARK: - Shared OpenAI-Compatible Realtime Transcription
+// MARK: - OpenAI-Compatible Realtime Transcription
 
-// Provider-agnostic support for the OpenAI Realtime transcription protocol
-// (`GET wss://<host>/v1/realtime?intent=transcription`), reused by any plugin that
-// talks to an OpenAI-compatible realtime endpoint (OpenAI itself, Azure OpenAI /
-// Microsoft Foundry, or other BYO deployments). Callers are responsible for
-// building the provider-specific `URLRequest` (host, path, query, and
-// authorization headers); this type owns the WebSocket lifecycle, session
-// configuration payload, PCM resampling/encoding, and transcript assembly.
+// Provider-agnostic protocol support scoped to this plugin bundle so it remains
+// loadable against released v1 host SDKs. The caller builds the endpoint-specific
+// request; these types own the WebSocket lifecycle, session configuration, PCM
+// resampling/encoding, and transcript assembly.
 
 public enum PluginOpenAILiveTranscriptionDelay: String, CaseIterable, Sendable {
     case minimal
@@ -274,10 +271,8 @@ private final class PluginOpenAIRealtimeWebSocketDelegate: NSObject, URLSessionW
 }
 
 /// A `LiveTranscriptionSession` that streams 24 kHz PCM audio to an OpenAI-compatible
-/// realtime transcription endpoint over a WebSocket. Callers supply a fully-formed
-/// `URLRequest` (scheme/host/path/query and authorization headers), so this type can
-/// be reused for OpenAI itself, Azure OpenAI / Microsoft Foundry, or any other
-/// OpenAI-compatible BYO deployment.
+/// realtime transcription endpoint over a WebSocket. The plugin supplies a fully
+/// formed `URLRequest` containing the endpoint path, query, and authorization.
 public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
     public static let sourceSampleRate = 16_000
     public static let targetSampleRate = 24_000

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -846,4 +846,374 @@ final class OpenAICompatiblePluginTests: XCTestCase {
             headerFields: nil
         )!
     }
+
+    // MARK: - Realtime Transport: Migration & Defaults
+
+    func testSavedProfilesWithoutTransportDecodeAsAuto() throws {
+        let savedProfiles = Data(
+            """
+            [
+              {
+                "id": "openai-compatible",
+                "name": "OpenAI Compatible",
+                "baseURL": "https://legacy-profile.test",
+                "selectedModelId": "whisper-legacy",
+                "selectedLLMModelId": "chat-legacy",
+                "llmTemperatureModeRaw": "providerDefault",
+                "llmTemperatureValue": 0.3,
+                "fetchedModels": []
+              }
+            ]
+            """.utf8
+        )
+        let host = try PluginTestHostServices(defaults: ["profiles": savedProfiles])
+        let plugin = OpenAICompatiblePlugin()
+
+        plugin.activate(host: host)
+
+        let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+        XCTAssertEqual(profile.transcriptionTransport, .auto)
+        XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
+    }
+
+    func testLegacyConfigurationMigratesWithAutoTransport() throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://legacy.test", "selectedModel": "whisper-legacy"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+
+        plugin.activate(host: host)
+
+        let profile = try XCTUnwrap(plugin.profileSnapshots.first)
+        XCTAssertEqual(profile.transcriptionTransport, .auto)
+    }
+
+    // MARK: - Realtime Transport: Auto Resolution
+
+    func testAutoTransportResolvesKnownRealtimeModelIDsToRealtime() throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        for modelId in ["gpt-live-transcribe", "gpt-realtime-whisper", "GPT-Live-Transcribe"] {
+            plugin.selectModel(modelId, for: plugin.providerId)
+            XCTAssertEqual(
+                plugin.resolvedTranscriptionTransport(for: plugin.providerId),
+                .realtime,
+                "Expected \(modelId) to auto-resolve to realtime"
+            )
+            XCTAssertTrue(plugin.supportsStreaming(for: plugin.providerId))
+        }
+    }
+
+    func testAutoTransportResolvesUnknownModelIDsToBatch() throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        for modelId in ["whisper-1", "gpt-4o-transcribe", "my-custom-azure-deployment"] {
+            plugin.selectModel(modelId, for: plugin.providerId)
+            XCTAssertEqual(
+                plugin.resolvedTranscriptionTransport(for: plugin.providerId),
+                .batch,
+                "Expected \(modelId) to auto-resolve to batch"
+            )
+            XCTAssertFalse(plugin.supportsStreaming(for: plugin.providerId))
+        }
+    }
+
+    // MARK: - Realtime Transport: Explicit Override
+
+    func testExplicitBatchTransportOverridesKnownRealtimeModelID() throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test", "selectedModel": "gpt-live-transcribe"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        plugin.setTranscriptionTransport(.batch, for: plugin.providerId)
+
+        XCTAssertEqual(plugin.resolvedTranscriptionTransport(for: plugin.providerId), .batch)
+        XCTAssertFalse(plugin.supportsStreaming(for: plugin.providerId))
+    }
+
+    func testExplicitRealtimeTransportOverridesCustomAzureDeploymentAlias() throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://foundry-krubenok.services.ai.azure.com/openai",
+                "selectedModel": "my-gpt-live-transcribe-deployment",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        plugin.setTranscriptionTransport(.realtime, for: plugin.providerId)
+
+        XCTAssertEqual(plugin.resolvedTranscriptionTransport(for: plugin.providerId), .realtime)
+        XCTAssertTrue(plugin.supportsStreaming(for: plugin.providerId))
+    }
+
+    func testAdditionalProfileTransportIsIndependentFromDefaultProfile() throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test", "selectedModel": "gpt-live-transcribe"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        let alter = plugin.addProfile(named: "Alter")
+        plugin.setBaseURL("https://alter.test", for: alter.id)
+        plugin.selectModel("whisper-1", for: alter.id)
+
+        // Default profile auto-resolves to realtime (gpt-live-transcribe), the
+        // additional profile auto-resolves to batch (whisper-1) — independent state.
+        XCTAssertTrue(plugin.supportsStreaming(for: plugin.providerId))
+        XCTAssertFalse(plugin.supportsStreaming(for: alter.id))
+
+        let engine = try XCTUnwrap(plugin.additionalTranscriptionEngines.first)
+        XCTAssertFalse(engine.supportsStreaming)
+    }
+
+    // MARK: - Realtime URL Construction
+
+    func testRealtimeURLConvertsHTTPSToWSSAndAppendsRealtimePathAndIntent() throws {
+        let url = try XCTUnwrap(
+            OpenAICompatiblePlugin.realtimeRequestURL(
+                baseURL: "https://foundry-krubenok.services.ai.azure.com/openai",
+                apiVersion: ""
+            )
+        )
+
+        XCTAssertEqual(url.scheme, "wss")
+        XCTAssertEqual(url.host, "foundry-krubenok.services.ai.azure.com")
+        XCTAssertEqual(url.path, "/openai/v1/realtime")
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.queryItems, [URLQueryItem(name: "intent", value: "transcription")])
+    }
+
+    func testRealtimeURLConvertsHTTPToWS() throws {
+        let url = try XCTUnwrap(
+            OpenAICompatiblePlugin.realtimeRequestURL(baseURL: "http://localhost:11434", apiVersion: "")
+        )
+
+        XCTAssertEqual(url.scheme, "ws")
+        XCTAssertEqual(url.path, "/v1/realtime")
+    }
+
+    func testRealtimeURLPreservesConfiguredBasePathAndExistingQuery() throws {
+        let url = try XCTUnwrap(
+            OpenAICompatiblePlugin.realtimeRequestURL(
+                baseURL: "https://example.test/openai?tenant=contoso",
+                apiVersion: ""
+            )
+        )
+
+        XCTAssertEqual(url.path, "/openai/v1/realtime")
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(
+            components.queryItems,
+            [
+                URLQueryItem(name: "tenant", value: "contoso"),
+                URLQueryItem(name: "intent", value: "transcription"),
+            ]
+        )
+    }
+
+    func testRealtimeURLAppliesConfiguredAPIVersionWithoutDuplication() throws {
+        let url = try XCTUnwrap(
+            OpenAICompatiblePlugin.realtimeRequestURL(
+                baseURL: "https://foundry-krubenok.services.ai.azure.com/openai",
+                apiVersion: "preview"
+            )
+        )
+
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(
+            components.queryItems,
+            [
+                URLQueryItem(name: "api-version", value: "preview"),
+                URLQueryItem(name: "intent", value: "transcription"),
+            ]
+        )
+    }
+
+    func testRealtimeURLReturnsNilForInvalidBaseURL() {
+        XCTAssertNil(OpenAICompatiblePlugin.realtimeRequestURL(baseURL: "http://[::1", apiVersion: ""))
+    }
+
+    // MARK: - Realtime Auth
+
+    func testRealtimeRequestAppliesBearerAuthenticationForNonAzureEndpoints() throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test"],
+            secrets: ["api-key": "sk-test"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+
+        let request = try XCTUnwrap(plugin.realtimeRequest(for: profile, profileId: plugin.providerId))
+
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test")
+        XCTAssertNil(request.value(forHTTPHeaderField: "api-key"))
+    }
+
+    func testRealtimeRequestAppliesAzureAPIKeyHeaderAlongsideBearer() throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://foundry-krubenok.services.ai.azure.com/openai",
+                "apiVersion": "preview",
+            ],
+            secrets: ["api-key": "azure-key"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
+
+        let request = try XCTUnwrap(plugin.realtimeRequest(for: profile, profileId: plugin.providerId))
+
+        XCTAssertEqual(request.url?.scheme, "wss")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer azure-key")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "api-key"), "azure-key")
+    }
+
+    // MARK: - Live Session: Batch/Translate Guardrails
+
+    func testCreateLiveTranscriptionSessionThrowsForBatchResolvedModelSoHostCanFallBack() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test", "selectedModel": "whisper-1"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.createLiveTranscriptionSession(
+                language: nil,
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true }
+            )
+            XCTFail("Expected batch-routed models to throw so the host preview-loop fallback engages")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testCreateLiveTranscriptionSessionThrowsWithoutSelectedModel() async throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://example.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.createLiveTranscriptionSession(
+                language: nil,
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true }
+            )
+            XCTFail("Expected noModelSelected")
+        } catch let error as PluginTranscriptionError {
+            guard case .noModelSelected = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testCreateLiveTranscriptionSessionRejectsTranslationForRealtimeModels() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["baseURL": "https://example.test", "selectedModel": "gpt-live-transcribe"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.createLiveTranscriptionSession(
+                language: nil,
+                translate: true,
+                prompt: nil,
+                onProgress: { _ in true }
+            )
+            XCTFail("Expected realtime translation to be rejected")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.localizedCaseInsensitiveContains("translat"))
+        }
+    }
+
+    // MARK: - Realtime Session Configuration Payload (shared SDK types)
+
+    func testContextAwareRealtimeSessionPayloadIncludesLanguagesKeywordsAndDelay() throws {
+        let configuration = PluginOpenAIRealtimeTranscriptionConfiguration(
+            modelID: "my-gpt-live-transcribe-deployment",
+            languageSelection: PluginLanguageSelection(languageHints: ["de", "en"]),
+            prompt: "Interview about TypeWhisper.",
+            keywords: PluginOpenAIRealtimeTranscriptionConfiguration.normalizedRealtimeKeywords(
+                from: [PluginDictionaryTermHint(text: "TypeWhisper"), PluginDictionaryTermHint(text: "<bad>")]
+            ),
+            delay: .low,
+            usesContextAwareHints: true
+        )
+
+        let payload = PluginOpenAIRealtimeTranscriptionSession.sessionUpdatePayload(configuration: configuration)
+
+        let session = try XCTUnwrap(payload["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertEqual(transcription["model"] as? String, "my-gpt-live-transcribe-deployment")
+        XCTAssertEqual(transcription["languages"] as? [String], ["de", "en"])
+        XCTAssertEqual(transcription["prompt"] as? String, "Interview about TypeWhisper.")
+        XCTAssertEqual(transcription["keywords"] as? [String], ["TypeWhisper"])
+        XCTAssertEqual(transcription["delay"] as? String, "low")
+        XCTAssertNil(transcription["language"])
+    }
+
+    func testLegacyRealtimeSessionPayloadUsesSingularLanguageAndOmitsHints() throws {
+        let configuration = PluginOpenAIRealtimeTranscriptionConfiguration(
+            modelID: "gpt-realtime-whisper",
+            languageSelection: PluginLanguageSelection(requestedLanguage: "de"),
+            prompt: "Ignored for legacy protocol",
+            keywords: [],
+            delay: nil,
+            usesContextAwareHints: false
+        )
+
+        let payload = PluginOpenAIRealtimeTranscriptionSession.sessionUpdatePayload(configuration: configuration)
+
+        let session = try XCTUnwrap(payload["session"] as? [String: Any])
+        let audio = try XCTUnwrap(session["audio"] as? [String: Any])
+        let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
+
+        XCTAssertEqual(transcription["model"] as? String, "gpt-realtime-whisper")
+        XCTAssertEqual(transcription["language"] as? String, "de")
+        XCTAssertNil(transcription["languages"])
+        XCTAssertNil(transcription["prompt"])
+        XCTAssertNil(transcription["keywords"])
+        XCTAssertNil(transcription["delay"])
+    }
+
+    func testRealtimeTranscriptCollectorAndSessionAssembleTranscript() async throws {
+        let collector = PluginOpenAIRealtimeTranscriptCollector()
+        _ = try await collector.applyEvent(Data(
+            #"{"type":"conversation.item.input_audio_transcription.completed","item_id":"item_1","transcript":"Guten Tag"}"#.utf8
+        ))
+        let session = PluginOpenAIRealtimeTranscriptionSession(
+            webSocketTask: nil,
+            receiveTask: nil,
+            collector: collector,
+            language: "de",
+            onProgress: { _ in true }
+        )
+
+        let result = try await session.finish()
+        await session.cancel()
+
+        XCTAssertEqual(result.text, "Guten Tag")
+        XCTAssertEqual(result.detectedLanguage, "de")
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -305,7 +305,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let host = try PluginTestHostServices(
             defaults: [
                 "baseURL": "https://example.test/openai?tenant=contoso",
-                "selectedModel": "gpt-live-transcribe",
+                "selectedModel": "gpt-transcribe",
                 "selectedLLMModel": "gpt-chat",
             ]
         )
@@ -1143,7 +1143,73 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         }
     }
 
-    // MARK: - Realtime Session Configuration Payload (shared SDK types)
+    func testRegularTranscriptionStreamsRealtimeAudioWithoutLivePreview() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedModel": "gpt-live-transcribe",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        let session = RealtimeSessionSpy(
+            result: PluginTranscriptionResult(text: "Direct realtime result", detectedLanguage: "en")
+        )
+        let connector = RealtimeSessionConnectorSpy(session: session)
+        plugin.realtimeSessionConnector = connector
+        let samples = Array(repeating: Float(0.25), count: 16_001)
+
+        let result = try await plugin.transcribe(
+            audio: AudioData(
+                samples: samples,
+                wavData: PluginWavEncoder.encode(samples),
+                duration: Double(samples.count) / 16_000
+            ),
+            language: "en",
+            translate: false,
+            prompt: "Direct transcription"
+        )
+
+        let recordedConnection = await connector.snapshot()
+        let connection = try XCTUnwrap(recordedConnection)
+        let sessionSnapshot = await session.snapshot()
+        XCTAssertEqual(connection.request.url?.path, "/v1/realtime")
+        XCTAssertEqual(connection.configuration.modelID, "gpt-live-transcribe")
+        XCTAssertEqual(connection.configuration.languageSelection.requestedLanguage, "en")
+        XCTAssertEqual(connection.configuration.prompt, "Direct transcription")
+        XCTAssertEqual(sessionSnapshot.chunkSizes, [16_000, 1])
+        XCTAssertEqual(sessionSnapshot.samples, samples)
+        XCTAssertEqual(sessionSnapshot.finishCount, 1)
+        XCTAssertEqual(sessionSnapshot.cancelCount, 0)
+        XCTAssertEqual(result.text, "Direct realtime result")
+    }
+
+    func testRealtimeHelperIsCompiledIntoPluginModule() {
+        XCTAssertTrue(
+            String(reflecting: PluginOpenAIRealtimeTranscriptionSession.self)
+                .hasPrefix("OpenAICompatiblePlugin.")
+        )
+    }
+
+    func testTransportSettingsHaveGermanAndJapaneseLocalizations() throws {
+        let catalogURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Localizable.xcstrings")
+        let catalogData = try Data(contentsOf: catalogURL)
+        let catalog = try XCTUnwrap(JSONSerialization.jsonObject(with: catalogData) as? [String: Any])
+        let strings = try XCTUnwrap(catalog["strings"] as? [String: Any])
+        let helpText = "Auto uses realtime streaming only for known realtime model IDs (gpt-live-transcribe, gpt-realtime-whisper) and batch upload otherwise. Choose Realtime to force streaming for any OpenAI-compatible server that supports the /v1/realtime WebSocket API, including custom deployment aliases (e.g. an Azure OpenAI or Microsoft Foundry gpt-live-transcribe deployment) — some providers, including Azure, require a preview API version for realtime transcription. Choose Batch to always use /v1/audio/transcriptions."
+
+        for key in ["Transcription Transport", "Auto", "Batch", "Realtime", helpText] {
+            let entry = try XCTUnwrap(strings[key] as? [String: Any], "Missing localization key: \(key)")
+            let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any])
+            XCTAssertNotNil(localizations["de"], "Missing German localization for \(key)")
+            XCTAssertNotNil(localizations["ja"], "Missing Japanese localization for \(key)")
+        }
+    }
+
+    // MARK: - Realtime Session Configuration Payload
 
     func testContextAwareRealtimeSessionPayloadIncludesLanguagesKeywordsAndDelay() throws {
         let configuration = PluginOpenAIRealtimeTranscriptionConfiguration(
@@ -1252,6 +1318,73 @@ final class OpenAICompatiblePluginTests: XCTestCase {
             XCTFail("Expected cancellation")
         } catch is CancellationError {
             // Expected.
+        }
+    }
+
+    private actor RealtimeSessionConnectorSpy: OpenAICompatibleRealtimeSessionConnecting {
+        struct Connection: Sendable {
+            let request: URLRequest
+            let configuration: PluginOpenAIRealtimeTranscriptionConfiguration
+        }
+
+        private let session: any LiveTranscriptionSession
+        private var connection: Connection?
+
+        init(session: any LiveTranscriptionSession) {
+            self.session = session
+        }
+
+        func connect(
+            request: URLRequest,
+            configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> any LiveTranscriptionSession {
+            connection = Connection(request: request, configuration: configuration)
+            return session
+        }
+
+        func snapshot() -> Connection? {
+            connection
+        }
+    }
+
+    private actor RealtimeSessionSpy: LiveTranscriptionSession {
+        struct Snapshot: Sendable {
+            let samples: [Float]
+            let chunkSizes: [Int]
+            let finishCount: Int
+            let cancelCount: Int
+        }
+
+        private let result: PluginTranscriptionResult
+        private var chunks: [[Float]] = []
+        private var finishCount = 0
+        private var cancelCount = 0
+
+        init(result: PluginTranscriptionResult) {
+            self.result = result
+        }
+
+        func appendAudio(samples: [Float]) async throws {
+            chunks.append(samples)
+        }
+
+        func finish() async throws -> PluginTranscriptionResult {
+            finishCount += 1
+            return result
+        }
+
+        func cancel() async {
+            cancelCount += 1
+        }
+
+        func snapshot() -> Snapshot {
+            Snapshot(
+                samples: chunks.flatMap { $0 },
+                chunkSizes: chunks.map(\.count),
+                finishCount: finishCount,
+                cancelCount: cancelCount
+            )
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -940,7 +940,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
     func testExplicitRealtimeTransportOverridesCustomAzureDeploymentAlias() throws {
         let host = try PluginTestHostServices(
             defaults: [
-                "baseURL": "https://foundry-krubenok.services.ai.azure.com/openai",
+                "baseURL": "https://foundry-example.services.ai.azure.com/openai",
                 "selectedModel": "my-gpt-live-transcribe-deployment",
             ]
         )
@@ -977,13 +977,13 @@ final class OpenAICompatiblePluginTests: XCTestCase {
     func testRealtimeURLConvertsHTTPSToWSSAndAppendsRealtimePathAndIntent() throws {
         let url = try XCTUnwrap(
             OpenAICompatiblePlugin.realtimeRequestURL(
-                baseURL: "https://foundry-krubenok.services.ai.azure.com/openai",
+                baseURL: "https://foundry-example.services.ai.azure.com/openai",
                 apiVersion: ""
             )
         )
 
         XCTAssertEqual(url.scheme, "wss")
-        XCTAssertEqual(url.host, "foundry-krubenok.services.ai.azure.com")
+        XCTAssertEqual(url.host, "foundry-example.services.ai.azure.com")
         XCTAssertEqual(url.path, "/openai/v1/realtime")
 
         let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
@@ -1021,7 +1021,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
     func testRealtimeURLAppliesConfiguredAPIVersionWithoutDuplication() throws {
         let url = try XCTUnwrap(
             OpenAICompatiblePlugin.realtimeRequestURL(
-                baseURL: "https://foundry-krubenok.services.ai.azure.com/openai",
+                baseURL: "https://foundry-example.services.ai.azure.com/openai",
                 apiVersion: "preview"
             )
         )
@@ -1060,7 +1060,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
     func testRealtimeRequestAppliesAzureAPIKeyHeaderAlongsideBearer() throws {
         let host = try PluginTestHostServices(
             defaults: [
-                "baseURL": "https://foundry-krubenok.services.ai.azure.com/openai",
+                "baseURL": "https://foundry-example.services.ai.azure.com/openai",
                 "apiVersion": "preview",
             ],
             secrets: ["api-key": "azure-key"]
@@ -1162,8 +1162,12 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let session = try XCTUnwrap(payload["session"] as? [String: Any])
         let audio = try XCTUnwrap(session["audio"] as? [String: Any])
         let input = try XCTUnwrap(audio["input"] as? [String: Any])
+        let format = try XCTUnwrap(input["format"] as? [String: Any])
         let transcription = try XCTUnwrap(input["transcription"] as? [String: Any])
 
+        XCTAssertEqual(format["type"] as? String, "audio/pcm")
+        XCTAssertEqual(format["rate"] as? Int, PluginOpenAIRealtimeTranscriptionSession.targetSampleRate)
+        XCTAssertTrue(input["turn_detection"] is NSNull)
         XCTAssertEqual(transcription["model"] as? String, "my-gpt-live-transcribe-deployment")
         XCTAssertEqual(transcription["languages"] as? [String], ["de", "en"])
         XCTAssertEqual(transcription["prompt"] as? String, "Interview about TypeWhisper.")
@@ -1215,5 +1219,39 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(result.text, "Guten Tag")
         XCTAssertEqual(result.detectedLanguage, "de")
+    }
+
+    func testRealtimeTranscriptCollectorUsesStableFallbackForMissingItemID() async throws {
+        let collector = PluginOpenAIRealtimeTranscriptCollector()
+
+        _ = try await collector.applyEvent(Data(
+            #"{"type":"conversation.item.input_audio_transcription.delta","delta":"Guten "}"#.utf8
+        ))
+        _ = try await collector.applyEvent(Data(
+            #"{"type":"conversation.item.input_audio_transcription.delta","delta":"Tag"}"#.utf8
+        ))
+        _ = try await collector.applyEvent(Data(
+            #"{"type":"conversation.item.input_audio_transcription.completed","transcript":"Guten Tag"}"#.utf8
+        ))
+
+        let currentText = await collector.currentText()
+        XCTAssertEqual(currentText, "Guten Tag")
+    }
+
+    func testRealtimeSocketOpenWaiterResumesWhenCancelled() async throws {
+        let waiter = PluginOpenAIRealtimeWebSocketOpenWaiter()
+        let waitTask = Task {
+            try await waiter.waitForOpen()
+        }
+
+        await Task.yield()
+        waitTask.cancel()
+
+        do {
+            try await waitTask.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
     }
 }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginOpenAIRealtimeTranscription.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginOpenAIRealtimeTranscription.swift
@@ -101,6 +101,8 @@ public struct PluginOpenAIRealtimeTranscriptionConfiguration: Sendable {
 }
 
 public actor PluginOpenAIRealtimeTranscriptCollector {
+    private static let unidentifiedItemID = "__typewhisper_unidentified_item__"
+
     private var completedOrder: [String] = []
     private var completedTexts: [String: String] = [:]
     private var deltaTexts: [String: String] = [:]
@@ -119,12 +121,12 @@ public actor PluginOpenAIRealtimeTranscriptCollector {
 
         switch type {
         case "conversation.item.input_audio_transcription.delta":
-            let itemID = json["item_id"] as? String ?? UUID().uuidString
+            let itemID = json["item_id"] as? String ?? Self.unidentifiedItemID
             let delta = json["delta"] as? String ?? ""
             deltaTexts[itemID, default: ""].append(delta)
             return currentText()
         case "conversation.item.input_audio_transcription.completed":
-            let itemID = json["item_id"] as? String ?? UUID().uuidString
+            let itemID = json["item_id"] as? String ?? Self.unidentifiedItemID
             let transcript = (json["transcript"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
             if !transcript.isEmpty {
                 if completedTexts[itemID] == nil {
@@ -203,20 +205,24 @@ public final class PluginOpenAIRealtimeWebSocketOpenWaiter: @unchecked Sendable 
     public init() {}
 
     public func waitForOpen() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            let result = state.withLock { state -> Result<Void, Error>? in
-                if state.opened {
-                    return .success(())
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                let result = state.withLock { state -> Result<Void, Error>? in
+                    if state.opened {
+                        return .success(())
+                    }
+                    if let failure = state.failure {
+                        return .failure(failure)
+                    }
+                    state.continuations.append(continuation)
+                    return nil
                 }
-                if let failure = state.failure {
-                    return .failure(failure)
+                if let result {
+                    continuation.resume(with: result)
                 }
-                state.continuations.append(continuation)
-                return nil
             }
-            if let result {
-                continuation.resume(with: result)
-            }
+        } onCancel: {
+            markFailed(CancellationError())
         }
     }
 
@@ -309,7 +315,7 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
     /// Opens the WebSocket described by `request`, sends the `session.update` event
     /// derived from `configuration`, and waits for the server to confirm the session
     /// before returning. `request` must already carry provider-specific authorization
-    /// headers (e.g. `Authorization: Bearer ...` or `api-key: ...`).
+    /// headers (for example, `Authorization: Bearer <token>` or `api-key: <key>`).
     public static func connect(
         request: URLRequest,
         configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
@@ -477,13 +483,15 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
         }
 
         if shouldFinish, let webSocketTask {
+            defer {
+                receiveTask?.cancel()
+                webSocketTask.cancel(with: .normalClosure, reason: nil)
+                urlSession?.finishTasksAndInvalidate()
+            }
             if !(await collector.hasCompletedTranscript) {
                 try? await webSocketTask.send(.string(#"{"type":"input_audio_buffer.commit"}"#))
             }
             try await waitForCompletedTranscript()
-            receiveTask?.cancel()
-            webSocketTask.cancel(with: .normalClosure, reason: nil)
-            urlSession?.finishTasksAndInvalidate()
         }
 
         if let error = await collector.error {
@@ -534,6 +542,7 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
             }
             try await Task.sleep(for: .milliseconds(100))
         }
+        throw PluginTranscriptionError.networkError("Realtime API did not complete the transcript.")
     }
 
     private static func resample16kTo24k(_ samples: [Float]) -> [Float] {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginOpenAIRealtimeTranscription.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginOpenAIRealtimeTranscription.swift
@@ -1,0 +1,581 @@
+import Foundation
+import os
+
+// MARK: - Shared OpenAI-Compatible Realtime Transcription
+
+// Provider-agnostic support for the OpenAI Realtime transcription protocol
+// (`GET wss://<host>/v1/realtime?intent=transcription`), reused by any plugin that
+// talks to an OpenAI-compatible realtime endpoint (OpenAI itself, Azure OpenAI /
+// Microsoft Foundry, or other BYO deployments). Callers are responsible for
+// building the provider-specific `URLRequest` (host, path, query, and
+// authorization headers); this type owns the WebSocket lifecycle, session
+// configuration payload, PCM resampling/encoding, and transcript assembly.
+
+public enum PluginOpenAILiveTranscriptionDelay: String, CaseIterable, Sendable {
+    case minimal
+    case low
+    case medium
+    case high
+    case xhigh
+
+    public var displayName: String {
+        switch self {
+        case .minimal:
+            "Minimal"
+        case .low:
+            "Low"
+        case .medium:
+            "Medium"
+        case .high:
+            "High"
+        case .xhigh:
+            "X High"
+        }
+    }
+}
+
+public struct PluginOpenAIRealtimeTranscriptionConfiguration: Sendable {
+    public let modelID: String
+    public let languageSelection: PluginLanguageSelection
+    public let prompt: String?
+    public let keywords: [String]
+    public let delay: PluginOpenAILiveTranscriptionDelay?
+    public let usesContextAwareHints: Bool
+
+    public init(
+        modelID: String,
+        languageSelection: PluginLanguageSelection,
+        prompt: String?,
+        keywords: [String],
+        delay: PluginOpenAILiveTranscriptionDelay?,
+        usesContextAwareHints: Bool
+    ) {
+        self.modelID = modelID
+        self.languageSelection = languageSelection
+        self.prompt = prompt
+        self.keywords = keywords
+        self.delay = delay
+        self.usesContextAwareHints = usesContextAwareHints
+    }
+
+    public var fallbackLanguage: String? {
+        if let requestedLanguage = languageSelection.requestedLanguage?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !requestedLanguage.isEmpty {
+            return requestedLanguage
+        }
+
+        let languages = Self.normalizedLanguages(from: languageSelection)
+        return languages.count == 1 ? languages[0] : nil
+    }
+
+    public static func normalizedLanguages(from selection: PluginLanguageSelection) -> [String] {
+        var seen = Set<String>()
+        var languages: [String] = []
+        let candidates = [selection.requestedLanguage].compactMap { $0 } + selection.languageHints
+
+        for candidate in candidates {
+            let language = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !language.isEmpty else { continue }
+            let dedupeKey = language.lowercased()
+            guard seen.insert(dedupeKey).inserted else { continue }
+            languages.append(language)
+        }
+
+        return languages
+    }
+
+    /// Filters dictionary term hints down to the realtime `keywords` array shape:
+    /// deduplicated, and excluding characters (`<`, `>`, `\r`, `\n`) the realtime
+    /// transcription protocol does not accept in keyword strings.
+    public static func normalizedRealtimeKeywords(from dictionaryTermHints: [PluginDictionaryTermHint]) -> [String] {
+        PluginDictionaryTerms.normalizedTermHints(from: dictionaryTermHints)
+            .map(\.text)
+            .filter { keyword in
+                !keyword.contains("<")
+                    && !keyword.contains(">")
+                    && !keyword.contains("\r")
+                    && !keyword.contains("\n")
+            }
+    }
+}
+
+public actor PluginOpenAIRealtimeTranscriptCollector {
+    private var completedOrder: [String] = []
+    private var completedTexts: [String: String] = [:]
+    private var deltaTexts: [String: String] = [:]
+    private var serverError: String?
+    private var connectionFailure: String?
+    private var sessionReady = false
+
+    public init() {}
+
+    @discardableResult
+    public func applyEvent(_ data: Data) throws -> String? {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else {
+            throw PluginTranscriptionError.apiError("Invalid OpenAI realtime event")
+        }
+
+        switch type {
+        case "conversation.item.input_audio_transcription.delta":
+            let itemID = json["item_id"] as? String ?? UUID().uuidString
+            let delta = json["delta"] as? String ?? ""
+            deltaTexts[itemID, default: ""].append(delta)
+            return currentText()
+        case "conversation.item.input_audio_transcription.completed":
+            let itemID = json["item_id"] as? String ?? UUID().uuidString
+            let transcript = (json["transcript"] as? String ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if !transcript.isEmpty {
+                if completedTexts[itemID] == nil {
+                    completedOrder.append(itemID)
+                }
+                completedTexts[itemID] = transcript
+                deltaTexts[itemID] = nil
+            }
+            return currentText()
+        case "session.updated", "transcription_session.updated":
+            sessionReady = true
+            return nil
+        case "conversation.item.input_audio_transcription.failed":
+            let message = Self.errorMessage(from: json) ?? "OpenAI realtime transcription failed"
+            serverError = message
+            throw PluginTranscriptionError.apiError(message)
+        case "error":
+            let message = Self.errorMessage(from: json) ?? "Unknown OpenAI realtime error"
+            serverError = message
+            throw PluginTranscriptionError.apiError(message)
+        default:
+            return nil
+        }
+    }
+
+    public func currentText() -> String {
+        var parts = completedOrder.compactMap { completedTexts[$0] }
+        let interim = deltaTexts
+            .filter { completedTexts[$0.key] == nil }
+            .sorted { $0.key < $1.key }
+            .map(\.value)
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+        parts.append(contentsOf: interim)
+        return parts.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public func finalResult(fallbackLanguage: String?) -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: currentText(), detectedLanguage: fallbackLanguage)
+    }
+
+    public func recordConnectionFailure(_ message: String) {
+        if serverError == nil {
+            connectionFailure = message
+        }
+    }
+
+    public var hasCompletedTranscript: Bool {
+        !completedOrder.isEmpty
+    }
+
+    public var isSessionReady: Bool {
+        sessionReady
+    }
+
+    public var error: String? {
+        serverError ?? connectionFailure
+    }
+
+    private static func errorMessage(from json: [String: Any]) -> String? {
+        if let error = json["error"] as? [String: Any] {
+            return error["message"] as? String ?? error["type"] as? String
+        }
+        return json["message"] as? String
+    }
+}
+
+public final class PluginOpenAIRealtimeWebSocketOpenWaiter: @unchecked Sendable {
+    private struct State {
+        var opened = false
+        var failure: Error?
+        var continuations: [CheckedContinuation<Void, Error>] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    public init() {}
+
+    public func waitForOpen() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let result = state.withLock { state -> Result<Void, Error>? in
+                if state.opened {
+                    return .success(())
+                }
+                if let failure = state.failure {
+                    return .failure(failure)
+                }
+                state.continuations.append(continuation)
+                return nil
+            }
+            if let result {
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    public func markOpened() {
+        let continuations = state.withLock { state -> [CheckedContinuation<Void, Error>] in
+            guard !state.opened, state.failure == nil else { return [] }
+            state.opened = true
+            let continuations = state.continuations
+            state.continuations = []
+            return continuations
+        }
+        continuations.forEach { $0.resume() }
+    }
+
+    public func markFailed(_ error: Error) {
+        let continuations = state.withLock { state -> [CheckedContinuation<Void, Error>] in
+            guard !state.opened, state.failure == nil else { return [] }
+            state.failure = error
+            let continuations = state.continuations
+            state.continuations = []
+            return continuations
+        }
+        continuations.forEach { $0.resume(throwing: error) }
+    }
+}
+
+private final class PluginOpenAIRealtimeWebSocketDelegate: NSObject, URLSessionWebSocketDelegate, @unchecked Sendable {
+    private let openWaiter: PluginOpenAIRealtimeWebSocketOpenWaiter
+
+    init(openWaiter: PluginOpenAIRealtimeWebSocketOpenWaiter) {
+        self.openWaiter = openWaiter
+        super.init()
+    }
+
+    func urlSession(
+        _ session: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        didOpenWithProtocol protocol: String?
+    ) {
+        openWaiter.markOpened()
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        if let error {
+            openWaiter.markFailed(error)
+        }
+    }
+}
+
+/// A `LiveTranscriptionSession` that streams 24 kHz PCM audio to an OpenAI-compatible
+/// realtime transcription endpoint over a WebSocket. Callers supply a fully-formed
+/// `URLRequest` (scheme/host/path/query and authorization headers), so this type can
+/// be reused for OpenAI itself, Azure OpenAI / Microsoft Foundry, or any other
+/// OpenAI-compatible BYO deployment.
+public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
+    public static let sourceSampleRate = 16_000
+    public static let targetSampleRate = 24_000
+    public static let socketOpenTimeoutNanoseconds: UInt64 = 10_000_000_000
+    public static let sessionReadyTimeoutNanoseconds: UInt64 = 3_000_000_000
+
+    private struct State {
+        var finished = false
+        var cancelled = false
+    }
+
+    private let urlSession: URLSession?
+    private let webSocketTask: URLSessionWebSocketTask?
+    private let receiveTask: Task<Void, Never>?
+    private let collector: PluginOpenAIRealtimeTranscriptCollector
+    private let fallbackLanguage: String?
+    private let onProgress: @Sendable (String) -> Bool
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    public init(
+        urlSession: URLSession? = nil,
+        webSocketTask: URLSessionWebSocketTask?,
+        receiveTask: Task<Void, Never>?,
+        collector: PluginOpenAIRealtimeTranscriptCollector,
+        language: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) {
+        self.urlSession = urlSession
+        self.webSocketTask = webSocketTask
+        self.receiveTask = receiveTask
+        self.collector = collector
+        self.fallbackLanguage = language
+        self.onProgress = onProgress
+    }
+
+    /// Opens the WebSocket described by `request`, sends the `session.update` event
+    /// derived from `configuration`, and waits for the server to confirm the session
+    /// before returning. `request` must already carry provider-specific authorization
+    /// headers (e.g. `Authorization: Bearer ...` or `api-key: ...`).
+    public static func connect(
+        request: URLRequest,
+        configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginOpenAIRealtimeTranscriptionSession {
+        let openWaiter = PluginOpenAIRealtimeWebSocketOpenWaiter()
+        let delegate = PluginOpenAIRealtimeWebSocketDelegate(openWaiter: openWaiter)
+        let urlSession = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        let webSocketTask = urlSession.webSocketTask(with: request)
+        let collector = PluginOpenAIRealtimeTranscriptCollector()
+
+        webSocketTask.resume()
+        try await waitForSocketOpen(openWaiter)
+
+        let receiveTask = Task { [webSocketTask, collector, onProgress] in
+            do {
+                while !Task.isCancelled {
+                    let message = try await webSocketTask.receive()
+                    guard let data = Self.data(from: message) else { continue }
+                    if let text = try await collector.applyEvent(data), !text.isEmpty {
+                        _ = onProgress(text)
+                    }
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await collector.recordConnectionFailure(realtimeErrorDescription(error))
+            }
+        }
+
+        do {
+            try await webSocketTask.send(
+                .string(try jsonString(sessionUpdatePayload(configuration: configuration)))
+            )
+            try await waitForSessionReady(collector)
+        } catch {
+            receiveTask.cancel()
+            webSocketTask.cancel(with: .goingAway, reason: nil)
+            urlSession.finishTasksAndInvalidate()
+            if let collectorError = await collector.error {
+                throw PluginTranscriptionError.apiError(collectorError)
+            }
+            throw error
+        }
+
+        return PluginOpenAIRealtimeTranscriptionSession(
+            urlSession: urlSession,
+            webSocketTask: webSocketTask,
+            receiveTask: receiveTask,
+            collector: collector,
+            language: configuration.fallbackLanguage,
+            onProgress: onProgress
+        )
+    }
+
+    private static func waitForSessionReady(_ collector: PluginOpenAIRealtimeTranscriptCollector) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    if await collector.isSessionReady {
+                        return
+                    }
+                    if let error = await collector.error {
+                        throw PluginTranscriptionError.apiError(error)
+                    }
+                    try await Task.sleep(for: .milliseconds(50))
+                }
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: sessionReadyTimeoutNanoseconds)
+                throw PluginTranscriptionError.networkError("Realtime API did not confirm the transcription session.")
+            }
+
+            defer { group.cancelAll() }
+            try await group.next()
+        }
+    }
+
+    public static func sessionUpdatePayload(
+        configuration: PluginOpenAIRealtimeTranscriptionConfiguration
+    ) -> [String: Any] {
+        var transcription: [String: Any] = ["model": configuration.modelID]
+
+        if configuration.usesContextAwareHints {
+            let languages = PluginOpenAIRealtimeTranscriptionConfiguration.normalizedLanguages(
+                from: configuration.languageSelection
+            )
+            if !languages.isEmpty {
+                transcription["languages"] = languages
+            }
+            if let prompt = configuration.prompt?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+               !prompt.isEmpty {
+                transcription["prompt"] = prompt
+            }
+            if !configuration.keywords.isEmpty {
+                transcription["keywords"] = configuration.keywords
+            }
+            if let delay = configuration.delay {
+                transcription["delay"] = delay.rawValue
+            }
+        } else if let language = configuration.languageSelection.requestedLanguage?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+                  !language.isEmpty {
+            transcription["language"] = language
+        }
+
+        return [
+            "type": "session.update",
+            "session": [
+                "type": "transcription",
+                "audio": [
+                    "input": [
+                        "format": [
+                            "type": "audio/pcm",
+                            "rate": targetSampleRate,
+                        ],
+                        "transcription": transcription,
+                        "turn_detection": NSNull(),
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    public static func pcm16DataForRealtime(_ samples: [Float]) -> Data {
+        let resampled = resample16kTo24k(samples)
+        var data = Data(capacity: resampled.count * MemoryLayout<Int16>.size)
+        for sample in resampled {
+            let clamped = max(-1.0, min(1.0, sample))
+            var int16 = Int16(clamped * 32767.0).littleEndian
+            withUnsafeBytes(of: &int16) { data.append(contentsOf: $0) }
+        }
+        return data
+    }
+
+    public func appendAudio(samples: [Float]) async throws {
+        guard !state.withLock({ $0.finished || $0.cancelled }) else { return }
+        guard let webSocketTask else { return }
+        if let error = await collector.error {
+            throw PluginTranscriptionError.apiError(error)
+        }
+        let data = Self.pcm16DataForRealtime(samples)
+        guard !data.isEmpty else { return }
+        do {
+            try await webSocketTask.send(.string(try Self.jsonString([
+                "type": "input_audio_buffer.append",
+                "audio": data.base64EncodedString(),
+            ])))
+        } catch {
+            if let collectorError = await collector.error {
+                throw PluginTranscriptionError.apiError(collectorError)
+            }
+            let message = Self.realtimeErrorDescription(error)
+            await collector.recordConnectionFailure(message)
+            throw PluginTranscriptionError.networkError(message)
+        }
+    }
+
+    public func finish() async throws -> PluginTranscriptionResult {
+        let shouldFinish = state.withLock { state in
+            guard !state.finished else { return false }
+            state.finished = true
+            return !state.cancelled
+        }
+
+        if shouldFinish, let webSocketTask {
+            if !(await collector.hasCompletedTranscript) {
+                try? await webSocketTask.send(.string(#"{"type":"input_audio_buffer.commit"}"#))
+            }
+            try await waitForCompletedTranscript()
+            receiveTask?.cancel()
+            webSocketTask.cancel(with: .normalClosure, reason: nil)
+            urlSession?.finishTasksAndInvalidate()
+        }
+
+        if let error = await collector.error {
+            throw PluginTranscriptionError.apiError(error)
+        }
+
+        let result = await collector.finalResult(fallbackLanguage: fallbackLanguage)
+        if result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, webSocketTask != nil {
+            throw PluginTranscriptionError.apiError("Realtime API returned no transcript")
+        }
+        return result
+    }
+
+    public func cancel() async {
+        let shouldCancel = state.withLock { state in
+            guard !state.cancelled else { return false }
+            state.cancelled = true
+            return true
+        }
+        guard shouldCancel else { return }
+        receiveTask?.cancel()
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        urlSession?.finishTasksAndInvalidate()
+    }
+
+    private static func waitForSocketOpen(_ waiter: PluginOpenAIRealtimeWebSocketOpenWaiter) async throws {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await waiter.waitForOpen()
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: socketOpenTimeoutNanoseconds)
+                throw PluginTranscriptionError.networkError("Realtime WebSocket did not open.")
+            }
+
+            defer { group.cancelAll() }
+            try await group.next()
+        }
+    }
+
+    private func waitForCompletedTranscript() async throws {
+        for _ in 0..<100 {
+            if await collector.hasCompletedTranscript {
+                return
+            }
+            if let error = await collector.error {
+                throw PluginTranscriptionError.apiError(error)
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+    }
+
+    private static func resample16kTo24k(_ samples: [Float]) -> [Float] {
+        guard !samples.isEmpty else { return [] }
+        let ratio = Double(targetSampleRate) / Double(sourceSampleRate)
+        let targetCount = max(1, Int((Double(samples.count) * ratio).rounded()))
+        guard samples.count > 1 else {
+            return Array(repeating: samples[0], count: targetCount)
+        }
+
+        return (0..<targetCount).map { targetIndex in
+            let sourcePosition = Double(targetIndex) * Double(sourceSampleRate) / Double(targetSampleRate)
+            let lowerIndex = min(Int(sourcePosition.rounded(.down)), samples.count - 1)
+            let upperIndex = min(lowerIndex + 1, samples.count - 1)
+            let fraction = Float(sourcePosition - Double(lowerIndex))
+            return samples[lowerIndex] + (samples[upperIndex] - samples[lowerIndex]) * fraction
+        }
+    }
+
+    private static func jsonString(_ object: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: object)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw PluginTranscriptionError.apiError("Failed to encode realtime event")
+        }
+        return string
+    }
+
+    private static func data(from message: URLSessionWebSocketTask.Message) -> Data? {
+        switch message {
+        case .string(let text):
+            return text.data(using: .utf8)
+        case .data(let data):
+            return data
+        @unknown default:
+            return nil
+        }
+    }
+
+    private static func realtimeErrorDescription(_ error: Error) -> String {
+        if let transcriptionError = error as? PluginTranscriptionError {
+            return transcriptionError.localizedDescription
+        }
+        return error.localizedDescription
+    }
+}


### PR DESCRIPTION
## Summary

Adds realtime transcription support to the OpenAI Compatible plugin for arbitrary OpenAI-compatible and BYO endpoints, including Azure OpenAI and Microsoft Foundry `gpt-live-transcribe` deployments.

The per-profile `api-version` support and Azure `api-key` authentication required by this work landed in #1051. This PR adds the realtime transport layer without adding new ABI requirements to the host SDK.

## Problem

OpenAI Compatible previously routed every selected model through batch `/v1/audio/transcriptions`. Realtime-only deployments could appear healthy during model discovery and connection checks, then fail transcription with `DeploymentNotFound` because they only support `/v1/realtime?intent=transcription`.

This also affected dictation when live transcript preview was disabled, because final transcription called the regular `transcribe()` path.

## What changed

- Adds per-profile `Auto`, `Batch`, and `Realtime` transport selection.
  - `Auto` recognizes `gpt-live-transcribe` and `gpt-realtime-whisper` as realtime models and preserves batch behavior for other model IDs.
  - Explicit `Realtime` supports custom deployment aliases.
  - Explicit `Batch` overrides the known-model heuristic.
- Adds a provider-configurable realtime WebSocket implementation inside the OpenAI Compatible plugin bundle.
  - Keeping this code in the plugin target avoids requiring new `TypeWhisperPluginSDK` symbols and preserves compatibility with released v1 hosts.
  - The Release bundle was loaded successfully against the TypeWhisper 1.6.0 (1047) embedded SDK during validation.
- Routes both live-preview sessions and regular/direct `transcribe()` calls through realtime when selected.
  - Regular transcription streams the complete recording through one session in bounded 16k-sample chunks, then finishes the session.
  - Batch models continue using the existing upload path.
- Preserves configured base paths and query items while constructing WebSocket URLs, converts `https` to `wss` and `http` to `ws`, appends `/v1/realtime`, and applies `intent=transcription` and `api-version` without duplication.
- Uses Bearer authentication for standard compatible endpoints and the existing Azure `api-key` behavior from #1051.
- Matches the existing OpenAI plugin's context-aware `gpt-live-transcribe` and legacy `gpt-realtime-whisper` session payloads, including language, prompt, and dictionary semantics.
- Rejects realtime translation with a clear error.
- Cleans up the WebSocket and delegated URL session on open timeout, cancellation, delegate failure, session update failure, and readiness failure.
- Adds localized German and Japanese strings for the transport controls and help text.

## Compatibility notes

`OpenAIPlugin.swift` remains unchanged to avoid regressions in the shipped OpenAI/ChatGPT integration. The OpenAI Compatible implementation follows the same protocol behavior but is compiled into its own bundle so plugin-only installation continues to work with released hosts declaring SDK compatibility `v1`.

Custom deployment names cannot reveal whether they require the context-aware or legacy payload shape. The current best-effort heuristic treats IDs containing `whisper` as legacy and other IDs as context-aware; users can explicitly select the transport independently.

## Tests

Focused coverage includes:

- profile migration, defaults, auto routing, and explicit overrides
- default and additional-profile capability reporting
- WebSocket scheme/path/query/API-version construction
- Bearer and Azure `api-key` authentication
- context-aware and legacy session payloads
- transcript delta/completion assembly, including missing `item_id`
- cancellation-aware socket-open waiting and explicit completion timeout errors
- regular/direct realtime transcription without live preview
- one-shot audio chunking and complete sample delivery
- plugin-module ownership of the realtime helper
- German and Japanese localization catalog entries

Results:

- 49/49 `OpenAICompatiblePluginTests` passed
- 41/41 `OpenAIPluginTests` passed
- GitHub app tests, plugin SDK tests, Release build, CodeQL, and analysis checks passed

## Test plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests
swift test --package-path TypeWhisperPluginSDK --filter OpenAIPluginTests
xcodebuild build -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin -configuration Debug
xcodebuild build -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin -configuration Release
```

Bundle compatibility was also verified by loading the Release plugin with a compiled `Bundle.loadAndReturnError()` probe whose rpath points at the released TypeWhisper 1.6.0 (1047) `TypeWhisperPluginSDK.framework`.

## Local plugin build/install

```bash
xcodebuild build -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin \
  -configuration Release -destination 'platform=macOS,arch=arm64'

BUNDLE="$(xcodebuild -project TypeWhisper.xcodeproj -scheme OpenAICompatiblePlugin \
  -configuration Release -showBuildSettings 2>/dev/null \
  | awk -F'= ' '/ BUILT_PRODUCTS_DIR /{print $2; exit}')/OpenAICompatiblePlugin.bundle"

mkdir -p "$HOME/Library/Application Support/TypeWhisper/Plugins"
rm -rf "$HOME/Library/Application Support/TypeWhisper/Plugins/OpenAICompatiblePlugin.bundle"
cp -R "$BUNDLE" "$HOME/Library/Application Support/TypeWhisper/Plugins/"
```

No credentials or secrets are included in this change.

Do not merge; awaiting coordinator review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added realtime transcription with streaming audio and incremental transcript updates.
  * Added Auto, Batch, and Realtime transport options in settings, with automatic model-based selection.
  * Added support for language and dictionary hints, authentication, cancellation, and session recovery.
  * Added profile-specific transport settings with backward-compatible defaults.
* **Bug Fixes**
  * Improved fallback behavior and clearer errors when realtime transcription is unavailable.
* **Localization**
  * Added German and Japanese translations for transcription transport settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->