### PR TITLE
Add recovery audio retention controls

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -74,7 +74,10 @@ final class ServiceContainer: ObservableObject {
         modelManagerService = ModelManagerService()
         audioFileService = AudioFileService()
         audioRecordingService = AudioRecordingService(
-            inputActivationGuard: inputActivationGuard
+            inputActivationGuard: inputActivationGuard,
+            recoveryAudioStore: DictationRecoveryAudioStore(
+                retentionPolicy: DictationRecoveryRetentionPolicy.load(from: .standard)
+            )
         )
         hotkeyService = HotkeyService()
         textInsertionService = TextInsertionService()

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -624,7 +624,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue,
             UserDefaultsKeys.appFormattingEnabled: true,
             UserDefaultsKeys.transcriptionNumberNormalizationEnabled: true,
-            UserDefaultsKeys.targetAppCorrectionLearningEnabled: false
+            UserDefaultsKeys.targetAppCorrectionLearningEnabled: false,
+            UserDefaultsKeys.dictationRecoveryRetentionDays: DictationRecoveryRetentionPolicy.defaultPolicy.rawValue
         ])
     }
 

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -135,6 +135,7 @@ enum UserDefaultsKeys {
     static let dictationRecoveryModel = "dictationRecoveryModel"
     static let dictationRecoveryLanguage = "dictationRecoveryLanguage"
     static let dictationRecoveryAutomaticFallbackEnabled = "dictationRecoveryAutomaticFallbackEnabled"
+    static let dictationRecoveryRetentionDays = "dictationRecoveryRetentionDays"
 
     // MARK: - Watch Folder
     static let watchFolderBookmark = "watchFolderBookmark"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -4049,6 +4049,160 @@
         }
       }
     },
+    "Auto-delete recovery recordings" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellungsaufnahmen automatisch löschen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元用録音を自動削除"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动删除恢复录音"
+          }
+        }
+      }
+    },
+    "Immediately (disable recovery)" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sofort (Wiederherstellung deaktivieren)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すぐに（復元を無効化）"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "立即（停用恢复）"
+          }
+        }
+      }
+    },
+    "1 day" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 Tag"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 日"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1 天"
+          }
+        }
+      }
+    },
+    "7 days" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 Tage"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 日"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7 天"
+          }
+        }
+      }
+    },
+    "Recovery recordings are stored only on this Mac. Immediately prevents TypeWhisper from creating local recovery WAV files. History audio is controlled separately, and cloud engines may still receive audio for transcription." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellungsaufnahmen werden nur auf diesem Mac gespeichert. „Sofort“ verhindert, dass TypeWhisper lokale Wiederherstellungs-WAV-Dateien erstellt. Verlaufs-Audio wird separat gesteuert und Cloud-Engines können weiterhin Audio zur Transkription erhalten."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元用録音はこのMacにのみ保存されます。「すぐに」を選ぶと、TypeWhisperはローカルの復元用WAVファイルを作成しません。履歴の音声保存は別に管理され、クラウドエンジンは文字起こしのために音声を受信する場合があります。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复录音仅存储在这台 Mac 上。选择“立即”后，TypeWhisper 不会创建本地恢复 WAV 文件。历史记录中的音频由单独的设置控制，云端引擎仍可能接收音频以进行转录。"
+          }
+        }
+      }
+    },
+    "Recovery recording is disabled" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellungsaufnahme ist deaktiviert"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "復元用録音は無効です"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复录音已停用"
+          }
+        }
+      }
+    },
+    "Storage" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speicher"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ストレージ"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "存储"
+          }
+        }
+      }
+    },
     "Auto-detect" : {
       "extractionState" : "stale",
       "localizations" : {

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -1605,6 +1605,22 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         recoveryAudioStore.recoveryURLs
     }
 
+    @MainActor
+    @discardableResult
+    func updateRecoveryRetentionPolicy(_ policy: DictationRecoveryRetentionPolicy) -> [URL] {
+        let urls = recoveryAudioStore.updateRetentionPolicy(policy)
+        publishRecoverableRecordingURLs(urls)
+        return urls
+    }
+
+    @MainActor
+    @discardableResult
+    func refreshRecoveryRecordings() -> [URL] {
+        let urls = recoveryAudioStore.refreshRetention()
+        publishRecoverableRecordingURLs(urls)
+        return urls
+    }
+
     @discardableResult
     func preserveActiveRecoveryRecording() -> URL? {
         let url = recoveryAudioStore.preserveActiveRecording()

--- a/TypeWhisper/Services/DictationRecoveryAudioStore.swift
+++ b/TypeWhisper/Services/DictationRecoveryAudioStore.swift
@@ -1,5 +1,35 @@
 import Foundation
 
+enum DictationRecoveryRetentionPolicy: Int, CaseIterable, Sendable {
+    case immediately = -1
+    case oneDay = 1
+    case sevenDays = 7
+    case thirtyDays = 30
+    case sixtyDays = 60
+    case ninetyDays = 90
+    case oneHundredEightyDays = 180
+    case never = 0
+
+    static let defaultPolicy: Self = .thirtyDays
+
+    static func load(from defaults: UserDefaults) -> Self {
+        guard let storedValue = defaults.object(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays) as? NSNumber,
+              let policy = Self(rawValue: storedValue.intValue)
+        else {
+            return defaultPolicy
+        }
+        return policy
+    }
+
+    var keepsRecoveryFiles: Bool {
+        self != .immediately
+    }
+
+    var retentionDays: Int? {
+        rawValue > 0 ? rawValue : nil
+    }
+}
+
 /// Persists the active dictation as a temporary 16 kHz mono PCM WAV so the
 /// audio can be recovered if transcription fails after recording has stopped.
 final class DictationRecoveryAudioStore: @unchecked Sendable {
@@ -18,34 +48,58 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
     private let directory: URL
     private let activeFileURL: URL
     private let fileManager: FileManager
+    private let now: @Sendable () -> Date
     private let queue = DispatchQueue(label: "com.typewhisper.dictation-recovery-audio", qos: .utility)
 
     private var activeHandle: FileHandle?
     private var activeSampleCount = 0
     private var hasActiveRecording = false
     private var recoverySerialNumber: UInt64 = 0
+    private var retentionPolicy: DictationRecoveryRetentionPolicy
 
     init(
         directory: URL = AppConstants.appSupportDirectory
             .appendingPathComponent("dictation-recovery", isDirectory: true),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        retentionPolicy: DictationRecoveryRetentionPolicy = .defaultPolicy,
+        now: @escaping @Sendable () -> Date = Date.init
     ) {
-        try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        let standardizedDirectory = directory.resolvingSymlinksInPath().standardizedFileURL
+        let standardizedInput = directory.standardizedFileURL
+        let standardizedDirectory: URL
+        if fileManager.fileExists(atPath: standardizedInput.path) {
+            standardizedDirectory = standardizedInput.resolvingSymlinksInPath().standardizedFileURL
+        } else {
+            let resolvedParent = standardizedInput
+                .deletingLastPathComponent()
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+            standardizedDirectory = resolvedParent
+                .appendingPathComponent(standardizedInput.lastPathComponent, isDirectory: true)
+                .standardizedFileURL
+        }
         self.directory = standardizedDirectory
         self.activeFileURL = standardizedDirectory.appendingPathComponent(Constants.activeFileName)
         self.fileManager = fileManager
+        self.retentionPolicy = retentionPolicy
+        self.now = now
+
+        // An active file cannot be recovered safely because its WAV header is
+        // finalized only after recording stops. Never leave crash residue on disk.
+        removeItemIfExists(at: activeFileURL)
+        applyRetentionPolicy()
     }
 
     var recoveryURLs: [URL] {
         queue.sync {
-            storedRecoveryURLs()
+            applyRetentionPolicy()
+            return storedRecoveryURLs()
         }
     }
 
     var latestRecoveryURL: URL? {
         queue.sync {
-            storedRecoveryURLs().first
+            applyRetentionPolicy()
+            return storedRecoveryURLs().first
         }
     }
 
@@ -53,7 +107,13 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
         queue.sync {
             closeActiveHandle()
             removeItemIfExists(at: activeFileURL)
+            activeSampleCount = 0
+            hasActiveRecording = false
+            applyRetentionPolicy()
+
+            guard retentionPolicy.keepsRecoveryFiles else { return }
             try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            guard !itemExists(at: activeFileURL) else { return }
 
             fileManager.createFile(
                 atPath: activeFileURL.path,
@@ -69,10 +129,10 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
 
     func append(_ samples: [Float]) {
         guard !samples.isEmpty else { return }
-        let data = Self.pcm16Data(from: samples)
 
-        queue.async { [weak self] in
+        queue.async { [weak self, samples] in
             guard let self, self.hasActiveRecording, let activeHandle = self.activeHandle else { return }
+            let data = Self.pcm16Data(from: samples)
             do {
                 try activeHandle.write(contentsOf: data)
                 self.activeSampleCount += samples.count
@@ -88,6 +148,15 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
     @discardableResult
     func preserveActiveRecording() -> URL? {
         queue.sync {
+            guard retentionPolicy.keepsRecoveryFiles else {
+                closeActiveHandle()
+                activeSampleCount = 0
+                hasActiveRecording = false
+                removeItemIfExists(at: activeFileURL)
+                removeStoredRecoveries()
+                return nil
+            }
+
             guard hasActiveRecording else {
                 return storedRecoveryURLs().first
             }
@@ -113,6 +182,23 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
                 removeItemIfExists(at: activeFileURL)
                 return storedRecoveryURLs().first
             }
+        }
+    }
+
+    @discardableResult
+    func updateRetentionPolicy(_ policy: DictationRecoveryRetentionPolicy) -> [URL] {
+        queue.sync {
+            retentionPolicy = policy
+            applyRetentionPolicy()
+            return storedRecoveryURLs()
+        }
+    }
+
+    @discardableResult
+    func refreshRetention() -> [URL] {
+        queue.sync {
+            applyRetentionPolicy()
+            return storedRecoveryURLs()
         }
     }
 
@@ -175,9 +261,34 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
     private func isStoredRecoveryFile(_ url: URL) -> Bool {
         let canonicalURL = canonicalFileURL(url)
         guard canonicalURL.deletingLastPathComponent() == directory else { return false }
-        guard url.pathExtension.lowercased() == Constants.recoveryFileExtension else { return false }
+        guard isRegularNonSymlinkFile(url) else { return false }
         let fileName = url.lastPathComponent
-        return fileName == Constants.legacyLatestFileName || fileName.hasPrefix(Constants.recoveryFilePrefix)
+        return fileName == Constants.legacyLatestFileName || isGeneratedRecoveryFileName(fileName)
+    }
+
+    private func isGeneratedRecoveryFileName(_ fileName: String) -> Bool {
+        let suffix = ".\(Constants.recoveryFileExtension)"
+        guard fileName.hasPrefix(Constants.recoveryFilePrefix), fileName.hasSuffix(suffix) else { return false }
+
+        let stemStart = fileName.index(fileName.startIndex, offsetBy: Constants.recoveryFilePrefix.count)
+        let stemEnd = fileName.index(fileName.endIndex, offsetBy: -suffix.count)
+        let components = fileName[stemStart..<stemEnd].split(separator: "-", omittingEmptySubsequences: false)
+        guard components.count == 4 || components.count == 5 else { return false }
+        guard hasASCIIDigits(components[0], count: 8),
+              hasASCIIDigits(components[1], count: 6),
+              hasASCIIDigits(components[2], count: 3),
+              components[3].count >= 4,
+              hasASCIIDigits(components[3])
+        else {
+            return false
+        }
+
+        return components.count == 4 || hasASCIIDigits(components[4])
+    }
+
+    private func hasASCIIDigits(_ value: Substring, count: Int? = nil) -> Bool {
+        guard !value.isEmpty, count == nil || value.count == count else { return false }
+        return value.utf8.allSatisfy { (48...57).contains($0) }
     }
 
     private func contentModificationDate(for url: URL) -> Date {
@@ -188,10 +299,24 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
         url.resolvingSymlinksInPath().standardizedFileURL
     }
 
+    private func isRegularNonSymlinkFile(_ url: URL) -> Bool {
+        guard let values = try? url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]) else {
+            return false
+        }
+        return values.isRegularFile == true && values.isSymbolicLink != true
+    }
+
+    private func itemExists(at url: URL) -> Bool {
+        if fileManager.fileExists(atPath: url.path) {
+            return true
+        }
+        return (try? url.resourceValues(forKeys: [.isSymbolicLinkKey]).isSymbolicLink) == true
+    }
+
     private func makeUniqueRecoveryFileURL() -> URL {
         try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
         recoverySerialNumber += 1
-        let baseName = "\(Constants.recoveryFilePrefix)\(Self.recoveryTimestamp(from: Date()))-\(String(format: "%04llu", recoverySerialNumber))"
+        let baseName = "\(Constants.recoveryFilePrefix)\(Self.recoveryTimestamp(from: now()))-\(String(format: "%04llu", recoverySerialNumber))"
         var candidate = directory
             .appendingPathComponent(baseName)
             .appendingPathExtension(Constants.recoveryFileExtension)
@@ -209,6 +334,24 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
 
     private func removeStoredRecoveries() {
         for url in storedRecoveryURLs() {
+            removeItemIfExists(at: url)
+        }
+    }
+
+    private func applyRetentionPolicy() {
+        guard retentionPolicy.keepsRecoveryFiles else {
+            closeActiveHandle()
+            activeSampleCount = 0
+            hasActiveRecording = false
+            removeItemIfExists(at: activeFileURL)
+            removeStoredRecoveries()
+            return
+        }
+
+        guard let retentionDays = retentionPolicy.retentionDays else { return }
+        let currentDate = now()
+        let cutoff = Calendar.current.date(byAdding: .day, value: -retentionDays, to: currentDate) ?? currentDate
+        for url in storedRecoveryURLs() where contentModificationDate(for: url) < cutoff {
             removeItemIfExists(at: url)
         }
     }
@@ -232,7 +375,7 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
     }
 
     private func removeItemIfExists(at url: URL) {
-        guard fileManager.fileExists(atPath: url.path) else { return }
+        guard fileManager.fileExists(atPath: url.path), isRegularNonSymlinkFile(url) else { return }
         try? fileManager.removeItem(at: url)
     }
 

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -372,6 +372,7 @@ private struct DiagnosticsReport: Encodable {
         let translationTargetLanguage: String?
         let historyRetentionDays: Int
         let saveAudioWithHistory: Bool
+        let dictationRecoveryRetentionDays: Int
         let memoryEnabled: Bool
         let memoryCaptureScope: String
         let appFormattingEnabled: Bool
@@ -642,6 +643,7 @@ final class ErrorLogService: ObservableObject {
                 translationTargetLanguage: defaults.string(forKey: UserDefaultsKeys.translationTargetLanguage),
                 historyRetentionDays: defaults.integer(forKey: UserDefaultsKeys.historyRetentionDays),
                 saveAudioWithHistory: defaults.bool(forKey: UserDefaultsKeys.saveAudioWithHistory),
+                dictationRecoveryRetentionDays: DictationRecoveryRetentionPolicy.load(from: defaults).rawValue,
                 memoryEnabled: defaults.bool(forKey: UserDefaultsKeys.memoryEnabled),
                 memoryCaptureScope: MemoryCaptureScope.load(from: defaults).rawValue,
                 appFormattingEnabled: defaults.bool(forKey: UserDefaultsKeys.appFormattingEnabled),

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -623,7 +623,8 @@ enum SettingsBackupExporter {
         pluginRegistryService: PluginRegistryService,
         historyService: HistoryService,
         usageStatisticsService: UsageStatisticsService,
-        userDefaults: UserDefaults = .standard
+        userDefaults: UserDefaults = .standard,
+        recoveryRetentionPolicyDidChange: ((DictationRecoveryRetentionPolicy) -> Void)? = nil
     ) async -> ImportResult {
         var result = ImportResult()
 
@@ -849,6 +850,9 @@ enum SettingsBackupExporter {
         apply(preferences.dictationRecoveryLanguage, forKey: UserDefaultsKeys.dictationRecoveryLanguage)
         apply(preferences.dictationRecoveryAutomaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
         apply(preferences.dictationRecoveryRetentionDays, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
+        if preferences.dictationRecoveryRetentionDays != nil {
+            recoveryRetentionPolicyDidChange?(DictationRecoveryRetentionPolicy.load(from: userDefaults))
+        }
         apply(preferences.fileTranscriptionLanguage, forKey: UserDefaultsKeys.fileTranscriptionLanguage)
         apply(preferences.recorderMicEnabled, forKey: UserDefaultsKeys.recorderMicEnabled)
         apply(preferences.recorderSystemAudioEnabled, forKey: UserDefaultsKeys.recorderSystemAudioEnabled)

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -182,6 +182,7 @@ enum SettingsBackupExporter {
         // Dictation Recovery
         var dictationRecoveryLanguage: String? = nil
         var dictationRecoveryAutomaticFallbackEnabled: Bool? = nil
+        var dictationRecoveryRetentionDays: Int? = nil
         // File Transcription
         var fileTranscriptionLanguage: String? = nil
         // Recorder
@@ -227,6 +228,7 @@ enum SettingsBackupExporter {
             if requireSecondEscapeToCancelRecording != nil { count += 1 }
             if dictationRecoveryLanguage != nil { count += 1 }
             if dictationRecoveryAutomaticFallbackEnabled != nil { count += 1 }
+            if dictationRecoveryRetentionDays != nil { count += 1 }
             if fileTranscriptionLanguage != nil { count += 1 }
             if recorderMicEnabled != nil { count += 1 }
             if recorderSystemAudioEnabled != nil { count += 1 }
@@ -571,6 +573,9 @@ enum SettingsBackupExporter {
                 requireSecondEscapeToCancelRecording: userDefaults.object(forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording) as? Bool,
                 dictationRecoveryLanguage: userDefaults.string(forKey: UserDefaultsKeys.dictationRecoveryLanguage),
                 dictationRecoveryAutomaticFallbackEnabled: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled) as? Bool,
+                dictationRecoveryRetentionDays: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays) == nil
+                    ? nil
+                    : DictationRecoveryRetentionPolicy.load(from: userDefaults).rawValue,
                 fileTranscriptionLanguage: userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionLanguage),
                 recorderMicEnabled: userDefaults.object(forKey: UserDefaultsKeys.recorderMicEnabled) as? Bool,
                 recorderSystemAudioEnabled: userDefaults.object(forKey: UserDefaultsKeys.recorderSystemAudioEnabled) as? Bool,
@@ -843,6 +848,7 @@ enum SettingsBackupExporter {
         apply(preferences.requireSecondEscapeToCancelRecording, forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording)
         apply(preferences.dictationRecoveryLanguage, forKey: UserDefaultsKeys.dictationRecoveryLanguage)
         apply(preferences.dictationRecoveryAutomaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
+        apply(preferences.dictationRecoveryRetentionDays, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
         apply(preferences.fileTranscriptionLanguage, forKey: UserDefaultsKeys.fileTranscriptionLanguage)
         apply(preferences.recorderMicEnabled, forKey: UserDefaultsKeys.recorderMicEnabled)
         apply(preferences.recorderSystemAudioEnabled, forKey: UserDefaultsKeys.recorderSystemAudioEnabled)

--- a/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
@@ -76,6 +76,13 @@ final class DictationRecoveryViewModel: ObservableObject {
             defaults.set(automaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
         }
     }
+    @Published var retentionPolicy: DictationRecoveryRetentionPolicy {
+        didSet {
+            defaults.set(retentionPolicy.rawValue, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
+            guard isInitialized, oldValue != retentionPolicy else { return }
+            updateRecoveryURLs(audioRecordingService.updateRecoveryRetentionPolicy(retentionPolicy))
+        }
+    }
 
     private let audioRecordingService: AudioRecordingService
     private let modelManager: ModelManagerService
@@ -120,7 +127,8 @@ final class DictationRecoveryViewModel: ObservableObject {
             )
         }
         self.engineReadinessChecker = engineReadinessChecker
-        let initialRecoveryURLs = audioRecordingService.recoveryRecordingURLs
+        let retentionPolicy = DictationRecoveryRetentionPolicy.load(from: defaults)
+        let initialRecoveryURLs = audioRecordingService.updateRecoveryRetentionPolicy(retentionPolicy)
         self.recoveries = initialRecoveryURLs.map { RecoveryItem(url: $0) }
         self.selectedRecoveryID = initialRecoveryURLs.first?.path
         self.languageSelection = LanguageSelection(
@@ -130,6 +138,7 @@ final class DictationRecoveryViewModel: ObservableObject {
         self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryEngine)
         self.selectedModel = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryModel)
         self.automaticFallbackEnabled = defaults.bool(forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
+        self.retentionPolicy = retentionPolicy
         self.isInitialized = true
 
         audioRecordingService.$recoverableRecordingURLs
@@ -155,6 +164,10 @@ final class DictationRecoveryViewModel: ObservableObject {
 
     var hasRecoveryContent: Bool {
         hasRecovery || lastSavedHistoryRecordID != nil
+    }
+
+    var isRecoveryStorageDisabled: Bool {
+        retentionPolicy == .immediately
     }
 
     var selectedRecovery: RecoveryItem? {
@@ -302,6 +315,7 @@ final class DictationRecoveryViewModel: ObservableObject {
                 )
 
                 let historyID = UUID()
+                let historyAudioSamples = defaults.bool(forKey: UserDefaultsKeys.saveAudioWithHistory) ? samples : nil
                 historyService.addRecord(
                     id: historyID,
                     rawText: result.text,
@@ -312,7 +326,7 @@ final class DictationRecoveryViewModel: ObservableObject {
                     language: result.detectedLanguage ?? languageSelection.requestedLanguage,
                     engineUsed: result.engineUsed,
                     modelUsed: historyModelDisplayName(result: result),
-                    audioSamples: samples,
+                    audioSamples: historyAudioSamples,
                     pipelineSteps: [localizedAppText("Recovered recording", de: "Wiederhergestellte Aufnahme")]
                 )
                 lastSavedRecoveryFileName = url.lastPathComponent
@@ -340,6 +354,10 @@ final class DictationRecoveryViewModel: ObservableObject {
     func discardRecovery(_ recovery: RecoveryItem) {
         audioRecordingService.discardRecoveryRecording(at: recovery.url)
         updateRecoveryURLs(audioRecordingService.recoveryRecordingURLs)
+    }
+
+    func refreshRecoveries() {
+        updateRecoveryURLs(audioRecordingService.refreshRecoveryRecordings())
     }
 
     private func updateRecoveryURLs(_ urls: [URL]) {

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -657,7 +657,10 @@ struct AdvancedSettingsView: View {
             pluginManager: container.pluginManager,
             pluginRegistryService: container.pluginRegistryService,
             historyService: container.historyService,
-            usageStatisticsService: container.usageStatisticsService
+            usageStatisticsService: container.usageStatisticsService,
+            recoveryRetentionPolicyDidChange: { policy in
+                _ = container.audioRecordingService.updateRecoveryRetentionPolicy(policy)
+            }
         )
 
         backupImportResultMessage = backupImportSummary(result)

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -15,10 +15,29 @@ struct DictationRecoveryView: View {
                 .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
         .frame(minWidth: 500, minHeight: 400)
+        .onAppear {
+            viewModel.refreshRecoveries()
+        }
     }
 
     private var recoveryForm: some View {
         Form {
+            Section(String(localized: "Storage")) {
+                Picker(
+                    String(localized: "Auto-delete recovery recordings"),
+                    selection: $viewModel.retentionPolicy
+                ) {
+                    ForEach(DictationRecoveryRetentionPolicy.allCases, id: \.self) { policy in
+                        Text(retentionLabel(for: policy)).tag(policy)
+                    }
+                }
+                .disabled(viewModel.isProcessing)
+
+                Text(String(localized: "Recovery recordings are stored only on this Mac. Immediately prevents TypeWhisper from creating local recovery WAV files. History audio is controlled separately, and cloud engines may still receive audio for transcription."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             if let lastSavedRecoveryFileName = viewModel.lastSavedRecoveryFileName {
                 Section(String(localized: "History")) {
                     HStack(spacing: 10) {
@@ -63,6 +82,14 @@ struct DictationRecoveryView: View {
                     if let recovery = viewModel.selectedRecovery {
                         recoveryRow(recovery)
                     }
+                }
+            } else if viewModel.isRecoveryStorageDisabled {
+                Section {
+                    Label(
+                        String(localized: "Recovery recording is disabled"),
+                        systemImage: "lock"
+                    )
+                    .foregroundStyle(.secondary)
                 }
             } else if !viewModel.hasRecoveryContent {
                 Section {
@@ -197,6 +224,27 @@ struct DictationRecoveryView: View {
         return localizedAppLanguageOptions(for: supportedLanguages)
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
             .map { (code: $0.code, name: $0.name) }
+    }
+
+    private func retentionLabel(for policy: DictationRecoveryRetentionPolicy) -> String {
+        switch policy {
+        case .immediately:
+            String(localized: "Immediately (disable recovery)")
+        case .oneDay:
+            String(localized: "1 day")
+        case .sevenDays:
+            String(localized: "7 days")
+        case .thirtyDays:
+            String(localized: "30 days")
+        case .sixtyDays:
+            String(localized: "60 days")
+        case .ninetyDays:
+            String(localized: "90 days")
+        case .oneHundredEightyDays:
+            String(localized: "180 days")
+        case .never:
+            String(localized: "Never")
+        }
     }
 
     private func statusSystemImage(for state: DictationRecoveryViewModel.RecoveryState) -> String {

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -194,5 +194,9 @@ final class AppFormatterServiceTests: XCTestCase {
 
         XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.appFormattingEnabled) as? Bool, true)
         XCTAssertEqual(defaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) as? Bool, true)
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays) as? Int,
+            DictationRecoveryRetentionPolicy.thirtyDays.rawValue
+        )
     }
 }

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -535,6 +535,26 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(service.latestRecoveryRecordingURL, url)
     }
 
+    func testImmediateRetentionKeepsInMemoryAudioWithoutCreatingRecoveryFile() async throws {
+        let directory = makeRecoveryTestDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory, retentionPolicy: .immediately)
+        let service = AudioRecordingService(recoveryAudioStore: store)
+        service.hasMicrophonePermissionOverride = true
+        service.startRecordingOverride = {}
+        service.stopRecordingOverride = { _ in service.getCurrentBuffer() }
+        let samples: [Float] = [0.25, -0.25, 0.5]
+
+        try service.startRecording()
+        service.testingProcessConvertedSamples(samples)
+
+        XCTAssertEqual(service.getCurrentBuffer(), samples)
+        let stoppedSamples = await service.stopRecording(policy: .immediate)
+        XCTAssertEqual(stoppedSamples, samples)
+        XCTAssertNil(service.preserveActiveRecoveryRecording())
+        XCTAssertNil(service.latestRecoveryRecordingURL)
+        XCTAssertTrue(try recoveryFileNames(in: directory).isEmpty)
+    }
+
     func testRecoveryCircuitBreakerPreservesBufferedRecoveryAudio() throws {
         let directory = makeRecoveryTestDirectory()
         let store = DictationRecoveryAudioStore(directory: directory)

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -112,7 +112,7 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         let directory = makeTemporaryDirectory()
         let outsideDirectory = makeTemporaryDirectory()
         let outsideURL = outsideDirectory
-            .appendingPathComponent("dictation-recovery-outside")
+            .appendingPathComponent("dictation-recovery-20330518-033320-000-0001")
             .appendingPathExtension("wav")
         FileManager.default.createFile(atPath: outsideURL.path, contents: Data([1, 2, 3]))
 
@@ -121,6 +121,204 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         store.discardRecovery(at: outsideURL)
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: outsideURL.path))
+    }
+
+    func testRetentionPolicyDefaultsToThirtyDaysForMissingOrUnknownValues() throws {
+        let suiteName = "DictationRecoveryRetentionPolicyTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        XCTAssertEqual(DictationRecoveryRetentionPolicy.load(from: defaults), .thirtyDays)
+
+        defaults.set(999, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
+        XCTAssertEqual(DictationRecoveryRetentionPolicy.load(from: defaults), .thirtyDays)
+
+        for policy in DictationRecoveryRetentionPolicy.allCases {
+            defaults.set(policy.rawValue, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
+            XCTAssertEqual(DictationRecoveryRetentionPolicy.load(from: defaults), policy)
+        }
+    }
+
+    func testAllFiniteRetentionPoliciesRemoveOnlyExpiredRecoveries() throws {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let policies: [DictationRecoveryRetentionPolicy] = [
+            .oneDay,
+            .sevenDays,
+            .thirtyDays,
+            .sixtyDays,
+            .ninetyDays,
+            .oneHundredEightyDays,
+        ]
+
+        for policy in policies {
+            let retentionDays = try XCTUnwrap(policy.retentionDays)
+            let directory = makeTemporaryDirectory()
+            let expiredURL = try makeRecoveryFile(
+                in: directory,
+                named: "dictation-recovery-20330518-033320-000-0001.wav",
+                modifiedAt: Calendar.current.date(byAdding: .day, value: -(retentionDays + 1), to: now)!
+            )
+            let retainedURL = try makeRecoveryFile(
+                in: directory,
+                named: "dictation-recovery-20330518-033320-000-0002.wav",
+                modifiedAt: Calendar.current.date(byAdding: .day, value: -(retentionDays - 1), to: now)!
+            )
+            let boundaryURL = try makeRecoveryFile(
+                in: directory,
+                named: "dictation-recovery-20330518-033320-000-0003.wav",
+                modifiedAt: Calendar.current.date(byAdding: .day, value: -retentionDays, to: now)!
+            )
+
+            let store = DictationRecoveryAudioStore(
+                directory: directory,
+                retentionPolicy: policy,
+                now: { now }
+            )
+
+            XCTAssertFalse(FileManager.default.fileExists(atPath: expiredURL.path), "\(policy)")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: retainedURL.path), "\(policy)")
+            XCTAssertTrue(FileManager.default.fileExists(atPath: boundaryURL.path), "\(policy)")
+            XCTAssertEqual(store.recoveryURLs, [retainedURL, boundaryURL], "\(policy)")
+        }
+    }
+
+    func testThirtyDayRetentionRemovesExpiredLegacyFileAndPreservesUnrelatedFile() throws {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let directory = makeTemporaryDirectory()
+        let oldDate = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -31, to: now))
+        let recentDate = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -29, to: now))
+        let expiredRecoveryURL = try makeRecoveryFile(
+            in: directory,
+            named: "dictation-recovery-20330518-033320-000-0001.wav",
+            modifiedAt: oldDate
+        )
+        let legacyRecoveryURL = try makeRecoveryFile(
+            in: directory,
+            named: "last-dictation-recovery.wav",
+            modifiedAt: oldDate
+        )
+        let recentRecoveryURL = try makeRecoveryFile(
+            in: directory,
+            named: "dictation-recovery-20330518-033320-000-0002.wav",
+            modifiedAt: recentDate
+        )
+        let similarlyNamedURL = try makeRecoveryFile(
+            in: directory,
+            named: "dictation-recovery-not-a-canonical-name.wav",
+            modifiedAt: oldDate
+        )
+        let unrelatedURL = try makeRecoveryFile(
+            in: directory,
+            named: "unrelated.wav",
+            modifiedAt: oldDate
+        )
+
+        let store = DictationRecoveryAudioStore(
+            directory: directory,
+            retentionPolicy: .thirtyDays,
+            now: { now }
+        )
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: expiredRecoveryURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyRecoveryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: recentRecoveryURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: similarlyNamedURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelatedURL.path))
+        XCTAssertEqual(store.recoveryURLs, [recentRecoveryURL])
+    }
+
+    func testNeverRetentionPreservesOldRecovery() throws {
+        let now = Date(timeIntervalSince1970: 2_000_000_000)
+        let directory = makeTemporaryDirectory()
+        let oldDate = try XCTUnwrap(Calendar.current.date(byAdding: .day, value: -365, to: now))
+        let oldRecoveryURL = try makeRecoveryFile(
+            in: directory,
+            named: "dictation-recovery-20330518-033320-000-0001.wav",
+            modifiedAt: oldDate
+        )
+
+        let store = DictationRecoveryAudioStore(
+            directory: directory,
+            retentionPolicy: .never,
+            now: { now }
+        )
+
+        XCTAssertEqual(store.recoveryURLs, [oldRecoveryURL])
+        XCTAssertTrue(FileManager.default.fileExists(atPath: oldRecoveryURL.path))
+    }
+
+    func testImmediatelyDeletesStoredAndActiveRecoveriesAndPreventsNewFiles() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory, retentionPolicy: .never)
+        store.startNewRecording()
+        store.append([0.1])
+        _ = try XCTUnwrap(store.preserveActiveRecording())
+        store.startNewRecording()
+        store.append([0.2])
+
+        XCTAssertTrue(try fileNames(in: directory).contains { $0.hasSuffix(".wav") })
+
+        XCTAssertTrue(store.updateRetentionPolicy(.immediately).isEmpty)
+        XCTAssertTrue(try fileNames(in: directory).isEmpty)
+
+        store.startNewRecording()
+        store.append([0.3])
+
+        XCTAssertNil(store.preserveActiveRecording())
+        XCTAssertTrue(store.recoveryURLs.isEmpty)
+        XCTAssertTrue(try fileNames(in: directory).isEmpty)
+    }
+
+    func testInitializationRemovesStaleActiveFileWithoutDeletingUnrelatedFiles() throws {
+        let directory = makeTemporaryDirectory()
+        let activeURL = try makeRecoveryFile(
+            in: directory,
+            named: "active-dictation-recovery.wav",
+            modifiedAt: Date()
+        )
+        let unrelatedURL = try makeRecoveryFile(
+            in: directory,
+            named: "notes.txt",
+            modifiedAt: Date()
+        )
+
+        _ = DictationRecoveryAudioStore(directory: directory, retentionPolicy: .never)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: activeURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unrelatedURL.path))
+    }
+
+    func testRetentionProtectsForeignDirectoriesAndSymlinksWithRecoveryNames() throws {
+        let directory = makeTemporaryDirectory()
+        let outsideDirectory = makeTemporaryDirectory()
+        let outsideURL = outsideDirectory.appendingPathComponent("voice.wav")
+        try Data([9, 8, 7]).write(to: outsideURL)
+
+        let canonicalNamedDirectory = directory.appendingPathComponent(
+            "dictation-recovery-20330518-033320-000-0001.wav",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: canonicalNamedDirectory, withIntermediateDirectories: false)
+        let nestedURL = canonicalNamedDirectory.appendingPathComponent("keep.txt")
+        try Data([1]).write(to: nestedURL)
+
+        let canonicalNamedSymlink = directory.appendingPathComponent(
+            "dictation-recovery-20330518-033320-000-0002.wav"
+        )
+        try FileManager.default.createSymbolicLink(at: canonicalNamedSymlink, withDestinationURL: outsideURL)
+        let activeSymlink = directory.appendingPathComponent("active-dictation-recovery.wav")
+        try FileManager.default.createSymbolicLink(at: activeSymlink, withDestinationURL: outsideURL)
+
+        let store = DictationRecoveryAudioStore(directory: directory, retentionPolicy: .immediately)
+        store.startNewRecording()
+        store.append([0.5])
+
+        XCTAssertNil(store.preserveActiveRecording())
+        XCTAssertTrue(FileManager.default.fileExists(atPath: nestedURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: canonicalNamedSymlink.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: activeSymlink.path))
+        XCTAssertEqual(try Data(contentsOf: outsideURL), Data([9, 8, 7]))
     }
 
     @MainActor
@@ -175,6 +373,13 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
     private func fileNames(in directory: URL) throws -> [String] {
         guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
         return try FileManager.default.contentsOfDirectory(atPath: directory.path)
+    }
+
+    private func makeRecoveryFile(in directory: URL, named name: String, modifiedAt date: Date) throws -> URL {
+        let url = directory.appendingPathComponent(name)
+        try Data([1, 2, 3]).write(to: url)
+        try FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+        return url
     }
 
     private func readUInt32(_ data: Data, at offset: Int) -> UInt32 {

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -404,10 +404,13 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         // while leaving a developer's real preferences untouched.
         let livePreviewEngineKey = UserDefaultsKeys.livePreviewEngineId
         let previewEnabledKey = UserDefaultsKeys.indicatorTranscriptPreviewEnabled
+        let recoveryRetentionKey = UserDefaultsKeys.dictationRecoveryRetentionDays
         let originalLivePreviewEngine = UserDefaults.standard.object(forKey: livePreviewEngineKey)
         let originalPreviewEnabled = UserDefaults.standard.object(forKey: previewEnabledKey)
+        let originalRecoveryRetention = UserDefaults.standard.object(forKey: recoveryRetentionKey)
         UserDefaults.standard.removeObject(forKey: livePreviewEngineKey)
         UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+        UserDefaults.standard.removeObject(forKey: recoveryRetentionKey)
         defer {
             if let originalLivePreviewEngine {
                 UserDefaults.standard.set(originalLivePreviewEngine, forKey: livePreviewEngineKey)
@@ -418,6 +421,11 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
                 UserDefaults.standard.set(originalPreviewEnabled, forKey: previewEnabledKey)
             } else {
                 UserDefaults.standard.removeObject(forKey: previewEnabledKey)
+            }
+            if let originalRecoveryRetention {
+                UserDefaults.standard.set(originalRecoveryRetention, forKey: recoveryRetentionKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: recoveryRetentionKey)
             }
         }
         let textInsertionService = TextInsertionService()

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -606,6 +606,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
 
     func testRecoveryTranscribeUsesRecoveryEngineAndModelOverrides() async throws {
         let defaults = try makeDefaults()
+        defaults.set(true, forKey: UserDefaultsKeys.saveAudioWithHistory)
         let directory = makeTemporaryDirectory()
         let historyService = HistoryService(appSupportDirectory: makeTemporaryDirectory())
         let store = DictationRecoveryAudioStore(directory: directory)
@@ -674,6 +675,80 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.recoveries.map(\.url), [olderRecoveryURL])
         XCTAssertEqual(audioRecordingService.latestRecoveryRecordingURL, olderRecoveryURL)
         XCTAssertFalse(FileManager.default.fileExists(atPath: selectedRecoveryURL.path))
+    }
+
+    func testRecoveryTranscribeOmitsHistoryAudioWhenDisabled() async throws {
+        let defaults = try makeDefaults()
+        defaults.set(false, forKey: UserDefaultsKeys.saveAudioWithHistory)
+        let directory = makeTemporaryDirectory()
+        let historyService = HistoryService(appSupportDirectory: makeTemporaryDirectory())
+        let store = DictationRecoveryAudioStore(directory: directory)
+        store.startNewRecording()
+        store.append([0.2, -0.2])
+        let recoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        let audioRecordingService = AudioRecordingService(recoveryAudioStore: store)
+        let viewModel = DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: ModelManagerService(),
+            historyService: historyService,
+            audioFileService: AudioFileService(),
+            defaults: defaults,
+            audioSamplesLoader: { _ in [0.2, -0.2] },
+            transcriptionRunner: { _, _, _, _, _ in
+                TranscriptionResult(
+                    text: "Recovered without audio",
+                    detectedLanguage: "en",
+                    duration: 1,
+                    processingTime: 0.1,
+                    engineUsed: "test",
+                    segments: []
+                )
+            },
+            engineReadinessChecker: { _ in true }
+        )
+
+        viewModel.transcribe()
+        try await waitForRecoveryToSave(viewModel, historyService: historyService)
+
+        let historyRecord = try XCTUnwrap(historyService.records.first)
+        XCTAssertNil(historyService.audioFileURL(for: historyRecord))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recoveryURL.path))
+        XCTAssertTrue(viewModel.recoveries.isEmpty)
+    }
+
+    func testRecoveryRetentionPolicyDefaultsToThirtyDaysAndImmediatelyClearsStorage() throws {
+        let defaults = try makeDefaults()
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory, retentionPolicy: .never)
+        store.startNewRecording()
+        store.append([0.1])
+        let recoveryURL = try XCTUnwrap(store.preserveActiveRecording())
+        let audioRecordingService = AudioRecordingService(recoveryAudioStore: store)
+        let viewModel = DictationRecoveryViewModel(
+            audioRecordingService: audioRecordingService,
+            modelManager: ModelManagerService(),
+            historyService: HistoryService(appSupportDirectory: makeTemporaryDirectory()),
+            audioFileService: AudioFileService(),
+            defaults: defaults
+        )
+
+        XCTAssertEqual(viewModel.retentionPolicy, .thirtyDays)
+        XCTAssertEqual(viewModel.recoveries.map(\.url), [recoveryURL])
+
+        viewModel.retentionPolicy = .immediately
+
+        XCTAssertEqual(
+            defaults.integer(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays),
+            DictationRecoveryRetentionPolicy.immediately.rawValue
+        )
+        XCTAssertTrue(viewModel.isRecoveryStorageDisabled)
+        XCTAssertTrue(viewModel.recoveries.isEmpty)
+        XCTAssertTrue(audioRecordingService.recoveryRecordingURLs.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: recoveryURL.path))
+
+        store.startNewRecording()
+        store.append([0.2])
+        XCTAssertNil(store.preserveActiveRecording())
     }
 
     func testRecoveryDiscardDeletesOnlySelectedRecoveryFile() throws {

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -479,6 +479,7 @@ final class SettingsBackupExporterTests: XCTestCase {
 
         let destination = try makeFixture()
         defer { teardown(destination) }
+        var appliedRecoveryRetentionPolicy: DictationRecoveryRetentionPolicy?
 
         let result = await SettingsBackupExporter.importBackup(
             backup,
@@ -491,7 +492,8 @@ final class SettingsBackupExporterTests: XCTestCase {
             pluginRegistryService: destination.pluginRegistryService,
             historyService: destination.historyService,
             usageStatisticsService: destination.usageStatisticsService,
-            userDefaults: destination.userDefaults
+            userDefaults: destination.userDefaults,
+            recoveryRetentionPolicyDidChange: { appliedRecoveryRetentionPolicy = $0 }
         )
 
         XCTAssertTrue(result.updateChannelApplied)
@@ -506,7 +508,35 @@ final class SettingsBackupExporterTests: XCTestCase {
             false
         )
         XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays), 7)
+        XCTAssertEqual(appliedRecoveryRetentionPolicy, .sevenDays)
         XCTAssertNil(destination.userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine))
+    }
+
+    func testBuildBackupExportsEffectiveRegisteredRecoveryRetentionPolicy() throws {
+        let source = try makeFixture()
+        defer { teardown(source) }
+
+        source.userDefaults.register(defaults: [
+            UserDefaultsKeys.dictationRecoveryRetentionDays: DictationRecoveryRetentionPolicy.thirtyDays.rawValue,
+        ])
+        XCTAssertNil(
+            source.userDefaults.persistentDomain(forName: source.suiteName)?[
+                UserDefaultsKeys.dictationRecoveryRetentionDays
+            ]
+        )
+
+        let backup = SettingsBackupExporter.buildBackup(
+            workflowService: source.workflowService,
+            dictionaryService: source.dictionaryService,
+            snippetService: source.snippetService,
+            profileService: source.profileService,
+            promptActionService: source.promptActionService,
+            pluginManager: source.pluginManager,
+            historyService: source.historyService,
+            userDefaults: source.userDefaults
+        )
+
+        XCTAssertEqual(backup.preferences.dictationRecoveryRetentionDays, 30)
     }
 
     func testCategoryCountsReflectBackupContents() throws {

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -451,6 +451,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.userDefaults.set("overlay", forKey: UserDefaultsKeys.indicatorStyle)
         source.userDefaults.set(false, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
         source.userDefaults.set(true, forKey: UserDefaultsKeys.recorderSystemAudioEnabled)
+        source.userDefaults.set(7, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
         // Deliberately excluded: engine/model selections must not be exported.
         source.userDefaults.set("com.typewhisper.some-engine", forKey: UserDefaultsKeys.fileTranscriptionEngine)
 
@@ -474,6 +475,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         XCTAssertEqual(backup.preferences.indicatorStyle, "overlay")
         XCTAssertEqual(backup.preferences.indicatorVisibleInScreenCaptures, false)
         XCTAssertEqual(backup.preferences.recorderSystemAudioEnabled, true)
+        XCTAssertEqual(backup.preferences.dictationRecoveryRetentionDays, 7)
 
         let destination = try makeFixture()
         defer { teardown(destination) }
@@ -503,6 +505,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             destination.userDefaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
             false
         )
+        XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays), 7)
         XCTAssertNil(destination.userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine))
     }
 


### PR DESCRIPTION
## Context

Follow-up to the privacy and automatic-deletion question in [PR #534](https://github.com/TypeWhisper/typewhisper-mac/pull/534#issuecomment-5184027367).

Recovery WAVs previously remained on disk after failed dictations until they were recovered or discarded, with no configurable retention period or opt-out.

## Summary

- adds a Recovery storage policy with Immediately, 1, 7, 30, 60, 90, or 180 days, and Never
- defaults new and existing installations without a stored value to 30 days
- makes Immediately delete existing recovery WAVs and prevents future recovery WAV writes while preserving the in-memory transcription and fallback pipeline
- cleans up only canonical recovery files, including legacy files, and protects unrelated files and symlinks
- applies cleanup at startup, after policy changes, when Recovery is refreshed, and before a new recording
- respects “Save audio with transcriptions” after successful recovery
- includes the optional policy in settings backups, applies imported policies immediately, and reports the effective value in support diagnostics
- adds complete English, German, Japanese, and Simplified Chinese UI localization

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] `PATH="/opt/homebrew/bin:$PATH" bash scripts/pr-preflight.sh origin/main`
- [x] Full macOS test suite (1,359 tests, 0 failures):

```bash
set -o pipefail
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO | tee recovery-retention-test.log
```

- [x] `bash scripts/check_first_party_warnings.sh recovery-retention-test.log`
- [x] `python3 scripts/check_localization_completeness.py`
- [x] Signed development build and launch:

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.codex/worktrees/recovery-audio-retention/typewhisper-mac
```

- [ ] Manual UI click-through was not run because the local UI automation session was unavailable; policy persistence, cleanup, disabled recovery behavior, and History audio behavior are covered by automated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retention periods for dictation recovery recordings, including immediate deletion.
  * Added controls to refresh recovery recordings and manage automatic cleanup.
  * Added clear messaging when recovery storage is disabled.
  * Included retention settings in diagnostics and settings backups.
  * Added German, Japanese, and Simplified Chinese translations for recovery settings.

* **Bug Fixes**
  * Improved cleanup of expired, stale, legacy, and invalid recovery files.
  * Prevented recovery recordings from being saved when storage is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->