### PR TITLE
Fix calendar access entitlement

### DIFF
--- a/TypeWhisper/Resources/TypeWhisper.entitlements
+++ b/TypeWhisper/Resources/TypeWhisper.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.automation.apple-events</key>
 	<true/>
+	<key>com.apple.security.personal-information.calendars</key>
+	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
 	<key>com.apple.security.application-groups</key>

--- a/TypeWhisperTests/PremiumSettingsViewTests.swift
+++ b/TypeWhisperTests/PremiumSettingsViewTests.swift
@@ -195,7 +195,7 @@ final class PremiumSettingsViewTests: XCTestCase {
         }
     }
 
-    func testPlistHasCalendarUsageCopyAndEntitlementsRemainCalendarFree() throws {
+    func testPlistHasCalendarUsageCopyAndCalendarEntitlement() throws {
         let root = repositoryRoot
         let plistData = try Data(contentsOf: root.appendingPathComponent("TypeWhisper/Resources/Info.plist"))
         let plist = try XCTUnwrap(
@@ -204,10 +204,19 @@ final class PremiumSettingsViewTests: XCTestCase {
         let usage = try XCTUnwrap(plist["NSCalendarsFullAccessUsageDescription"] as? String)
         XCTAssertFalse(usage.isEmpty)
 
-        let entitlements = try String(contentsOf: root.appendingPathComponent(
+        let entitlementData = try Data(contentsOf: root.appendingPathComponent(
             "TypeWhisper/Resources/TypeWhisper.entitlements"
-        ), encoding: .utf8)
-        XCTAssertFalse(entitlements.localizedCaseInsensitiveContains("calendar"))
+        ))
+        let entitlements = try XCTUnwrap(
+            PropertyListSerialization.propertyList(
+                from: entitlementData,
+                format: nil
+            ) as? [String: Any]
+        )
+        XCTAssertEqual(
+            entitlements["com.apple.security.personal-information.calendars"] as? Bool,
+            true
+        )
     }
 
     func testLocalCalendarSettingsAreNotPartOfBackupExporter() throws {


### PR DESCRIPTION
## Context

This is a follow-up to #1050 and the [customer report](https://github.com/TypeWhisper/typewhisper-mac/pull/1050#issuecomment-5224909947).

The retryable permission flow from #1066 correctly exposed the underlying EventKit failure, but the signed app still lacked `com.apple.security.personal-information.calendars`. On the affected hardened-runtime path, macOS TCC rejects the calendar request before it can show the system permission dialog.

## Changes

- Add the Calendar personal-information entitlement to the main app signature.
- Update the existing settings regression test to require both the Full Access usage description and the Calendar entitlement.
- Leave the EventKit flow, Premium gates, Plugin SDK, synchronization, and calendar storage unchanged.

## Behavior

The existing `Request Calendar Access` action can now reach the native macOS Full Access dialog instead of failing at the TCC policy gate.

## Test plan

Focused calendar and Premium settings tests:

```bash
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO \
  -only-testing:TypeWhisperTests/CalendarMeetingAutomationControllerTests \
  -only-testing:TypeWhisperTests/PremiumSettingsViewTests
```

Full application tests:

```bash
xcodebuild test \
  -project TypeWhisper.xcodeproj \
  -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' \
  CODE_SIGNING_REQUIRED=NO \
  CODE_SIGNING_ALLOWED=NO
```

Repository preflight:

```bash
PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  bash scripts/pr-preflight.sh origin/main
```

Additional verification:

- `git diff --check`
- Plist and JSON validation
- Localization completeness
- First-party warning gate
- Signed Dev bundle strict signature verification
- Signed Dev bundle contains the Calendar entitlement and the Full Access usage description
- After resetting Calendar TCC only for `com.typewhisper.mac.dev`, the native macOS Full Access dialog appears

The focused run passed 25 tests. The full application rerun passed 1,521 tests. The Plugin SDK preflight passed 532 tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled calendar access for the app, supporting calendar-related functionality.

* **Tests**
  * Updated validation checks to confirm that calendar access is correctly configured and enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->