### PR TITLE
Add Obsidian live sync and Markdown templates

### DIFF
--- a/TypeWhisper/Services/HistoryService.swift
+++ b/TypeWhisper/Services/HistoryService.swift
@@ -1,16 +1,34 @@
 import Foundation
 import SwiftData
 import Combine
+import TypeWhisperPluginSDK
 import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "HistoryService")
 
 @MainActor
 final class HistoryService: ObservableObject {
+    static let pluginSyncActionID = "com.typewhisper.history.transcription-updated"
+
+    private struct PluginSyncPayload: Codable {
+        let id: UUID
+        let rawText: String
+        let finalText: String
+        let language: String?
+        let engineUsed: String
+        let modelUsed: String?
+        let durationSeconds: Double
+        let appName: String?
+        let bundleIdentifier: String?
+        let url: String?
+        let pipelineSteps: [String]
+    }
+
     @Published var records: [TranscriptionRecord] = []
 
     private let modelContainer: ModelContainer
     private let modelContext: ModelContext
+    private let eventEmitter: @MainActor (TypeWhisperEvent) -> Void
 
     private(set) var totalRecords: Int = 0
     private(set) var totalWords: Int = 0
@@ -18,8 +36,14 @@ final class HistoryService: ObservableObject {
 
     private let audioDirectory: URL
 
-    init(appSupportDirectory: URL = AppConstants.appSupportDirectory) {
+    init(
+        appSupportDirectory: URL = AppConstants.appSupportDirectory,
+        eventEmitter: @escaping @MainActor (TypeWhisperEvent) -> Void = { event in
+            EventBus.shared?.emit(event)
+        }
+    ) {
         let storeDir = appSupportDirectory
+        self.eventEmitter = eventEmitter
 
         let audioDir = storeDir.appendingPathComponent("audio", isDirectory: true)
         try? FileManager.default.createDirectory(at: audioDir, withIntermediateDirectories: true)
@@ -115,6 +139,35 @@ final class HistoryService: ObservableObject {
         record.wordsCount = finalText.split(separator: " ").count
         save()
         fetchRecords()
+        let payload = PluginSyncPayload(
+            id: record.id,
+            rawText: record.rawText,
+            finalText: record.finalText,
+            language: record.language,
+            engineUsed: record.engineUsed,
+            modelUsed: record.modelUsed,
+            durationSeconds: record.durationSeconds,
+            appName: record.appName,
+            bundleIdentifier: record.appBundleIdentifier,
+            url: record.appURL,
+            pipelineSteps: record.pipelineStepList
+        )
+        guard let data = try? JSONEncoder().encode(payload),
+              let message = String(data: data, encoding: .utf8) else {
+            logger.error("Failed to encode history plugin sync payload")
+            return
+        }
+        // Keep the public plugin SDK on compatibility line v1 by using its existing
+        // action-completed envelope for this private host-to-plugin notification.
+        eventEmitter(.actionCompleted(ActionCompletedPayload(
+            timestamp: record.timestamp,
+            actionId: Self.pluginSyncActionID,
+            success: true,
+            message: message,
+            url: record.appURL,
+            appName: record.appName,
+            bundleIdentifier: record.appBundleIdentifier
+        )))
     }
 
     func deleteRecord(_ record: TranscriptionRecord) {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1856,6 +1856,11 @@ final class DictationViewModel: ObservableObject {
                 partialText = ""
                 var insertedTextForCorrectionTracking: String?
                 var targetAppCorrectionBaseline: TextInsertionService.FocusedTextObservation?
+                let modelDisplayName = transcription.modelDisplayName
+                var pipelineSteps = ppResult.appliedSteps
+                if transcription.usedRecoveryFallback {
+                    pipelineSteps.append(localizedAppText("Recovery fallback", de: "Recovery-Fallback"))
+                }
 
                 // Route to action plugin or insert text
                 if let actionPluginId = self.effectiveActionPluginId,
@@ -1905,12 +1910,6 @@ final class DictationViewModel: ObservableObject {
                     )))
                 }
 
-                let modelDisplayName = transcription.modelDisplayName
-                var pipelineSteps = ppResult.appliedSteps
-                if transcription.usedRecoveryFallback {
-                    pipelineSteps.append(localizedAppText("Recovery fallback", de: "Recovery-Fallback"))
-                }
-
                 if let insertedTextForCorrectionTracking {
                     let contributionContext: CorrectionContributionContext? = improveTypeWhisperCaptureEnabled
                         ? CorrectionContributionContext(
@@ -1929,6 +1928,7 @@ final class DictationViewModel: ObservableObject {
                 if UserDefaults.standard.object(forKey: UserDefaultsKeys.historyEnabled) as? Bool ?? true {
                     historyService.addRecord(
                         id: transcriptionID,
+                        timestamp: completionTimestamp,
                         rawText: result.text,
                         finalText: text,
                         appName: activeApp.name,
@@ -1944,6 +1944,7 @@ final class DictationViewModel: ObservableObject {
                 }
 
                 EventBus.shared.emit(.transcriptionCompleted(TranscriptionCompletedPayload(
+                    timestamp: completionTimestamp,
                     rawText: result.text,
                     finalText: text,
                     language: language,

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings
@@ -331,6 +331,94 @@
         }
       }
     },
+    "Keep exported individual notes up to date when their transcript is edited in TypeWhisper. External Obsidian edits may be overwritten.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Exportierte Einzelnotizen aktuell halten, wenn ihr Transkript in TypeWhisper bearbeitet wird. Externe Änderungen in Obsidian können überschrieben werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TypeWhisper で文字起こしを編集したとき、エクスポート済みの個別ノートを更新します。Obsidian 側の編集は上書きされる場合があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 TypeWhisper 中编辑转录时，保持已导出的单独笔记为最新状态。Obsidian 中的外部编辑可能会被覆盖。"
+          }
+        }
+      }
+    },
+    "Live Sync History Edits": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verlaufsänderungen live synchronisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "履歴の編集をライブ同期"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时同步历史编辑"
+          }
+        }
+      }
+    },
+    "Live Sync is available for individual notes only.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live-Sync ist nur für einzelne Notizen verfügbar."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライブ同期は個別ノートでのみ利用できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "实时同步仅适用于单独笔记。"
+          }
+        }
+      }
+    },
+    "Note Template": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notizvorlage"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノートテンプレート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "笔记模板"
+          }
+        }
+      }
+    },
     "No vault selected": {
       "localizations": {
         "de": {
@@ -371,6 +459,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "占位符：{{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}"
+          }
+        }
+      }
+    },
+    "Placeholders: {{TRANSCRIPT}}, {{RAW_TRANSCRIPT}}, {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}, {{URL}}, {{ENGINE}}, {{MODEL}}, {{DURATION}}, {{WORDS}}": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Platzhalter: {{TRANSCRIPT}}, {{RAW_TRANSCRIPT}}, {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}, {{URL}}, {{ENGINE}}, {{MODEL}}, {{DURATION}}, {{WORDS}}"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プレースホルダー: {{TRANSCRIPT}}, {{RAW_TRANSCRIPT}}, {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}, {{URL}}, {{ENGINE}}, {{MODEL}}, {{DURATION}}, {{WORDS}}"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "占位符：{{TRANSCRIPT}}, {{RAW_TRANSCRIPT}}, {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}, {{URL}}, {{ENGINE}}, {{MODEL}}, {{DURATION}}, {{WORDS}}"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -8,6 +8,7 @@ import TypeWhisperPluginSDK
 final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.obsidian"
     static let pluginName = "Obsidian"
+    private static let historySyncActionID = "com.typewhisper.history.transcription-updated"
 
     var actionName: String { "Save to Obsidian" }
     var actionId: String { "obsidian-save-note" }
@@ -20,12 +21,15 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     fileprivate var _vaultPath: String = ""
     fileprivate var _subfolder: String = "TypeWhisper"
     fileprivate var _filenameTemplate: String = "{{DATE}} {{TIME}} {{APP}}"
+    fileprivate var _noteTemplate: String = "{{TRANSCRIPT}}"
     fileprivate var _dailyNoteEnabled: Bool = false
     fileprivate var _dailyNoteFormat: String = "{{DATE}}"
     fileprivate var _dailyNoteAppendTemplate: String = "## {{TIME}}\n\n{{TEXT}}"
     fileprivate var _frontmatterEnabled: Bool = true
     fileprivate var _frontmatterTags: [String] = ["typewhisper"]
     fileprivate var _autoExportEnabled: Bool = false
+    fileprivate var _liveSyncEnabled: Bool = true
+    private var liveSyncEntries: [String: LiveSyncEntry] = [:]
 
     required override init() {
         super.init()
@@ -55,12 +59,20 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         _vaultPath = host?.userDefault(forKey: "vaultPath") as? String ?? ""
         _subfolder = host?.userDefault(forKey: "subfolder") as? String ?? "TypeWhisper"
         _filenameTemplate = host?.userDefault(forKey: "filenameTemplate") as? String ?? "{{DATE}} {{TIME}} {{APP}}"
+        _noteTemplate = host?.userDefault(forKey: "noteTemplate") as? String ?? "{{TRANSCRIPT}}"
         _dailyNoteEnabled = host?.userDefault(forKey: "dailyNoteEnabled") as? Bool ?? false
         _dailyNoteFormat = host?.userDefault(forKey: "dailyNoteFormat") as? String ?? "{{DATE}}"
         _dailyNoteAppendTemplate = host?.userDefault(forKey: "dailyNoteAppendTemplate") as? String ?? DailyNoteAppendPreset.timestamp.template
         _frontmatterEnabled = host?.userDefault(forKey: "frontmatterEnabled") as? Bool ?? true
         _frontmatterTags = host?.userDefault(forKey: "frontmatterTags") as? [String] ?? ["typewhisper"]
         _autoExportEnabled = host?.userDefault(forKey: "autoExportEnabled") as? Bool ?? false
+        _liveSyncEnabled = host?.userDefault(forKey: "liveSyncEnabled") as? Bool ?? true
+        if let data = host?.userDefault(forKey: "liveSyncEntries") as? Data,
+           let entries = try? JSONDecoder().decode([String: LiveSyncEntry].self, from: data) {
+            liveSyncEntries = entries
+        } else {
+            liveSyncEntries = [:]
+        }
 
         // Auto-detect vault if none set
         if _vaultPath.isEmpty {
@@ -82,12 +94,19 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
             subscriptionId = nil
         }
 
-        guard _autoExportEnabled else { return }
+        guard _autoExportEnabled || _liveSyncEnabled else { return }
 
         subscriptionId = host?.eventBus.subscribe { [weak self] event in
             switch event {
             case .transcriptionCompleted(let payload):
-                await self?.autoExport(payload: payload)
+                if self?._autoExportEnabled == true {
+                    await self?.autoExport(payload: payload)
+                } else if self?._liveSyncEnabled == true {
+                    await self?.adoptMatchingActionExport(payload: payload)
+                }
+            case .actionCompleted(let payload) where payload.actionId == Self.historySyncActionID:
+                guard self?._liveSyncEnabled == true else { return }
+                await self?.liveSync(payload: payload)
             default:
                 break
             }
@@ -123,8 +142,92 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
 
     // MARK: - File Writing
 
-    private func resolveTemplate(_ template: String, appName: String?, language: String?, timeFormat: String = "HH-mm-ss") -> String {
-        let now = Date()
+    private struct HistorySyncPayload: Codable, Sendable {
+        let id: UUID
+        let rawText: String
+        let finalText: String
+        let language: String?
+        let engineUsed: String
+        let modelUsed: String?
+        let durationSeconds: Double
+        let appName: String?
+        let bundleIdentifier: String?
+        let url: String?
+        let pipelineSteps: [String]
+    }
+
+    private struct NoteContext: Codable, Sendable {
+        let timestamp: Date
+        let rawText: String
+        let finalText: String
+        let appName: String?
+        let bundleIdentifier: String?
+        let url: String?
+        let language: String?
+        let engineUsed: String?
+        let modelUsed: String?
+        let durationSeconds: Double?
+        let pipelineSteps: [String]
+
+        init(input: String, actionContext: ActionContext) {
+            timestamp = Date()
+            rawText = actionContext.originalText.isEmpty ? input : actionContext.originalText
+            finalText = input
+            appName = actionContext.appName
+            bundleIdentifier = actionContext.bundleIdentifier
+            url = actionContext.url
+            language = actionContext.language
+            engineUsed = nil
+            modelUsed = nil
+            durationSeconds = nil
+            pipelineSteps = []
+        }
+
+        init(_ payload: TranscriptionCompletedPayload) {
+            timestamp = payload.timestamp
+            rawText = payload.rawText
+            finalText = payload.finalText
+            appName = payload.appName
+            bundleIdentifier = payload.bundleIdentifier
+            url = payload.url
+            language = payload.language
+            engineUsed = payload.engineUsed
+            modelUsed = payload.modelUsed
+            durationSeconds = payload.durationSeconds
+            pipelineSteps = []
+        }
+
+        init(_ payload: HistorySyncPayload, timestamp: Date) {
+            self.timestamp = timestamp
+            rawText = payload.rawText
+            finalText = payload.finalText
+            appName = payload.appName
+            bundleIdentifier = payload.bundleIdentifier
+            url = payload.url
+            language = payload.language
+            engineUsed = payload.engineUsed
+            modelUsed = payload.modelUsed
+            durationSeconds = payload.durationSeconds
+            pipelineSteps = payload.pipelineSteps
+        }
+    }
+
+    private struct LiveSyncEntry: Codable, Sendable {
+        let path: String
+        let context: NoteContext
+        let awaitingCompletion: Bool
+    }
+
+    private struct WrittenNote {
+        let name: String
+        let path: String
+    }
+
+    private func resolveTemplate(
+        _ template: String,
+        context: NoteContext,
+        timeFormat: String = "HH-mm-ss"
+    ) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.calendar = Calendar(identifier: .gregorian)
         dateFormatter.locale = Locale(identifier: "en_US_POSIX")
@@ -135,35 +238,67 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         timeFormatter.dateFormat = timeFormat
 
         var result = template
-        result = result.replacingOccurrences(of: "{{DATE}}", with: dateFormatter.string(from: now))
-        result = result.replacingOccurrences(of: "{{TIME}}", with: timeFormatter.string(from: now))
-        result = result.replacingOccurrences(of: "{{APP}}", with: appName ?? "Unknown")
-        result = result.replacingOccurrences(of: "{{LANGUAGE}}", with: language ?? "unknown")
-        result = result.replacingOccurrences(of: "{{LANG}}", with: language ?? "unknown")
+        let duration = context.durationSeconds.map {
+            String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"), $0)
+        } ?? ""
+        let values: [String: String] = [
+            "APP": context.appName ?? "Unknown",
+            "BUNDLE_ID": context.bundleIdentifier ?? "",
+            "DATE": dateFormatter.string(from: context.timestamp),
+            "DURATION": duration,
+            "ENGINE": context.engineUsed ?? "",
+            "LANG": context.language ?? "unknown",
+            "LANGUAGE": context.language ?? "unknown",
+            "MODEL": context.modelUsed ?? "",
+            "PROCESSING": context.pipelineSteps.joined(separator: ", "),
+            "RAW_TRANSCRIPT": context.rawText,
+            "TEXT": context.finalText,
+            "TIME": timeFormatter.string(from: context.timestamp),
+            "TRANSCRIPT": context.finalText,
+            "URL": context.url ?? "",
+            "WORDS": String(context.finalText.split(whereSeparator: { $0.isWhitespace }).count),
+        ]
+        for (key, value) in values {
+            result = result.replacingOccurrences(of: "{{\(key)}}", with: value)
+            result = result.replacingOccurrences(of: "{{\(key.lowercased())}}", with: value)
+        }
         return result
     }
 
-    private func resolveDailyNoteAppendTemplate(_ template: String, text: String, appName: String?, url: String?, language: String?) -> String {
-        var result = resolveTemplate(template, appName: appName, language: language, timeFormat: "HH:mm")
-        result = result.replacingOccurrences(of: "{{TEXT}}", with: text)
-        result = result.replacingOccurrences(of: "{{URL}}", with: url ?? "")
-        return result
+    private func resolveDailyNoteAppendTemplate(_ template: String, context: NoteContext) -> String {
+        resolveTemplate(template, context: context, timeFormat: "HH:mm")
     }
 
     private func sanitizeFilename(_ name: String) -> String {
-        let illegal = CharacterSet(charactersIn: "/:\\*?\"<>|")
-        return name.components(separatedBy: illegal).joined()
+        let illegal = CharacterSet(charactersIn: "/:\\*?\"<>|[]")
+            .union(.controlCharacters)
+        return name
+            .components(separatedBy: illegal)
+            .joined()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func buildFrontmatter(appName: String?, bundleId: String?, url: String?, language: String?) -> String {
+    private func buildFrontmatter(context: NoteContext, includeAppMetadata: Bool = true) -> String {
         var lines = ["---"]
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
-        lines.append("date: \(formatter.string(from: Date()))")
-        if let app = appName { lines.append("app: \(app)") }
-        if let bid = bundleId { lines.append("bundleId: \(bid)") }
-        if let u = url { lines.append("url: \(u)") }
-        if let lang = language { lines.append("language: \(lang)") }
+        lines.append("date: \(formatter.string(from: context.timestamp))")
+        if includeAppMetadata, let app = context.appName { lines.append("app: \(app)") }
+        if includeAppMetadata, let bid = context.bundleIdentifier { lines.append("bundleId: \(bid)") }
+        if includeAppMetadata, let url = context.url { lines.append("url: \(url)") }
+        if let language = context.language { lines.append("language: \(language)") }
+        if let engine = context.engineUsed { lines.append("engine: \(engine)") }
+        if let model = context.modelUsed { lines.append("model: \(model)") }
+        if let duration = context.durationSeconds {
+            lines.append("duration: \(String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"), duration))")
+        }
+        lines.append("words: \(context.finalText.split(whereSeparator: { $0.isWhitespace }).count)")
+        if !context.pipelineSteps.isEmpty {
+            lines.append("processing:")
+            for step in context.pipelineSteps {
+                lines.append("  - \(step)")
+            }
+        }
         if !_frontmatterTags.isEmpty {
             lines.append("tags:")
             for tag in _frontmatterTags {
@@ -174,7 +309,20 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         return lines.joined(separator: "\n")
     }
 
-    private func writeNote(text: String, appName: String?, bundleId: String?, url: String?, language: String?) throws -> String {
+    private func renderNote(context: NoteContext) -> String {
+        var content = ""
+        if _frontmatterEnabled {
+            content += buildFrontmatter(context: context)
+            content += "\n\n"
+        }
+        let template = _noteTemplate.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "{{TRANSCRIPT}}"
+            : _noteTemplate
+        content += resolveTemplate(template, context: context)
+        return content
+    }
+
+    private func writeNote(context: NoteContext) throws -> WrittenNote {
         guard !_vaultPath.isEmpty else {
             throw NSError(domain: "ObsidianPlugin", code: 1, userInfo: [NSLocalizedDescriptionKey: "No vault configured"])
         }
@@ -191,34 +339,28 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         try fm.createDirectory(atPath: folderPath, withIntermediateDirectories: true)
 
         if _dailyNoteEnabled {
-            return try writeDailyNote(text: text, folderPath: folderPath, appName: appName, bundleId: bundleId, url: url, language: language)
+            return try writeDailyNote(context: context, folderPath: folderPath)
         } else {
-            return try writeNewNote(text: text, folderPath: folderPath, appName: appName, bundleId: bundleId, url: url, language: language)
+            return try writeNewNote(context: context, folderPath: folderPath)
         }
     }
 
-    private func writeNewNote(text: String, folderPath: String, appName: String?, bundleId: String?, url: String?, language: String?) throws -> String {
-        let resolvedName = resolveTemplate(_filenameTemplate, appName: appName, language: language)
+    private func writeNewNote(context: NoteContext, folderPath: String) throws -> WrittenNote {
+        let resolvedName = resolveTemplate(_filenameTemplate, context: context)
         let sanitized = sanitizeFilename(resolvedName)
         let filename = sanitized.isEmpty ? "Note" : sanitized
         let filePath = (folderPath as NSString).appendingPathComponent("\(filename).md")
 
-        var content = ""
-        if _frontmatterEnabled {
-            content += buildFrontmatter(appName: appName, bundleId: bundleId, url: url, language: language)
-            content += "\n\n"
-        }
-        content += text
-
         // Handle duplicate filenames
         let finalPath = uniquePath(for: filePath)
-        try content.write(toFile: finalPath, atomically: true, encoding: .utf8)
+        try renderNote(context: context).write(toFile: finalPath, atomically: true, encoding: .utf8)
 
-        return ((finalPath as NSString).lastPathComponent as NSString).deletingPathExtension
+        let name = ((finalPath as NSString).lastPathComponent as NSString).deletingPathExtension
+        return WrittenNote(name: name, path: finalPath)
     }
 
-    private func writeDailyNote(text: String, folderPath: String, appName: String?, bundleId: String?, url: String?, language: String?) throws -> String {
-        let resolvedName = resolveTemplate(_dailyNoteFormat, appName: appName, language: language)
+    private func writeDailyNote(context: NoteContext, folderPath: String) throws -> WrittenNote {
+        let resolvedName = resolveTemplate(_dailyNoteFormat, context: context)
         let sanitized = sanitizeFilename(resolvedName)
         let filename = sanitized.isEmpty ? "Daily" : sanitized
         let filePath = (folderPath as NSString).appendingPathComponent("\(filename).md")
@@ -226,10 +368,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         let fm = FileManager.default
         let appendContent = resolveDailyNoteAppendTemplate(
             _dailyNoteAppendTemplate,
-            text: text,
-            appName: appName,
-            url: url,
-            language: language
+            context: context
         )
 
         if fm.fileExists(atPath: filePath) {
@@ -254,19 +393,91 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
             var content = ""
             if _frontmatterEnabled {
                 let includeAppMeta = _dailyNoteFormat.contains("{{APP}}")
-                content += buildFrontmatter(
-                    appName: includeAppMeta ? appName : nil,
-                    bundleId: includeAppMeta ? bundleId : nil,
-                    url: includeAppMeta ? url : nil,
-                    language: language
-                )
+                content += buildFrontmatter(context: context, includeAppMetadata: includeAppMeta)
                 content += "\n\n"
             }
             content += appendContent
             try content.write(toFile: filePath, atomically: true, encoding: .utf8)
         }
 
-        return filename
+        return WrittenNote(name: filename, path: filePath)
+    }
+
+    private func liveSyncKey(for timestamp: Date) -> String {
+        String(timestamp.timeIntervalSinceReferenceDate.bitPattern, radix: 16)
+    }
+
+    private func persistLiveSyncEntries() {
+        guard let data = try? JSONEncoder().encode(liveSyncEntries) else {
+            print("[ObsidianPlugin] Failed to persist live sync entries")
+            return
+        }
+        saveSetting(data, forKey: "liveSyncEntries")
+    }
+
+    private func storeLiveSyncEntry(path: String, context: NoteContext, awaitingCompletion: Bool) {
+        liveSyncEntries[liveSyncKey(for: context.timestamp)] = LiveSyncEntry(
+            path: path,
+            context: context,
+            awaitingCompletion: awaitingCompletion
+        )
+        persistLiveSyncEntries()
+    }
+
+    private func removeLiveSyncEntry(forKey key: String) {
+        liveSyncEntries.removeValue(forKey: key)
+        persistLiveSyncEntries()
+    }
+
+    private func matchingEntryKey(
+        for context: NoteContext,
+        requireMatchingFinalText: Bool,
+        requireAwaitingCompletion: Bool = false
+    ) -> String? {
+        let exactKey = liveSyncKey(for: context.timestamp)
+        if let exactEntry = liveSyncEntries[exactKey],
+           entryMatches(
+               exactEntry,
+               context: context,
+               requireMatchingFinalText: requireMatchingFinalText,
+               requireAwaitingCompletion: requireAwaitingCompletion
+           ) {
+            return exactKey
+        }
+
+        return liveSyncEntries
+            .filter { _, entry in
+                abs(entry.context.timestamp.timeIntervalSince(context.timestamp)) <= 60
+                    && entryMatches(
+                        entry,
+                        context: context,
+                        requireMatchingFinalText: requireMatchingFinalText,
+                        requireAwaitingCompletion: requireAwaitingCompletion
+                    )
+            }
+            .min { lhs, rhs in
+                abs(lhs.value.context.timestamp.timeIntervalSince(context.timestamp))
+                    < abs(rhs.value.context.timestamp.timeIntervalSince(context.timestamp))
+            }?
+            .key
+    }
+
+    private func entryMatches(
+        _ entry: LiveSyncEntry,
+        context: NoteContext,
+        requireMatchingFinalText: Bool,
+        requireAwaitingCompletion: Bool
+    ) -> Bool {
+        entry.context.rawText == context.rawText
+            && entry.context.bundleIdentifier == context.bundleIdentifier
+            && (!requireMatchingFinalText || entry.context.finalText == context.finalText)
+            && (!requireAwaitingCompletion || entry.awaitingCompletion)
+    }
+
+    private func isInsideConfiguredVault(_ path: String) -> Bool {
+        let vaultURL = URL(fileURLWithPath: _vaultPath, isDirectory: true).standardizedFileURL
+        let noteURL = URL(fileURLWithPath: path, isDirectory: false).standardizedFileURL
+        return noteURL.path.hasPrefix(vaultURL.path + "/") && noteURL.pathExtension.lowercased() == "md"
     }
 
     private func uniquePath(for path: String) -> String {
@@ -295,16 +506,14 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         }
 
         do {
-            let noteName = try writeNote(
-                text: input,
-                appName: context.appName,
-                bundleId: context.bundleIdentifier,
-                url: context.url,
-                language: context.language
-            )
+            let noteContext = NoteContext(input: input, actionContext: context)
+            let note = try writeNote(context: noteContext)
+            if _liveSyncEnabled, !_dailyNoteEnabled {
+                storeLiveSyncEntry(path: note.path, context: noteContext, awaitingCompletion: true)
+            }
             return ActionResult(
                 success: true,
-                message: noteName,
+                message: note.name,
                 icon: "checkmark.circle.fill",
                 displayDuration: 3
             )
@@ -321,16 +530,98 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         guard !text.isEmpty else { return }
 
         do {
-            _ = try writeNote(
-                text: text,
-                appName: payload.appName,
-                bundleId: payload.bundleIdentifier,
-                url: payload.url,
-                language: payload.language
-            )
+            if _liveSyncEnabled,
+               !_dailyNoteEnabled,
+               await adoptMatchingActionExport(payload: payload) {
+                return
+            }
+            let noteContext = NoteContext(payload)
+            let note = try writeNote(context: noteContext)
+            if _liveSyncEnabled, !_dailyNoteEnabled {
+                storeLiveSyncEntry(path: note.path, context: noteContext, awaitingCompletion: false)
+            }
         } catch {
             print("[ObsidianPlugin] Auto-export failed: \(error)")
         }
+    }
+
+    @discardableResult
+    private func adoptMatchingActionExport(payload: TranscriptionCompletedPayload) async -> Bool {
+        guard !_dailyNoteEnabled, isConfigured else { return false }
+        let completedContext = NoteContext(payload)
+        guard let oldKey = matchingEntryKey(
+            for: completedContext,
+            requireMatchingFinalText: true,
+            requireAwaitingCompletion: true
+        ),
+              let existingEntry = liveSyncEntries[oldKey] else { return false }
+
+        let newKey = liveSyncKey(for: completedContext.timestamp)
+        let adoptedEntry = LiveSyncEntry(
+            path: existingEntry.path,
+            context: completedContext,
+            awaitingCompletion: false
+        )
+        guard isInsideConfiguredVault(adoptedEntry.path),
+              FileManager.default.fileExists(atPath: adoptedEntry.path) else {
+            removeLiveSyncEntry(forKey: oldKey)
+            return false
+        }
+
+        do {
+            try rewriteLiveSyncEntry(adoptedEntry)
+            liveSyncEntries.removeValue(forKey: oldKey)
+            liveSyncEntries[newKey] = adoptedEntry
+            persistLiveSyncEntries()
+            return true
+        } catch {
+            print("[ObsidianPlugin] Failed to associate an action export with its transcription: \(error)")
+            return false
+        }
+    }
+
+    private func liveSync(payload: ActionCompletedPayload) async {
+        guard !_dailyNoteEnabled,
+              payload.success,
+              let data = payload.message.data(using: .utf8),
+              let update = try? JSONDecoder().decode(HistorySyncPayload.self, from: data) else { return }
+
+        let updatedContext = NoteContext(update, timestamp: payload.timestamp)
+        guard let oldKey = matchingEntryKey(for: updatedContext, requireMatchingFinalText: false),
+              let existingEntry = liveSyncEntries[oldKey] else { return }
+        guard isInsideConfiguredVault(existingEntry.path) else {
+            removeLiveSyncEntry(forKey: oldKey)
+            print("[ObsidianPlugin] Live sync ignored a note path outside the configured vault")
+            return
+        }
+
+        do {
+            let updatedEntry = LiveSyncEntry(
+                path: existingEntry.path,
+                context: updatedContext,
+                awaitingCompletion: false
+            )
+            try rewriteLiveSyncEntry(updatedEntry)
+            let newKey = liveSyncKey(for: updatedContext.timestamp)
+            liveSyncEntries.removeValue(forKey: oldKey)
+            liveSyncEntries[newKey] = updatedEntry
+            persistLiveSyncEntries()
+        } catch {
+            print("[ObsidianPlugin] Live sync failed: \(error)")
+        }
+    }
+
+    private func rewriteLiveSyncEntry(_ entry: LiveSyncEntry) throws {
+        let noteURL = URL(fileURLWithPath: entry.path)
+        try FileManager.default.createDirectory(
+            at: noteURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try renderNote(context: entry.context).write(
+            to: noteURL,
+            atomically: true,
+            encoding: .utf8
+        )
     }
 
     // MARK: - Settings View
@@ -348,6 +639,7 @@ private struct ObsidianSettingsView: View {
     @State private var detectedVaults: [ObsidianPlugin.VaultInfo] = []
     @State private var subfolder: String = "TypeWhisper"
     @State private var filenameTemplate: String = "{{DATE}} {{TIME}} {{APP}}"
+    @State private var noteTemplate: String = "{{TRANSCRIPT}}"
     @State private var dailyNoteEnabled: Bool = false
     @State private var dailyNoteFormat: String = "{{DATE}}"
     @State private var dailyNoteAppendTemplate: String = DailyNoteAppendPreset.timestamp.template
@@ -355,6 +647,7 @@ private struct ObsidianSettingsView: View {
     @State private var frontmatterEnabled: Bool = true
     @State private var tagsInput: String = "typewhisper"
     @State private var autoExportEnabled: Bool = false
+    @State private var liveSyncEnabled: Bool = true
     private let bundle = pluginModuleBundle
 
     var body: some View {
@@ -440,6 +733,25 @@ private struct ObsidianSettingsView: View {
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 108)
+
+                    if !dailyNoteEnabled {
+                        Text("Note Template", bundle: bundle)
+                            .font(.subheadline.weight(.medium))
+                            .padding(.top, 4)
+
+                        TextEditor(text: $noteTemplate)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(height: 112)
+                            .overlay(RoundedRectangle(cornerRadius: 6).stroke(Color.secondary.opacity(0.25)))
+                            .onChange(of: noteTemplate) { _, newValue in
+                                plugin._noteTemplate = newValue
+                                plugin.saveSetting(newValue, forKey: "noteTemplate")
+                            }
+
+                        Text("Placeholders: {{TRANSCRIPT}}, {{RAW_TRANSCRIPT}}, {{DATE}}, {{TIME}}, {{APP}}, {{LANGUAGE}}, {{URL}}, {{ENGINE}}, {{MODEL}}, {{DURATION}}, {{WORDS}}", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
 
                 Divider()
@@ -561,6 +873,28 @@ private struct ObsidianSettingsView: View {
                         plugin.saveSetting(newValue, forKey: "autoExportEnabled")
                         plugin.updateAutoExportSubscription()
                     }
+
+                    Toggle(isOn: $liveSyncEnabled) {
+                        VStack(alignment: .leading) {
+                            Text("Live Sync History Edits", bundle: bundle)
+                                .font(.headline)
+                            Text("Keep exported individual notes up to date when their transcript is edited in TypeWhisper. External Obsidian edits may be overwritten.", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .disabled(dailyNoteEnabled)
+                    .onChange(of: liveSyncEnabled) { _, newValue in
+                        plugin._liveSyncEnabled = newValue
+                        plugin.saveSetting(newValue, forKey: "liveSyncEnabled")
+                        plugin.updateAutoExportSubscription()
+                    }
+
+                    if dailyNoteEnabled {
+                        Text("Live Sync is available for individual notes only.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
 
                 Divider()
@@ -598,6 +932,7 @@ private struct ObsidianSettingsView: View {
             vaultPath = plugin._vaultPath
             subfolder = plugin._subfolder
             filenameTemplate = plugin._filenameTemplate
+            noteTemplate = plugin._noteTemplate
             dailyNoteEnabled = plugin._dailyNoteEnabled
             dailyNoteFormat = plugin._dailyNoteFormat
             dailyNoteAppendTemplate = plugin._dailyNoteAppendTemplate
@@ -605,6 +940,7 @@ private struct ObsidianSettingsView: View {
             frontmatterEnabled = plugin._frontmatterEnabled
             tagsInput = plugin._frontmatterTags.joined(separator: ", ")
             autoExportEnabled = plugin._autoExportEnabled
+            liveSyncEnabled = plugin._liveSyncEnabled
             detectedVaults = ObsidianPlugin.detectVaults() ?? []
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import TypeWhisperPluginSDK
+import os
 
 // MARK: - Plugin Entry Point
 
@@ -9,6 +10,8 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.obsidian"
     static let pluginName = "Obsidian"
     private static let historySyncActionID = "com.typewhisper.history.transcription-updated"
+    private static let liveSyncEntryRetention: TimeInterval = 30 * 24 * 60 * 60
+    private static let liveSyncEntryLimit = 500
 
     var actionName: String { "Save to Obsidian" }
     var actionId: String { "obsidian-save-note" }
@@ -29,7 +32,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     fileprivate var _frontmatterTags: [String] = ["typewhisper"]
     fileprivate var _autoExportEnabled: Bool = false
     fileprivate var _liveSyncEnabled: Bool = true
-    private var liveSyncEntries: [String: LiveSyncEntry] = [:]
+    private let liveSyncEntries = OSAllocatedUnfairLock(initialState: [String: LiveSyncEntry]())
 
     required override init() {
         super.init()
@@ -67,11 +70,16 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         _frontmatterTags = host?.userDefault(forKey: "frontmatterTags") as? [String] ?? ["typewhisper"]
         _autoExportEnabled = host?.userDefault(forKey: "autoExportEnabled") as? Bool ?? false
         _liveSyncEnabled = host?.userDefault(forKey: "liveSyncEnabled") as? Bool ?? true
+        let storedEntries: [String: LiveSyncEntry]
         if let data = host?.userDefault(forKey: "liveSyncEntries") as? Data,
            let entries = try? JSONDecoder().decode([String: LiveSyncEntry].self, from: data) {
-            liveSyncEntries = entries
+            storedEntries = entries
         } else {
-            liveSyncEntries = [:]
+            storedEntries = [:]
+        }
+        liveSyncEntries.withLock { entries in
+            entries = storedEntries
+            persistLiveSyncEntries(&entries)
         }
 
         // Auto-detect vault if none set
@@ -283,12 +291,12 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime]
         lines.append("date: \(formatter.string(from: context.timestamp))")
-        if includeAppMetadata, let app = context.appName { lines.append("app: \(app)") }
-        if includeAppMetadata, let bid = context.bundleIdentifier { lines.append("bundleId: \(bid)") }
-        if includeAppMetadata, let url = context.url { lines.append("url: \(url)") }
-        if let language = context.language { lines.append("language: \(language)") }
-        if let engine = context.engineUsed { lines.append("engine: \(engine)") }
-        if let model = context.modelUsed { lines.append("model: \(model)") }
+        if includeAppMetadata, let app = context.appName { lines.append("app: \(yamlScalar(app))") }
+        if includeAppMetadata, let bid = context.bundleIdentifier { lines.append("bundleId: \(yamlScalar(bid))") }
+        if includeAppMetadata, let url = context.url { lines.append("url: \(yamlScalar(url))") }
+        if let language = context.language { lines.append("language: \(yamlScalar(language))") }
+        if let engine = context.engineUsed { lines.append("engine: \(yamlScalar(engine))") }
+        if let model = context.modelUsed { lines.append("model: \(yamlScalar(model))") }
         if let duration = context.durationSeconds {
             lines.append("duration: \(String(format: "%.1f", locale: Locale(identifier: "en_US_POSIX"), duration))")
         }
@@ -296,17 +304,27 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         if !context.pipelineSteps.isEmpty {
             lines.append("processing:")
             for step in context.pipelineSteps {
-                lines.append("  - \(step)")
+                lines.append("  - \(yamlScalar(step))")
             }
         }
         if !_frontmatterTags.isEmpty {
             lines.append("tags:")
             for tag in _frontmatterTags {
-                lines.append("  - \(tag)")
+                lines.append("  - \(yamlScalar(tag))")
             }
         }
         lines.append("---")
         return lines.joined(separator: "\n")
+    }
+
+    private func yamlScalar(_ value: String) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        guard let data = try? encoder.encode(value),
+              let encoded = String(data: data, encoding: .utf8) else {
+            return "\"\""
+        }
+        return encoded
     }
 
     private func renderNote(context: NoteContext) -> String {
@@ -407,35 +425,64 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         String(timestamp.timeIntervalSinceReferenceDate.bitPattern, radix: 16)
     }
 
-    private func persistLiveSyncEntries() {
-        guard let data = try? JSONEncoder().encode(liveSyncEntries) else {
+    @discardableResult
+    private func pruneLiveSyncEntries(_ entries: inout [String: LiveSyncEntry], now: Date = Date()) -> Bool {
+        let originalCount = entries.count
+        let cutoff = now.addingTimeInterval(-Self.liveSyncEntryRetention)
+        entries = entries.filter { $0.value.context.timestamp >= cutoff }
+
+        if entries.count > Self.liveSyncEntryLimit {
+            entries = Dictionary(
+                uniqueKeysWithValues: entries
+                    .sorted { lhs, rhs in
+                        if lhs.value.context.timestamp == rhs.value.context.timestamp {
+                            return lhs.key < rhs.key
+                        }
+                        return lhs.value.context.timestamp > rhs.value.context.timestamp
+                    }
+                    .prefix(Self.liveSyncEntryLimit)
+                    .map { ($0.key, $0.value) }
+            )
+        }
+        return entries.count != originalCount
+    }
+
+    private func persistLiveSyncEntries(_ entries: inout [String: LiveSyncEntry]) {
+        pruneLiveSyncEntries(&entries)
+        guard let data = try? JSONEncoder().encode(entries) else {
             print("[ObsidianPlugin] Failed to persist live sync entries")
             return
         }
         saveSetting(data, forKey: "liveSyncEntries")
     }
 
-    private func storeLiveSyncEntry(path: String, context: NoteContext, awaitingCompletion: Bool) {
-        liveSyncEntries[liveSyncKey(for: context.timestamp)] = LiveSyncEntry(
+    private func storeLiveSyncEntry(
+        path: String,
+        context: NoteContext,
+        awaitingCompletion: Bool,
+        entries: inout [String: LiveSyncEntry]
+    ) {
+        entries[liveSyncKey(for: context.timestamp)] = LiveSyncEntry(
             path: path,
             context: context,
             awaitingCompletion: awaitingCompletion
         )
-        persistLiveSyncEntries()
+        persistLiveSyncEntries(&entries)
     }
 
-    private func removeLiveSyncEntry(forKey key: String) {
-        liveSyncEntries.removeValue(forKey: key)
-        persistLiveSyncEntries()
+    private func removeLiveSyncEntry(forKey key: String, entries: inout [String: LiveSyncEntry]) {
+        entries.removeValue(forKey: key)
+        persistLiveSyncEntries(&entries)
     }
 
     private func matchingEntryKey(
         for context: NoteContext,
         requireMatchingFinalText: Bool,
-        requireAwaitingCompletion: Bool = false
+        requireAwaitingCompletion: Bool = false,
+        entries: [String: LiveSyncEntry]
     ) -> String? {
         let exactKey = liveSyncKey(for: context.timestamp)
-        if let exactEntry = liveSyncEntries[exactKey],
+        if let exactEntry = entries[exactKey],
            entryMatches(
                exactEntry,
                context: context,
@@ -445,7 +492,7 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
             return exactKey
         }
 
-        return liveSyncEntries
+        return entries
             .filter { _, entry in
                 abs(entry.context.timestamp.timeIntervalSince(context.timestamp)) <= 60
                     && entryMatches(
@@ -507,9 +554,17 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
 
         do {
             let noteContext = NoteContext(input: input, actionContext: context)
-            let note = try writeNote(context: noteContext)
-            if _liveSyncEnabled, !_dailyNoteEnabled {
-                storeLiveSyncEntry(path: note.path, context: noteContext, awaitingCompletion: true)
+            let note = try liveSyncEntries.withLock { entries in
+                let note = try writeNote(context: noteContext)
+                if _liveSyncEnabled, !_dailyNoteEnabled {
+                    storeLiveSyncEntry(
+                        path: note.path,
+                        context: noteContext,
+                        awaitingCompletion: true,
+                        entries: &entries
+                    )
+                }
+                return note
             }
             return ActionResult(
                 success: true,
@@ -530,15 +585,22 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         guard !text.isEmpty else { return }
 
         do {
-            if _liveSyncEnabled,
-               !_dailyNoteEnabled,
-               await adoptMatchingActionExport(payload: payload) {
-                return
-            }
-            let noteContext = NoteContext(payload)
-            let note = try writeNote(context: noteContext)
-            if _liveSyncEnabled, !_dailyNoteEnabled {
-                storeLiveSyncEntry(path: note.path, context: noteContext, awaitingCompletion: false)
+            try liveSyncEntries.withLock { entries in
+                if _liveSyncEnabled,
+                   !_dailyNoteEnabled,
+                   adoptMatchingActionExport(payload: payload, entries: &entries) {
+                    return
+                }
+                let noteContext = NoteContext(payload)
+                let note = try writeNote(context: noteContext)
+                if _liveSyncEnabled, !_dailyNoteEnabled {
+                    storeLiveSyncEntry(
+                        path: note.path,
+                        context: noteContext,
+                        awaitingCompletion: false,
+                        entries: &entries
+                    )
+                }
             }
         } catch {
             print("[ObsidianPlugin] Auto-export failed: \(error)")
@@ -547,14 +609,30 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
 
     @discardableResult
     private func adoptMatchingActionExport(payload: TranscriptionCompletedPayload) async -> Bool {
+        liveSyncEntries.withLock { entries in
+            adoptMatchingActionExport(payload: payload, entries: &entries)
+        }
+    }
+
+    private func adoptMatchingActionExport(
+        payload: TranscriptionCompletedPayload,
+        entries: inout [String: LiveSyncEntry]
+    ) -> Bool {
         guard !_dailyNoteEnabled, isConfigured else { return false }
+        let didPrune = pruneLiveSyncEntries(&entries)
         let completedContext = NoteContext(payload)
         guard let oldKey = matchingEntryKey(
             for: completedContext,
             requireMatchingFinalText: true,
-            requireAwaitingCompletion: true
+            requireAwaitingCompletion: true,
+            entries: entries
         ),
-              let existingEntry = liveSyncEntries[oldKey] else { return false }
+              let existingEntry = entries[oldKey] else {
+            if didPrune {
+                persistLiveSyncEntries(&entries)
+            }
+            return false
+        }
 
         let newKey = liveSyncKey(for: completedContext.timestamp)
         let adoptedEntry = LiveSyncEntry(
@@ -564,15 +642,15 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
         )
         guard isInsideConfiguredVault(adoptedEntry.path),
               FileManager.default.fileExists(atPath: adoptedEntry.path) else {
-            removeLiveSyncEntry(forKey: oldKey)
+            removeLiveSyncEntry(forKey: oldKey, entries: &entries)
             return false
         }
 
         do {
             try rewriteLiveSyncEntry(adoptedEntry)
-            liveSyncEntries.removeValue(forKey: oldKey)
-            liveSyncEntries[newKey] = adoptedEntry
-            persistLiveSyncEntries()
+            entries.removeValue(forKey: oldKey)
+            entries[newKey] = adoptedEntry
+            persistLiveSyncEntries(&entries)
             return true
         } catch {
             print("[ObsidianPlugin] Failed to associate an action export with its transcription: \(error)")
@@ -587,27 +665,39 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
               let update = try? JSONDecoder().decode(HistorySyncPayload.self, from: data) else { return }
 
         let updatedContext = NoteContext(update, timestamp: payload.timestamp)
-        guard let oldKey = matchingEntryKey(for: updatedContext, requireMatchingFinalText: false),
-              let existingEntry = liveSyncEntries[oldKey] else { return }
-        guard isInsideConfiguredVault(existingEntry.path) else {
-            removeLiveSyncEntry(forKey: oldKey)
-            print("[ObsidianPlugin] Live sync ignored a note path outside the configured vault")
-            return
-        }
+        liveSyncEntries.withLock { entries in
+            let didPrune = pruneLiveSyncEntries(&entries)
+            guard let oldKey = matchingEntryKey(
+                for: updatedContext,
+                requireMatchingFinalText: false,
+                entries: entries
+            ),
+                  let existingEntry = entries[oldKey] else {
+                if didPrune {
+                    persistLiveSyncEntries(&entries)
+                }
+                return
+            }
+            guard isInsideConfiguredVault(existingEntry.path) else {
+                removeLiveSyncEntry(forKey: oldKey, entries: &entries)
+                print("[ObsidianPlugin] Live sync ignored a note path outside the configured vault")
+                return
+            }
 
-        do {
-            let updatedEntry = LiveSyncEntry(
-                path: existingEntry.path,
-                context: updatedContext,
-                awaitingCompletion: false
-            )
-            try rewriteLiveSyncEntry(updatedEntry)
-            let newKey = liveSyncKey(for: updatedContext.timestamp)
-            liveSyncEntries.removeValue(forKey: oldKey)
-            liveSyncEntries[newKey] = updatedEntry
-            persistLiveSyncEntries()
-        } catch {
-            print("[ObsidianPlugin] Live sync failed: \(error)")
+            do {
+                let updatedEntry = LiveSyncEntry(
+                    path: existingEntry.path,
+                    context: updatedContext,
+                    awaitingCompletion: false
+                )
+                try rewriteLiveSyncEntry(updatedEntry)
+                let newKey = liveSyncKey(for: updatedContext.timestamp)
+                entries.removeValue(forKey: oldKey)
+                entries[newKey] = updatedEntry
+                persistLiveSyncEntries(&entries)
+            } catch {
+                print("[ObsidianPlugin] Live sync failed: \(error)")
+            }
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/ObsidianPlugin.swift
@@ -522,9 +522,29 @@ final class ObsidianPlugin: NSObject, ActionPlugin, @unchecked Sendable {
     }
 
     private func isInsideConfiguredVault(_ path: String) -> Bool {
-        let vaultURL = URL(fileURLWithPath: _vaultPath, isDirectory: true).standardizedFileURL
-        let noteURL = URL(fileURLWithPath: path, isDirectory: false).standardizedFileURL
-        return noteURL.path.hasPrefix(vaultURL.path + "/") && noteURL.pathExtension.lowercased() == "md"
+        guard !_vaultPath.isEmpty else { return false }
+        let vaultURL = URL(fileURLWithPath: _vaultPath, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let noteURL = URL(fileURLWithPath: path, isDirectory: false)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let vaultComponents = vaultURL.pathComponents
+        let noteComponents = noteURL.pathComponents
+        guard noteComponents.count > vaultComponents.count,
+              noteURL.pathExtension.compare("md", options: .caseInsensitive) == .orderedSame else {
+            return false
+        }
+
+        let volumeIsCaseSensitive = (try? vaultURL.resourceValues(
+            forKeys: [.volumeSupportsCaseSensitiveNamesKey]
+        ).volumeSupportsCaseSensitiveNames) ?? true
+        return zip(vaultComponents, noteComponents).allSatisfy { vaultComponent, noteComponent in
+            if volumeIsCaseSensitive {
+                return vaultComponent == noteComponent
+            }
+            return vaultComponent.compare(noteComponent, options: .caseInsensitive) == .orderedSame
+        }
     }
 
     private func uniquePath(for path: String) -> String {

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -44,6 +44,18 @@ final class ObsidianPluginTests: XCTestCase {
     private static let workflowInstructionHelp = "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\"."
     private static let copyInstructionTitle = "Copy Instruction"
 
+    func testManifestDeclaresVersionAndHostBoundary() throws {
+        let manifest = try JSONDecoder().decode(
+            PluginManifest.self,
+            from: Data(contentsOf: Self.pluginRoot.appendingPathComponent("manifest.json"))
+        )
+
+        XCTAssertEqual(manifest.id, "com.typewhisper.obsidian")
+        XCTAssertEqual(manifest.version, "1.1.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
+    }
+
     func testExecuteFailsForInvalidVaultPath() async throws {
         let invalidVaultURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("obsidian-invalid-\(UUID().uuidString)", isDirectory: false)

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -471,6 +471,103 @@ final class ObsidianPluginTests: XCTestCase {
         plugin.deactivate()
     }
 
+    func testLiveSyncRejectsPersistedEntryThroughSymlinkOutsideConfiguredVault() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultContainment")
+        let outsideURL = try Self.makeTemporaryDirectory(prefix: "ObsidianOutsideVault")
+        defer {
+            try? FileManager.default.removeItem(at: vaultURL)
+            try? FileManager.default.removeItem(at: outsideURL)
+        }
+        let outsideNoteURL = outsideURL.appendingPathComponent("outside.md")
+        try "Original outside content".write(to: outsideNoteURL, atomically: true, encoding: .utf8)
+        let symlinkURL = vaultURL.appendingPathComponent("linked-outside", isDirectory: true)
+        try FileManager.default.createSymbolicLink(at: symlinkURL, withDestinationURL: outsideURL)
+        let persistedNoteURL = symlinkURL.appendingPathComponent("outside.md")
+        let timestamp = Date()
+        let storedEntry = StoredLiveSyncEntry(
+            path: persistedNoteURL.path,
+            context: Self.storedNoteContext(timestamp: timestamp),
+            awaitingCompletion: false
+        )
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: [
+                "vaultPath": vaultURL.path,
+                "liveSyncEnabled": true,
+                "liveSyncEntries": try JSONEncoder().encode([
+                    Self.liveSyncKey(for: timestamp): storedEntry,
+                ]),
+            ],
+            eventBus: eventBus
+        )
+        let plugin = ObsidianPlugin()
+        plugin.activate(host: host)
+
+        await eventBus.emit(try Self.historyUpdateEvent(
+            id: UUID(),
+            timestamp: timestamp,
+            rawText: "Raw text",
+            finalText: "Changed content",
+            language: "en",
+            engineUsed: "test",
+            modelUsed: nil,
+            durationSeconds: 1,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            pipelineSteps: []
+        ))
+
+        XCTAssertEqual(try String(contentsOf: outsideNoteURL, encoding: .utf8), "Original outside content")
+        let persistedData = try XCTUnwrap(host.userDefault(forKey: "liveSyncEntries") as? Data)
+        XCTAssertTrue(try JSONDecoder().decode([String: StoredLiveSyncEntry].self, from: persistedData).isEmpty)
+        plugin.deactivate()
+    }
+
+    func testDailyNoteModeIgnoresHistoryLiveSyncEvents() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultDailyGuard")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+        let noteURL = vaultURL.appendingPathComponent("tracked.md")
+        try "Original daily content".write(to: noteURL, atomically: true, encoding: .utf8)
+        let timestamp = Date()
+        let storedEntry = StoredLiveSyncEntry(
+            path: noteURL.path,
+            context: Self.storedNoteContext(timestamp: timestamp),
+            awaitingCompletion: false
+        )
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: [
+                "vaultPath": vaultURL.path,
+                "dailyNoteEnabled": true,
+                "liveSyncEnabled": true,
+                "liveSyncEntries": try JSONEncoder().encode([
+                    Self.liveSyncKey(for: timestamp): storedEntry,
+                ]),
+            ],
+            eventBus: eventBus
+        )
+        let plugin = ObsidianPlugin()
+        plugin.activate(host: host)
+
+        await eventBus.emit(try Self.historyUpdateEvent(
+            id: UUID(),
+            timestamp: timestamp,
+            rawText: "Raw text",
+            finalText: "Changed content",
+            language: "en",
+            engineUsed: "test",
+            modelUsed: nil,
+            durationSeconds: 1,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            pipelineSteps: []
+        ))
+
+        XCTAssertEqual(try String(contentsOf: noteURL, encoding: .utf8), "Original daily content")
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: vaultURL.path), ["tracked.md"])
+        plugin.deactivate()
+    }
+
     func testActionNameMatchesWorkflowInstructionTarget() {
         let plugin = ObsidianPlugin()
 
@@ -542,6 +639,26 @@ final class ObsidianPluginTests: XCTestCase {
             appName: appName,
             bundleIdentifier: bundleIdentifier
         ))
+    }
+
+    private static func storedNoteContext(timestamp: Date) -> StoredNoteContext {
+        StoredNoteContext(
+            timestamp: timestamp,
+            rawText: "Raw text",
+            finalText: "Final text",
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            url: nil,
+            language: "en",
+            engineUsed: "test",
+            modelUsed: nil,
+            durationSeconds: 1,
+            pipelineSteps: []
+        )
+    }
+
+    private static func liveSyncKey(for timestamp: Date) -> String {
+        String(timestamp.timeIntervalSinceReferenceDate.bitPattern, radix: 16)
     }
 
     private static func makeTemporaryDirectory(prefix: String) throws -> URL {

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -19,6 +19,26 @@ final class ObsidianPluginTests: XCTestCase {
         let pipelineSteps: [String]
     }
 
+    private struct StoredNoteContext: Codable {
+        let timestamp: Date
+        let rawText: String
+        let finalText: String
+        let appName: String?
+        let bundleIdentifier: String?
+        let url: String?
+        let language: String?
+        let engineUsed: String?
+        let modelUsed: String?
+        let durationSeconds: Double?
+        let pipelineSteps: [String]
+    }
+
+    private struct StoredLiveSyncEntry: Codable {
+        let path: String
+        let context: StoredNoteContext
+        let awaitingCompletion: Bool
+    }
+
     private static let historySyncActionID = "com.typewhisper.history.transcription-updated"
     private static let workflowInstructionTitle = "Workflow Instruction"
     private static let workflowInstructionHelp = "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\"."
@@ -54,6 +74,7 @@ final class ObsidianPluginTests: XCTestCase {
             "vaultPath": vaultURL.path,
             "subfolder": "Captured",
             "frontmatterEnabled": true,
+            "frontmatterTags": ["team: voice", "#capture"],
         ])
         let plugin = ObsidianPlugin()
         plugin.activate(host: host)
@@ -61,10 +82,10 @@ final class ObsidianPluginTests: XCTestCase {
         let result = try await plugin.execute(
             input: "Captured text",
             context: ActionContext(
-                appName: "Notes",
+                appName: "Research: Notes #1",
                 bundleIdentifier: "com.apple.Notes",
-                url: "https://example.com",
-                language: "en",
+                url: "https://example.com/search?q=voice#result",
+                language: "en: US",
                 originalText: "Captured text"
             )
         )
@@ -79,8 +100,12 @@ final class ObsidianPluginTests: XCTestCase {
 
         let content = try String(contentsOf: files[0], encoding: .utf8)
         XCTAssertTrue(content.contains("---"))
-        XCTAssertTrue(content.contains("app: Notes"))
-        XCTAssertTrue(content.contains("language: en"))
+        XCTAssertTrue(content.contains("app: \"Research: Notes #1\""))
+        XCTAssertTrue(content.contains("bundleId: \"com.apple.Notes\""))
+        XCTAssertTrue(content.contains("url: \"https://example.com/search?q=voice#result\""))
+        XCTAssertTrue(content.contains("language: \"en: US\""))
+        XCTAssertTrue(content.contains("  - \"team: voice\""))
+        XCTAssertTrue(content.contains("  - \"#capture\""))
         XCTAssertTrue(content.contains("Captured text"))
     }
 
@@ -114,7 +139,7 @@ final class ObsidianPluginTests: XCTestCase {
         let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultLiveSync")
         defer { try? FileManager.default.removeItem(at: vaultURL) }
         let id = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
-        let timestamp = Date(timeIntervalSince1970: 1_754_668_800)
+        let timestamp = Date()
         let eventBus = PluginTestEventBus()
         let host = try PluginTestHostServices(
             defaults: [
@@ -388,11 +413,62 @@ final class ObsidianPluginTests: XCTestCase {
 
         let content = try String(contentsOf: files[0], encoding: .utf8)
         XCTAssertTrue(content.contains("---"))
-        XCTAssertFalse(content.contains("app: Brave Browser"))
-        XCTAssertFalse(content.contains("bundleId: com.brave.Browser"))
-        XCTAssertFalse(content.contains("url: https://example.com"))
-        XCTAssertTrue(content.contains("language: it"))
+        XCTAssertFalse(content.contains("app: \"Brave Browser\""))
+        XCTAssertFalse(content.contains("bundleId: \"com.brave.Browser\""))
+        XCTAssertFalse(content.contains("url: \"https://example.com\""))
+        XCTAssertTrue(content.contains("language: \"it\""))
         XCTAssertTrue(content.contains("First entry"))
+    }
+
+    func testActivationPrunesExpiredEntriesAndCapsPersistentLiveSyncStore() throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultPruning")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+        let now = Date()
+        let context: (Date) -> StoredNoteContext = { timestamp in
+            StoredNoteContext(
+                timestamp: timestamp,
+                rawText: "Raw text",
+                finalText: "Final text",
+                appName: "Notes",
+                bundleIdentifier: "com.apple.Notes",
+                url: nil,
+                language: "en",
+                engineUsed: "test",
+                modelUsed: nil,
+                durationSeconds: 1,
+                pipelineSteps: []
+            )
+        }
+        var storedEntries: [String: StoredLiveSyncEntry] = [
+            "expired": StoredLiveSyncEntry(
+                path: vaultURL.appendingPathComponent("expired.md").path,
+                context: context(now.addingTimeInterval(-31 * 24 * 60 * 60)),
+                awaitingCompletion: false
+            ),
+        ]
+        for index in 0...500 {
+            let key = String(format: "recent-%03d", index)
+            storedEntries[key] = StoredLiveSyncEntry(
+                path: vaultURL.appendingPathComponent("\(key).md").path,
+                context: context(now.addingTimeInterval(-TimeInterval(index))),
+                awaitingCompletion: false
+            )
+        }
+
+        let host = try PluginTestHostServices(defaults: [
+            "vaultPath": vaultURL.path,
+            "liveSyncEntries": try JSONEncoder().encode(storedEntries),
+        ])
+        let plugin = ObsidianPlugin()
+        plugin.activate(host: host)
+
+        let persistedData = try XCTUnwrap(host.userDefault(forKey: "liveSyncEntries") as? Data)
+        let persistedEntries = try JSONDecoder().decode([String: StoredLiveSyncEntry].self, from: persistedData)
+        XCTAssertEqual(persistedEntries.count, 500)
+        XCTAssertNil(persistedEntries["expired"])
+        XCTAssertNotNil(persistedEntries["recent-000"])
+        XCTAssertNil(persistedEntries["recent-500"])
+        plugin.deactivate()
     }
 
     func testActionNameMatchesWorkflowInstructionTarget() {

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -5,6 +5,21 @@ import XCTest
 @testable import ObsidianPlugin
 
 final class ObsidianPluginTests: XCTestCase {
+    private struct HistorySyncPayload: Encodable {
+        let id: UUID
+        let rawText: String
+        let finalText: String
+        let language: String?
+        let engineUsed: String
+        let modelUsed: String?
+        let durationSeconds: Double
+        let appName: String?
+        let bundleIdentifier: String?
+        let url: String?
+        let pipelineSteps: [String]
+    }
+
+    private static let historySyncActionID = "com.typewhisper.history.transcription-updated"
     private static let workflowInstructionTitle = "Workflow Instruction"
     private static let workflowInstructionHelp = "Create a Custom Workflow, paste this into Instruction, and set Action Target to \"Save to Obsidian\"."
     private static let copyInstructionTitle = "Copy Instruction"
@@ -67,6 +82,175 @@ final class ObsidianPluginTests: XCTestCase {
         XCTAssertTrue(content.contains("app: Notes"))
         XCTAssertTrue(content.contains("language: en"))
         XCTAssertTrue(content.contains("Captured text"))
+    }
+
+    func testIndividualNoteTemplateResolvesAvailableMetadataAndSanitizesFilename() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultTemplate")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+
+        let host = try PluginTestHostServices(defaults: [
+            "vaultPath": vaultURL.path,
+            "subfolder": "",
+            "filenameTemplate": "[{{APP}}]: report?",
+            "noteTemplate": "# {{app}}\n\n{{transcript}}\n\nOriginal: {{raw_transcript}}\nWords: {{words}}",
+            "frontmatterEnabled": false,
+        ])
+        let plugin = ObsidianPlugin()
+        plugin.activate(host: host)
+
+        let result = try await plugin.execute(
+            input: "Clean final text",
+            context: ActionContext(appName: "Notes", originalText: "Raw text")
+        )
+
+        XCTAssertTrue(result.success)
+        let files = try FileManager.default.contentsOfDirectory(at: vaultURL, includingPropertiesForKeys: nil)
+        XCTAssertEqual(files.map(\.lastPathComponent), ["Notes report.md"])
+        let content = try String(contentsOf: try XCTUnwrap(files.first), encoding: .utf8)
+        XCTAssertEqual(content, "# Notes\n\nClean final text\n\nOriginal: Raw text\nWords: 3")
+    }
+
+    func testAutoExportLiveSyncUpdatesSameFileAfterPluginReactivation() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultLiveSync")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+        let id = UUID(uuidString: "55555555-5555-4555-8555-555555555555")!
+        let timestamp = Date(timeIntervalSince1970: 1_754_668_800)
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: [
+                "vaultPath": vaultURL.path,
+                "subfolder": "Captured",
+                "filenameTemplate": "{{DATE}} {{TIME}}",
+                "noteTemplate": "## Transcript\n\n{{TRANSCRIPT}}",
+                "frontmatterEnabled": true,
+                "autoExportEnabled": true,
+                "liveSyncEnabled": true,
+            ],
+            eventBus: eventBus
+        )
+        var plugin: ObsidianPlugin? = ObsidianPlugin()
+        plugin?.activate(host: host)
+
+        await eventBus.emit(.transcriptionCompleted(TranscriptionCompletedPayload(
+            timestamp: timestamp,
+            rawText: "Initial raw text",
+            finalText: "Initial final text",
+            language: "en",
+            engineUsed: "parakeet",
+            modelUsed: "TDT",
+            durationSeconds: 4,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            ruleName: nil
+        )))
+
+        let folderURL = vaultURL.appendingPathComponent("Captured", isDirectory: true)
+        let initialFiles = try FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: nil)
+        let noteURL = try XCTUnwrap(initialFiles.first)
+        XCTAssertEqual(initialFiles.count, 1)
+        XCTAssertTrue(try String(contentsOf: noteURL, encoding: .utf8).contains("Initial final text"))
+
+        plugin?.deactivate()
+        plugin = ObsidianPlugin()
+        plugin?.activate(host: host)
+
+        await eventBus.emit(try Self.historyUpdateEvent(
+            id: id,
+            timestamp: timestamp,
+            rawText: "Initial raw text",
+            finalText: "Corrected final text",
+            language: "en",
+            engineUsed: "parakeet",
+            modelUsed: "TDT",
+            durationSeconds: 4,
+            appName: "Notes",
+            bundleIdentifier: "com.apple.Notes",
+            pipelineSteps: []
+        ))
+
+        let updatedFiles = try FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: nil)
+        XCTAssertEqual(updatedFiles, initialFiles)
+        let updatedContent = try String(contentsOf: noteURL, encoding: .utf8)
+        XCTAssertTrue(updatedContent.contains("Corrected final text"))
+        XCTAssertFalse(updatedContent.contains("Initial final text"))
+        plugin?.deactivate()
+    }
+
+    func testWorkflowActionLiveSyncPersistsMappingWithoutDuplicateAutoExport() async throws {
+        let vaultURL = try Self.makeTemporaryDirectory(prefix: "ObsidianVaultWorkflowLiveSync")
+        defer { try? FileManager.default.removeItem(at: vaultURL) }
+        let id = UUID(uuidString: "66666666-6666-4666-8666-666666666666")!
+        let timestamp = Date()
+        let eventBus = PluginTestEventBus()
+        let host = try PluginTestHostServices(
+            defaults: [
+                "vaultPath": vaultURL.path,
+                "subfolder": "Captured",
+                "filenameTemplate": "{{DATE}} {{TIME}}",
+                "noteTemplate": "{{TRANSCRIPT}}\n\nEngine: {{ENGINE}}\nProcessing: {{PROCESSING}}",
+                "frontmatterEnabled": true,
+                "autoExportEnabled": true,
+                "liveSyncEnabled": true,
+            ],
+            eventBus: eventBus
+        )
+        var plugin: ObsidianPlugin? = ObsidianPlugin()
+        plugin?.activate(host: host)
+
+        let result = try await plugin?.execute(
+            input: "Workflow result",
+            context: ActionContext(
+                appName: "Notes",
+                language: "en",
+                originalText: "Raw workflow text"
+            )
+        )
+        XCTAssertEqual(result?.success, true)
+
+        await eventBus.emit(.transcriptionCompleted(TranscriptionCompletedPayload(
+            timestamp: timestamp,
+            rawText: "Raw workflow text",
+            finalText: "Workflow result",
+            language: "en",
+            engineUsed: "parakeet",
+            modelUsed: "TDT",
+            durationSeconds: 4,
+            appName: "Notes",
+            ruleName: nil
+        )))
+
+        let folderURL = vaultURL.appendingPathComponent("Captured", isDirectory: true)
+        let initialFiles = try FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: nil)
+        let noteURL = try XCTUnwrap(initialFiles.first)
+        XCTAssertEqual(initialFiles.count, 1)
+        let initialContent = try String(contentsOf: noteURL, encoding: .utf8)
+        XCTAssertTrue(initialContent.contains("Engine: parakeet"))
+
+        plugin?.deactivate()
+        plugin = ObsidianPlugin()
+        plugin?.activate(host: host)
+        await eventBus.emit(try Self.historyUpdateEvent(
+            id: id,
+            timestamp: timestamp,
+            rawText: "Raw workflow text",
+            finalText: "Corrected workflow result",
+            language: "en",
+            engineUsed: "parakeet",
+            modelUsed: "TDT",
+            durationSeconds: 4,
+            appName: "Notes",
+            bundleIdentifier: nil,
+            pipelineSteps: ["Cleanup"]
+        ))
+
+        XCTAssertEqual(
+            try FileManager.default.contentsOfDirectory(at: folderURL, includingPropertiesForKeys: nil),
+            initialFiles
+        )
+        let updatedContent = try String(contentsOf: noteURL, encoding: .utf8)
+        XCTAssertTrue(updatedContent.contains("Corrected workflow result"))
+        XCTAssertTrue(updatedContent.contains("Processing: Cleanup"))
+        plugin?.deactivate()
     }
 
     func testAutoExportDailyNoteAppendsTranscriptions() async throws {
@@ -243,6 +427,45 @@ final class ObsidianPluginTests: XCTestCase {
         for staleTerm in ["PromptAction", "Recommended Prompt", "Copy Prompt", "Create a new PromptAction"] {
             XCTAssertFalse(combinedCopy.contains(staleTerm), "\(staleTerm) should not appear in Obsidian settings copy")
         }
+    }
+
+    private static func historyUpdateEvent(
+        id: UUID,
+        timestamp: Date,
+        rawText: String,
+        finalText: String,
+        language: String?,
+        engineUsed: String,
+        modelUsed: String?,
+        durationSeconds: Double,
+        appName: String?,
+        bundleIdentifier: String?,
+        url: String? = nil,
+        pipelineSteps: [String]
+    ) throws -> TypeWhisperEvent {
+        let payload = HistorySyncPayload(
+            id: id,
+            rawText: rawText,
+            finalText: finalText,
+            language: language,
+            engineUsed: engineUsed,
+            modelUsed: modelUsed,
+            durationSeconds: durationSeconds,
+            appName: appName,
+            bundleIdentifier: bundleIdentifier,
+            url: url,
+            pipelineSteps: pipelineSteps
+        )
+        let message = try XCTUnwrap(String(data: JSONEncoder().encode(payload), encoding: .utf8))
+        return .actionCompleted(ActionCompletedPayload(
+            timestamp: timestamp,
+            actionId: historySyncActionID,
+            success: true,
+            message: message,
+            url: url,
+            appName: appName,
+            bundleIdentifier: bundleIdentifier
+        ))
     }
 
     private static func makeTemporaryDirectory(prefix: String) throws -> URL {

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
@@ -1,15 +1,15 @@
 {
     "id": "com.typewhisper.obsidian",
     "name": "Obsidian",
-    "version": "1.0.7",
+    "version": "1.1.0",
     "minHostVersion": "0.9.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",
-    "description": "Save transcriptions to your Obsidian vault as Markdown notes. Supports daily notes, frontmatter, and auto-export.",
+    "description": "Save transcriptions to your Obsidian vault as Markdown notes. Supports templates, YAML frontmatter, auto-export, and live sync.",
     "descriptions": {
-        "de": "Transkriptionen als Markdown-Notizen in deinem Obsidian-Vault speichern. Unterstützt Tagesnotizen, Frontmatter und Auto-Export.",
-        "ja": "文字起こしをMarkdownノートとしてObsidian Vaultに保存します。デイリーノート、frontmatter、自動エクスポートに対応します。"
+        "de": "Transkriptionen als Markdown-Notizen in deinem Obsidian-Vault speichern. Unterstützt Vorlagen, YAML-Frontmatter, Auto-Export und Live-Sync.",
+        "ja": "文字起こしをMarkdownノートとしてObsidian Vaultに保存します。テンプレート、YAMLフロントマター、自動エクスポート、ライブ同期に対応します。"
     },
     "category": "action",
     "iconSystemName": "doc.text",

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.obsidian",
     "name": "Obsidian",
     "version": "1.1.0",
-    "minHostVersion": "0.9.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperTests/HistoryServiceTests.swift
+++ b/TypeWhisperTests/HistoryServiceTests.swift
@@ -1,7 +1,54 @@
 import XCTest
+import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class HistoryServiceTests: XCTestCase {
+    @MainActor
+    func testUpdateRecordEmitsCompletePluginSyncPayloadWithoutChangingSDKABI() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let id = UUID(uuidString: "44444444-4444-4444-8444-444444444444")!
+        let timestamp = Date(timeIntervalSince1970: 1_754_668_800)
+        var emittedEvents: [TypeWhisperEvent] = []
+        let service = HistoryService(appSupportDirectory: appSupportDirectory) { event in
+            emittedEvents.append(event)
+        }
+
+        service.addRecord(
+            id: id,
+            timestamp: timestamp,
+            rawText: "Original text",
+            finalText: "Original text",
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes",
+            appURL: "https://example.com",
+            durationSeconds: 7.5,
+            language: "en",
+            engineUsed: "parakeet",
+            modelUsed: "TDT",
+            pipelineSteps: ["Cleanup"]
+        )
+
+        let record = try XCTUnwrap(service.records.first)
+        service.updateRecord(record, finalText: "Corrected text")
+
+        XCTAssertEqual(emittedEvents.count, 1)
+        guard case .actionCompleted(let event) = try XCTUnwrap(emittedEvents.first) else {
+            return XCTFail("Expected an actionCompleted plugin sync envelope")
+        }
+        XCTAssertEqual(event.actionId, HistoryService.pluginSyncActionID)
+        XCTAssertEqual(event.timestamp, timestamp)
+        XCTAssertEqual(event.appName, "Notes")
+        XCTAssertEqual(event.url, "https://example.com")
+
+        let data = try XCTUnwrap(event.message.data(using: .utf8))
+        let payload = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(payload["id"] as? String, id.uuidString)
+        XCTAssertEqual(payload["rawText"] as? String, "Original text")
+        XCTAssertEqual(payload["finalText"] as? String, "Corrected text")
+        XCTAssertEqual(payload["pipelineSteps"] as? [String], ["Cleanup"])
+    }
+
     @MainActor
     func testAddSearchUniqueDomainsAndPurgeHistory() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()


### PR DESCRIPTION
## Context

Issue #1083 asks for Obsidian-compatible transcript storage with native Markdown, configurable templates and filenames, YAML metadata, and a persistent link that keeps exported notes current when transcripts are edited in TypeWhisper.

## Summary

- add configurable Markdown note templates with available transcript and recording metadata placeholders
- expand YAML frontmatter and sanitize Obsidian-incompatible filename characters while keeping chronological defaults
- persist individual-note mappings so History edits rewrite the original Markdown file across plugin restarts
- associate workflow action exports with the completion event to avoid duplicate auto-exports
- keep Daily Note mode append-only and warn that external Obsidian edits can be overwritten by live sync
- reuse the existing SDK v1 action event envelope for History notifications without changing the public plugin ABI
- bump the Obsidian plugin manifest to 1.1.0
- require TypeWhisper 1.6.0 because History live sync depends on the new host event

Unavailable generated concepts such as attendees, summaries, and action items are not fabricated; templates expose the metadata TypeWhisper currently has.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter "ObsidianPluginTests|PluginManifestTests|TypeWhisperEventTests"`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" -derivedDataPath /tmp/typewhisper-issue1083-focused CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:TypeWhisperTests/HistoryServiceTests`
- [x] `git diff --check origin/main..HEAD`
- [x] `jq empty TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Localizable.xcstrings`

Closes #1083

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added live synchronization for exported Obsidian notes, including updates after transcription history edits.
  - Added configurable note templates, expanded placeholders, and YAML frontmatter metadata.
  - Added a Live Sync setting and improved export behavior to prevent duplicate notes.
  - Added German, Japanese, and Simplified Chinese translations for live-sync settings and template features.
  - Updated the Obsidian plugin to version 1.1.0 with broader feature descriptions.

- **Bug Fixes**
  - History updates now preserve note files while refreshing their content.
  - Transcription history and completion events now include accurate timestamps and processing details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
