### PR TITLE
Fix auto-enter in apps without Accessibility text roles

### DIFF
--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -31,7 +31,6 @@ final class TextInsertionService {
 
     var accessibilityGrantedOverride: Bool?
     var pasteboardProvider: () -> NSPasteboard = { .general }
-    var focusedTextFieldOverride: (() -> Bool)?
     var focusedTextElementOverride: (() -> AXUIElement?)?
     var focusedTextStateOverride: ((AXUIElement) -> FocusedTextSnapshot?)?
     var textSelectionOverride: (() -> TextSelection?)?
@@ -395,7 +394,6 @@ final class TextInsertionService {
             throw TextInsertionError.accessibilityNotGranted
         }
 
-        let hadFocusedTextField = autoEnter && hasFocusedTextField()
         let formattedClipboardPayload = ClipboardContentFormatter.payload(for: text, outputFormat: outputFormat)
         let requiresPasteboardInsertion = ClipboardContentFormatter.requiresPasteboardInsertion(
             outputFormat: outputFormat
@@ -416,7 +414,7 @@ final class TextInsertionService {
         if preserveClipboard, !requiresPasteboardInsertion, !prefersSyntheticPaste,
            let focusedElement = getFocusedTextElement(),
            insertTextAtAndVerifyChange(element: focusedElement, text: text) {
-            if hadFocusedTextField {
+            if autoEnter {
                 try? await Task.sleep(for: .milliseconds(50))
                 simulateReturn()
             }
@@ -471,7 +469,7 @@ final class TextInsertionService {
             )
         }
 
-        if hadFocusedTextField {
+        if autoEnter {
             try? await Task.sleep(for: .milliseconds(50))
             simulateReturn()
         }
@@ -529,27 +527,6 @@ final class TextInsertionService {
         return elementPosition(from: axElement)
     }
 
-    /// Checks if the currently focused UI element is a text input field.
-    func hasFocusedTextField() -> Bool {
-        if let focusedTextFieldOverride {
-            return focusedTextFieldOverride()
-        }
-        guard isAccessibilityGranted else { return false }
-
-        let systemWide = AXUIElementCreateSystemWide()
-        var focusedElement: AnyObject?
-        let result = AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedElement)
-        guard result == .success, let element = focusedElement else { return false }
-
-        let axElement = element as! AXUIElement
-        var roleValue: AnyObject?
-        let roleResult = AXUIElementCopyAttributeValue(axElement, kAXRoleAttribute as CFString, &roleValue)
-        guard roleResult == .success, let role = roleValue as? String else { return false }
-
-        let textRoles = ["AXTextField", "AXTextArea", "AXComboBox", "AXSearchField", "AXWebArea"]
-        return textRoles.contains(role)
-    }
-
     private func caretRect(from element: AXUIElement) -> CGRect? {
         var selectedRangeValue: AnyObject?
         let rangeResult = AXUIElementCopyAttributeValue(
@@ -586,13 +563,14 @@ final class TextInsertionService {
             return
         }
         let returnKeyCode: CGKeyCode = 0x24
-        let keyDown = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: true)
+        let eventSource = CGEventSource(stateID: .combinedSessionState)
+        let keyDown = CGEvent(keyboardEventSource: eventSource, virtualKey: returnKeyCode, keyDown: true)
         keyDown?.flags = []
-        keyDown?.post(tap: .cgSessionEventTap)
+        keyDown?.post(tap: .cghidEventTap)
 
-        let keyUp = CGEvent(keyboardEventSource: nil, virtualKey: returnKeyCode, keyDown: false)
+        let keyUp = CGEvent(keyboardEventSource: eventSource, virtualKey: returnKeyCode, keyDown: false)
         keyUp?.flags = []
-        keyUp?.post(tap: .cgSessionEventTap)
+        keyUp?.post(tap: .cghidEventTap)
     }
 
     private func simulatePaste() {

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -109,7 +109,6 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         let textInsertionService = TextInsertionService()
         textInsertionService.accessibilityGrantedOverride = true
         textInsertionService.pasteboardProvider = { pasteboard }
-        textInsertionService.focusedTextFieldOverride = { true }
 
         var pasteCount = 0
         var returnCount = 0

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4297,12 +4297,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testAutoEnterSkipsReturnWithoutFocusedTextField() async throws {
+    func testAutoEnterTriggersReturnWhenAXFocusedTextRoleIsUnavailable() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
-        service.focusedTextFieldOverride = { false }
 
         var didSimulatePaste = false
         service.pasteSimulatorOverride = {
@@ -4317,17 +4316,16 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         _ = try await service.insertText("Hello", autoEnter: true)
 
         XCTAssertTrue(didSimulatePaste)
-        XCTAssertFalse(didSimulateReturn)
+        XCTAssertTrue(didSimulateReturn)
         XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
     }
 
     @MainActor
-    func testAutoEnterTriggersReturnWithFocusedTextField() async throws {
+    func testDisabledAutoEnterSkipsReturnAfterPaste() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
-        service.focusedTextFieldOverride = { true }
         service.pasteSimulatorOverride = {}
 
         var didSimulateReturn = false
@@ -4335,14 +4333,14 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             didSimulateReturn = true
         }
 
-        _ = try await service.insertText("Hello", autoEnter: true)
+        _ = try await service.insertText("Hello", autoEnter: false)
 
-        XCTAssertTrue(didSimulateReturn)
+        XCTAssertFalse(didSimulateReturn)
         XCTAssertEqual(pasteboard.string(forType: .string), "Hello")
     }
 
     @MainActor
-    func testPreserveClipboardAvoidsPasteboardWhenVerifiedAccessibilityInsertionSucceeds() async throws {
+    func testAutoEnterTriggersReturnAfterVerifiedAccessibilityInsertionWithoutPasteboard() async throws {
         let service = TextInsertionService()
         let pasteboard = NSPasteboard.withUniqueName()
         let element = AXUIElementCreateSystemWide()
@@ -4370,14 +4368,20 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         service.pasteSimulatorOverride = {
             didSimulatePaste = true
         }
+        var didSimulateReturn = false
+        service.returnSimulatorOverride = {
+            didSimulateReturn = true
+        }
 
         pasteboard.clearContents()
         pasteboard.setString("Existing", forType: .string)
 
-        _ = try await service.insertText("Hello", preserveClipboard: true)
+        let result = try await service.insertText("Hello", preserveClipboard: true, autoEnter: true)
 
         XCTAssertEqual(insertedText, "Hello")
         XCTAssertFalse(didSimulatePaste)
+        XCTAssertTrue(didSimulateReturn)
+        XCTAssertEqual(result, .insertedViaAccessibility)
         XCTAssertEqual(pasteboard.string(forType: .string), "Existing")
     }
 

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4302,6 +4302,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let pasteboard = NSPasteboard.withUniqueName()
         service.accessibilityGrantedOverride = true
         service.pasteboardProvider = { pasteboard }
+        service.focusedTextElementOverride = { nil }
 
         var didSimulatePaste = false
         service.pasteSimulatorOverride = {


### PR DESCRIPTION
## Summary

- honor explicit auto-enter after verified Accessibility insertion and synthetic paste even when the target does not expose a standard AX text role
- send Return through a combined-session CGEvent source at the HID event tap, matching the working Enigo path used by Handy
- add regressions for AX-unavailable targets, disabled auto-enter, direct Accessibility insertion, and recent-transcription behavior

## Context

Discussion: https://github.com/TypeWhisper/typewhisper-mac/discussions/1095

Zed uses GPUI and does not expose the standard AppKit Accessibility text roles TypeWhisper previously required. Text paste succeeded, but TypeWhisper skipped Return before posting any key event.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -disableAutomaticPackageResolution -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests CODE_SIGNING_ALLOWED=NO` (196 tests, 0 failures)
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac` (signed development build succeeded)
- [x] Manually verified in Zed 1.14.2 that auto-enter pastes the transcription and sends Return (confirmed by Marco)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automatic Return-key behavior after text insertion.
  - Return is now triggered reliably even when focused-field information is unavailable.
  - Disabling automatic Return continues to prevent the key event.
  - Verified accessibility-based insertion now triggers Return without using the clipboard.
  - Improved consistency when inserting transcriptions into supported applications, including cases where the active text field cannot be identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->