### PR TITLE
Release Speechmatics plugin 1.0.8

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.speechmatics",
     "name": "Speechmatics",
-    "version": "1.0.0",
+    "version": "1.0.8",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

This release publishes the Speechmatics fixes merged in #1069 for #1067:

- route US REST/Batch traffic through the documented `us1.asr.api.speechmatics.com` endpoint;
- map generic Chinese `zh` to the Speechmatics Mandarin `cmn` pack and stop advertising unsupported packs;
- send automatic language identification directly through the Batch API instead of attempting an unsupported realtime handshake first.

The latest public Speechmatics release is 1.0.7, while the source manifest still reported 1.0.0. This PR aligns the manifest with the next public version, 1.0.8.

## Changes

- Bump `SpeechmaticsPlugin` from 1.0.0 to 1.0.8.

## Verification

- Manual live smoke passed with Speechmatics using EU + Auto.
- Manual live smoke passed with Speechmatics using US + Auto, including a successful TLS 1.3 connection and final transcript.
- The Chinese mapping remains covered by the focused automated suite; no manual Chinese smoke was performed.

## Test plan

```bash
python3 -m json.tool TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json >/dev/null
swift test --package-path TypeWhisperPluginSDK --filter SpeechmaticsPluginTests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Speechmatics plugin to version 1.0.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->