### PR TITLE
Fix Speechmatics US batch routing and language packs

### DIFF
--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -253,6 +253,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "SpeechmaticsPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/SpeechmaticsPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "AssemblyAIPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/AssemblyAIPlugin",
@@ -530,6 +540,15 @@ let package = Package(
                 "SonioxPlugin",
             ],
             path: "Plugins/SonioxPlugin/Tests"
+        ),
+        .testTarget(
+            name: "SpeechmaticsPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "SpeechmaticsPlugin",
+            ],
+            path: "Plugins/SpeechmaticsPlugin/Tests"
         ),
         .testTarget(
             name: "AssemblyAIPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -107,19 +107,27 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
 
     // MARK: - Region Helpers
 
-    fileprivate var wsHost: String {
-        switch _selectedRegion {
+    // The realtime and batch namespaces do not share region labels: realtime keeps
+    // the legacy "usa" prefix, while batch only serves the numbered SaaS endpoints
+    // (eu1/eu2/us1/us2/au1). "usa.asr.api.speechmatics.com" is not a registered
+    // host and fails the TLS handshake.
+    static func wsHost(forRegion region: String?) -> String {
+        switch region {
         case "us": return "usa.rt.speechmatics.com"
         default: return "eu2.rt.speechmatics.com"
         }
     }
 
-    fileprivate var batchHost: String {
-        switch _selectedRegion {
-        case "us": return "usa.asr.api.speechmatics.com"
+    static func batchHost(forRegion region: String?) -> String {
+        switch region {
+        case "us": return "us1.asr.api.speechmatics.com"
         default: return "asr.api.speechmatics.com"
         }
     }
+
+    fileprivate var wsHost: String { Self.wsHost(forRegion: _selectedRegion) }
+
+    fileprivate var batchHost: String { Self.batchHost(forRegion: _selectedRegion) }
 
     // MARK: - Transcription (REST Fallback)
 

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -121,6 +121,12 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         return languagePackAliases[language] ?? language
     }
 
+    // Language identification is a batch-only feature, so "auto" is not a value the
+    // realtime endpoint accepts.
+    static func supportsRealtimeStreaming(language: String?) -> Bool {
+        languagePack(for: language) != "auto"
+    }
+
     // MARK: - Region Helpers
 
     // The realtime and batch namespaces do not share region labels: realtime keeps
@@ -178,6 +184,19 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         }
         guard let modelId = _selectedModelId else {
             throw PluginTranscriptionError.noModelSelected
+        }
+
+        // Without a language the job needs language identification, which only the
+        // batch API offers - opening the realtime endpoint would just get rejected
+        // and reach a transcript through the fallback below.
+        guard Self.supportsRealtimeStreaming(language: language) else {
+            return try await transcribeREST(
+                audio: audio,
+                language: language,
+                modelId: modelId,
+                apiKey: apiKey,
+                prompt: prompt
+            )
         }
 
         do {

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -94,15 +94,31 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var dictionaryTermsBudget: DictionaryTermsBudget { Self.dictionaryBudget }
 
+    // Codes that map 1:1 onto a Speechmatics language pack. The previous list also
+    // advertised gu/is/ka/kk/ml/mk/pa/sq/sr/te, none of which Speechmatics serves -
+    // picking any of them failed the job with HTTP 400 "Languagepack is not supported".
+    static let languagePackCodes: [String] = [
+        "ar", "bg", "ca", "cmn", "cs", "cy", "da", "de", "el", "en",
+        "es", "et", "eu", "fa", "fi", "fr", "ga", "gl", "he", "hi",
+        "hr", "hu", "id", "it", "ja", "ko", "lt", "lv", "ms", "mt",
+        "nl", "no", "pl", "pt", "ro", "ru", "sk", "sl", "sv", "sw",
+        "ta", "th", "tr", "uk", "ur", "vi", "yue",
+    ]
+
+    // Speechmatics identifies Mandarin by its ISO 639-3 code, but the app's spoken
+    // language list only offers the generic "zh", so it is advertised as an alias and
+    // resolved before the request is built.
+    static let languagePackAliases: [String: String] = [
+        "zh": "cmn",
+    ]
+
     var supportedLanguages: [String] {
-        [
-            "ar", "bg", "ca", "cmn", "cs", "cy", "da", "de", "el", "en",
-            "es", "et", "eu", "fa", "fi", "fr", "ga", "gl", "gu", "he",
-            "hi", "hr", "hu", "id", "is", "it", "ja", "ka", "kk", "ko",
-            "lt", "lv", "mk", "ml", "ms", "mt", "nl", "no", "pa", "pl",
-            "pt", "ro", "ru", "sk", "sl", "sq", "sr", "sv", "sw", "ta",
-            "te", "th", "tr", "uk", "ur", "vi", "yue", "zh",
-        ]
+        Self.languagePackCodes + ["zh"]
+    }
+
+    static func languagePack(for language: String?) -> String {
+        guard let language, !language.isEmpty else { return "auto" }
+        return languagePackAliases[language] ?? language
     }
 
     // MARK: - Region Helpers
@@ -215,7 +231,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
 
         let boundary = UUID().uuidString
 
-        let lang = (language?.isEmpty == false) ? language! : "auto"
+        let lang = Self.languagePack(for: language)
         var transcriptionConfig: [String: Any] = [
             "language": lang,
             "operating_point": modelId,
@@ -372,7 +388,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         wsTask.resume()
 
         // Send StartRecognition message
-        let lang = (language?.isEmpty == false) ? language! : "auto"
+        let lang = Self.languagePack(for: language)
         var transcriptionConfig: [String: Any] = [
             "language": lang,
             "operating_point": modelId,

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
@@ -65,6 +65,16 @@ final class SpeechmaticsPluginTests: XCTestCase {
         }
     }
 
+    func testRealtimeStreamingIsSkippedWhenLanguageIdentificationIsNeeded() {
+        XCTAssertFalse(SpeechmaticsPlugin.supportsRealtimeStreaming(language: nil))
+        XCTAssertFalse(SpeechmaticsPlugin.supportsRealtimeStreaming(language: ""))
+    }
+
+    func testRealtimeStreamingIsUsedForExplicitLanguages() {
+        XCTAssertTrue(SpeechmaticsPlugin.supportsRealtimeStreaming(language: "de"))
+        XCTAssertTrue(SpeechmaticsPlugin.supportsRealtimeStreaming(language: "zh"))
+    }
+
     func testUnsupportedLanguagesAreNoLongerAdvertised() {
         let plugin = SpeechmaticsPlugin()
         for code in ["gu", "is", "ka", "kk", "ml", "mk", "pa", "sq", "sr", "te"] {

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
@@ -29,4 +29,49 @@ final class SpeechmaticsPluginTests: XCTestCase {
         XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: "eu"), "eu2.rt.speechmatics.com")
         XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: nil), "eu2.rt.speechmatics.com")
     }
+
+    // Language packs documented at docs.speechmatics.com/introduction/supported-languages
+    private static let documentedLanguagePacks: Set<String> = [
+        "auto", "ar", "ba", "eu", "be", "bn", "bg", "yue", "ca", "hr",
+        "cs", "da", "nl", "en", "eo", "et", "fi", "fr", "gl", "de",
+        "el", "he", "hi", "hu", "id", "ia", "ga", "it", "ja", "ko",
+        "lv", "lt", "ms", "mt", "cmn", "mr", "mn", "no", "fa", "pl",
+        "pt", "ro", "ru", "sk", "sl", "es", "sw", "sv", "ta", "th",
+        "tr", "uk", "ur", "ug", "vi", "cy",
+    ]
+
+    func testChineseResolvesToMandarinLanguagePack() {
+        XCTAssertEqual(SpeechmaticsPlugin.languagePack(for: "zh"), "cmn")
+    }
+
+    func testAutoDetectIsRequestedWhenNoLanguageIsSelected() {
+        XCTAssertEqual(SpeechmaticsPlugin.languagePack(for: nil), "auto")
+        XCTAssertEqual(SpeechmaticsPlugin.languagePack(for: ""), "auto")
+    }
+
+    func testUnaliasedLanguagesArePassedThrough() {
+        XCTAssertEqual(SpeechmaticsPlugin.languagePack(for: "de"), "de")
+        XCTAssertEqual(SpeechmaticsPlugin.languagePack(for: "yue"), "yue")
+    }
+
+    func testEveryAdvertisedLanguageResolvesToADocumentedPack() {
+        let plugin = SpeechmaticsPlugin()
+        for code in plugin.supportedLanguages {
+            let pack = SpeechmaticsPlugin.languagePack(for: code)
+            XCTAssertTrue(
+                Self.documentedLanguagePacks.contains(pack),
+                "\(code) resolves to \(pack), which Speechmatics rejects with HTTP 400"
+            )
+        }
+    }
+
+    func testUnsupportedLanguagesAreNoLongerAdvertised() {
+        let plugin = SpeechmaticsPlugin()
+        for code in ["gu", "is", "ka", "kk", "ml", "mk", "pa", "sq", "sr", "te"] {
+            XCTAssertFalse(
+                plugin.supportedLanguages.contains(code),
+                "\(code) has no Speechmatics language pack"
+            )
+        }
+    }
 }

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/Tests/SpeechmaticsPluginTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import SpeechmaticsPlugin
+
+final class SpeechmaticsPluginTests: XCTestCase {
+    func testUSRegionUsesDocumentedBatchEndpoint() {
+        XCTAssertEqual(
+            SpeechmaticsPlugin.batchHost(forRegion: "us"),
+            "us1.asr.api.speechmatics.com"
+        )
+    }
+
+    func testEURegionAndUnknownRegionsUseDefaultBatchEndpoint() {
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: "eu"), "asr.api.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: nil), "asr.api.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.batchHost(forRegion: "unknown"), "asr.api.speechmatics.com")
+    }
+
+    func testBatchHostsNeverUseTheRealtimeRegionLabel() {
+        for region in ["eu", "us", "unknown", nil] {
+            XCTAssertFalse(
+                SpeechmaticsPlugin.batchHost(forRegion: region).hasPrefix("usa."),
+                "\"usa\" is a realtime-only label and is unregistered in the batch namespace"
+            )
+        }
+    }
+
+    func testRealtimeHostsAreUnchanged() {
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: "us"), "usa.rt.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: "eu"), "eu2.rt.speechmatics.com")
+        XCTAssertEqual(SpeechmaticsPlugin.wsHost(forRegion: nil), "eu2.rt.speechmatics.com")
+    }
+}


### PR DESCRIPTION
# Fix Speechmatics US batch routing and language packs

Closes #1067

> **Supersedes #1068.** This PR contains the US Batch endpoint fix together with the remaining language-pack and automatic-language routing fixes, so #1067 can land in one squash merge without the stacked-branch conflict.

## Summary

This PR resolves both Speechmatics defects reported in #1067:

- US REST/Batch requests used the unregistered `usa.asr.api.speechmatics.com` host, breaking transcription and API-key validation with TLS errors.
- The plugin advertised unsupported language codes and sent generic `zh` directly to Speechmatics instead of the Mandarin `cmn` pack.

Selecting Chinese failed every job with:

```
API error: Submit failed HTTP 400: {"code":400,"detail":"Languagepack 'zh' is not supported..."}
```

Speechmatics identifies Chinese language packs by ISO 639-3 code — `cmn` for Mandarin, `yue` for Cantonese — and serves no `zh` pack. The plugin advertised `zh` in `supportedLanguages`, the host normalizes a language selection only by set membership (`LanguageSelection.normalizedForSupportedLanguages`), so `zh` survived normalization and went into `transcription_config.language` verbatim on both the batch and WebSocket paths.

`zh` was not the only bad entry. Diffed against the [documented language packs](https://docs.speechmatics.com/introduction/supported-languages), **11 of the 58 advertised codes have no Speechmatics pack** and fail identically: `gu`, `is`, `ka`, `kk`, `ml`, `mk`, `pa`, `sq`, `sr`, `te`, `zh`. Because `SettingsViewModel.availableLanguages` unions `supportedLanguages` across all installed engines, these codes also widened the language picker for every other engine.

## Changes

- Routes US REST/Batch requests through the documented `us1.asr.api.speechmatics.com` endpoint while leaving realtime routing unchanged.
- Added `languagePack(for:)`, shared by the batch and WebSocket request builders, resolving `zh` → `cmn` and keeping `auto` for an unset language on the batch path.
- `zh` stays advertised as an alias: the app's own `defaultSpokenLanguageCodes` only offers the generic code, so dropping it outright would silently downgrade Chinese users to auto-detect.
- Removed the ten codes with no language pack from `supportedLanguages`.
- Tests assert that every advertised code resolves to a documented pack, so a future addition cannot reintroduce this class of bug.
- Follow-up from review: requests with no language selected no longer open the realtime endpoint. Speechmatics documents language identification as [batch-only](https://docs.speechmatics.com/speech-to-text/languages), so `"auto"` is not a value `StartRecognition` accepts — the WebSocket was opened, rejected, and only produced a transcript via the REST fallback. Those requests now go straight to the batch API. Same outcome, one less impossible handshake, and control flow no longer routed through an exception. This is pre-existing behaviour (`"auto"` replaced a hardcoded `"en"` in 8424649), fixed here because this branch already owns which language value reaches the API.

Deliberately out of scope:

- Speechmatics packs the plugin still does not offer (`ba`, `be`, `bn`, `eo`, `ia`, `mr`, `mn`, `ug`, and the bilingual packs) — adding languages is a feature, not this fix.
- `supportedLanguages` lists both `zh` and `cmn`, so the picker shows two Chinese entries that now behave identically.
- The batch path reports Speechmatics' `metadata.language` as `detectedLanguage`, so auto-detected Mandarin returns `cmn` while the app's canonical code is `zh`. `CohereLocalPlugin.swift:664` does the reverse canonicalization for the same reason.

## Test Plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter SpeechmaticsPluginTests
bash scripts/pr-preflight.sh
```

Manual:
1. Validate an API key and transcribe with Region **US** → REST/Batch requests complete without the TLS hostname error.
2. Settings → set transcription language to **Chinese**, Region **EU**, record a dictation → produces a transcript instead of HTTP 400.
3. Set language to **Auto** → still transcribes; the batch request keeps `"language": "auto"`, and the log no longer shows `WebSocket streaming failed, falling back to REST`.
4. Set language to German → unchanged, still streams partial results over the WebSocket.

> Maintainer verification on exact head `0e00fce1bf18e939f359ad5bdecabfba8bf81ee6`: 11 focused Speechmatics tests, the full 532-test Plugin SDK suite via `scripts/pr-preflight.sh`, and the Xcode SpeechmaticsPlugin target build passed with no first-party warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Speechmatics transcription support to the plugin package, including localized resources.
  * Added automatic fallback to REST transcription when realtime language identification is required.

* **Bug Fixes**
  * Corrected US batch transcription endpoint routing.
  * Improved language handling, including Chinese mapping and autodetection for missing selections.
  * Removed unsupported language options while preserving region-specific realtime routing.

* **Tests**
  * Added coverage for routing, language aliases, autodetection, and supported-language validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
