### PR TITLE
Fix recorder retranscription for auto-unloaded models

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -62,6 +62,31 @@ enum ModelAutoUnloadPolicy {
     }
 }
 
+enum TranscriptionEngineReadiness {
+    /// Whether the plugin has the persisted model state consumed by
+    /// `triggerRestoreModel`. The key is scoped by the plugin manifest ID, not
+    /// by an engine provider ID; the two identifiers may differ.
+    static func hasPersistedRestorableModel(
+        pluginId: String,
+        defaults: UserDefaults = .standard
+    ) -> Bool {
+        defaults.object(forKey: "plugin.\(pluginId).loadedModel") != nil
+    }
+
+    /// A selected engine is actionable when authentication is available and it
+    /// is already configured, can restore persisted model state, or has a
+    /// provider-specific preparation fallback such as Apple Speech's catalog.
+    static func engineIsReadyOrRestorable(
+        authAvailable: Bool,
+        isConfigured: Bool,
+        hasPersistedRestorableModel: Bool,
+        hasPreparationFallback: Bool
+    ) -> Bool {
+        guard authAvailable else { return false }
+        return isConfigured || hasPersistedRestorableModel || hasPreparationFallback
+    }
+}
+
 struct ModelAutoUnloadDiagnosticsSnapshot: Encodable, Equatable, Sendable {
     struct Entry: Encodable, Equatable, Sendable {
         let pluginClassName: String
@@ -312,10 +337,22 @@ final class ModelManagerService: ObservableObject {
     }
 
     func canPrepareForTranscription(_ engine: TranscriptionEnginePlugin) -> Bool {
-        guard canUseForTranscription(engine) else { return false }
-        if engine.isConfigured { return true }
-        guard engine.providerId == AppleSpeechModelSelection.providerId else { return false }
-        return engine.selectedModelId != nil || !engine.modelCatalog.isEmpty
+        let isAppleSpeech = engine.providerId == AppleSpeechModelSelection.providerId
+        let hasPreparationFallback = isAppleSpeech
+            && (engine.selectedModelId != nil || !engine.modelCatalog.isEmpty)
+        let pluginId = isAppleSpeech
+            ? nil
+            : PluginManager.shared?.loadedTranscriptionPlugin(for: engine.providerId)?.manifest.id
+        let hasPersistedRestorableModel = pluginId.map {
+            TranscriptionEngineReadiness.hasPersistedRestorableModel(pluginId: $0)
+        } ?? false
+
+        return TranscriptionEngineReadiness.engineIsReadyOrRestorable(
+            authAvailable: canUseForTranscription(engine),
+            isConfigured: engine.isConfigured,
+            hasPersistedRestorableModel: hasPersistedRestorableModel,
+            hasPreparationFallback: hasPreparationFallback
+        )
     }
 
     /// Resolve display name for a given engine/model override combination

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2335,54 +2335,11 @@ final class DictationViewModel: ObservableObject {
     /// `prepareEngineForTranscription` → `triggerRestoreModel`), AND actually able
     /// to produce a preview — via a native live session or the batch fallback.
     func canUseEngineForPreview(_ engine: TranscriptionEnginePlugin) -> Bool {
-        // `loadedModel` is persisted by the host under the plugin's MANIFEST id
-        // (`HostServicesImpl.setUserDefault` writes `plugin.<manifest.id>.<key>`),
-        // which is not the engine's `providerId` — e.g. "parakeet" vs
-        // "com.typewhisper.parakeet". Resolve through the plugin so the lookup
-        // reads the key the plugin actually wrote; an unresolvable engine is not
-        // restorable, so it correctly fails the readiness gate.
-        let pluginId = PluginManager.shared?.loadedTranscriptionPlugin(for: engine.providerId)?.manifest.id
-        guard Self.engineIsReadyOrRestorableForPreview(
-            authAvailable: modelManager.canUseForTranscription(engine),
-            isConfigured: engine.isConfigured,
-            hasPersistedRestorableModel: pluginId.map { Self.hasPersistedRestorableModel(pluginId: $0) } ?? false,
-            canPrepare: modelManager.canPrepareForTranscription(engine)
-        ) else { return false }
+        guard modelManager.canPrepareForTranscription(engine) else { return false }
         if engine is any LiveTranscriptionCapablePlugin { return true }
         let allowsFallback = (engine as? any TranscriptPreviewFallbackPolicyProviding)?
             .allowsTranscriptPreviewFallback ?? true
         return allowsFallback
-    }
-
-    /// Whether the plugin has a persisted `loadedModel` default —  the state
-    /// `triggerRestoreModel` restores from. Auto-unload keeps it (restorable);
-    /// manually unloading a model clears it (restore is a no-op, so the engine
-    /// must not be treated as available). Same plugin-scoped convention key the
-    /// host special-cases in `HostServicesImpl.userDefault(forKey:)`.
-    ///
-    /// Takes the plugin's MANIFEST id, not an engine `providerId` — the two differ
-    /// (`com.typewhisper.parakeet` vs `parakeet`) and only the former matches what
-    /// `HostServicesImpl` wrote.
-    nonisolated static func hasPersistedRestorableModel(
-        pluginId: String,
-        defaults: UserDefaults = .standard
-    ) -> Bool {
-        defaults.object(forKey: "plugin.\(pluginId).loadedModel") != nil
-    }
-
-    /// Pure readiness predicate for the preview engine. A persisted restorable
-    /// model counts as available even when it is not currently loaded
-    /// (`isConfigured == false`) — auto-unloaded local engines restore at
-    /// session start. `canPrepare` additionally keeps Apple Speech's
-    /// catalog-based grace from `canPrepareForTranscription`.
-    nonisolated static func engineIsReadyOrRestorableForPreview(
-        authAvailable: Bool,
-        isConfigured: Bool,
-        hasPersistedRestorableModel: Bool,
-        canPrepare: Bool
-    ) -> Bool {
-        guard authAvailable else { return false }
-        return isConfigured || hasPersistedRestorableModel || canPrepare
     }
 
     enum PreviewEngineResolution: Equatable {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -88,6 +88,14 @@ private final class OutOfOrderRecordingsLoader: @unchecked Sendable {
 
 @MainActor
 final class AudioRecorderViewModelTests: XCTestCase {
+    private struct RestorableRecorderFixture {
+        let viewModel: AudioRecorderViewModel
+        let plugin: AudioRecorderRestorableTranscriptionPlugin
+        let recording: AudioRecorderViewModel.RecordingItem
+        let transcriptURL: URL
+        let failureURL: URL
+    }
+
     func testRecorderFilesAreLoadedOffMainThreadDuringInitialization() throws {
         let probe = BlockingRecordingsLoader()
         defer { probe.release.signal() }
@@ -582,6 +590,63 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(request.translate)
         XCTAssertTrue(request.prompt?.contains("TypeWhisper") == true)
         XCTAssertTrue(plugin.selectedModelOverrides.contains("universal-3-5-pro"))
+    }
+
+    func testRecorderRetranscriptionIsAvailableForAutoUnloadedRestorableEngine() async throws {
+        let fixture = try await makeRestorableRecorderFixture(hasPersistedModel: true)
+
+        XCTAssertFalse(fixture.plugin.isConfigured)
+        XCTAssertTrue(fixture.viewModel.canTranscribeRecording(fixture.recording))
+        XCTAssertEqual(fixture.plugin.restoreCount, 0)
+    }
+
+    func testRecorderRetranscriptionRestoresAutoUnloadedEngineAndSavesTranscript() async throws {
+        let fixture = try await makeRestorableRecorderFixture(hasPersistedModel: true)
+
+        XCTAssertTrue(fixture.viewModel.canTranscribeRecording(fixture.recording))
+        fixture.viewModel.transcribeRecording(fixture.recording)
+        try await waitForRetranscriptionToFinish(fixture.viewModel)
+
+        XCTAssertEqual(fixture.plugin.restoreCount, 1)
+        XCTAssertTrue(fixture.plugin.isConfigured)
+        XCTAssertEqual(
+            try String(contentsOf: fixture.transcriptURL, encoding: .utf8),
+            "restored transcription"
+        )
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.failureURL.path))
+    }
+
+    func testRecorderRetranscriptionStaysDisabledAfterManualUnload() async throws {
+        let fixture = try await makeRestorableRecorderFixture(hasPersistedModel: false)
+
+        XCTAssertFalse(fixture.plugin.isConfigured)
+        XCTAssertNotNil(fixture.plugin.selectedModelId, "A retained selection alone must not imply restorable state")
+        XCTAssertFalse(fixture.viewModel.canTranscribeRecording(fixture.recording))
+        XCTAssertEqual(fixture.plugin.restoreCount, 0)
+    }
+
+    func testRecorderRetranscriptionSurfacesMissingRestorableModelError() async throws {
+        let restoreMessage = "Downloaded model is missing. Re-download it in Integrations."
+        let fixture = try await makeRestorableRecorderFixture(
+            restoreBehavior: .fails(restoreMessage),
+            hasPersistedModel: true
+        )
+
+        XCTAssertTrue(fixture.viewModel.canTranscribeRecording(fixture.recording))
+        fixture.viewModel.transcribeRecording(fixture.recording)
+        try await waitForRetranscriptionToFinish(fixture.viewModel)
+
+        let failure = try JSONDecoder().decode(
+            AudioRecorderViewModel.RecordingTranscriptionFailure.self,
+            from: Data(contentsOf: fixture.failureURL)
+        )
+        XCTAssertEqual(fixture.plugin.restoreCount, 1)
+        XCTAssertFalse(fixture.plugin.isConfigured)
+        XCTAssertEqual(failure.phase, .finalTranscription)
+        XCTAssertTrue(failure.providerError.contains("Failed to load model"))
+        XCTAssertTrue(failure.providerError.contains(restoreMessage))
+        XCTAssertTrue(fixture.viewModel.errorMessage?.contains(restoreMessage) == true)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.transcriptURL.path))
     }
 
     func testRetranscriptionAudioLoadFailurePreservesExistingTranscript() async throws {
@@ -1085,6 +1150,51 @@ final class AudioRecorderViewModelTests: XCTestCase {
         return try XCTUnwrap(session, file: file, line: line)
     }
 
+    private func makeRestorableRecorderFixture(
+        restoreBehavior: AudioRecorderRestorableTranscriptionPlugin.RestoreBehavior = .succeeds,
+        hasPersistedModel: Bool
+    ) async throws -> RestorableRecorderFixture {
+        try preserveStandardDefaults(additionalKeys: [
+            AudioRecorderRestorableTranscriptionPlugin.loadedModelDefaultsKey
+        ])
+        let plugin = setupRestorablePluginManager(restoreBehavior: restoreBehavior)
+        if hasPersistedModel {
+            UserDefaults.standard.set(
+                AudioRecorderRestorableTranscriptionPlugin.modelId,
+                forKey: AudioRecorderRestorableTranscriptionPlugin.loadedModelDefaultsKey
+            )
+        }
+
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.setPluginRestoreWaitConfigurationForTesting(
+            initialAttempts: 1,
+            busyAttempts: 1,
+            pollInterval: .milliseconds(1)
+        )
+        modelManager.selectProvider(plugin.providerId)
+
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Restorable.wav")
+        try Data("audio".utf8).write(to: audioURL)
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        return RestorableRecorderFixture(
+            viewModel: viewModel,
+            plugin: plugin,
+            recording: try XCTUnwrap(viewModel.recordings.first),
+            transcriptURL: audioURL.deletingPathExtension().appendingPathExtension("txt"),
+            failureURL: failureSidecarURL(for: audioURL)
+        )
+    }
+
     private func setupEventBus() {
         let previousEventBus: EventBus? = EventBus.shared
         EventBus.shared = EventBus()
@@ -1151,13 +1261,42 @@ final class AudioRecorderViewModelTests: XCTestCase {
         PluginManager.shared = pluginManager
     }
 
-    private func preserveStandardDefaults() throws {
-        let keys = [
+    private func setupRestorablePluginManager(
+        restoreBehavior: AudioRecorderRestorableTranscriptionPlugin.RestoreBehavior
+    ) -> AudioRecorderRestorableTranscriptionPlugin {
+        let previousPluginManager = PluginManager.shared
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+        }
+
+        let appSupportDirectory = makeTemporaryDirectory()
+        let plugin = AudioRecorderRestorableTranscriptionPlugin(restoreBehavior: restoreBehavior)
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: AudioRecorderRestorableTranscriptionPlugin.pluginId,
+                    name: AudioRecorderRestorableTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "AudioRecorderRestorableTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+        return plugin
+    }
+
+    private func preserveStandardDefaults(additionalKeys: [String] = []) throws {
+        let keys = Array(Set([
             UserDefaultsKeys.selectedEngine,
             UserDefaultsKeys.selectedModelId,
             UserDefaultsKeys.selectedInputDeviceUID,
             UserDefaultsKeys.inputDevicePriorityList
-        ]
+        ] + additionalKeys))
         let originals = Dictionary(uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) })
         for key in keys {
             UserDefaults.standard.removeObject(forKey: key)
@@ -1191,6 +1330,77 @@ final class AudioRecorderViewModelTests: XCTestCase {
             try? FileManager.default.removeItem(at: directory)
         }
         return directory
+    }
+}
+
+private final class AudioRecorderRestorableTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, PluginSettingsActivityReporting, @unchecked Sendable {
+    enum RestoreBehavior: Sendable {
+        case succeeds
+        case fails(String)
+    }
+
+    private struct State {
+        var isConfigured = false
+        var currentSettingsActivity: PluginSettingsActivity?
+        var restoreCount = 0
+    }
+
+    static let pluginId = "com.typewhisper.mock.audio-recorder-restorable"
+    static let pluginName = "Audio Recorder Restorable Mock"
+    static let modelId = "restorable-model"
+    static let loadedModelDefaultsKey = "plugin.\(pluginId).loadedModel"
+
+    let providerId = "recorder-restorable"
+    let providerDisplayName = "Recorder Restorable"
+    let transcriptionModels = [PluginModelInfo(id: modelId, displayName: "Restorable Model")]
+    var selectedModelId: String? { Self.modelId }
+    var supportsTranslation = false
+    var isConfigured: Bool { stateLock.withLock { state.isConfigured } }
+    var currentSettingsActivity: PluginSettingsActivity? {
+        stateLock.withLock { state.currentSettingsActivity }
+    }
+    var restoreCount: Int { stateLock.withLock { state.restoreCount } }
+
+    private let restoreBehavior: RestoreBehavior
+    private let stateLock = NSLock()
+    private var state = State()
+
+    required override init() {
+        self.restoreBehavior = .succeeds
+        super.init()
+    }
+
+    init(restoreBehavior: RestoreBehavior) {
+        self.restoreBehavior = restoreBehavior
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectModel(_ modelId: String) {}
+
+    @objc func triggerRestoreModel() {
+        stateLock.withLock {
+            state.restoreCount += 1
+            switch restoreBehavior {
+            case .succeeds:
+                state.isConfigured = true
+                state.currentSettingsActivity = nil
+            case .fails(let message):
+                state.isConfigured = false
+                state.currentSettingsActivity = PluginSettingsActivity(message: message, isError: true)
+            }
+        }
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        guard isConfigured else { throw PluginTranscriptionError.notConfigured }
+        return PluginTranscriptionResult(text: "restored transcription", detectedLanguage: language)
     }
 }
 

--- a/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
+++ b/TypeWhisperTests/LivePreviewEngineResolutionTests.swift
@@ -1,6 +1,9 @@
+import Foundation
 import XCTest
+import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
+@MainActor
 final class LivePreviewEngineResolutionTests: XCTestCase {
     func testNoPreferenceFollowsDictationEngine() {
         XCTAssertEqual(
@@ -105,38 +108,39 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
 
     // MARK: - Ready-or-restorable predicate
 
-    func testAutoUnloadedLocalEngineWithPersistedLoadedModelIsRestorable() {
+    func testAutoUnloadedLocalEngineWithPersistedLoadedModelIsRestorable() throws {
         // Error class: rejecting an installed local preview engine whose model
-        // was AUTO-UNLOADED (isConfigured == false, canPrepareForTranscription
-        // == false for non-Apple engines) even though its persisted loadedModel
-        // state restores at session start via triggerRestoreModel — which
-        // silently re-routed the preview to the metered dictation engine
-        // (review finding on #943).
-        XCTAssertTrue(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: true,
-                isConfigured: false,
-                hasPersistedRestorableModel: true,
-                canPrepare: false
-            )
+        // was AUTO-UNLOADED even though its persisted loadedModel state restores
+        // at session start via triggerRestoreModel — which silently re-routed
+        // the preview to the metered dictation engine (review finding on #943).
+        let plugin = LivePreviewReadinessPlugin(isConfigured: false)
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefault(
+            key: LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            value: "restorable-model"
         )
+
+        XCTAssertTrue(modelManager.canPrepareForTranscription(plugin))
     }
 
-    func testManuallyUnloadedEngineIsNotRestorable() {
+    func testManuallyUnloadedEngineIsNotRestorable() throws {
         // Error class: treating a retained model SELECTION as restorable after a
         // MANUAL unload — plugins keep selectedModel but clear the persisted
         // loadedModel default, so triggerRestoreModel is a no-op and a preview
         // session can never become ready; the engine must resolve as
         // unavailable (suppressed preview), not as an override that fails
         // every fallback poll (second-round review finding on #943).
-        XCTAssertFalse(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: true,
-                isConfigured: false,
-                hasPersistedRestorableModel: false,
-                canPrepare: false
-            )
+        let plugin = LivePreviewReadinessPlugin(
+            isConfigured: false,
+            selectedModelId: "retained-selection"
         )
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefault(
+            key: LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            value: nil
+        )
+
+        XCTAssertFalse(modelManager.canPrepareForTranscription(plugin))
     }
 
     func testHasPersistedRestorableModelReadsPluginScopedKey() {
@@ -145,13 +149,13 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
         defaults.removePersistentDomain(forName: suite)
 
         XCTAssertFalse(
-            DictationViewModel.hasPersistedRestorableModel(
+            TranscriptionEngineReadiness.hasPersistedRestorableModel(
                 pluginId: "com.typewhisper.parakeet", defaults: defaults
             )
         )
         defaults.set("parakeet-tdt-0.6b-v3", forKey: "plugin.com.typewhisper.parakeet.loadedModel")
         XCTAssertTrue(
-            DictationViewModel.hasPersistedRestorableModel(
+            TranscriptionEngineReadiness.hasPersistedRestorableModel(
                 pluginId: "com.typewhisper.parakeet", defaults: defaults
             )
         )
@@ -163,73 +167,80 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
     /// "parakeet"). Looking the key up under the provider id silently never matches,
     /// which would make every auto-unloaded local preview engine resolve as
     /// unavailable. Lock the distinction so the lookup cannot regress to a provider id.
-    func testPersistedRestorableModelDoesNotMatchProviderIdKey() {
-        let suite = "LivePreviewEngineResolutionTests-restore-idform"
-        let defaults = UserDefaults(suiteName: suite)!
-        defaults.removePersistentDomain(forName: suite)
+    func testPersistedRestorableModelUsesManifestIdInsteadOfProviderId() throws {
+        let plugin = LivePreviewReadinessPlugin(isConfigured: false)
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefaults(keys: [
+            LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            LivePreviewReadinessPlugin.providerLoadedModelDefaultsKey
+        ])
 
-        // Exactly what the plugin host persists.
-        defaults.set("parakeet-tdt-0.6b-v3", forKey: "plugin.com.typewhisper.parakeet.loadedModel")
-
-        XCTAssertTrue(
-            DictationViewModel.hasPersistedRestorableModel(
-                pluginId: "com.typewhisper.parakeet", defaults: defaults
-            ),
-            "manifest-id lookup must find the key the host wrote"
+        UserDefaults.standard.set(
+            "restorable-model",
+            forKey: LivePreviewReadinessPlugin.providerLoadedModelDefaultsKey
         )
         XCTAssertFalse(
-            DictationViewModel.hasPersistedRestorableModel(
-                pluginId: "parakeet", defaults: defaults
-            ),
-            "a providerId-shaped lookup must not match — it is the regression this guards"
+            modelManager.canPrepareForTranscription(plugin),
+            "a providerId-shaped key must not make the engine restorable"
         )
-        defaults.removePersistentDomain(forName: suite)
+
+        UserDefaults.standard.set(
+            "restorable-model",
+            forKey: LivePreviewReadinessPlugin.loadedModelDefaultsKey
+        )
+        XCTAssertTrue(
+            modelManager.canPrepareForTranscription(plugin),
+            "the owning plugin's manifest-id key must make the engine restorable"
+        )
     }
 
-    func testConfiguredEngineIsReady() {
-        XCTAssertTrue(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: true,
-                isConfigured: true,
-                hasPersistedRestorableModel: false,
-                canPrepare: true
-            )
+    func testConfiguredEngineIsReady() throws {
+        let plugin = LivePreviewReadinessPlugin(isConfigured: true)
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefault(
+            key: LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            value: nil
         )
+
+        XCTAssertTrue(modelManager.canPrepareForTranscription(plugin))
     }
 
     func testAppleCatalogGraceStillApplies() {
         // Apple Speech may have no selected model yet still be preparable from
         // its catalog — canPrepareForTranscription's existing grace is preserved.
-        XCTAssertTrue(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: true,
-                isConfigured: false,
-                hasPersistedRestorableModel: false,
-                canPrepare: true
-            )
+        let plugin = LivePreviewReadinessPlugin(
+            providerId: AppleSpeechModelSelection.providerId,
+            isConfigured: false,
+            availableModels: [PluginModelInfo(id: "speechanalyzer-en_US", displayName: "English")]
         )
+        let modelManager = ModelManagerService()
+
+        XCTAssertTrue(modelManager.canPrepareForTranscription(plugin))
     }
 
-    func testNeverConfiguredEngineIsUnavailable() {
-        XCTAssertFalse(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: true,
-                isConfigured: false,
-                hasPersistedRestorableModel: false,
-                canPrepare: false
-            )
+    func testNeverConfiguredEngineIsUnavailable() throws {
+        let plugin = LivePreviewReadinessPlugin(isConfigured: false)
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefault(
+            key: LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            value: nil
         )
+
+        XCTAssertFalse(modelManager.canPrepareForTranscription(plugin))
     }
 
-    func testAuthUnavailableRejectsEvenConfiguredEngines() {
-        XCTAssertFalse(
-            DictationViewModel.engineIsReadyOrRestorableForPreview(
-                authAvailable: false,
-                isConfigured: true,
-                hasPersistedRestorableModel: true,
-                canPrepare: true
-            )
+    func testAuthUnavailableRejectsEvenConfiguredEngines() throws {
+        let plugin = LivePreviewReadinessPlugin(
+            isConfigured: true,
+            authAvailable: false
         )
+        let modelManager = try installReadinessPlugin(plugin)
+        preserveStandardDefault(
+            key: LivePreviewReadinessPlugin.loadedModelDefaultsKey,
+            value: "restorable-model"
+        )
+
+        XCTAssertFalse(modelManager.canPrepareForTranscription(plugin))
     }
 
     // MARK: - Persistence
@@ -250,5 +261,117 @@ final class LivePreviewEngineResolutionTests: XCTestCase {
         XCTAssertNil(DictationViewModel.loadLivePreviewEngineId(defaults: defaults))
 
         defaults.removePersistentDomain(forName: "LivePreviewEngineResolutionTests")
+    }
+
+    private func installReadinessPlugin(
+        _ plugin: LivePreviewReadinessPlugin
+    ) throws -> ModelManagerService {
+        let previousPluginManager = PluginManager.shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: LivePreviewReadinessPlugin.pluginId,
+                    name: LivePreviewReadinessPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "LivePreviewReadinessPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+        return ModelManagerService()
+    }
+
+    private func preserveStandardDefault(key: String, value: Any?) {
+        preserveStandardDefaults(keys: [key])
+        if let value {
+            UserDefaults.standard.set(value, forKey: key)
+        }
+    }
+
+    private func preserveStandardDefaults(keys: [String]) {
+        let originals = Dictionary(
+            uniqueKeysWithValues: keys.map { ($0, UserDefaults.standard.object(forKey: $0)) }
+        )
+        keys.forEach(UserDefaults.standard.removeObject(forKey:))
+        addTeardownBlock {
+            for (key, value) in originals {
+                if let value {
+                    UserDefaults.standard.set(value, forKey: key)
+                } else {
+                    UserDefaults.standard.removeObject(forKey: key)
+                }
+            }
+        }
+    }
+}
+
+private final class LivePreviewReadinessPlugin: NSObject, TranscriptionModelCatalogProviding, PluginAuthRoleStatusProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.live-preview-readiness"
+    static let pluginName = "Live Preview Readiness Mock"
+    static let defaultProviderId = "live-preview-readiness"
+    static let loadedModelDefaultsKey = "plugin.\(pluginId).loadedModel"
+    static let providerLoadedModelDefaultsKey = "plugin.\(defaultProviderId).loadedModel"
+
+    let providerId: String
+    let isConfigured: Bool
+    let selectedModelId: String?
+    let availableModels: [PluginModelInfo]
+    let authAvailable: Bool
+    let providerDisplayName = "Live Preview Readiness"
+    let transcriptionModels: [PluginModelInfo] = []
+    let supportsTranslation = false
+
+    init(
+        providerId: String = defaultProviderId,
+        isConfigured: Bool,
+        selectedModelId: String? = nil,
+        availableModels: [PluginModelInfo] = [],
+        authAvailable: Bool = true
+    ) {
+        self.providerId = providerId
+        self.isConfigured = isConfigured
+        self.selectedModelId = selectedModelId
+        self.availableModels = availableModels
+        self.authAvailable = authAvailable
+        super.init()
+    }
+
+    required override init() {
+        self.providerId = Self.defaultProviderId
+        self.isConfigured = false
+        self.selectedModelId = nil
+        self.availableModels = []
+        self.authAvailable = true
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func selectModel(_ modelId: String) {}
+
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        role == .transcription && !authAvailable
+            ? .unavailable(reason: "Transcription authentication is unavailable.")
+            : .available
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "preview", detectedLanguage: language)
     }
 }


### PR DESCRIPTION
## Context

Recorder retranscription could become unavailable after restarting TypeWhisper when a local transcription model such as Parakeet had been unloaded by the automatic model-unload policy. The model remained restorable through the plugin's persisted `loadedModel` state, and the shared transcription path already performs lazy restoration, but `ModelManagerService.canPrepareForTranscription` rejected every unloaded non-Apple engine before that path could run.

Closes #1029

## Changes

- make `ModelManagerService.canPrepareForTranscription` own the shared ready-or-restorable rule
- resolve persisted model state through the owning plugin's manifest ID
- keep authentication and Apple Speech preparation boundaries unchanged
- reuse the shared readiness gate for live preview
- add Recorder restore, manual-unload, and actionable failure coverage
- exercise manifest-ID resolution, Apple catalog preparation, authentication, and manual unload through the real service in live-preview tests

## Verification

```bash
set -o pipefail
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests \
  -only-testing:TypeWhisperTests/LivePreviewEngineResolutionTests \
  -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests \
  CODE_SIGN_IDENTITY="-" \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  | tee /tmp/typewhisper-issue-1029-tests.log

bash scripts/check_first_party_warnings.sh /tmp/typewhisper-issue-1029-tests.log
./scripts/pr-preflight.sh origin/main
```

- Focused XCTest selection: 72 tests passed, 0 failures
- First-party warning gate: passed
- PR preflight: passed with Python 3.11 (513 Plugin SDK tests, 0 failures)
- Development app: built and signed from `72f2a9091da9902c7174a4b6d0943c275af55de7`
- Parakeet plugin: built, signed, installed, enabled, and the app was relaunched
- Manual Recorder UI smoke: pending because local UI automation capture failed with ScreenCaptureKit error `-3811`; the development profile has Parakeet TDT v3, persisted restorable state, and a 600-second auto-unload policy


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription readiness detection for installed and previously used engines.
  * Preview availability now correctly supports native live transcription and transcript fallback.
  * Improved handling of authentication, configuration, automatic model restoration, and manual unload scenarios.
  * Added Apple Speech catalog and model fallback support when determining readiness.

* **Tests**
  * Expanded coverage for model restoration, restoration failures, persistence, and preview engine selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->