### PR TITLE
test: cover TextEdit correction learning regression

### DIFF
--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -54,6 +54,53 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertEqual(dictionaryService.correctionsCount, 1)
     }
 
+    func testLearnsReportedTextEditCorrectionAfterTransientObservationAndReturn() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let element = AXUIElementCreateSystemWide()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.focusedTextElementOverride = { element }
+        var captureCount = 0
+        textInsertionService.focusedTextStateOverride = { _ in
+            captureCount += 1
+            guard captureCount > 1 else { return nil }
+            let value = "Beeper\n"
+            return (value: value, selectedText: nil, selectedRange: NSRange(location: value.count, length: 0))
+        }
+
+        let commitEmitter = CommitEmitterBox()
+        var sleepCount = 0
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            pollSchedule: [.milliseconds(0), .milliseconds(0)],
+            sleep: { _ in
+                sleepCount += 1
+                if sleepCount == 2 {
+                    commitEmitter.emit(.returnKey)
+                }
+            },
+            makeCommitObserver: commitObserver(capturing: commitEmitter)
+        )
+        let baseline = TextInsertionService.FocusedTextObservation(
+            element: element,
+            value: "Biper",
+            selectedText: nil,
+            selectedRange: NSRange(location: 5, length: 0)
+        )
+
+        let result = await service.trackInsertion(insertedText: "Biper", baseline: baseline)
+
+        XCTAssertEqual(result.snapshot.outcome, .learned)
+        XCTAssertEqual(result.snapshot.commitSignal, .returnKey)
+        XCTAssertEqual(result.learnedCorrections.first?.original, "Biper")
+        XCTAssertEqual(result.learnedCorrections.first?.replacement, "Beeper")
+        XCTAssertEqual(dictionaryService.correctionsCount, 1)
+    }
+
     func testSkipsSentenceRewriteAfterCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Issue context

Issue #1097 reports that automatic correction learning on stable 1.5.1 did not persist a supported `Biper` to `Beeper` edit in TextEdit. Current `main` already contains the transient Accessibility-observation and commit handling delivered in #878; this PR locks the exact reported path so it remains covered in Daily builds.

Closes #1097

## What changed

- add an end-to-end service regression for a blank TextEdit-style insertion
- reproduce a transient first Accessibility read failure
- verify Return commits `Biper` to `Beeper` even when TextEdit appends a newline
- verify exactly one auto-learned dictionary correction is persisted

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination platform=macOS,arch=arm64 -parallel-testing-enabled NO CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/TargetAppCorrectionLearningServiceTests -only-testing:TypeWhisperTests/TextDiffServiceTests
```

Result: passed, 25 tests, 0 failures.

```bash
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac
```

Result: passed; signed development app built and launched from `/Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for correction learning when the initial text observation is unavailable.
  * Verified that later text changes trigger the correct replacement, Return-key commit signal, learned outcome, and dictionary persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->