### PR TITLE
Point the US region at a documented Speechmatics batch endpoint

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -253,6 +253,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "SpeechmaticsPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/SpeechmaticsPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "AssemblyAIPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/AssemblyAIPlugin",
@@ -530,6 +540,15 @@ let package = Package(
                 "SonioxPlugin",
             ],
             path: "Plugins/SonioxPlugin/Tests"
+        ),
+        .testTarget(
+            name: "SpeechmaticsPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "SpeechmaticsPlugin",
+            ],
+            path: "Plugins/SpeechmaticsPlugin/Tests"
         ),
         .testTarget(
             name: "AssemblyAIPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -107,19 +107,27 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
 
     // MARK: - Region Helpers
 
-    fileprivate var wsHost: String {
-        switch _selectedRegion {
+    // The realtime and batch namespaces do not share region labels: realtime keeps
+    // the legacy "usa" prefix, while batch only serves the numbered SaaS endpoints
+    // (eu1/eu2/us1/us2/au1). "usa.asr.api.speechmatics.com" is not a registered
+    // host and fails the TLS handshake.
+    static func wsHost(forRegion region: String?) -> String {
+        switch region {
         case "us": return "usa.rt.speechmatics.com"
         default: return "eu2.rt.speechmatics.com"
         }
     }
 
-    fileprivate var batchHost: String {
-        switch _selectedRegion {
-        case "us": return "usa.asr.api.speechmatics.com"
+    static func batchHost(forRegion region: String?) -> String {
+        switch region {
+        case "us": return "us1.asr.api.speechmatics.com"
         default: return "asr.api.speechmatics.com"
         }
     }
+
+    fileprivate var wsHost: String { Self.wsHost(forRegion: _selectedRegion) }
+
+    fileprivate var batchHost: String { Self.batchHost(forRegion: _selectedRegion) }
 
     // MARK: - Transcription (REST Fallback)
 

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import SpeechmaticsPlugin
+
+final class SpeechmaticsPluginTests: XCTestCase {
+    func testUSRegionUsesDocumentedBatchEndpoint() {
+        XCTAssertEqual(
+            SpeechmaticsPlugin.batchHost(forRegion: "us"),
+            "us1.asr.api.speechmatics.com"
+        )
+    }
+
+    func testEURegionAndUnknownRegionsUseDefaultBatchEndpoint() {
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: "eu"), "asr.api.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: nil), "asr.api.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: "unknown"), "asr.api.speechmatics.com")
+    }
+
+    func testBatchHostsNeverUseTheRealtimeRegionLabel() {
+        for region in ["eu", "us", "unknown", nil] {
+            XCTAssertFalse(
+                SpeechmaticsPlugin.batchHost(forRegion: region).hasPrefix("usa."),
+                "\"usa\" is a realtime-only label and is unregistered in the batch namespace"
+            )
+        }
+    }
+
+    func testRealtimeHostsAreUnchanged() {
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: "us"), "usa.rt.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: "eu"), "eu2.rt.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: nil), "eu2.rt.speechmatics.com")
+    }
+}


### PR DESCRIPTION
# Point the US region at a documented Speechmatics batch endpoint

Closes #1067

## Summary

With Region set to **US**, every Speechmatics REST/Batch call failed with `A TLS error caused the secure connection to fail.`

`batchHost` mapped `us` to `usa.asr.api.speechmatics.com`, which is not a registered host. `usa` is the value of the deprecated `region` query parameter for temporary keys (documented as having no effect) and a legacy prefix in the *realtime* namespace; the batch namespace only serves the documented SaaS endpoints `eu1` / `eu2` / `us1` / `us2` / `au1`. The prefix was copied from `wsHost` in 8424649, when the REST path was first made region-aware — the US batch path has never worked.

The failure is at the TLS layer, not DNS: the name resolves, TCP connects, and the handshake is then reset because the hostname is not on the CDN. An unregistered control name in the same namespace behaves identically.

| Host | `curl -I` |
| --- | --- |
| `usa.asr.api.speechmatics.com` (before) | TLS handshake reset |
| `us1.asr.api.speechmatics.com` (after) | `HTTP/2 200` |
| `asr.api.speechmatics.com` (EU default, unchanged) | `HTTP/2 200` |
| `nonexistent-xyz.asr.api.speechmatics.com` (control) | TLS handshake reset |

This was not limited to transcription — `validateApiKey` shares the same mapping, so saving a valid API key under Region = US reported **Invalid API Key**.

`wsHost` is left alone: `usa.rt.speechmatics.com` is live and answers exactly like the documented `us.rt.speechmatics.com`, which is why the WebSocket path never surfaced the bug and only the REST fallback did.

## Changes

- `batchHost` for `us` → `us1.asr.api.speechmatics.com`.
- Host mapping moved to `static func wsHost(forRegion:)` / `batchHost(forRegion:)` so it is testable; the `fileprivate` properties now delegate.
- Added an SPM target and test target for `SpeechmaticsPlugin` (it had neither), plus host-mapping tests.

The EU default (`asr.api.speechmatics.com`) is deliberately untouched — it works today, and changing it would alter behavior for users who are not affected by this bug.

## Test Plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter SpeechmaticsPluginTests
bash scripts/pr-preflight.sh
```

Manual:
1. Settings → Speechmatics → set Region to **US**, save a valid API key → key validates instead of reporting "Invalid API Key".
2. Transcribe a file with Region = US → completes instead of failing with the TLS error.
3. Repeat with Region = **EU** → unchanged.

> Note for reviewers: the Plugin SDK tests could not be executed on the machine this was prepared on (Xcode is not installed there, so `XCTest` is unavailable and every existing test target fails to build for the same reason). `swift build --package-path TypeWhisperPluginSDK --target SpeechmaticsPlugin` succeeds, and the mapping functions were exercised directly against the built module. Please confirm the test run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Speechmatics plugin, including localized resources and testing coverage.

* **Bug Fixes**
  * Corrected US batch transcription routing to use the supported Speechmatics endpoint.
  * Preserved existing realtime routing for US and other regions.
  * Improved handling of missing or unknown region settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->