### PR TITLE
Fix WhisperKit auto-reload after model unload

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -83,6 +83,7 @@ final class ModelManagerService: ObservableObject {
     struct LiveTranscriptionSessionHandle: Sendable {
         let providerId: String
         let session: any LiveTranscriptionSession
+        fileprivate let autoUnloadProtectedPlugin: any TranscriptionEnginePlugin
         fileprivate let cloudModelOverridePlugin: (any TranscriptionEnginePlugin)?
         fileprivate let cloudModelOverrideRestoreId: String?
     }
@@ -428,6 +429,14 @@ final class ModelManagerService: ObservableObject {
             )
         }
 
+        beginAutoUnloadProtectedUse(of: plugin)
+        var transfersAutoUnloadProtection = false
+        defer {
+            if !transfersAutoUnloadProtection {
+                endAutoUnloadProtectedUse(of: plugin)
+            }
+        }
+
         let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
         let preparationLanguage = preparationRequestedLanguage(
             for: languageSelection,
@@ -492,12 +501,15 @@ final class ModelManagerService: ObservableObject {
             throw error
         }
 
-        return LiveTranscriptionSessionHandle(
+        let handle = LiveTranscriptionSessionHandle(
             providerId: providerId,
             session: session,
+            autoUnloadProtectedPlugin: plugin,
             cloudModelOverridePlugin: overrideRestoreId == nil ? nil : plugin,
             cloudModelOverrideRestoreId: overrideRestoreId
         )
+        transfersAutoUnloadProtection = true
+        return handle
     }
 
     func finishLiveTranscriptionSession(
@@ -509,12 +521,13 @@ final class ModelManagerService: ObservableObject {
         normalizeNumbers: Bool? = nil
     ) async throws -> TranscriptionResult {
         let startTime = CFAbsoluteTimeGetCurrent()
-        defer { restoreCloudModelOverride(for: handle) }
+        defer {
+            restoreCloudModelOverride(for: handle)
+            endAutoUnloadProtectedUse(of: handle.autoUnloadProtectedPlugin)
+        }
 
         let result = try await handle.session.finish()
         let processingTime = CFAbsoluteTimeGetCurrent() - startTime
-
-        scheduleAutoUnloadIfNeeded()
 
         return TranscriptionNormalizationService.normalizeResult(
             text: result.text,
@@ -531,8 +544,11 @@ final class ModelManagerService: ObservableObject {
     }
 
     func cancelLiveTranscriptionSession(_ handle: LiveTranscriptionSessionHandle) async {
+        defer {
+            restoreCloudModelOverride(for: handle)
+            endAutoUnloadProtectedUse(of: handle.autoUnloadProtectedPlugin)
+        }
         await handle.session.cancel()
-        restoreCloudModelOverride(for: handle)
     }
 
     func transcribe(
@@ -580,18 +596,24 @@ final class ModelManagerService: ObservableObject {
             )
         }
 
+        beginAutoUnloadProtectedUse(of: plugin)
+        var overrideRestoreId: String?
+        defer {
+            restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId)
+            endAutoUnloadProtectedUse(of: plugin)
+        }
+
         let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
         let preparationLanguage = preparationRequestedLanguage(
             for: languageSelection,
             runtimeSelection: runtimeSelection,
             plugin: plugin
         )
-        let overrideRestoreId = try await prepareEngineForTranscription(
+        overrideRestoreId = try await prepareEngineForTranscription(
             plugin,
             requestedLanguage: preparationLanguage,
             cloudModelOverride: cloudModelOverride
         )
-        defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         guard plugin.isConfigured else {
             throw modelNotLoadedError(for: plugin)
@@ -614,8 +636,6 @@ final class ModelManagerService: ObservableObject {
         )
 
         let processingTime = CFAbsoluteTimeGetCurrent() - startTime
-
-        scheduleAutoUnloadIfNeeded()
 
         return TranscriptionNormalizationService.normalizeResult(
             text: result.text,
@@ -732,18 +752,24 @@ final class ModelManagerService: ObservableObject {
             )
         }
 
+        beginAutoUnloadProtectedUse(of: plugin)
+        var overrideRestoreId: String?
+        defer {
+            restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId)
+            endAutoUnloadProtectedUse(of: plugin)
+        }
+
         let runtimeSelection = runtimeLanguageSelection(for: languageSelection, plugin: plugin)
         let preparationLanguage = preparationRequestedLanguage(
             for: languageSelection,
             runtimeSelection: runtimeSelection,
             plugin: plugin
         )
-        let overrideRestoreId = try await prepareEngineForTranscription(
+        overrideRestoreId = try await prepareEngineForTranscription(
             plugin,
             requestedLanguage: preparationLanguage,
             cloudModelOverride: cloudModelOverride
         )
-        defer { restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId) }
 
         guard plugin.isConfigured else {
             throw modelNotLoadedError(for: plugin)
@@ -768,8 +794,6 @@ final class ModelManagerService: ObservableObject {
         )
 
         let processingTime = CFAbsoluteTimeGetCurrent() - startTime
-
-        scheduleAutoUnloadIfNeeded()
 
         return TranscriptionNormalizationService.normalizeResult(
             text: result.text,

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -78,12 +78,30 @@ struct ModelAutoUnloadDiagnosticsSnapshot: Encodable, Equatable, Sendable {
     let entries: [Entry]
 }
 
+private final class AutoUnloadProtectionLease: @unchecked Sendable {
+    private let lock = NSLock()
+    private let plugin: any TranscriptionEnginePlugin
+    private var isReleased = false
+
+    init(plugin: any TranscriptionEnginePlugin) {
+        self.plugin = plugin
+    }
+
+    func takePluginForRelease() -> (any TranscriptionEnginePlugin)? {
+        lock.withLock {
+            guard !isReleased else { return nil }
+            isReleased = true
+            return plugin
+        }
+    }
+}
+
 @MainActor
 final class ModelManagerService: ObservableObject {
     struct LiveTranscriptionSessionHandle: Sendable {
         let providerId: String
         let session: any LiveTranscriptionSession
-        fileprivate let autoUnloadProtectedPlugin: any TranscriptionEnginePlugin
+        fileprivate let autoUnloadProtectionLease: AutoUnloadProtectionLease
         fileprivate let cloudModelOverridePlugin: (any TranscriptionEnginePlugin)?
         fileprivate let cloudModelOverrideRestoreId: String?
     }
@@ -504,7 +522,7 @@ final class ModelManagerService: ObservableObject {
         let handle = LiveTranscriptionSessionHandle(
             providerId: providerId,
             session: session,
-            autoUnloadProtectedPlugin: plugin,
+            autoUnloadProtectionLease: AutoUnloadProtectionLease(plugin: plugin),
             cloudModelOverridePlugin: overrideRestoreId == nil ? nil : plugin,
             cloudModelOverrideRestoreId: overrideRestoreId
         )
@@ -523,7 +541,7 @@ final class ModelManagerService: ObservableObject {
         let startTime = CFAbsoluteTimeGetCurrent()
         defer {
             restoreCloudModelOverride(for: handle)
-            endAutoUnloadProtectedUse(of: handle.autoUnloadProtectedPlugin)
+            releaseAutoUnloadProtection(for: handle)
         }
 
         let result = try await handle.session.finish()
@@ -546,9 +564,14 @@ final class ModelManagerService: ObservableObject {
     func cancelLiveTranscriptionSession(_ handle: LiveTranscriptionSessionHandle) async {
         defer {
             restoreCloudModelOverride(for: handle)
-            endAutoUnloadProtectedUse(of: handle.autoUnloadProtectedPlugin)
+            releaseAutoUnloadProtection(for: handle)
         }
         await handle.session.cancel()
+    }
+
+    private func releaseAutoUnloadProtection(for handle: LiveTranscriptionSessionHandle) {
+        guard let plugin = handle.autoUnloadProtectionLease.takePluginForRelease() else { return }
+        endAutoUnloadProtectedUse(of: plugin)
     }
 
     func transcribe(

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -6,7 +6,7 @@ import TypeWhisperPluginSDK
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
     private static let maxConditioningPromptChars = 500
@@ -23,6 +23,8 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     fileprivate var modelState: WhisperModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
     private var modelLoadGeneration = 0
+    private let modelUseLock = NSLock()
+    private var activeModelUseCount = 0
     fileprivate var slowModelLoadWarningDuration = WhisperKitPlugin.defaultSlowModelLoadWarningDuration
     #if DEBUG
     private(set) var restoreLoadedModelInvocationCountForTesting = 0
@@ -89,6 +91,26 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
     private func invalidateModelLoad() {
         modelLoadGeneration += 1
+    }
+
+    private func beginModelUse() {
+        modelUseLock.withLock {
+            activeModelUseCount += 1
+        }
+    }
+
+    private func endModelUse() {
+        modelUseLock.withLock {
+            guard activeModelUseCount > 0 else { return }
+            activeModelUseCount -= 1
+        }
+    }
+
+    private func autoUnloadIfIdle() {
+        modelUseLock.withLock {
+            guard activeModelUseCount == 0 else { return }
+            unloadModel(clearPersistence: false)
+        }
     }
 
     private func isCurrentModelLoad(_ generation: Int) -> Bool {
@@ -235,6 +257,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
+        beginModelUse()
+        defer { endModelUse() }
+
         guard let whisperKit else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -286,6 +311,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         onProgress: @Sendable @escaping (String) -> Bool,
         onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        beginModelUse()
+        defer { endModelUse() }
+
         guard let whisperKit else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -472,6 +500,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     fileprivate func loadModel(_ modelDef: WhisperModelDef) async {
+        beginModelUse()
+        defer { endModelUse() }
+
         guard !(isConfigured && loadedModelId == modelDef.id) else { return }
         guard !isModelLoadInProgress(for: modelDef.id) else { return }
 
@@ -585,7 +616,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         }
     }
 
-    @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
+    @objc func triggerAutoUnload() { autoUnloadIfIdle() }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
 
     func unloadModel(clearPersistence: Bool = true) {
@@ -609,6 +640,18 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
     var loadingModelIdForTesting: String? {
         loadingModelId
+    }
+
+    var activeModelUseCountForTesting: Int {
+        modelUseLock.withLock { activeModelUseCount }
+    }
+
+    func beginModelUseForTesting() {
+        beginModelUse()
+    }
+
+    func endModelUseForTesting() {
+        endModelUse()
     }
 
     func setModelStateForTesting(_ state: WhisperModelState, loadedModelId: String? = nil) {

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -23,8 +23,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     fileprivate var modelState: WhisperModelState = .notLoaded
     fileprivate var downloadProgress: Double = 0
     private var modelLoadGeneration = 0
-    private let modelUseLock = NSLock()
+    private let modelUseCondition = NSCondition()
     private var activeModelUseCount = 0
+    private var isAutoUnloading = false
     fileprivate var slowModelLoadWarningDuration = WhisperKitPlugin.defaultSlowModelLoadWarningDuration
     #if DEBUG
     private(set) var restoreLoadedModelInvocationCountForTesting = 0
@@ -94,23 +95,35 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     private func beginModelUse() {
-        modelUseLock.withLock {
-            activeModelUseCount += 1
+        modelUseCondition.lock()
+        while isAutoUnloading {
+            modelUseCondition.wait()
         }
+        activeModelUseCount += 1
+        modelUseCondition.unlock()
     }
 
     private func endModelUse() {
-        modelUseLock.withLock {
+        modelUseCondition.withLock {
             guard activeModelUseCount > 0 else { return }
             activeModelUseCount -= 1
         }
     }
 
     private func autoUnloadIfIdle() {
-        modelUseLock.withLock {
-            guard activeModelUseCount == 0 else { return }
-            unloadModel(clearPersistence: false)
+        let claimedUnload = modelUseCondition.withLock {
+            guard activeModelUseCount == 0, !isAutoUnloading else { return false }
+            isAutoUnloading = true
+            return true
         }
+        guard claimedUnload else { return }
+
+        unloadModel(clearPersistence: false)
+
+        modelUseCondition.lock()
+        isAutoUnloading = false
+        modelUseCondition.broadcast()
+        modelUseCondition.unlock()
     }
 
     private func isCurrentModelLoad(_ generation: Int) -> Bool {
@@ -643,7 +656,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     var activeModelUseCountForTesting: Int {
-        modelUseLock.withLock { activeModelUseCount }
+        modelUseCondition.withLock { activeModelUseCount }
     }
 
     func beginModelUseForTesting() {

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -220,6 +220,45 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
     }
 
+    private actor TranscriptionUseGate {
+        private var entries = 0
+        private var released = false
+        private var entryWaiters: [(target: Int, continuation: CheckedContinuation<Void, Never>)] = []
+        private var releaseWaiters: [CheckedContinuation<Void, Never>] = []
+
+        func enter() {
+            entries += 1
+            let readyWaiters = entryWaiters.filter { entries >= $0.target }
+            entryWaiters.removeAll { entries >= $0.target }
+            for waiter in readyWaiters {
+                waiter.continuation.resume()
+            }
+        }
+
+        func waitForEntries(_ target: Int) async {
+            if entries >= target { return }
+            await withCheckedContinuation { continuation in
+                entryWaiters.append((target, continuation))
+            }
+        }
+
+        func waitForRelease() async {
+            if released { return }
+            await withCheckedContinuation { continuation in
+                releaseWaiters.append(continuation)
+            }
+        }
+
+        func releaseAll() {
+            released = true
+            let waiters = releaseWaiters
+            releaseWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
+        }
+    }
+
     @objc(APIRouterMockLLMProviderPlugin)
     private final class MockLLMProviderPlugin: NSObject, LLMProviderPlugin, LLMProviderIdentityProviding, LLMProviderSetupStatusProviding, LLMTemperatureControllableProvider, PluginSettingsActivityReporting, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.llm" }
@@ -413,6 +452,68 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             try? await Task.sleep(for: .milliseconds(25))
         }
         XCTAssertEqual(plugin.autoUnloadCount, expected, file: file, line: line)
+    }
+
+    @MainActor
+    private func waitForAutoUnloadCount(
+        _ plugin: AutoUnloadProtectedTranscriptionPlugin,
+        toBecome expected: Int,
+        timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while ContinuousClock.now < deadline {
+            if plugin.autoUnloadCount == expected {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(plugin.autoUnloadCount, expected, file: file, line: line)
+    }
+
+    @MainActor
+    private func assertAutoUnloadCount(
+        _ plugin: AutoUnloadProtectedTranscriptionPlugin,
+        remains expected: Int,
+        duration: Duration = .milliseconds(300),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        let deadline = ContinuousClock.now.advanced(by: duration)
+        while ContinuousClock.now < deadline {
+            let actual = plugin.autoUnloadCount
+            if actual != expected {
+                XCTFail("Expected autoUnloadCount to remain \(expected), got \(actual)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(plugin.autoUnloadCount, expected, file: file, line: line)
+    }
+
+    @MainActor
+    private func makeAutoUnloadModelManager(
+        plugin: AutoUnloadProtectedTranscriptionPlugin,
+        appSupportDirectory: URL
+    ) -> ModelManagerService {
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: AutoUnloadProtectedTranscriptionPlugin.pluginId,
+                    name: AutoUnloadProtectedTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "APIRouterAutoUnloadProtectedTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        return ModelManagerService()
     }
 
     @MainActor
@@ -868,6 +969,125 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
             PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
+    @objc(APIRouterAutoUnloadProtectedTranscriptionPlugin)
+    private final class AutoUnloadProtectedTranscriptionPlugin: NSObject, LiveTranscriptionCapablePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.auto-unload-transcription" }
+        static var pluginName: String { "Auto-Unload Protected Mock Transcription" }
+
+        enum BatchBehavior: Sendable {
+            case immediate
+            case waitForRelease
+            case waitForCancellation
+            case fail
+        }
+
+        private let stateLock = NSLock()
+        private var _configured = true
+        private var _autoUnloadCount = 0
+        private var _restoreCount = 0
+        private var _batchBehavior = BatchBehavior.immediate
+        let transcriptionGate = TranscriptionUseGate()
+        var restoreDelay: Duration = .milliseconds(0)
+
+        var configured: Bool {
+            get { stateLock.withLock { _configured } }
+            set { stateLock.withLock { _configured = newValue } }
+        }
+
+        var autoUnloadCount: Int {
+            stateLock.withLock { _autoUnloadCount }
+        }
+
+        var restoreCount: Int {
+            stateLock.withLock { _restoreCount }
+        }
+
+        var batchBehavior: BatchBehavior {
+            get { stateLock.withLock { _batchBehavior } }
+            set { stateLock.withLock { _batchBehavior = newValue } }
+        }
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "auto-unload-transcription" }
+        var providerDisplayName: String { "Auto-Unload Protected Mock" }
+        var isConfigured: Bool { configured }
+        var transcriptionModels: [PluginModelInfo] {
+            [PluginModelInfo(id: "tiny", displayName: "Tiny")]
+        }
+        var selectedModelId: String? { "tiny" }
+        var supportsTranslation: Bool { false }
+        func selectModel(_ modelId: String) {}
+
+        @objc func triggerAutoUnload() {
+            stateLock.withLock {
+                _autoUnloadCount += 1
+                _configured = false
+            }
+        }
+
+        @objc func triggerRestoreModel() {
+            let delay = restoreDelay
+            stateLock.withLock {
+                _restoreCount += 1
+            }
+            Task { [weak self] in
+                try? await Task.sleep(for: delay)
+                self?.configured = true
+            }
+        }
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?
+        ) async throws -> PluginTranscriptionResult {
+            switch batchBehavior {
+            case .immediate:
+                break
+            case .waitForRelease:
+                await transcriptionGate.enter()
+                await transcriptionGate.waitForRelease()
+            case .waitForCancellation:
+                await transcriptionGate.enter()
+                try await Task.sleep(for: .seconds(60))
+            case .fail:
+                throw PluginTranscriptionError.apiError("Expected test failure")
+            }
+
+            return PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+
+        func createLiveTranscriptionSession(
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> any LiveTranscriptionSession {
+            MockLiveSession(language: language)
+        }
+
+        private actor MockLiveSession: LiveTranscriptionSession {
+            let language: String?
+
+            init(language: String?) {
+                self.language = language
+            }
+
+            func appendAudio(samples: [Float]) async throws {}
+
+            func finish() async throws -> PluginTranscriptionResult {
+                PluginTranscriptionResult(text: "live transcription", detectedLanguage: language)
+            }
+
+            func cancel() async {}
         }
     }
 
@@ -7803,6 +8023,251 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         XCTAssertEqual(result, "processed")
         XCTAssertEqual(activityManager.reasons, ["Local prompt processing with Gemma 4 (MLX)"])
+    }
+
+    @MainActor
+    func testOverlappingTranscriptionsDelayImmediateAutoUnloadUntilLastUseCompletes() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        plugin.batchBehavior = .waitForRelease
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+        modelManager.scheduleAutoUnloadIfNeeded(for: plugin)
+
+        let first = Task { @MainActor in
+            try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 1_600),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: plugin.providerId
+            )
+        }
+        let second = Task { @MainActor in
+            try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 1_600),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: plugin.providerId
+            )
+        }
+
+        await plugin.transcriptionGate.waitForEntries(2)
+        await assertAutoUnloadCount(plugin, remains: 0)
+
+        await plugin.transcriptionGate.releaseAll()
+        let firstResult = try await first.value
+        let secondResult = try await second.value
+        XCTAssertEqual(firstResult.text, "transcribed")
+        XCTAssertEqual(secondResult.text, "transcribed")
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testRestoreAndTranscriptionCancelPreviouslyScheduledImmediateAutoUnload() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        plugin.restoreDelay = .milliseconds(200)
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+        modelManager.scheduleAutoUnloadIfNeeded(for: plugin)
+        plugin.configured = false
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 1_600),
+            language: nil,
+            task: .transcribe,
+            engineOverrideId: plugin.providerId
+        )
+
+        XCTAssertEqual(result.text, "transcribed")
+        XCTAssertEqual(plugin.restoreCount, 1)
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testTranscriptionErrorReleasesImmediateAutoUnloadProtection() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        plugin.batchBehavior = .fail
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+
+        do {
+            _ = try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 1_600),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: plugin.providerId,
+                onProgress: { _ in true }
+            )
+            XCTFail("Expected transcription failure")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Expected apiError, got \(error)")
+            }
+            XCTAssertEqual(message, "Expected test failure")
+        }
+
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testTranscriptionCancellationReleasesImmediateAutoUnloadProtection() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        plugin.batchBehavior = .waitForCancellation
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+
+        let transcription = Task { @MainActor in
+            try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 1_600),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: plugin.providerId
+            )
+        }
+        await plugin.transcriptionGate.waitForEntries(1)
+        transcription.cancel()
+
+        do {
+            _ = try await transcription.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testLiveTranscriptionKeepsImmediateAutoUnloadProtectedUntilFinish() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+        modelManager.scheduleAutoUnloadIfNeeded(for: plugin)
+
+        let optionalHandle = try await modelManager.createLiveTranscriptionSession(
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: plugin.providerId,
+            onProgress: { _ in true }
+        )
+        let handle = try XCTUnwrap(optionalHandle)
+        await assertAutoUnloadCount(plugin, remains: 0)
+
+        let result = try await modelManager.finishLiveTranscriptionSession(
+            handle,
+            bufferedDuration: 1,
+            language: "en"
+        )
+        XCTAssertEqual(result.text, "live transcription")
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testLiveTranscriptionKeepsImmediateAutoUnloadProtectedUntilCancel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+
+        let optionalHandle = try await modelManager.createLiveTranscriptionSession(
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: plugin.providerId,
+            onProgress: { _ in true }
+        )
+        let handle = try XCTUnwrap(optionalHandle)
+        await assertAutoUnloadCount(plugin, remains: 0)
+
+        await modelManager.cancelLiveTranscriptionSession(handle)
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
     }
 
     @MainActor

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -989,8 +989,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         private var _autoUnloadCount = 0
         private var _restoreCount = 0
         private var _batchBehavior = BatchBehavior.immediate
+        private var _restoreDelay: Duration = .milliseconds(0)
         let transcriptionGate = TranscriptionUseGate()
-        var restoreDelay: Duration = .milliseconds(0)
 
         var configured: Bool {
             get { stateLock.withLock { _configured } }
@@ -1008,6 +1008,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         var batchBehavior: BatchBehavior {
             get { stateLock.withLock { _batchBehavior } }
             set { stateLock.withLock { _batchBehavior = newValue } }
+        }
+
+        var restoreDelay: Duration {
+            get { stateLock.withLock { _restoreDelay } }
+            set { stateLock.withLock { _restoreDelay = newValue } }
         }
 
         required override init() {}
@@ -8267,6 +8272,59 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         await assertAutoUnloadCount(plugin, remains: 0)
 
         await modelManager.cancelLiveTranscriptionSession(handle)
+        await waitForAutoUnloadCount(plugin, toBecome: 1)
+    }
+
+    @MainActor
+    func testCopiedLiveSessionHandleReleasesAutoUnloadProtectionOnlyOnce() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let originalAutoUnload = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        defer {
+            if let originalAutoUnload {
+                UserDefaults.standard.set(originalAutoUnload, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            }
+        }
+        UserDefaults.standard.set(-1, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+
+        let plugin = AutoUnloadProtectedTranscriptionPlugin()
+        let modelManager = makeAutoUnloadModelManager(
+            plugin: plugin,
+            appSupportDirectory: appSupportDirectory
+        )
+
+        let optionalFirstHandle = try await modelManager.createLiveTranscriptionSession(
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: plugin.providerId,
+            onProgress: { _ in true }
+        )
+        let firstHandle = try XCTUnwrap(optionalFirstHandle)
+        let copiedFirstHandle = firstHandle
+        let optionalSecondHandle = try await modelManager.createLiveTranscriptionSession(
+            language: "en",
+            task: .transcribe,
+            engineOverrideId: plugin.providerId,
+            onProgress: { _ in true }
+        )
+        let secondHandle = try XCTUnwrap(optionalSecondHandle)
+
+        _ = try await modelManager.finishLiveTranscriptionSession(
+            firstHandle,
+            bufferedDuration: 1,
+            language: "en"
+        )
+        await modelManager.cancelLiveTranscriptionSession(copiedFirstHandle)
+        await assertAutoUnloadCount(plugin, remains: 0)
+
+        _ = try await modelManager.finishLiveTranscriptionSession(
+            secondHandle,
+            bufferedDuration: 1,
+            language: "en"
+        )
         await waitForAutoUnloadCount(plugin, toBecome: 1)
     }
 

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -239,6 +239,56 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertNil(host.userDefault(forKey: "loadedModel"))
     }
 
+    func testAutoUnloadWaitsForAllActiveModelUsesAndKeepsLoadedModelMarker() throws {
+        let modelId = "openai_whisper-tiny"
+        let host = try makeHost(
+            defaults: [
+                "selectedModel": modelId,
+                "loadedModel": modelId,
+            ],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        plugin.beginModelUseForTesting()
+        plugin.beginModelUseForTesting()
+
+        plugin.triggerAutoUnload()
+        XCTAssertEqual(plugin.activeModelUseCountForTesting, 2)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+
+        plugin.endModelUseForTesting()
+        plugin.triggerAutoUnload()
+        XCTAssertEqual(plugin.activeModelUseCountForTesting, 1)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+
+        plugin.endModelUseForTesting()
+        plugin.triggerAutoUnload()
+
+        XCTAssertEqual(plugin.activeModelUseCountForTesting, 0)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, modelId)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+    }
+
+    func testEndingModelUseCannotUnderflowActiveUseCount() {
+        let plugin = WhisperKitPlugin()
+
+        plugin.endModelUseForTesting()
+        plugin.beginModelUseForTesting()
+        plugin.endModelUseForTesting()
+        plugin.endModelUseForTesting()
+
+        XCTAssertEqual(plugin.activeModelUseCountForTesting, 0)
+    }
+
+    func testWhisperKitDeclaresHostModelLifecyclePolicyAwareness() {
+        let plugin: any TypeWhisperPlugin = WhisperKitPlugin()
+
+        XCTAssertNotNil(plugin as? any HostModelLifecyclePolicyAwarePlugin)
+    }
+
     func testReadyModelStateClearsLoadingSettingsActivity() throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-large-v3_turbo",


### PR DESCRIPTION
## Issue context

WhisperKit could unload between model restoration and transcription when automatic model unloading was enabled. With the Immediate policy this also raced with active model loading/transcription, producing `No model loaded`, `Cloud provider not configured`, or tokenizer-unavailable failures. Qwen was unaffected because its lifecycle already protects active model use.

## What changed

- keep host auto-unload protection active across restore, batch transcription, and the complete live-session lifetime
- make WhisperKit ignore auto-unload callbacks while model loading or transcription is active
- preserve the persisted loaded-model marker during automatic unload so lazy restore remains available
- declare WhisperKit host lifecycle-policy awareness and bump the plugin manifest to 1.1.4
- cover overlapping use, restore, error, cancellation, finish, and live-session cancellation paths

Closes #1058

## Test plan

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-1058-full.log
swift test --package-path TypeWhisperPluginSDK
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$PWD"
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --clean --run WhisperKitPlugin --enable-plugin com.typewhisper.whisperkit "$PWD"
curl --fail-with-body --max-time 1200 -sS -X POST "http://127.0.0.1:8978/v1/transcribe?await_download=1" -F "file=@/tmp/typewhisper-1058-smoke.wav" -F "language=de" -F "engine=whisper"
```

## Verification

- 1,369 app tests passed with zero failures
- 513 Plugin SDK tests passed with zero failures
- first-party warning gate passed
- Apple Development-signed WhisperKit 1.1.4 bundle loaded in TypeWhisper-Dev
- reproduced the pre-fix race after Tiny downloaded: the old host unloaded the restored model before transcription and returned a configuration error
- post-fix first transcription succeeded, the catalog then reported `downloaded: true` and `loaded: false` after Immediate auto-unload, and an identical second transcription lazy-restored Tiny and succeeded again


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transcription reliability during overlapping, live, cancelled, or failed sessions.
  - Prevented models from unloading while actively in use, avoiding interruptions and potential transcription failures.
  - Ensured model resources are released correctly after sessions and one-time transcriptions finish.

- **Improvements**
  - Updated the WhisperKit plugin to version 1.1.4.
  - Improved automatic model lifecycle handling during transcription.
  - Added safeguards for concurrent transcription and session cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->