### PR TITLE
Add bulk plugin updates and automatic restart

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -26707,6 +26707,29 @@
         }
       }
     },
+    "Some Plugins Could Not Be Updated" : {
+      "comment" : "The title of an alert shown when one or more plugins fail during a bulk update.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einige Plugins konnten nicht aktualisiert werden"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一部のプラグインを更新できませんでした"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "部分插件无法更新"
+          }
+        }
+      }
+    },
     "Sound" : {
       "localizations" : {
         "de" : {
@@ -29052,6 +29075,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "工作流面板"
+          }
+        }
+      }
+    },
+    "These plugins could not be updated: %@. Successful updates remain installed. TypeWhisper was not restarted." : {
+      "comment" : "An alert message listing failed plugin updates and explaining why the app did not restart. The argument is a comma-separated list of plugin names.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Plugins konnten nicht aktualisiert werden: %1$@. Erfolgreiche Updates bleiben installiert. TypeWhisper wurde nicht neu gestartet."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次のプラグインを更新できませんでした：%1$@。成功した更新はインストールされたままです。TypeWhisperは再起動されませんでした。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "以下插件无法更新：%1$@。成功的更新仍保持已安装状态。TypeWhisper 未重新启动。"
           }
         }
       }
@@ -31735,6 +31781,29 @@
         }
       }
     },
+    "Update All and Restart" : {
+      "comment" : "A button that updates every eligible installed plugin and restarts TypeWhisper after success.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alle aktualisieren und neu starten"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべて更新して再起動"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部更新并重新启动"
+          }
+        }
+      }
+    },
     "Update Available" : {
       "localizations" : {
         "de" : {
@@ -31814,6 +31883,29 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "更新"
+          }
+        }
+      }
+    },
+    "Updating %lld of %lld..." : {
+      "comment" : "Progress shown while updating all eligible plugins. The first argument is the completed count and the second is the total count.",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktualisiere %1$lld von %2$lld …"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%2$lld件中%1$lld件を更新中…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在更新第 %1$lld 个，共 %2$lld 个…"
           }
         }
       }

--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -479,6 +479,7 @@ final class PluginRegistryService: ObservableObject {
     @Published var fetchState: FetchState = .idle
     @Published var installStates: [String: InstallState] = [:]
     @Published var availableUpdatesCount: Int = 0
+    @Published private(set) var bulkUpdateProgress: BulkUpdateProgress?
 
     private var lastFetchDate: Date?
     private var activeInstallPluginIDs: Set<String> = []
@@ -505,12 +506,50 @@ final class PluginRegistryService: ObservableObject {
         case restartRequired
         case error(String)
 
+        var isInProgress: Bool {
+            switch self {
+            case .downloading, .extracting:
+                return true
+            case .restartRequired, .error:
+                return false
+            }
+        }
+
         var requiresRestart: Bool {
             if case .restartRequired = self {
                 return true
             }
             return false
         }
+    }
+
+    struct BulkUpdateProgress: Equatable {
+        let completed: Int
+        let total: Int
+    }
+
+    struct BulkUpdateFailure: Equatable {
+        let pluginId: String
+        let pluginName: String
+    }
+
+    struct BulkUpdateResult: Equatable {
+        let attemptedPluginIDs: [String]
+        let failures: [BulkUpdateFailure]
+
+        var shouldRelaunch: Bool {
+            !attemptedPluginIDs.isEmpty && failures.isEmpty
+        }
+
+        static let empty = BulkUpdateResult(attemptedPluginIDs: [], failures: [])
+    }
+
+    var isBulkUpdating: Bool {
+        bulkUpdateProgress != nil
+    }
+
+    var hasInstallInProgress: Bool {
+        installStates.values.contains(where: \.isInProgress)
     }
 
     // MARK: - Version Comparison
@@ -679,16 +718,64 @@ final class PluginRegistryService: ObservableObject {
     }
 
     func updateAvailableUpdatesCount() {
-        guard let pluginManager = PluginManager.shared else {
-            availableUpdatesCount = 0
-            return
+        availableUpdatesCount = availableUpdatePlugins().count
+    }
+
+    func availableUpdatePlugins() -> [RegistryPlugin] {
+        guard let pluginManager = PluginManager.shared else { return [] }
+
+        return registry
+            .filter { plugin in
+                guard pluginManager.externalBundleNotice(
+                    for: plugin.id,
+                    registryPlugin: plugin
+                )?.requiresConfirmation != true else {
+                    return false
+                }
+
+                if case .updateAvailable = installInfo(for: plugin.id) {
+                    return true
+                }
+                return false
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    func updateAllAvailablePlugins() async -> BulkUpdateResult {
+        await updateAllAvailablePlugins { [weak self] plugin in
+            guard let self else { return false }
+            return await self.downloadAndInstall(plugin)
+        }
+    }
+
+    func updateAllAvailablePlugins(
+        using install: (RegistryPlugin) async -> Bool
+    ) async -> BulkUpdateResult {
+        guard !isBulkUpdating, !hasInstallInProgress else { return .empty }
+
+        let plugins = availableUpdatePlugins()
+        guard !plugins.isEmpty else { return .empty }
+
+        bulkUpdateProgress = BulkUpdateProgress(completed: 0, total: plugins.count)
+        defer { bulkUpdateProgress = nil }
+
+        var attemptedPluginIDs: [String] = []
+        var failures: [BulkUpdateFailure] = []
+
+        for (index, plugin) in plugins.enumerated() {
+            attemptedPluginIDs.append(plugin.id)
+            if !(await install(plugin)) {
+                failures.append(BulkUpdateFailure(pluginId: plugin.id, pluginName: plugin.name))
+            }
+            bulkUpdateProgress = BulkUpdateProgress(completed: index + 1, total: plugins.count)
         }
 
-        let count = pluginManager.loadedPlugins.count(where: { plugin in
-            if case .updateAvailable = installInfo(for: plugin.manifest.id) { return true }
-            return false
-        })
-        availableUpdatesCount = count
+        return BulkUpdateResult(
+            attemptedPluginIDs: attemptedPluginIDs,
+            failures: failures
+        )
     }
 
     // MARK: - Install Info

--- a/TypeWhisper/Views/GeneralSettingsView.swift
+++ b/TypeWhisper/Views/GeneralSettingsView.swift
@@ -2,6 +2,13 @@ import SwiftUI
 import ServiceManagement
 import TypeWhisperPluginSDK
 
+private func completeApplicationRelaunch(_ application: NSRunningApplication?, _ error: Error?) {
+    guard application != nil, error == nil else { return }
+    Task { @MainActor in
+        NSApplication.shared.terminate(nil)
+    }
+}
+
 struct GeneralSettingsView: View {
     private enum AppVisibilityMode: String, CaseIterable {
         case menuBar
@@ -285,22 +292,11 @@ struct GeneralSettingsView: View {
         .frame(minWidth: 500, minHeight: 300)
         .alert(String(localized: "Restart Required"), isPresented: $showRestartAlert) {
             Button(String(localized: "Restart Now")) {
-                restartApp()
+                ApplicationRelauncher.relaunch()
             }
             Button(String(localized: "Later"), role: .cancel) {}
         } message: {
             Text(String(localized: "The language change will take effect after restarting TypeWhisper."))
-        }
-    }
-
-    private func restartApp() {
-        let bundleURL = Bundle.main.bundleURL
-        let config = NSWorkspace.OpenConfiguration()
-        config.createsNewApplicationInstance = true
-        NSWorkspace.shared.openApplication(at: bundleURL, configuration: config) { _, _ in
-            DispatchQueue.main.async {
-                NSApplication.shared.terminate(nil)
-            }
         }
     }
 
@@ -324,5 +320,19 @@ struct GeneralSettingsView: View {
             // Revert toggle on failure
             launchAtLogin = SMAppService.mainApp.status == .enabled
         }
+    }
+}
+
+@MainActor
+enum ApplicationRelauncher {
+    static func relaunch() {
+        let bundleURL = Bundle.main.bundleURL
+        let config = NSWorkspace.OpenConfiguration()
+        config.createsNewApplicationInstance = true
+        NSWorkspace.shared.openApplication(
+            at: bundleURL,
+            configuration: config,
+            completionHandler: completeApplicationRelaunch
+        )
     }
 }

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -193,6 +193,7 @@ struct PluginSettingsView: View {
     @State private var installFromFileError: String?
     @State private var uninstallError: String?
     @State private var incompatibleBundleRemovalError: String?
+    @State private var bulkUpdateFailures: [PluginRegistryService.BulkUpdateFailure] = []
     @State private var includeCommunityPlugins = true
     @State private var selectedCapabilityFilters: Set<PluginCategory> = []
     @State private var searchText = ""
@@ -319,6 +320,17 @@ struct PluginSettingsView: View {
                 Text(error)
             }
         }
+        .alert(
+            String(localized: "Some Plugins Could Not Be Updated"),
+            isPresented: .init(
+                get: { !bulkUpdateFailures.isEmpty },
+                set: { if !$0 { bulkUpdateFailures = [] } }
+            )
+        ) {
+            Button(String(localized: "OK")) { bulkUpdateFailures = [] }
+        } message: {
+            Text(bulkUpdateFailureMessage)
+        }
     }
 
     // MARK: - Header
@@ -328,21 +340,66 @@ struct PluginSettingsView: View {
             String(localized: "Integrations"),
             summary: integrationSummaryText
         ) {
-            HStack(spacing: 12) {
-                Button {
-                    pluginManager.openPluginsFolder()
-                } label: {
-                    Label(String(localized: "Open Plugins Folder"), systemImage: "folder")
-                }
-                .help(String(localized: "Open Plugins Folder"))
-
-                Button {
-                    installFromFile()
-                } label: {
-                    Label(localizedAppText("Install Plugin", de: "Plugin installieren"), systemImage: "plus")
-                }
-                .help(String(localized: "Install from File..."))
+            ViewThatFits(in: .horizontal) {
+                integrationHeaderActions(showLabels: true)
+                integrationHeaderActions(showLabels: false)
             }
+        }
+    }
+
+    private func integrationHeaderActions(showLabels: Bool) -> some View {
+        HStack(spacing: showLabels ? 12 : 8) {
+            if registryService.availableUpdatesCount > 0 || registryService.isBulkUpdating {
+                bulkUpdateControl
+            }
+
+            Button {
+                pluginManager.openPluginsFolder()
+            } label: {
+                if showLabels {
+                    Label(String(localized: "Open Plugins Folder"), systemImage: "folder")
+                } else {
+                    Image(systemName: "folder")
+                }
+            }
+            .help(String(localized: "Open Plugins Folder"))
+            .accessibilityLabel(String(localized: "Open Plugins Folder"))
+
+            Button {
+                installFromFile()
+            } label: {
+                if showLabels {
+                    Label(localizedAppText("Install Plugin", de: "Plugin installieren"), systemImage: "plus")
+                } else {
+                    Image(systemName: "plus")
+                }
+            }
+            .help(String(localized: "Install from File..."))
+            .accessibilityLabel(String(localized: "Install from File..."))
+            .disabled(registryService.isBulkUpdating)
+        }
+    }
+
+    @ViewBuilder
+    private var bulkUpdateControl: some View {
+        if let progress = registryService.bulkUpdateProgress {
+            HStack(spacing: 8) {
+                ProgressView(value: Double(progress.completed), total: Double(progress.total))
+                    .frame(width: 72)
+                Text(String(localized: "Updating \(progress.completed) of \(progress.total)..."))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            .accessibilityElement(children: .combine)
+        } else {
+            Button {
+                startBulkUpdate()
+            } label: {
+                Label(String(localized: "Update All and Restart"), systemImage: "arrow.triangle.2.circlepath")
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(registryService.hasInstallInProgress)
         }
     }
 
@@ -606,6 +663,7 @@ struct PluginSettingsView: View {
                             showUninstallAlert = true
                         }
                     )
+                    .disabled(registryService.isBulkUpdating)
                     .background {
                         integrationGroupedSurface(cornerRadius: 14)
                     }
@@ -1058,6 +1116,7 @@ struct PluginSettingsView: View {
                         openExternalURL(detailsURLString)
                     }
                 )
+                .disabled(registryService.isBulkUpdating)
                 .background {
                     integrationGroupedSurface(cornerRadius: 14)
                 }
@@ -1068,6 +1127,8 @@ struct PluginSettingsView: View {
     // MARK: - Install from File
 
     private func installFromFile() {
+        guard !registryService.isBulkUpdating else { return }
+
         let panel = NSOpenPanel()
         panel.allowedContentTypes = [.bundle, .zip]
         panel.allowsMultipleSelection = false
@@ -1087,6 +1148,8 @@ struct PluginSettingsView: View {
     }
 
     private func startInstall(_ plugin: RegistryPlugin) {
+        guard !registryService.isBulkUpdating else { return }
+
         if let notice = pluginManager.externalBundleNotice(for: plugin.id, registryPlugin: plugin),
            notice.requiresConfirmation {
             pendingBoundaryUpgradePlugin = plugin
@@ -1100,6 +1163,27 @@ struct PluginSettingsView: View {
                 completeSuccessfulInstall(pluginId: plugin.id, registryPlugin: plugin)
             }
         }
+    }
+
+    private func startBulkUpdate() {
+        guard !registryService.isBulkUpdating, !registryService.hasInstallInProgress else { return }
+
+        selectedTab = .installed
+        Task {
+            let result = await registryService.updateAllAvailablePlugins()
+            if result.shouldRelaunch {
+                ApplicationRelauncher.relaunch()
+            } else if !result.failures.isEmpty {
+                bulkUpdateFailures = result.failures
+            }
+        }
+    }
+
+    private var bulkUpdateFailureMessage: String {
+        let pluginNames = bulkUpdateFailures.map(\.pluginName).joined(separator: ", ")
+        return String(
+            localized: "These plugins could not be updated: \(pluginNames). Successful updates remain installed. TypeWhisper was not restarted."
+        )
     }
 
     @MainActor

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -481,6 +481,193 @@ final class PluginRegistryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testAvailableUpdatePluginsIncludesMarketplaceUpdatesInNameOrder() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateSelection")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateSelectionCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let bundledPluginsURL = try XCTUnwrap(Bundle.main.builtInPlugInsURL)
+        let bundledPlugin = Self.makeLoadedPlugin(
+            id: "com.typewhisper.bundled",
+            name: "Bundled Plugin",
+            version: "1.0.0",
+            sourceURL: bundledPluginsURL.appendingPathComponent("BundledPlugin.bundle")
+        )
+        let alphaPlugin = Self.makeLoadedPlugin(
+            id: "com.typewhisper.alpha",
+            name: "Alpha Community",
+            version: "1.0.0"
+        )
+        let zuluPlugin = Self.makeLoadedPlugin(
+            id: "com.typewhisper.zulu",
+            name: "Zulu Official",
+            version: "1.0.0"
+        )
+        let currentPlugin = Self.makeLoadedPlugin(
+            id: "com.typewhisper.current",
+            name: "Current Plugin",
+            version: "1.1.0"
+        )
+        pluginManager.loadedPlugins = [zuluPlugin, bundledPlugin, currentPlugin, alphaPlugin]
+
+        let incompatibleBundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("BundledPlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: incompatibleBundleURL,
+            pluginId: bundledPlugin.id,
+            pluginName: bundledPlugin.manifest.name,
+            version: bundledPlugin.manifest.version,
+            sdkCompatibilityVersion: nil
+        )
+        try pluginManager.loadPlugin(at: incompatibleBundleURL)
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+        service.registry = [
+            Self.makeRegistryPlugin(id: zuluPlugin.id, name: zuluPlugin.manifest.name, version: "1.1.0"),
+            Self.makeRegistryPlugin(id: alphaPlugin.id, source: .community, name: alphaPlugin.manifest.name, version: "1.2.0"),
+            Self.makeRegistryPlugin(id: bundledPlugin.id, name: bundledPlugin.manifest.name, version: "1.2.0"),
+            Self.makeRegistryPlugin(id: currentPlugin.id, name: currentPlugin.manifest.name, version: "1.1.0"),
+            Self.makeRegistryPlugin(id: "com.typewhisper.uninstalled", name: "Uninstalled Plugin", version: "1.0.0"),
+        ]
+
+        let bundledNotice = pluginManager.externalBundleNotice(
+            for: bundledPlugin.id,
+            registryPlugin: service.registry.first { $0.id == bundledPlugin.id }
+        )
+        service.updateAvailableUpdatesCount()
+
+        XCTAssertEqual(
+            service.availableUpdatePlugins().map(\.id),
+            [alphaPlugin.id, zuluPlugin.id]
+        )
+        XCTAssertEqual(service.availableUpdatesCount, 2)
+        XCTAssertEqual(bundledNotice?.requiresConfirmation, true)
+    }
+
+    @MainActor
+    func testBulkUpdateContinuesAfterFailureAndReportsProgress() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdate")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let plugins = [
+            Self.makeLoadedPlugin(id: "com.typewhisper.charlie", name: "Charlie", version: "1.0.0"),
+            Self.makeLoadedPlugin(id: "com.typewhisper.alpha", name: "Alpha", version: "1.0.0"),
+            Self.makeLoadedPlugin(id: "com.typewhisper.bravo", name: "Bravo", version: "1.0.0"),
+        ]
+        pluginManager.loadedPlugins = plugins
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+        service.registry = plugins.map {
+            Self.makeRegistryPlugin(id: $0.id, name: $0.manifest.name, version: "1.1.0")
+        }
+
+        var attemptedPluginIDs: [String] = []
+        var observedProgress: [PluginRegistryService.BulkUpdateProgress] = []
+        let result = await service.updateAllAvailablePlugins { plugin in
+            attemptedPluginIDs.append(plugin.id)
+            if let progress = service.bulkUpdateProgress {
+                observedProgress.append(progress)
+            }
+            return plugin.id != "com.typewhisper.bravo"
+        }
+
+        XCTAssertEqual(
+            attemptedPluginIDs,
+            ["com.typewhisper.alpha", "com.typewhisper.bravo", "com.typewhisper.charlie"]
+        )
+        XCTAssertEqual(result.attemptedPluginIDs, attemptedPluginIDs)
+        XCTAssertEqual(
+            result.failures,
+            [.init(pluginId: "com.typewhisper.bravo", pluginName: "Bravo")]
+        )
+        XCTAssertEqual(
+            observedProgress,
+            [
+                .init(completed: 0, total: 3),
+                .init(completed: 1, total: 3),
+                .init(completed: 2, total: 3),
+            ]
+        )
+        XCTAssertFalse(result.shouldRelaunch)
+        XCTAssertNil(service.bulkUpdateProgress)
+    }
+
+    @MainActor
+    func testBulkUpdateRelaunchDecisionRequiresSuccessfulAttempt() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateRelaunch")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateRelaunchCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let loadedPlugin = Self.makeLoadedPlugin(
+            id: "com.typewhisper.success",
+            name: "Successful Plugin",
+            version: "1.0.0"
+        )
+        pluginManager.loadedPlugins = [loadedPlugin]
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+        service.registry = [
+            Self.makeRegistryPlugin(id: loadedPlugin.id, name: loadedPlugin.manifest.name, version: "1.1.0"),
+        ]
+
+        let successfulResult = await service.updateAllAvailablePlugins { _ in true }
+        service.installStates[loadedPlugin.id] = .downloading(0.5)
+        var busyInstallerWasCalled = false
+        let busyResult = await service.updateAllAvailablePlugins { _ in
+            busyInstallerWasCalled = true
+            return true
+        }
+        service.installStates.removeValue(forKey: loadedPlugin.id)
+        service.registry = []
+        let emptyResult = await service.updateAllAvailablePlugins { _ in true }
+
+        XCTAssertTrue(successfulResult.shouldRelaunch)
+        XCTAssertEqual(successfulResult.attemptedPluginIDs, [loadedPlugin.id])
+        XCTAssertFalse(busyResult.shouldRelaunch)
+        XCTAssertTrue(busyResult.attemptedPluginIDs.isEmpty)
+        XCTAssertFalse(busyInstallerWasCalled)
+        XCTAssertFalse(emptyResult.shouldRelaunch)
+        XCTAssertTrue(emptyResult.attemptedPluginIDs.isEmpty)
+    }
+
+    @MainActor
     func testDownloadAndInstallReportsFailureForIncompatiblePlugin() async throws {
         let cacheDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -1402,6 +1589,58 @@ final class PluginRegistryServiceTests: XCTestCase {
               ]
             }
             """.utf8
+        )
+    }
+
+    private static func makeRegistryPlugin(
+        id: String,
+        source: PluginDistributionSource = .official,
+        name: String,
+        version: String
+    ) -> RegistryPlugin {
+        RegistryPlugin(
+            id: id,
+            source: source,
+            name: name,
+            version: version,
+            minHostVersion: "1.0.0",
+            sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+            minOSVersion: nil,
+            supportedArchitectures: nil,
+            author: "TypeWhisper",
+            description: "Test plugin",
+            category: "utility",
+            categories: ["utility"],
+            size: 10,
+            downloadURL: "https://example.com/\(id).zip",
+            iconSystemName: nil,
+            requiresAPIKey: nil,
+            hosting: nil,
+            descriptions: nil,
+            downloadCount: nil
+        )
+    }
+
+    private static func makeLoadedPlugin(
+        id: String,
+        name: String,
+        version: String,
+        sourceURL: URL? = nil,
+        isEnabled: Bool = true
+    ) -> LoadedPlugin {
+        LoadedPlugin(
+            manifest: PluginManifest(
+                id: id,
+                name: name,
+                version: version,
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                principalClass: "RuntimeUpdatePlugin"
+            ),
+            instance: MockRuntimeUpdatePlugin(),
+            bundle: Bundle.main,
+            sourceURL: sourceURL ?? FileManager.default.temporaryDirectory
+                .appendingPathComponent("\(id).bundle", isDirectory: true),
+            isEnabled: isEnabled
         )
     }
 


### PR DESCRIPTION
## Summary

- add a prominent **Update All and Restart** action to the Integrations header
- update every eligible Marketplace plugin sequentially with aggregate progress
- preserve row-level progress, rollback, restart-required, and failure states
- restart TypeWhisper automatically only after a fully successful batch
- keep partial failures installed and visible without restarting the app
- reuse a Swift 6-safe application relaunch path and localize the new UI in German, Japanese, and Simplified Chinese

## Issue context

Issue #1071 reports that users must currently find and update plugins one by one, and that continuing without restarting after runtime plugin replacement can leave the old plugin implementation active. This change builds on the existing restart-required placeholder behavior and adds one safe batch action.

Confirmation-required legacy bundle replacements and bundled plugins remain outside the batch.

Closes #1071

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests CODE_SIGNING_ALLOWED=NO`
- [x] `python3 scripts/check_localization_completeness.py`
- [x] `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- [x] `bash scripts/check_first_party_warnings.sh /tmp/typewhisper-1071-ship-build.log`

The focused suite passed 30 tests with 0 failures. The final build completed without first-party warnings. A real bulk update was not triggered because it would replace locally installed plugins and immediately restart the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a bulk update option for available plugins with sequential progress tracking and failure reporting.
  * Plugin installation controls are temporarily disabled while bulk updates are running.
  * The app now relaunches automatically when required after successful updates.
  * Available updates are sorted by localized plugin name and exclude items needing additional confirmation.

* **Localization**
  * Added German, Japanese, and Simplified Chinese translations for update alerts, actions, and progress messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->