### PR TITLE
Bump OpenAI Compatible plugin to 1.1.7

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openai-compatible",
     "name": "OpenAI Compatible",
-    "version": "1.1.0",
+    "version": "1.1.7",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump the OpenAI Compatible plugin manifest from 1.1.0 to 1.1.7
- prepare the realtime transcription changes from #1052 for an official plugin release
- satisfy the release workflow's exact manifest-version validation

## Impact

After this lands, the official plugin release workflow can publish `plugin-openai-compatible-v1.1.7` from `main`. The compatibility metadata remains unchanged at TypeWhisper 1.5.0, SDK v1, and macOS 14.0.

## Test plan

- `jq -e '.version == "1.1.7"' TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`

Release dispatch after merge:

`gh workflow run plugin-release.yml --repo TypeWhisper/typewhisper-mac --ref main -f plugin_name=openai-compatible -f plugin_version=1.1.7 -f distribution_source=official`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenAI Compatible plugin to version 1.1.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->