### PR TITLE
Bump Soniox plugin to 1.2.6

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump the Soniox plugin manifest from 1.2.5 to 1.2.6
- release the async resource cleanup and quota-error fix merged in #1064

No SDK compatibility or minimum host version changes are included.

## Test plan

- `jq empty TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json` — passed
- `swift test --package-path TypeWhisperPluginSDK --filter SonioxPluginTests` — 44 tests passed, 0 failures
- `git diff --check origin/main...HEAD` — passed
- `PATH="/opt/homebrew/bin:$PATH" bash scripts/pr-preflight.sh origin/main` — passed, including 521 SDK tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Soniox plugin to version 1.2.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->