### PR TITLE
Fix WhisperKit restore for workflow model overrides

### DIFF
--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -1572,9 +1572,10 @@ final class ModelManagerService: ObservableObject {
             return .unavailable
         }
 
+        let identityCheckModelId = plugin.selectedModelId == nil ? nil : preferredModelId
         switch await waitForPluginRestoreConfigured(
             plugin,
-            selectedModelId: preferredModelId
+            selectedModelId: identityCheckModelId
         ) {
         case .configured:
             return .configured

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -396,15 +396,16 @@ final class ModelManagerService: ObservableObject {
 
     /// Apply a one-shot cloud model override without persisting the default.
     ///
-    /// Returns the model id that should be restored after the transcription call completes
-    /// (nil means "no restore needed" -- either no override was applied or the plugin had no
-    /// previous selection to restore to). Callers must pair this with `restoreCloudModelOverride`
-    /// inside a `defer` so the original selection is restored even on throw.
+    /// Returns the previous selection plus the model id that should be restored after the
+    /// transcription call completes. A nil restore id means either no override was applied or
+    /// the plugin had no previous selection to restore to. Callers must pair this with
+    /// `restoreCloudModelOverride` inside a `defer` so the original selection is restored even
+    /// on throw.
     private func applyCloudModelOverride(
         plugin: any TranscriptionEnginePlugin,
         override: String?
-    ) -> String? {
-        guard let override else { return nil }
+    ) -> (restoreId: String?, previousId: String?) {
+        guard let override else { return (nil, nil) }
         let previousId = plugin.selectedModelId
         if previousId != override || !plugin.isConfigured {
             plugin.selectModel(override)
@@ -412,9 +413,9 @@ final class ModelManagerService: ObservableObject {
         // If the plugin had no previous selection we can't express "unselect" through the SDK,
         // so the override stays in place. For configured plugins selectedModelId is normally set.
         guard let previousId, previousId != override else {
-            return nil
+            return (nil, previousId)
         }
-        return previousId
+        return (previousId, previousId)
     }
 
     private func restoreCloudModelOverride(
@@ -1426,30 +1427,81 @@ final class ModelManagerService: ObservableObject {
         requestedLanguage: String?,
         cloudModelOverride: String?
     ) async throws -> String? {
-        let overrideRestoreId = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
+        let modelOverride = applyCloudModelOverride(plugin: plugin, override: cloudModelOverride)
+        let previousModelId = modelOverride.previousId
+        let overrideRestoreId = modelOverride.restoreId
 
-        if let cloudModelOverride {
-            let selectedModelId = plugin.selectedModelId ?? cloudModelOverride
-            _ = await waitForPluginConfigured(plugin, selectedModelId: selectedModelId)
+        do {
+            if let cloudModelOverride {
+                let selectedModelId = plugin.selectedModelId
+                let expectedModelId: String
+                if let selectedModelId,
+                   selectedModelId != previousModelId || cloudModelOverride == previousModelId {
+                    // Plugins may normalize legacy aliases during selectModel(). In that
+                    // case the canonical selected ID is the model that must become ready.
+                    expectedModelId = selectedModelId
+                } else {
+                    // If selection was rejected and the old ID remained unchanged, keep
+                    // checking the requested ID so a different loaded model is not accepted.
+                    expectedModelId = cloudModelOverride
+                }
+
+                if pluginConfiguredState(
+                    plugin,
+                    selectedModelId: expectedModelId,
+                    stopOnMismatchedSelection: true
+                ) == true {
+                    return overrideRestoreId
+                }
+
+                let restoreResult = await triggerRestoreModel(
+                    plugin,
+                    preferredModelId: expectedModelId
+                )
+                switch restoreResult {
+                case .configured:
+                    return overrideRestoreId
+                case .failed(let message):
+                    throw TranscriptionEngineError.modelLoadFailed(message)
+                case .unavailable:
+                    // Cloud plugins may not expose a local restore selector or a readable
+                    // selected-model identifier. Their selectModel implementation is the
+                    // source of truth, so preserve the existing configured behavior.
+                    if plugin.isConfigured, plugin.selectedModelId == nil {
+                        return overrideRestoreId
+                    }
+                    let prepared = await waitForPluginConfigured(
+                        plugin,
+                        selectedModelId: expectedModelId,
+                        stopOnMismatchedSelection: true
+                    )
+                    guard prepared else {
+                        throw modelNotLoadedError(for: plugin)
+                    }
+                    return overrideRestoreId
+                }
+            }
+
+            if plugin.providerId == AppleSpeechModelSelection.providerId {
+                let prepared = await triggerAppleSpeechModelPreparation(
+                    plugin,
+                    requestedLanguage: requestedLanguage
+                )
+                guard prepared else {
+                    throw modelNotLoadedError(for: plugin)
+                }
+            } else if !plugin.isConfigured {
+                let restoreResult = await triggerRestoreModel(plugin)
+                if case .failed(let message) = restoreResult {
+                    throw TranscriptionEngineError.modelLoadFailed(message)
+                }
+            }
+
             return overrideRestoreId
+        } catch {
+            restoreCloudModelOverride(plugin: plugin, previousId: overrideRestoreId)
+            throw error
         }
-
-        if plugin.providerId == AppleSpeechModelSelection.providerId {
-            let prepared = await triggerAppleSpeechModelPreparation(
-                plugin,
-                requestedLanguage: requestedLanguage
-            )
-            guard prepared else {
-                throw modelNotLoadedError(for: plugin)
-            }
-        } else if !plugin.isConfigured {
-            let restoreResult = await triggerRestoreModel(plugin)
-            if case .failed(let message) = restoreResult {
-                throw TranscriptionEngineError.modelLoadFailed(message)
-            }
-        }
-
-        return overrideRestoreId
     }
 
     private func modelNotLoadedError(for plugin: TranscriptionEnginePlugin) -> TranscriptionEngineError {
@@ -1502,15 +1554,28 @@ final class ModelManagerService: ObservableObject {
 
     /// Trigger model restore via ObjC dispatch (avoids Swift protocol witness table issues
     /// with dynamically loaded plugin bundles) and poll until ready.
-    private func triggerRestoreModel(_ plugin: TranscriptionEnginePlugin) async -> PluginRestoreResult {
-        let restoreSelector = NSSelectorFromString("triggerRestoreModel")
-        guard let nsPlugin = plugin as? NSObject,
-              nsPlugin.responds(to: restoreSelector) else {
+    private func triggerRestoreModel(
+        _ plugin: TranscriptionEnginePlugin,
+        preferredModelId: String? = nil
+    ) async -> PluginRestoreResult {
+        guard let nsPlugin = plugin as? NSObject else {
             return .unavailable
         }
-        _ = nsPlugin.perform(restoreSelector)
 
-        switch await waitForPluginRestoreConfigured(plugin) {
+        let preferredRestoreSelector = NSSelectorFromString("triggerRestoreModelForModel:")
+        let genericRestoreSelector = NSSelectorFromString("triggerRestoreModel")
+        if let preferredModelId, nsPlugin.responds(to: preferredRestoreSelector) {
+            _ = nsPlugin.perform(preferredRestoreSelector, with: preferredModelId as NSString)
+        } else if nsPlugin.responds(to: genericRestoreSelector) {
+            _ = nsPlugin.perform(genericRestoreSelector)
+        } else {
+            return .unavailable
+        }
+
+        switch await waitForPluginRestoreConfigured(
+            plugin,
+            selectedModelId: preferredModelId
+        ) {
         case .configured:
             return .configured
         case .failed(let message):
@@ -1544,11 +1609,22 @@ final class ModelManagerService: ObservableObject {
         ) ?? false
     }
 
-    private func waitForPluginRestoreConfigured(_ plugin: TranscriptionEnginePlugin) async -> PluginRestoreWaitResult {
+    private func waitForPluginRestoreConfigured(
+        _ plugin: TranscriptionEnginePlugin,
+        selectedModelId: String? = nil
+    ) async -> PluginRestoreWaitResult {
         var latestActivity: PluginSettingsActivity?
 
         for _ in 0..<pluginConfiguredWaitAttempts {
-            if plugin.isConfigured { return .configured }
+            if let configured = pluginConfiguredState(
+                plugin,
+                selectedModelId: selectedModelId,
+                stopOnMismatchedSelection: selectedModelId != nil
+            ) {
+                return configured
+                    ? .configured
+                    : .failed(Self.mismatchedRestoreMessage(selectedModelId: selectedModelId))
+            }
             if let activity = pluginSettingsActivity(plugin) {
                 latestActivity = activity
                 if activity.isError {
@@ -1558,14 +1634,30 @@ final class ModelManagerService: ObservableObject {
             try? await Task.sleep(for: pluginConfiguredPollInterval)
         }
 
-        if plugin.isConfigured { return .configured }
+        if let configured = pluginConfiguredState(
+            plugin,
+            selectedModelId: selectedModelId,
+            stopOnMismatchedSelection: selectedModelId != nil
+        ) {
+            return configured
+                ? .configured
+                : .failed(Self.mismatchedRestoreMessage(selectedModelId: selectedModelId))
+        }
 
         guard latestActivity != nil else {
             return .timedOut(activity: nil)
         }
 
         for _ in 0..<pluginRestoreBusyWaitAttempts {
-            if plugin.isConfigured { return .configured }
+            if let configured = pluginConfiguredState(
+                plugin,
+                selectedModelId: selectedModelId,
+                stopOnMismatchedSelection: selectedModelId != nil
+            ) {
+                return configured
+                    ? .configured
+                    : .failed(Self.mismatchedRestoreMessage(selectedModelId: selectedModelId))
+            }
             guard let activity = pluginSettingsActivity(plugin) else {
                 return .timedOut(activity: latestActivity)
             }
@@ -1576,7 +1668,15 @@ final class ModelManagerService: ObservableObject {
             try? await Task.sleep(for: pluginConfiguredPollInterval)
         }
 
-        if plugin.isConfigured { return .configured }
+        if let configured = pluginConfiguredState(
+            plugin,
+            selectedModelId: selectedModelId,
+            stopOnMismatchedSelection: selectedModelId != nil
+        ) {
+            return configured
+                ? .configured
+                : .failed(Self.mismatchedRestoreMessage(selectedModelId: selectedModelId))
+        }
         return .timedOut(activity: latestActivity)
     }
 
@@ -1603,5 +1703,12 @@ final class ModelManagerService: ObservableObject {
             return "Timed out while restoring the selected model."
         }
         return "Timed out while restoring the selected model: \(message)."
+    }
+
+    private static func mismatchedRestoreMessage(selectedModelId: String?) -> String {
+        guard let selectedModelId else {
+            return "The plugin restored a different model than requested."
+        }
+        return "The plugin restored a different model than the requested model \"\(selectedModelId)\"."
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -247,7 +247,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         host?.setUserDefault(modelId, forKey: "selectedModel")
 
         if shouldUnloadCurrentModel {
-            unloadModel(clearPersistence: false)
+            unloadModel(clearPersistence: true)
         }
 
         guard shouldRestoreDownloadedSelection(

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -239,8 +239,25 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {
+        guard Self.availableModels.contains(where: { $0.id == modelId }) else { return }
+
+        let previousLoadedModelId = loadedModelId
+        let shouldUnloadCurrentModel = previousLoadedModelId != nil && previousLoadedModelId != modelId
         _selectedModelId = modelId
         host?.setUserDefault(modelId, forKey: "selectedModel")
+
+        if shouldUnloadCurrentModel {
+            unloadModel(clearPersistence: false)
+        }
+
+        guard shouldRestoreDownloadedSelection(
+            modelId,
+            previousLoadedModelId: previousLoadedModelId
+        ) else {
+            return
+        }
+
+        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: modelId) }
     }
 
     var supportsTranslation: Bool { true }
@@ -631,6 +648,11 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
 
     @objc func triggerAutoUnload() { autoUnloadIfIdle() }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        let preferredModelId = modelId.map(String.init)
+        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: preferredModelId) }
+    }
 
     func unloadModel(clearPersistence: Bool = true) {
         invalidateModelLoad()
@@ -692,8 +714,14 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         startSlowModelLoadWarning(generation: generation)
     }
 
-    func restoreTargetModelIdForTesting(allowDownloads: Bool = true) -> String? {
-        modelDefinitionForRestore(allowDownloads: allowDownloads)?.id
+    func restoreTargetModelIdForTesting(
+        allowDownloads: Bool = true,
+        preferredModelId: String? = nil
+    ) -> String? {
+        modelDefinitionForRestore(
+            allowDownloads: allowDownloads,
+            preferredModelId: preferredModelId
+        )?.id
     }
     #endif
 
@@ -705,15 +733,34 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     }
 
     func restoreLoadedModel(allowDownloads: Bool = true) async {
+        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil)
+    }
+
+    func restoreLoadedModel(allowDownloads: Bool = true, preferredModelId: String?) async {
         #if DEBUG
         restoreLoadedModelInvocationCountForTesting += 1
         #endif
 
-        guard let modelDef = modelDefinitionForRestore(allowDownloads: allowDownloads) else { return }
+        guard let modelDef = modelDefinitionForRestore(
+            allowDownloads: allowDownloads,
+            preferredModelId: preferredModelId
+        ) else { return }
         await loadModel(modelDef)
     }
 
-    private func modelDefinitionForRestore(allowDownloads: Bool) -> WhisperModelDef? {
+    private func modelDefinitionForRestore(
+        allowDownloads: Bool,
+        preferredModelId: String? = nil
+    ) -> WhisperModelDef? {
+        if let preferredModelId = preferredModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !preferredModelId.isEmpty {
+            guard let modelDef = Self.availableModels.first(where: { $0.id == preferredModelId }),
+                  allowDownloads || isModelDownloaded(modelDef) else {
+                return nil
+            }
+            return modelDef
+        }
+
         let persistedLoadedId = host?.userDefault(forKey: "loadedModel") as? String
         let candidateIds = [persistedLoadedId, _selectedModelId]
 
@@ -730,6 +777,17 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         }
 
         return nil
+    }
+
+    private func shouldRestoreDownloadedSelection(
+        _ modelId: String,
+        previousLoadedModelId: String?
+    ) -> Bool {
+        guard previousLoadedModelId != modelId else { return false }
+        guard let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+            return false
+        }
+        return isModelDownloaded(modelDef)
     }
 
     fileprivate func isModelDownloaded(_ modelDef: WhisperModelDef) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -9026,8 +9026,12 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     func testModelOverrideRestoresRequestedAutoUnloadedModel() async throws {
         let selectedEngineKey = UserDefaultsKeys.selectedEngine
         let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        let originalEventBus = EventBus.shared
+        let originalPluginManager = PluginManager.shared
         UserDefaults.standard.removeObject(forKey: selectedEngineKey)
         defer {
+            EventBus.shared = originalEventBus
+            PluginManager.shared = originalPluginManager
             if let originalSelection {
                 UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
             } else {
@@ -9079,8 +9083,12 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     func testModelOverrideRejectsDifferentRestoredModel() async throws {
         let selectedEngineKey = UserDefaultsKeys.selectedEngine
         let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        let originalEventBus = EventBus.shared
+        let originalPluginManager = PluginManager.shared
         UserDefaults.standard.removeObject(forKey: selectedEngineKey)
         defer {
+            EventBus.shared = originalEventBus
+            PluginManager.shared = originalPluginManager
             if let originalSelection {
                 UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
             } else {

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -972,6 +972,61 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterPreferredModelRestoringTranscriptionPlugin)
+    private final class PreferredModelRestoringTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.preferred-model-restoring-transcription" }
+        static var pluginName: String { "Preferred Model Restoring Mock Transcription" }
+
+        var configured = false
+        var currentModelId: String? = "alpha"
+        var restoredModelId: String?
+        var modelIdToRestore: String?
+        var transcribedModelId: String?
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var providerId: String { "preferred-model-restoring-mock" }
+        var providerDisplayName: String { "Preferred Model Restoring Mock" }
+        var isConfigured: Bool { configured }
+        var transcriptionModels: [PluginModelInfo] {
+            [
+                PluginModelInfo(id: "alpha", displayName: "Alpha"),
+                PluginModelInfo(id: "beta", displayName: "Beta"),
+            ]
+        }
+        var selectedModelId: String? { currentModelId }
+        func selectModel(_ modelId: String) {
+            currentModelId = modelId
+        }
+        var supportsTranslation: Bool { false }
+
+        @objc func triggerRestoreModel() {
+            restoredModelId = "alpha"
+            currentModelId = "alpha"
+            configured = true
+        }
+
+        @objc(triggerRestoreModelForModel:)
+        func triggerRestoreModel(forModel modelId: NSString?) {
+            restoredModelId = modelId.map(String.init)
+            currentModelId = modelIdToRestore ?? restoredModelId
+            configured = true
+        }
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?
+        ) async throws -> PluginTranscriptionResult {
+            transcribedModelId = currentModelId
+            return PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     @objc(APIRouterAutoUnloadProtectedTranscriptionPlugin)
     private final class AutoUnloadProtectedTranscriptionPlugin: NSObject, LiveTranscriptionCapablePlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.auto-unload-transcription" }
@@ -3483,12 +3538,26 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         UserDefaults.standard.set(true, forKey: historyEnabledKey)
 
         context = await MainActor.run {
-            Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
+            Self.makeAPIContext(appSupportDirectory: appSupportDirectory)
         }
         let apiContext = try XCTUnwrap(context)
         let router = apiContext.router
 
-        let workflowID = try await MainActor.run {
+        let workflowSetup = try await MainActor.run {
+            let workflowPlugin = PreferredModelRestoringTranscriptionPlugin()
+            PluginManager.shared.loadedPlugins.append(LoadedPlugin(
+                manifest: PluginManifest(
+                    id: PreferredModelRestoringTranscriptionPlugin.pluginId,
+                    name: PreferredModelRestoringTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "APIRouterPreferredModelRestoringTranscriptionPlugin"
+                ),
+                instance: workflowPlugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            ))
+
             let globalPlugin = NamedTranscriptionPlugin(
                 providerId: "global-mock",
                 providerDisplayName: "Global Mock",
@@ -3520,16 +3589,19 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             }
             apiContext.textInsertionService.selectedTextOverride = { nil }
             apiContext.textInsertionService.pasteSimulatorOverride = {}
-            return try XCTUnwrap(apiContext.workflowService.addWorkflow(
+            let workflow = try XCTUnwrap(apiContext.workflowService.addWorkflow(
                 name: "Meeting notes",
                 template: .dictation,
                 trigger: .manual(),
                 behavior: WorkflowBehavior(
-                    transcriptionEngineId: "mock",
-                    transcriptionModelId: "tiny"
+                    transcriptionEngineId: workflowPlugin.providerId,
+                    transcriptionModelId: "beta"
                 )
-            )?.id.uuidString)
+            ))
+            return (workflow.id.uuidString, workflowPlugin)
         }
+        let workflowID = workflowSetup.0
+        let workflowPlugin = workflowSetup.1
 
         let start = try Self.jsonObject(
             await router.route(HTTPRequest(
@@ -3552,7 +3624,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(activeStatus["state"] as? String, "recording")
         XCTAssertEqual(activeStatus["active_workflow_id"] as? String, workflowID)
         XCTAssertEqual(activeStatus["active_workflow"] as? String, "Meeting notes")
-        XCTAssertEqual(activeStatus["active_model"] as? String, "tiny")
+        XCTAssertEqual(activeStatus["active_model"] as? String, "beta")
 
         await MainActor.run {
             apiContext.dictationViewModel.partialText = "transcribed"
@@ -3597,6 +3669,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         let recordID = await MainActor.run { apiContext.historyService.records.first?.id.uuidString }
         XCTAssertEqual(recordID, startID)
+        XCTAssertEqual(workflowPlugin.restoredModelId, "beta")
+        XCTAssertEqual(workflowPlugin.transcribedModelId, "beta")
+        XCTAssertEqual(workflowPlugin.selectedModelId, "alpha")
     }
 
     func testDictationEndpointsSpeakCompletedTranscriptionOnly() async throws {
@@ -8945,6 +9020,120 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         )
 
         XCTAssertEqual(plugin.selectedModelId, "alpha", "cloudModelOverride must not persist the plugin's default model")
+    }
+
+    @MainActor
+    func testModelOverrideRestoresRequestedAutoUnloadedModel() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = PreferredModelRestoringTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: PreferredModelRestoringTranscriptionPlugin.pluginId,
+                    name: PreferredModelRestoringTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "APIRouterPreferredModelRestoringTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let result = try await modelManager.transcribe(
+            audioSamples: [Float](repeating: 0, count: 16_000),
+            language: nil,
+            task: .transcribe,
+            engineOverrideId: nil,
+            cloudModelOverride: "beta",
+            prompt: nil
+        )
+
+        XCTAssertEqual(result.text, "transcribed")
+        XCTAssertEqual(plugin.restoredModelId, "beta")
+        XCTAssertEqual(plugin.transcribedModelId, "beta")
+        XCTAssertEqual(plugin.selectedModelId, "alpha", "The one-shot override must restore the previous selection")
+    }
+
+    @MainActor
+    func testModelOverrideRejectsDifferentRestoredModel() async throws {
+        let selectedEngineKey = UserDefaultsKeys.selectedEngine
+        let originalSelection = UserDefaults.standard.object(forKey: selectedEngineKey)
+        UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+        defer {
+            if let originalSelection {
+                UserDefaults.standard.set(originalSelection, forKey: selectedEngineKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: selectedEngineKey)
+            }
+        }
+
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let plugin = PreferredModelRestoringTranscriptionPlugin()
+        plugin.modelIdToRestore = "alpha"
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: PreferredModelRestoringTranscriptionPlugin.pluginId,
+                    name: PreferredModelRestoringTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    principalClass: "APIRouterPreferredModelRestoringTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        do {
+            _ = try await modelManager.transcribe(
+                audioSamples: [Float](repeating: 0, count: 16_000),
+                language: nil,
+                task: .transcribe,
+                engineOverrideId: nil,
+                cloudModelOverride: "beta",
+                prompt: nil
+            )
+            XCTFail("Expected mismatched model restore to fail")
+        } catch let error as TranscriptionEngineError {
+            guard case .modelLoadFailed(let detail) = error else {
+                return XCTFail("Expected modelLoadFailed, got \(error)")
+            }
+            XCTAssertTrue(detail.contains("beta"))
+        }
+
+        XCTAssertEqual(plugin.restoredModelId, "beta")
+        XCTAssertNil(plugin.transcribedModelId)
+        XCTAssertEqual(plugin.selectedModelId, "alpha", "A failed override must restore the previous selection")
     }
 
     @MainActor

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -205,6 +205,96 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertEqual(plugin.restoreTargetModelIdForTesting(allowDownloads: true), modelId)
     }
 
+    func testPreferredRestoreWinsOverPersistedLoadedModel() throws {
+        let persistedModelId = "openai_whisper-tiny"
+        let preferredModelId = "openai_whisper-large-v3_turbo"
+        let host = try makeHost(
+            defaults: [
+                "selectedModel": persistedModelId,
+                "loadedModel": persistedModelId,
+            ],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        _ = try makeUsableWhisperModelDirectory(host: host, modelId: persistedModelId)
+        _ = try makeUsableWhisperModelDirectory(host: host, modelId: preferredModelId)
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(
+            plugin.restoreTargetModelIdForTesting(
+                allowDownloads: false,
+                preferredModelId: preferredModelId
+            ),
+            preferredModelId
+        )
+    }
+
+    func testPreferredRestoreDoesNotFallBackWhenRequestedModelIsNotDownloaded() throws {
+        let persistedModelId = "openai_whisper-tiny"
+        let preferredModelId = "openai_whisper-large-v3_turbo"
+        let host = try makeHost(
+            defaults: [
+                "selectedModel": persistedModelId,
+                "loadedModel": persistedModelId,
+            ],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        _ = try makeUsableWhisperModelDirectory(host: host, modelId: persistedModelId)
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertNil(
+            plugin.restoreTargetModelIdForTesting(
+                allowDownloads: false,
+                preferredModelId: preferredModelId
+            )
+        )
+    }
+
+    func testSelectingDownloadedAutoUnloadedModelSchedulesRestore() async throws {
+        let modelId = "openai_whisper-tiny"
+        let host = try makeHost(shouldRestoreLoadedModelsPassively: false)
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        _ = try makeUsableWhisperModelDirectory(host: host, modelId: modelId)
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel(modelId)
+
+        #if DEBUG
+        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 1)
+        #endif
+        XCTAssertEqual(plugin.selectedModelId, modelId)
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, modelId)
+        plugin.deactivate()
+    }
+
+    func testSelectingUndownloadedModelDoesNotScheduleRestore() async throws {
+        let modelId = "openai_whisper-large-v3_turbo"
+        let host = try makeHost(shouldRestoreLoadedModelsPassively: false)
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel(modelId)
+
+        #if DEBUG
+        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 0)
+        #endif
+        XCTAssertEqual(plugin.selectedModelId, modelId)
+        XCTAssertFalse(plugin.isConfigured)
+    }
+
+    func testWhisperKitExposesPreferredModelRestoreSelector() {
+        let plugin = WhisperKitPlugin()
+
+        XCTAssertTrue(plugin.responds(to: NSSelectorFromString("triggerRestoreModelForModel:")))
+    }
+
     func testUnloadWithoutClearingPersistenceKeepsLoadedModelMarker() throws {
         let host = try makeHost(defaults: [
             "selectedModel": "openai_whisper-tiny",

--- a/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperTests/WhisperKitPluginLifecycleTests.swift
@@ -283,10 +283,12 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         plugin.selectModel(modelId)
 
         #if DEBUG
-        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 0)
+        try await Task.sleep(for: .milliseconds(200))
+        XCTAssertEqual(plugin.restoreLoadedModelInvocationCountForTesting, 0)
         #endif
         XCTAssertEqual(plugin.selectedModelId, modelId)
         XCTAssertFalse(plugin.isConfigured)
+        plugin.deactivate()
     }
 
     func testWhisperKitExposesPreferredModelRestoreSelector() {


### PR DESCRIPTION
## Context

Issue #1058 remained reproducible in dictation-only workflows after WhisperKit 1.1.4: when Immediate auto-unload released the selected WhisperKit model, a workflow-specific engine/model override did not request restoration of that exact model. The global default-engine path already worked.

## Changes

- make the host request and verify restoration of the exact workflow model override
- reject a restore that configures a different model and restore the previous selection on failure
- let WhisperKit 1.1.5 restore a newly selected downloaded model, including on existing hosts that do not expose the new model-specific restore request
- avoid downloading an uninstalled model merely because it was selected
- cover the full dictation workflow endpoint path plus host and WhisperKit lifecycle regressions

Closes #1058

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' DEVELOPMENT_TEAM=2D8ALY3LCL CODE_SIGN_STYLE=Automatic`
- `bash scripts/check_first_party_warnings.sh /tmp/typewhisper-issue-1058-xcodebuild.log`
- `scripts/pr-preflight.sh origin/main`
- `swift test --package-path TypeWhisperPluginSDK`
- `git diff --check`
- Build/install with `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run WhisperKitPlugin --enable-plugin com.typewhisper.whisperkit /Users/marco/Projects/typewhisper-mac`
- With `modelAutoUnloadSeconds=-1`, submit the same WhisperKit/Tiny engine+model override twice through `/v1/transcribe?await_download=1`; verify both transcriptions complete and `/v1/models` reports `downloaded: true, loaded: false` after each request
- Repeat the two-request Immediate smoke with host commit `5fb56ee62a43ee3ee5b9e29252833803c5847ef0` and the new WhisperKit 1.1.5 bundle to verify existing-host compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more reliable selection and restoration of transcription models.
  * Supports restoring a preferred model when its files are already downloaded.
  * Added model-specific restore controls for integrations.

* **Bug Fixes**
  * Prevents transcription when the restored model does not match the requested model.
  * Restores the previously selected model after failed overrides.
  * Improved handling of model identifiers and automatic model unloading.

* **Tests**
  * Added coverage for model overrides, restoration behavior, lifecycle scenarios, and failure handling.

* **Chores**
  * Updated the plugin version to 1.1.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->