### PR TITLE
Fix MCP tool catalog refresh

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientPlugin.swift
@@ -267,10 +267,13 @@ final class MCPClientPlugin: NSObject, AdditionalActionPluginsProviding, PluginS
         Task { await runtime.invalidate(serverID: id) }
     }
 
-    func discoverTools(serverID: UUID) async throws -> [MCPToolDescriptor] {
+    func discoverTools(
+        serverID: UUID,
+        forceRefresh: Bool = false
+    ) async throws -> [MCPToolDescriptor] {
         let server = try resolvedServer(id: serverID)
         do {
-            let tools = try await runtime.tools(for: server)
+            let tools = try await runtime.tools(for: server, forceRefresh: forceRefresh)
             recordActivity(
                 serverName: server.configuration.name,
                 actionName: nil,

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
@@ -98,12 +98,26 @@ actor MCPServerSession {
         self.toolCallTimeout = toolCallTimeout
     }
 
-    func tools() async throws -> [MCPToolDescriptor] {
+    func tools(forceRefresh: Bool = false) async throws -> [MCPToolDescriptor] {
+        let hadUsableConnection = hasUsableConnection
         try await ensureConnected()
+        if forceRefresh, hadUsableConnection {
+            catalogIsStale = true
+        }
         if catalogIsStale {
             try await refreshToolsWithTimeout()
         }
         return cachedTools
+    }
+
+    private var hasUsableConnection: Bool {
+        guard isConnected, client != nil, transport != nil else { return false }
+        switch resolvedServer.transport {
+        case .stdio:
+            return process?.isRunning == true
+        case .streamableHTTP:
+            return true
+        }
     }
 
     func call(
@@ -301,7 +315,7 @@ actor MCPServerSession {
         }
 
         let clientVersion = Bundle(for: MCPClientPlugin.self)
-            .object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.2.0"
+            .object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "0.2.1"
         let client = Client(name: "TypeWhisper", version: clientVersion, title: "TypeWhisper MCP Client")
 
         self.transport = transport
@@ -549,8 +563,11 @@ actor MCPClientRuntime {
 
     private var sessions: [UUID: Entry] = [:]
 
-    func tools(for server: MCPResolvedServer) async throws -> [MCPToolDescriptor] {
-        try await session(for: server).tools()
+    func tools(
+        for server: MCPResolvedServer,
+        forceRefresh: Bool = false
+    ) async throws -> [MCPToolDescriptor] {
+        try await session(for: server).tools(forceRefresh: forceRefresh)
     }
 
     func call(

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSettingsView.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSettingsView.swift
@@ -727,7 +727,7 @@ private struct MCPActionEditorView: View {
                             configureBindings(for: selectedTool)
                         }
                         Button(String(localized: "Refresh Tools", bundle: bundle)) {
-                            loadTools(resetSelection: false)
+                            loadTools(resetSelection: false, forceRefresh: true)
                         }
                     }
 
@@ -876,7 +876,7 @@ private struct MCPActionEditorView: View {
         )
     }
 
-    private func loadTools(resetSelection: Bool) {
+    private func loadTools(resetSelection: Bool, forceRefresh: Bool = false) {
         let requestID = UUID()
         let requestedServerID = serverID
         toolLoadRequestID = requestID
@@ -890,7 +890,10 @@ private struct MCPActionEditorView: View {
         errorMessage = nil
         Task {
             do {
-                let loaded = try await plugin.discoverTools(serverID: requestedServerID)
+                let loaded = try await plugin.discoverTools(
+                    serverID: requestedServerID,
+                    forceRefresh: forceRefresh
+                )
                 await MainActor.run {
                     guard toolLoadRequestID == requestID else { return }
                     tools = loaded

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
@@ -26,7 +26,7 @@ final class MCPClientPluginTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: Data(contentsOf: url))
 
         XCTAssertEqual(manifest.id, "com.typewhisper.mcp-client")
-        XCTAssertEqual(manifest.version, "0.2.0")
+        XCTAssertEqual(manifest.version, "0.2.1")
         XCTAssertEqual(manifest.minHostVersion, "1.6.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
         XCTAssertEqual(manifest.category, "action")
@@ -855,6 +855,34 @@ final class MCPClientPluginTests: XCTestCase {
         XCTAssertEqual(refreshed.first?.description, "Create a fixture task version 2")
         XCTAssertEqual(try Self.requestCount(at: fixture.counter), 2)
         await session.close()
+    }
+
+    func testForcedDiscoveryRefreshesCachedCatalogWithoutListChangedNotification() async throws {
+        let fixture = try Self.fixtureResources()
+        defer { try? FileManager.default.removeItem(at: fixture.counter) }
+        let configuration = MCPServerConfiguration(
+            name: "Fixture",
+            command: fixture.pythonPath,
+            arguments: [fixture.script.path, fixture.counter.path, "count-connection"],
+            launchAcknowledged: true
+        )
+        let server = MCPResolvedServer(
+            configuration: configuration,
+            executableURL: URL(fileURLWithPath: fixture.pythonPath),
+            environment: ProcessInfo.processInfo.environment,
+            secrets: []
+        )
+        let runtime = MCPClientRuntime()
+        addTeardownBlock { await runtime.closeAll() }
+
+        let initial = try await runtime.tools(for: server)
+        let cached = try await runtime.tools(for: server)
+        let refreshed = try await runtime.tools(for: server, forceRefresh: true)
+
+        XCTAssertEqual(initial.first?.description, "Create a fixture task version 1")
+        XCTAssertEqual(cached.first?.description, "Create a fixture task version 1")
+        XCTAssertEqual(refreshed.first?.description, "Create a fixture task version 2")
+        XCTAssertEqual(try Self.requestCount(at: fixture.counter), 3)
     }
 
     func testConcurrentDiscoverySharesOneConnectionAndCatalogLoad() async throws {

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.mcp-client",
     "name": "MCP Client",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

A follow-up report in #1085 showed that **Refresh Tools** in the MCP action editor reused the current session’s cached tool catalog, while **Connect & Load Tools** created a fresh session and fetched the latest catalog. MCP servers that do not emit `notifications/tools/list_changed` therefore kept showing stale tools in the action editor.

Closes #1085

## Changes

- make the explicit **Refresh Tools** action force a fresh `tools/list` request on an existing MCP session
- keep normal editor loads cached and avoid an unnecessary second fetch when establishing a new session
- add regression coverage for a server that changes its catalog without emitting `tools/list_changed`
- bump MCP Client to `0.2.1`

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter MCPClientPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme MCPClientPlugin -configuration Release -derivedDataPath "$(mktemp -d "${TMPDIR}typewhisper-mcp-release-build.XXXXXX")" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -destination "platform=macOS,arch=arm64" build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to force-refresh the available tools when discovering them.
  * The “Refresh Tools” action now bypasses cached tool data and retrieves the latest catalog.

* **Bug Fixes**
  * Improved tool refresh behavior for active connections.
  * Updated the plugin version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->