### PR TITLE
Clean up Soniox async resources and surface quota errors

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -139,6 +139,12 @@ private struct SonioxAsyncJobFailure: Error, Sendable {
     let transcriptionError: PluginTranscriptionError
 }
 
+private enum SonioxCleanupDeletionResult: Sendable {
+    case deleted
+    case stillProcessing
+    case failed
+}
+
 struct SonioxFetchedLanguage: Codable, Equatable, Sendable {
     let code: String
     let name: String?
@@ -822,6 +828,7 @@ final class SonioxPlugin: NSObject,
     static let defaultTTSModelId = "tts-rt-v1"
     static let ttsSampleRate = 24_000
     static let defaultVoiceId = "Maya"
+    private static let cleanupLogger = Logger(subsystem: "com.typewhisper.soniox", category: "RESTCleanup")
     static let fallbackVoices: [PluginVoiceInfo] = [
         PluginVoiceInfo(id: "Maya", displayName: "Maya"),
         PluginVoiceInfo(id: "Daniel", displayName: "Daniel"),
@@ -1415,12 +1422,228 @@ final class SonioxPlugin: NSObject,
         fileID: String,
         request configuration: SonioxAsyncTranscriptionRequest
     ) async throws -> PluginTranscriptionResult {
-        let transcriptionID = try await createTranscription(
-            fileID: fileID,
+        var transcriptionID: String?
+
+        do {
+            let createdTranscriptionID = try await createTranscription(
+                fileID: fileID,
+                request: configuration
+            )
+            transcriptionID = createdTranscriptionID
+            try await pollUntilCompleted(id: createdTranscriptionID, request: configuration)
+            let result = try await fetchTranscript(id: createdTranscriptionID, request: configuration)
+            await cleanupRESTResources(
+                fileID: fileID,
+                transcriptionID: createdTranscriptionID,
+                request: configuration
+            )
+            return result
+        } catch {
+            await cleanupRESTResources(
+                fileID: fileID,
+                transcriptionID: transcriptionID,
+                request: configuration
+            )
+            throw error
+        }
+    }
+
+    private func cleanupRESTResources(
+        fileID: String,
+        transcriptionID: String?,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async {
+        await Task.detached(priority: .utility) {
+            await Self.performRESTCleanup(
+                fileID: fileID,
+                transcriptionID: transcriptionID,
+                request: configuration
+            )
+        }.value
+    }
+
+    private static func performRESTCleanup(
+        fileID: String,
+        transcriptionID: String?,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async {
+        let transcriptionResult: SonioxCleanupDeletionResult
+        if let transcriptionID {
+            transcriptionResult = await deleteTranscription(
+                id: transcriptionID,
+                request: configuration
+            )
+        } else {
+            transcriptionResult = .deleted
+        }
+
+        await deleteFile(id: fileID, request: configuration)
+
+        guard case .stillProcessing = transcriptionResult,
+              let transcriptionID else {
+            return
+        }
+
+        await retryTranscriptionDeletionWithinCleanupWindow(
+            id: transcriptionID,
             request: configuration
         )
-        try await pollUntilCompleted(id: transcriptionID, request: configuration)
-        return try await fetchTranscript(id: transcriptionID, request: configuration)
+    }
+
+    private static func retryTranscriptionDeletionWithinCleanupWindow(
+        id transcriptionID: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async {
+        let resolved = await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask {
+                while !Task.isCancelled {
+                    do {
+                        try await Task.sleep(for: .seconds(1))
+                    } catch {
+                        return true
+                    }
+
+                    guard let status = await cleanupTranscriptionStatus(
+                        id: transcriptionID,
+                        request: configuration
+                    ) else {
+                        continue
+                    }
+
+                    if status == "missing" {
+                        return true
+                    }
+
+                    guard ["completed", "error", "failed"].contains(status) else {
+                        continue
+                    }
+
+                    let retryResult = await deleteTranscription(
+                        id: transcriptionID,
+                        request: configuration
+                    )
+                    if case .stillProcessing = retryResult {
+                        cleanupLogger.warning("Soniox cleanup could not delete a still-processing transcription")
+                    }
+                    return true
+                }
+
+                return true
+            }
+
+            group.addTask {
+                do {
+                    try await Task.sleep(for: .seconds(10))
+                    return false
+                } catch {
+                    return true
+                }
+            }
+
+            let firstResult = await group.next() ?? false
+            group.cancelAll()
+            return firstResult
+        }
+
+        if !resolved {
+            cleanupLogger.warning("Soniox cleanup timed out waiting for a transcription to become terminal")
+        }
+    }
+
+    private static func deleteTranscription(
+        id: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async -> SonioxCleanupDeletionResult {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/transcriptions/\(id)") else {
+            cleanupLogger.warning("Soniox cleanup could not construct the transcription deletion URL")
+            return .failed
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                cleanupLogger.warning("Soniox transcription cleanup received a non-HTTP response")
+                return .failed
+            }
+
+            switch httpResponse.statusCode {
+            case 204, 404:
+                return .deleted
+            case 409:
+                return .stillProcessing
+            default:
+                cleanupLogger.warning("Soniox transcription cleanup returned HTTP \(httpResponse.statusCode)")
+                return .failed
+            }
+        } catch {
+            cleanupLogger.warning("Soniox transcription cleanup request failed")
+            return .failed
+        }
+    }
+
+    private static func deleteFile(
+        id: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/files/\(id)") else {
+            cleanupLogger.warning("Soniox cleanup could not construct the file deletion URL")
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                cleanupLogger.warning("Soniox file cleanup received a non-HTTP response")
+                return
+            }
+
+            guard [204, 404].contains(httpResponse.statusCode) else {
+                cleanupLogger.warning("Soniox file cleanup returned HTTP \(httpResponse.statusCode)")
+                return
+            }
+        } catch {
+            cleanupLogger.warning("Soniox file cleanup request failed")
+        }
+    }
+
+    private static func cleanupTranscriptionStatus(
+        id: String,
+        request configuration: SonioxAsyncTranscriptionRequest
+    ) async -> String? {
+        guard let url = URL(string: "\(configuration.region.apiBaseURL)/v1/transcriptions/\(id)") else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(configuration.apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return nil
+            }
+            if httpResponse.statusCode == 404 {
+                return "missing"
+            }
+            guard httpResponse.statusCode == 200,
+                  let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return json["status"] as? String
+        } catch {
+            return nil
+        }
     }
 
     private func uploadFile(
@@ -1456,7 +1679,7 @@ final class SonioxPlugin: NSObject,
         case 200, 201: break
         case 401: throw PluginTranscriptionError.invalidApiKey
         case 413: throw PluginTranscriptionError.fileTooLarge
-        case 429: throw PluginTranscriptionError.rateLimited
+        case 429: throw Self.rateLimitError(from: data)
         default:
             let body = String(data: data, encoding: .utf8) ?? ""
             throw PluginTranscriptionError.apiError("Upload failed HTTP \(httpResponse.statusCode): \(body)")
@@ -1494,7 +1717,7 @@ final class SonioxPlugin: NSObject,
         switch httpResponse.statusCode {
         case 200, 201: break
         case 401: throw PluginTranscriptionError.invalidApiKey
-        case 429: throw PluginTranscriptionError.rateLimited
+        case 429: throw Self.rateLimitError(from: data)
         default:
             let body = String(data: data, encoding: .utf8) ?? ""
             throw PluginTranscriptionError.apiError("Create transcription failed HTTP \(httpResponse.statusCode): \(body)")
@@ -1657,7 +1880,7 @@ final class SonioxPlugin: NSObject,
         case 413:
             throw PluginTranscriptionError.fileTooLarge
         case 429:
-            throw PluginTranscriptionError.rateLimited
+            throw rateLimitError(from: data)
         default:
             throw PluginTranscriptionError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
         }
@@ -1939,7 +2162,18 @@ final class SonioxPlugin: NSObject,
 
             let (data, response) = try await PluginHTTPClient.data(for: request)
 
-            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+            guard let httpResponse = response as? HTTPURLResponse else {
+                continue
+            }
+
+            switch httpResponse.statusCode {
+            case 200:
+                break
+            case 401, 403:
+                throw PluginTranscriptionError.invalidApiKey
+            case 429:
+                throw Self.rateLimitError(from: data)
+            default:
                 continue
             }
 
@@ -1996,7 +2230,14 @@ final class SonioxPlugin: NSObject,
             throw PluginTranscriptionError.apiError("No HTTP response")
         }
 
-        guard httpResponse.statusCode == 200 else {
+        switch httpResponse.statusCode {
+        case 200:
+            break
+        case 401, 403:
+            throw PluginTranscriptionError.invalidApiKey
+        case 429:
+            throw Self.rateLimitError(from: data)
+        default:
             let body = String(data: data, encoding: .utf8) ?? ""
             throw PluginTranscriptionError.apiError("Fetch transcript failed HTTP \(httpResponse.statusCode): \(body)")
         }
@@ -2064,18 +2305,38 @@ final class SonioxPlugin: NSObject,
         return request
     }
 
-    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+    private static func providerErrorMessage(from data: Data) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            if let message = json["error_message"] as? String {
+            if let message = nonEmptyString(json["error_message"]) {
                 return message
             }
-            if let message = json["message"] as? String {
+            if let message = nonEmptyString(json["message"]) {
                 return message
             }
             if let error = json["error"] as? [String: Any],
-               let message = error["message"] as? String {
+               let message = nonEmptyString(error["message"]) {
                 return message
             }
+        }
+        return nil
+    }
+
+    private static func nonEmptyString(_ value: Any?) -> String? {
+        guard let value = value as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func rateLimitError(from data: Data) -> PluginTranscriptionError {
+        guard let message = providerErrorMessage(from: data) else {
+            return .rateLimited
+        }
+        return .apiError(message)
+    }
+
+    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+        if let message = providerErrorMessage(from: data) {
+            return message
         }
         if let body = String(data: data, encoding: .utf8), !body.isEmpty {
             return "HTTP \(statusCode): \(body)"

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -2307,10 +2307,10 @@ final class SonioxPlugin: NSObject,
 
     private static func providerErrorMessage(from data: Data) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-            if let message = nonEmptyString(json["error_message"]) {
+            if let message = nonEmptyString(json["message"]) {
                 return message
             }
-            if let message = nonEmptyString(json["message"]) {
+            if let message = nonEmptyString(json["error_message"]) {
                 return message
             }
             if let error = json["error"] as? [String: Any],

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -937,6 +937,10 @@ final class SonioxPluginTests: XCTestCase {
         let response = Self.httpResponse(url: "https://tts-rt.soniox.com/tts", statusCode: 429)
         let variants = [
             (Data(#"{"message":"Message field"}"#.utf8), "API error: Message field"),
+            (
+                Data(#"{"message":"Primary message","error_message":"Secondary message"}"#.utf8),
+                "API error: Primary message"
+            ),
             (Data(#"{"error_message":"Error message field"}"#.utf8), "API error: Error message field"),
             (Data(#"{"error":{"message":"Nested message field"}}"#.utf8), "API error: Nested message field"),
         ]

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -299,6 +299,14 @@ final class SonioxPluginTests: XCTestCase {
                     Data(#"{"text":"Async file transcript"}"#.utf8),
                     Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
                 ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123", statusCode: 204)
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
             ])
         }
 
@@ -332,8 +340,17 @@ final class SonioxPluginTests: XCTestCase {
                 "/v1/transcriptions",
                 "/v1/transcriptions/transcription_123",
                 "/v1/transcriptions/transcription_123/transcript",
+                "/v1/transcriptions/transcription_123",
+                "/v1/files/file_123",
             ]
         )
+
+        let deleteRequests = session.requestedRequests.suffix(2)
+        XCTAssertEqual(deleteRequests.map(\.httpMethod), ["DELETE", "DELETE"])
+        XCTAssertTrue(deleteRequests.allSatisfy {
+            $0.value(forHTTPHeaderField: "Authorization") == "Bearer soniox-key"
+                && $0.timeoutInterval == 10
+        })
 
         let uploadRequest = try XCTUnwrap(session.requestedRequests.first { $0.url?.path == "/v1/files" })
         let uploadBody = String(decoding: try XCTUnwrap(uploadRequest.httpBody), as: UTF8.self)
@@ -374,6 +391,14 @@ final class SonioxPluginTests: XCTestCase {
                     Data(#"{"text":"WAV retry transcript"}"#.utf8),
                     Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
                 ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions/transcription_123", statusCode: 204)
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
             ])
         }
 
@@ -396,6 +421,8 @@ final class SonioxPluginTests: XCTestCase {
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_123",
             "/v1/transcriptions/transcription_123/transcript",
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
         ])
 
         let firstUploadBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
@@ -455,6 +482,17 @@ final class SonioxPluginTests: XCTestCase {
                     )
                 ),
                 .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files/file_m4a", statusCode: 404)
+                ),
+                .success(
                     Data(#"{"id":"file_wav"}"#.utf8),
                     Self.httpResponse(url: "https://api.eu.soniox.com/v1/files", statusCode: 201)
                 ),
@@ -475,6 +513,17 @@ final class SonioxPluginTests: XCTestCase {
                         url: "https://api.eu.soniox.com/v1/transcriptions/transcription_wav/transcript",
                         statusCode: 200
                     )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_wav",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files/file_wav", statusCode: 404)
                 ),
             ])
         }
@@ -501,10 +550,14 @@ final class SonioxPluginTests: XCTestCase {
             "/v1/files",
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_m4a",
+            "/v1/transcriptions/transcription_m4a",
+            "/v1/files/file_m4a",
             "/v1/files",
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_wav",
             "/v1/transcriptions/transcription_wav/transcript",
+            "/v1/transcriptions/transcription_wav",
+            "/v1/files/file_wav",
         ])
         XCTAssertTrue(requests.allSatisfy { $0.url?.host == "api.eu.soniox.com" })
 
@@ -512,15 +565,15 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertTrue(firstUploadBody.contains(#"filename="audio.m4a""#))
         XCTAssertTrue(firstUploadBody.contains("Content-Type: audio/mp4"))
 
-        let retryUploadBody = String(decoding: try XCTUnwrap(requests[3].httpBody), as: UTF8.self)
+        let retryUploadBody = String(decoding: try XCTUnwrap(requests[5].httpBody), as: UTF8.self)
         XCTAssertTrue(retryUploadBody.contains(#"filename="audio.wav""#))
         XCTAssertTrue(retryUploadBody.contains("Content-Type: audio/wav"))
 
         XCTAssertEqual(requests[1].value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
-        XCTAssertEqual(requests[4].value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
+        XCTAssertEqual(requests[6].value(forHTTPHeaderField: "Authorization"), "Bearer soniox-key")
 
         var firstCreateBody = try Self.jsonBody(from: requests[1])
-        var retryCreateBody = try Self.jsonBody(from: requests[4])
+        var retryCreateBody = try Self.jsonBody(from: requests[6])
         XCTAssertEqual(firstCreateBody.removeValue(forKey: "file_id") as? String, "file_m4a")
         XCTAssertEqual(retryCreateBody.removeValue(forKey: "file_id") as? String, "file_wav")
         XCTAssertTrue(NSDictionary(dictionary: firstCreateBody).isEqual(to: retryCreateBody))
@@ -559,6 +612,14 @@ final class SonioxPluginTests: XCTestCase {
                         statusCode: 200
                     )
                 ),
+                .success(
+                    Data(#"{"message":"cleanup failed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 500
+                    )
+                ),
+                .failure(URLError(.cannotConnectToHost)),
             ])
         }
 
@@ -584,6 +645,8 @@ final class SonioxPluginTests: XCTestCase {
             "/v1/files",
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_m4a",
+            "/v1/transcriptions/transcription_m4a",
+            "/v1/files/file_m4a",
         ])
         let uploadBody = String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self)
         XCTAssertTrue(uploadBody.contains(#"filename="audio.m4a""#))
@@ -615,6 +678,17 @@ final class SonioxPluginTests: XCTestCase {
                     )
                 ),
                 .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_m4a",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_m4a", statusCode: 404)
+                ),
+                .success(
                     Data(#"{"id":"file_wav"}"#.utf8),
                     Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
                 ),
@@ -630,6 +704,17 @@ final class SonioxPluginTests: XCTestCase {
                         url: "https://api.soniox.com/v1/transcriptions/transcription_wav",
                         statusCode: 200
                     )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_wav",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_wav", statusCode: 404)
                 ),
             ])
         }
@@ -661,13 +746,397 @@ final class SonioxPluginTests: XCTestCase {
             "/v1/files",
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_m4a",
+            "/v1/transcriptions/transcription_m4a",
+            "/v1/files/file_m4a",
             "/v1/files",
             "/v1/transcriptions",
             "/v1/transcriptions/transcription_wav",
+            "/v1/transcriptions/transcription_wav",
+            "/v1/files/file_wav",
         ])
-        let retryUploadBody = String(decoding: try XCTUnwrap(requests[3].httpBody), as: UTF8.self)
+        let retryUploadBody = String(decoding: try XCTUnwrap(requests[5].httpBody), as: UTF8.self)
         XCTAssertTrue(retryUploadBody.contains(#"filename="audio.wav""#))
         XCTAssertTrue(retryUploadBody.contains("Content-Type: audio/wav"))
+    }
+
+    func testUpload429SurfacesSonioxQuotaMessage() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error_type":"limit_exceeded","message":"Total file count limit exceeded. Please delete some files."}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 429)
+                ),
+            ])
+        }
+
+        do {
+            _ = try await transcribeREST(using: plugin)
+            XCTFail("Expected the Soniox quota error")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: Total file count limit exceeded. Please delete some files."
+            )
+        }
+
+        XCTAssertEqual(store.sessions.first?.requestedPaths, ["/v1/files"])
+    }
+
+    func testCreateTranscription429SurfacesMessageAndDeletesUploadedFile() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"error_type":"limit_exceeded","error_message":"Total transcription count exceeded."}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 429)
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 204)
+                ),
+            ])
+        }
+
+        do {
+            _ = try await transcribeREST(using: plugin)
+            XCTFail("Expected the Soniox quota error")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: Total transcription count exceeded."
+            )
+        }
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/files/file_123",
+        ])
+        XCTAssertEqual(requests.last?.httpMethod, "DELETE")
+    }
+
+    func testPolling429SurfacesNestedMessageAndCleansUpBothResources() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"error_type":"limit_exceeded","error":{"message":"Async requests per minute exceeded."}}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 429
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
+            ])
+        }
+
+        do {
+            _ = try await transcribeREST(using: plugin)
+            XCTFail("Expected the Soniox quota error")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: Async requests per minute exceeded."
+            )
+        }
+
+        XCTAssertEqual(store.sessions.first?.requestedPaths, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_123",
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
+        ])
+    }
+
+    func testTranscriptFetch429SurfacesMessageAndCleansUpBothResources() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"message":"Transcript retrieval quota exceeded."}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript",
+                        statusCode: 429
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
+            ])
+        }
+
+        do {
+            _ = try await transcribeREST(using: plugin)
+            XCTFail("Expected the Soniox quota error")
+        } catch {
+            XCTAssertEqual(
+                (error as? PluginTranscriptionError)?.localizedDescription,
+                "API error: Transcript retrieval quota exceeded."
+            )
+        }
+
+        XCTAssertEqual(store.sessions.first?.requestedPaths.suffix(2), [
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
+        ])
+    }
+
+    func testHTTP429UsesProviderMessageVariantsAndFallsBackWhenMissing() throws {
+        let response = Self.httpResponse(url: "https://tts-rt.soniox.com/tts", statusCode: 429)
+        let variants = [
+            (Data(#"{"message":"Message field"}"#.utf8), "API error: Message field"),
+            (Data(#"{"error_message":"Error message field"}"#.utf8), "API error: Error message field"),
+            (Data(#"{"error":{"message":"Nested message field"}}"#.utf8), "API error: Nested message field"),
+        ]
+
+        for (data, expectedDescription) in variants {
+            XCTAssertThrowsError(try SonioxPlugin.validateHTTPResponse(data: data, response: response)) { error in
+                XCTAssertEqual((error as? PluginTranscriptionError)?.localizedDescription, expectedDescription)
+            }
+        }
+
+        for data in [Data(), Data("not-json".utf8), Data(#"{"message":"   "}"#.utf8)] {
+            XCTAssertThrowsError(try SonioxPlugin.validateHTTPResponse(data: data, response: response)) { error in
+                XCTAssertEqual(
+                    (error as? PluginTranscriptionError)?.localizedDescription,
+                    "Rate limit exceeded. Please wait and try again."
+                )
+            }
+        }
+    }
+
+    func testCleanupFailuresDoNotReplaceSuccessfulTranscript() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"Cleanup-independent transcript"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 500
+                    )
+                ),
+                .failure(URLError(.cannotConnectToHost)),
+            ])
+        }
+
+        let result = try await transcribeREST(using: plugin)
+
+        XCTAssertEqual(result.text, "Cleanup-independent transcript")
+        XCTAssertEqual(store.sessions.first?.requestedPaths.suffix(2), [
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
+        ])
+    }
+
+    func testCleanupRetriesTranscriptionDeletionAfterProcessingEnds() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"status":"completed"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(#"{"text":"Retry cleanup transcript"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123/transcript",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 409
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 204)
+                ),
+                .success(
+                    Data(#"{"status":"error"}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 204
+                    )
+                ),
+            ])
+        }
+
+        let result = try await transcribeREST(using: plugin)
+
+        XCTAssertEqual(result.text, "Retry cleanup transcript")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        let cleanupRequests = requests.suffix(4)
+        XCTAssertEqual(cleanupRequests.map(\.httpMethod), ["DELETE", "DELETE", "GET", "DELETE"])
+        XCTAssertEqual(cleanupRequests.map { $0.url?.path }, [
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
+            "/v1/transcriptions/transcription_123",
+            "/v1/transcriptions/transcription_123",
+        ])
+    }
+
+    func testCancellationStillCleansUpCreatedResources() async throws {
+        let plugin = try configuredPlugin()
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"file_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files", statusCode: 201)
+                ),
+                .success(
+                    Data(#"{"id":"transcription_123"}"#.utf8),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/transcriptions", statusCode: 201)
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
+            ])
+        }
+
+        let task = Task {
+            try await plugin.transcribe(
+                audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+                languageSelection: PluginLanguageSelection(languageHints: ["en"]),
+                translate: false,
+                prompt: nil,
+                onProgress: { _ in true },
+                onSourceProgress: { _ in true }
+            )
+        }
+
+        for _ in 0..<200 {
+            if store.sessions.first?.requestedRequests.count == 2 {
+                break
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        XCTAssertEqual(store.sessions.first?.requestedRequests.count, 2)
+
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected. Cleanup is awaited before the cancellation escapes.
+        } catch {
+            XCTFail("Expected CancellationError, got \(error)")
+        }
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.map(\.httpMethod), ["POST", "POST", "DELETE", "DELETE"])
+        XCTAssertEqual(requests.map { $0.url?.path }, [
+            "/v1/files",
+            "/v1/transcriptions",
+            "/v1/transcriptions/transcription_123",
+            "/v1/files/file_123",
+        ])
     }
 
     func testSourceProgressTranscriptionUsesSelectedRegionalRESTPath() async throws {
@@ -697,6 +1166,17 @@ final class SonioxPluginTests: XCTestCase {
                     Data(#"{"text":"EU transcript"}"#.utf8),
                     Self.httpResponse(url: "https://api.eu.soniox.com/v1/transcriptions/transcription_123/transcript", statusCode: 200)
                 ),
+                .success(
+                    Data(),
+                    Self.httpResponse(
+                        url: "https://api.eu.soniox.com/v1/transcriptions/transcription_123",
+                        statusCode: 204
+                    )
+                ),
+                .success(
+                    Data(),
+                    Self.httpResponse(url: "https://api.eu.soniox.com/v1/files/file_123", statusCode: 404)
+                ),
             ])
         }
 
@@ -718,6 +1198,8 @@ final class SonioxPluginTests: XCTestCase {
                 "https://api.eu.soniox.com/v1/transcriptions",
                 "https://api.eu.soniox.com/v1/transcriptions/transcription_123",
                 "https://api.eu.soniox.com/v1/transcriptions/transcription_123/transcript",
+                "https://api.eu.soniox.com/v1/transcriptions/transcription_123",
+                "https://api.eu.soniox.com/v1/files/file_123",
             ]
         )
     }
@@ -1003,6 +1485,24 @@ final class SonioxPluginTests: XCTestCase {
 
         let result = try await session.finish()
         XCTAssertEqual(result.text, "done")
+    }
+
+    private func configuredPlugin() throws -> SonioxPlugin {
+        let host = try PluginTestHostServices(secrets: ["api-key": "soniox-key"])
+        let plugin = SonioxPlugin()
+        plugin.activate(host: host)
+        return plugin
+    }
+
+    private func transcribeREST(using plugin: SonioxPlugin) async throws -> PluginTranscriptionResult {
+        try await plugin.transcribe(
+            audio: AudioData(samples: [0], wavData: Data("wav".utf8), duration: 1),
+            languageSelection: PluginLanguageSelection(languageHints: ["en"]),
+            translate: false,
+            prompt: nil,
+            onProgress: { _ in true },
+            onSourceProgress: { _ in true }
+        )
     }
 
     private static func jsonBody(from request: URLRequest) throws -> [String: Any] {


### PR DESCRIPTION
## Issue context

Issue #1063 reports that Soniox async uploads and transcription records created by TypeWhisper are never deleted. Because both resource types count against fixed Soniox project quotas, projects can eventually become blocked while the app surfaces a misleading generic rate-limit error.

## What changed

- Best-effort cleanup now deletes the transaction's transcription first and its uploaded file second after success, failure, retry, or cancellation.
- A create failure deletes the uploaded file; an M4A `invalid_audio_file` job is fully cleaned before the single WAV retry starts.
- Cleanup is awaited in a cancellation-independent utility task, treats 404 as idempotent success, and never replaces the transcript or original error.
- A 409 transcription deletion still triggers immediate file deletion, then polls within a bounded 10-second cleanup window and retries deletion after a terminal status.
- Soniox HTTP 429 responses now surface non-empty `message`, `error_message`, or nested `error.message` values for upload, create, poll, fetch, and TTS. Missing or invalid bodies retain the existing rate-limit fallback.
- Realtime transcription and public SDK APIs remain unchanged.

TypeWhisper only deletes IDs created by the current transaction. This change does not bulk-delete existing or unrelated Soniox resources.

Closes #1063

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests` — 44 tests passed, 0 failures
- `swift test --package-path TypeWhisperPluginSDK` — 521 tests passed, 0 failures
- `git diff --check origin/main...HEAD` — passed
- `PATH="/opt/homebrew/bin:$PATH" bash scripts/pr-preflight.sh origin/main` — passed, including 521 SDK tests
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run SonioxPlugin /Users/marco/.codex/worktrees/soniox-resource-cleanup/typewhisper-mac` — built, installed, signed, and relaunched TypeWhisper-Dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary transcription resources after successful, failed, cancelled, and rate-limited requests.
  * Added retries when deleting transcriptions that are still processing.
  * Improved rate-limit and authentication error messages by displaying provider details when available.
  * Added bounded timeouts and safer handling of cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->