### PR TITLE
Add Responses API to OpenAI Compatible plugin

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -666,6 +666,358 @@
           }
         }
       }
+    },
+    "Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fügt das nicht standardisierte Thinking-Feld für Chat Completions nur hinzu, wenn es aktiviert ist. Deaktiviert lassen, sofern Ihr Anbieter die Unterstützung nicht dokumentiert."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効な場合にのみ、非標準の Chat Completions thinking フィールドを追加します。プロバイダーが対応を明記していない限り、オフのままにしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅在启用时添加非标准的 Chat Completions thinking 字段。除非提供商明确说明支持，否则请保持关闭。"
+          }
+        }
+      }
+    },
+    "Chat Completions": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat Completions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat Completions"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "聊天补全"
+          }
+        }
+      }
+    },
+    "High": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        }
+      }
+    },
+    "LLM API": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM-API"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM API"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM API"
+          }
+        }
+      }
+    },
+    "Low": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Niedrig"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "低"
+          }
+        }
+      }
+    },
+    "Max": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        }
+      }
+    },
+    "Medium": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mittel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "中"
+          }
+        }
+      }
+    },
+    "Provider Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieterstandard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダーのデフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供商默认值"
+          }
+        }
+      }
+    },
+    "Provider Default omits reasoning. Other values send reasoning: { effort: ... } to /v1/responses.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bei Anbieterstandard wird reasoning weggelassen. Andere Werte senden reasoning: { effort: ... } an /v1/responses."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「プロバイダーのデフォルト」では reasoning を省略します。その他の値では reasoning: { effort: ... } を /v1/responses に送信します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“提供商默认值”会省略 reasoning。其他值会向 /v1/responses 发送 reasoning: { effort: ... }。"
+          }
+        }
+      }
+    },
+    "Provider Thinking Extension": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thinking-Erweiterung des Anbieters"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダーの Thinking 拡張"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供商 Thinking 扩展"
+          }
+        }
+      }
+    },
+    "Reasoning Effort": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reasoning-Aufwand"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推論エフォート"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "推理强度"
+          }
+        }
+      }
+    },
+    "Responses": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responses"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responses"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "响应"
+          }
+        }
+      }
+    },
+    "Temperature overrides are omitted when Responses reasoning effort is configured.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturüberschreibungen werden weggelassen, wenn für Responses ein Reasoning-Aufwand konfiguriert ist."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responses の推論エフォートが設定されている場合、温度の上書きは送信されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置 Responses 推理强度时，将不发送温度覆盖值。"
+          }
+        }
+      }
+    },
+    "Uses /v1/chat/completions for broad compatibility with existing providers.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendet /v1/chat/completions für breite Kompatibilität mit bestehenden Anbietern."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "既存のプロバイダーとの幅広い互換性のために /v1/chat/completions を使用します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 /v1/chat/completions，以广泛兼容现有提供商。"
+          }
+        }
+      }
+    },
+    "Uses /v1/responses with OpenAI-compatible input, output, and reasoning fields.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwendet /v1/responses mit OpenAI-kompatiblen Eingabe-, Ausgabe- und Reasoning-Feldern."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenAI 互換の入力、出力、reasoning フィールドで /v1/responses を使用します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 /v1/responses，并采用与 OpenAI 兼容的输入、输出和 reasoning 字段。"
+          }
+        }
+      }
+    },
+    "X High": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sehr hoch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最高"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超高"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -265,34 +265,6 @@
         }
       }
     },
-    "Thinking Mode": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Denkmodus"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thinking Mode"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "思考モード"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "思考模式"
-          }
-        }
-      }
-    },
     "Model name": {
       "localizations": {
         "de": {
@@ -667,28 +639,6 @@
         }
       }
     },
-    "Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Fügt das nicht standardisierte Thinking-Feld für Chat Completions nur hinzu, wenn es aktiviert ist. Deaktiviert lassen, sofern Ihr Anbieter die Unterstützung nicht dokumentiert."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "有効な場合にのみ、非標準の Chat Completions thinking フィールドを追加します。プロバイダーが対応を明記していない限り、オフのままにしてください。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "仅在启用时添加非标准的 Chat Completions thinking 字段。除非提供商明确说明支持，否则请保持关闭。"
-          }
-        }
-      }
-    },
     "Chat Completions": {
       "localizations": {
         "de": {
@@ -861,28 +811,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "“提供商默认值”会省略 reasoning。其他值会向 /v1/responses 发送 reasoning: { effort: ... }。"
-          }
-        }
-      }
-    },
-    "Provider Thinking Extension": {
-      "localizations": {
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Thinking-Erweiterung des Anbieters"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "プロバイダーの Thinking 拡張"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "提供商 Thinking 扩展"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Localizable.xcstrings
@@ -265,6 +265,34 @@
         }
       }
     },
+    "Thinking Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Denkmodus"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thinking Mode"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考モード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "思考模式"
+          }
+        }
+      }
+    },
     "Model name": {
       "localizations": {
         "de": {
@@ -639,6 +667,28 @@
         }
       }
     },
+    "Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fügt das nicht standardisierte Thinking-Feld für Chat Completions nur hinzu, wenn es aktiviert ist. Deaktiviert lassen, sofern Ihr Anbieter die Unterstützung nicht dokumentiert."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効な場合にのみ、非標準の Chat Completions thinking フィールドを追加します。プロバイダーが対応を明記していない限り、オフのままにしてください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "仅在启用时添加非标准的 Chat Completions thinking 字段。除非提供商明确说明支持，否则请保持关闭。"
+          }
+        }
+      }
+    },
     "Chat Completions": {
       "localizations": {
         "de": {
@@ -811,6 +861,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "“提供商默认值”会省略 reasoning。其他值会向 /v1/responses 发送 reasoning: { effort: ... }。"
+          }
+        }
+      }
+    },
+    "Provider Thinking Extension": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Thinking-Erweiterung des Anbieters"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダーの Thinking 拡張"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供商 Thinking 扩展"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -57,6 +57,61 @@ enum OpenAICompatibleResolvedTranscriptionTransport: Sendable, Equatable {
     case realtime
 }
 
+/// Per-profile LLM endpoint selection. Chat Completions remains the default so
+/// profiles created before Responses API support keep their existing behavior.
+enum OpenAICompatibleLLMAPI: String, Codable, CaseIterable, Sendable {
+    case chatCompletions = "chat-completions"
+    case responses
+
+    var displayName: String {
+        switch self {
+        case .chatCompletions:
+            "Chat Completions"
+        case .responses:
+            "Responses"
+        }
+    }
+
+    var path: String {
+        switch self {
+        case .chatCompletions:
+            "/v1/chat/completions"
+        case .responses:
+            "/v1/responses"
+        }
+    }
+}
+
+enum OpenAICompatibleReasoningEffort: String, Codable, CaseIterable, Sendable {
+    case providerDefault = ""
+    case low
+    case medium
+    case high
+    case xhigh
+    case max
+
+    var displayName: String {
+        switch self {
+        case .providerDefault:
+            "Provider Default"
+        case .low:
+            "Low"
+        case .medium:
+            "Medium"
+        case .high:
+            "High"
+        case .xhigh:
+            "X High"
+        case .max:
+            "Max"
+        }
+    }
+
+    var requestValue: String? {
+        self == .providerDefault ? nil : rawValue
+    }
+}
+
 /// Knowledge about the well-known OpenAI/Azure realtime transcription model
 /// IDs, mirroring the classification `OpenAIPlugin` uses for `gpt-live-transcribe`
 /// (context-aware) and `gpt-realtime-whisper` (legacy). Custom Azure/Foundry
@@ -102,6 +157,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var chatRequestTimeoutSeconds: TimeInterval?
     var thinkingEnabled: Bool
     var transcriptionTransportRaw: String
+    var llmAPIModeRaw: String
+    var reasoningEffortRaw: String
 
     static let defaultChatRequestTimeout: TimeInterval = 30
     static let minChatRequestTimeout: TimeInterval = 5
@@ -120,6 +177,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         case chatRequestTimeoutSeconds
         case thinkingEnabled
         case transcriptionTransportRaw
+        case llmAPIModeRaw
+        case reasoningEffortRaw
     }
 
     init(
@@ -134,7 +193,9 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
         thinkingEnabled: Bool = false,
-        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue
+        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
+        llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
+        reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
     ) {
         self.id = id
         self.name = name
@@ -148,6 +209,8 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
         self.thinkingEnabled = thinkingEnabled
         self.transcriptionTransportRaw = transcriptionTransportRaw
+        self.llmAPIModeRaw = llmAPIModeRaw
+        self.reasoningEffortRaw = reasoningEffortRaw
     }
 
     init(from decoder: Decoder) throws {
@@ -168,6 +231,11 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         // and only the known realtime model IDs switch transport.
         transcriptionTransportRaw = try container.decodeIfPresent(String.self, forKey: .transcriptionTransportRaw)
             ?? OpenAICompatibleTranscriptTransport.auto.rawValue
+        // Profiles saved before Responses API support always used Chat Completions.
+        llmAPIModeRaw = try container.decodeIfPresent(String.self, forKey: .llmAPIModeRaw)
+            ?? OpenAICompatibleLLMAPI.chatCompletions.rawValue
+        reasoningEffortRaw = try container.decodeIfPresent(String.self, forKey: .reasoningEffortRaw)
+            ?? OpenAICompatibleReasoningEffort.providerDefault.rawValue
     }
 
     var isDefault: Bool { id == Self.defaultId }
@@ -186,6 +254,14 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
 
     var transcriptionTransport: OpenAICompatibleTranscriptTransport {
         OpenAICompatibleTranscriptTransport(rawValue: transcriptionTransportRaw) ?? .auto
+    }
+
+    var llmAPI: OpenAICompatibleLLMAPI {
+        OpenAICompatibleLLMAPI(rawValue: llmAPIModeRaw) ?? .chatCompletions
+    }
+
+    var reasoningEffort: OpenAICompatibleReasoningEffort {
+        OpenAICompatibleReasoningEffort(rawValue: reasoningEffortRaw) ?? .providerDefault
     }
 
     /// Resolves the effective (non-`auto`) transport for the currently
@@ -211,7 +287,9 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
         thinkingEnabled: Bool = false,
-        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue
+        transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
+        llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
+        reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
     ) -> OpenAICompatibleProfile {
         OpenAICompatibleProfile(
             id: defaultId,
@@ -225,7 +303,9 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             fetchedModels: fetchedModels,
             chatRequestTimeoutSeconds: chatRequestTimeoutSeconds,
             thinkingEnabled: thinkingEnabled,
-            transcriptionTransportRaw: transcriptionTransportRaw
+            transcriptionTransportRaw: transcriptionTransportRaw,
+            llmAPIModeRaw: llmAPIModeRaw,
+            reasoningEffortRaw: reasoningEffortRaw
         )
     }
 }
@@ -612,6 +692,18 @@ final class OpenAICompatiblePlugin: NSObject,
         }
     }
 
+    func setLLMAPI(_ api: OpenAICompatibleLLMAPI, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.llmAPIModeRaw = api.rawValue
+        }
+    }
+
+    func setReasoningEffort(_ effort: OpenAICompatibleReasoningEffort, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.reasoningEffortRaw = effort.rawValue
+        }
+    }
+
     // MARK: - Profile Runtime
 
     func displayName(for profileId: String) -> String {
@@ -862,18 +954,36 @@ final class OpenAICompatiblePlugin: NSObject,
         guard !modelId.isEmpty else {
             throw PluginChatError.noModelSelected
         }
-        return try await processChatCompletion(
-            apiKey: apiKey(for: profileId) ?? "",
-            baseURL: profile.baseURL,
-            model: modelId,
-            systemPrompt: systemPrompt,
-            userText: userText,
-            temperature: providerTemperatureDirective(for: profileId)
-                .resolvedTemperature(applying: temperatureDirective),
-            requestTimeout: profile.resolvedChatRequestTimeout,
-            thinkingEnabled: profile.thinkingEnabled,
-            apiVersion: profile.apiVersion
-        )
+        let temperature = providerTemperatureDirective(for: profileId)
+            .resolvedTemperature(applying: temperatureDirective)
+        let apiKey = apiKey(for: profileId) ?? ""
+
+        switch profile.llmAPI {
+        case .chatCompletions:
+            return try await processChatCompletion(
+                apiKey: apiKey,
+                baseURL: profile.baseURL,
+                model: modelId,
+                systemPrompt: systemPrompt,
+                userText: userText,
+                temperature: temperature,
+                requestTimeout: profile.resolvedChatRequestTimeout,
+                thinkingEnabled: profile.thinkingEnabled,
+                apiVersion: profile.apiVersion
+            )
+        case .responses:
+            return try await processResponse(
+                apiKey: apiKey,
+                baseURL: profile.baseURL,
+                model: modelId,
+                systemPrompt: systemPrompt,
+                userText: userText,
+                temperature: profile.reasoningEffort.requestValue == nil ? temperature : nil,
+                reasoningEffort: profile.reasoningEffort.requestValue,
+                requestTimeout: profile.resolvedChatRequestTimeout,
+                apiVersion: profile.apiVersion
+            )
+        }
     }
 
     func fetchModels() async -> [FetchedModel] {
@@ -1030,7 +1140,11 @@ final class OpenAICompatiblePlugin: NSObject,
                 llmTemperatureModeRaw: host.userDefault(forKey: "llmTemperatureMode") as? String
                     ?? PluginLLMTemperatureMode.providerDefault.rawValue,
                 llmTemperatureValue: host.userDefault(forKey: "llmTemperatureValue") as? Double ?? 0.3,
-                fetchedModels: fetchedModels
+                fetchedModels: fetchedModels,
+                llmAPIModeRaw: host.userDefault(forKey: "llmAPIMode") as? String
+                    ?? OpenAICompatibleLLMAPI.chatCompletions.rawValue,
+                reasoningEffortRaw: host.userDefault(forKey: "reasoningEffort") as? String
+                    ?? OpenAICompatibleReasoningEffort.providerDefault.rawValue
             )
         ]
     }
@@ -1064,7 +1178,11 @@ final class OpenAICompatiblePlugin: NSObject,
                         host.userDefault(forKey: "apiVersion") as? String ?? ""
                     ),
                     selectedModelId: host.userDefault(forKey: "selectedModel") as? String ?? "",
-                    selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? ""
+                    selectedLLMModelId: host.userDefault(forKey: "selectedLLMModel") as? String ?? "",
+                    llmAPIModeRaw: host.userDefault(forKey: "llmAPIMode") as? String
+                        ?? OpenAICompatibleLLMAPI.chatCompletions.rawValue,
+                    reasoningEffortRaw: host.userDefault(forKey: "reasoningEffort") as? String
+                        ?? OpenAICompatibleReasoningEffort.providerDefault.rawValue
                 ),
                 at: 0
             )
@@ -1099,6 +1217,8 @@ final class OpenAICompatiblePlugin: NSObject,
         host.setUserDefault(defaultProfile.selectedLLMModelId, forKey: "selectedLLMModel")
         host.setUserDefault(defaultProfile.llmTemperatureModeRaw, forKey: "llmTemperatureMode")
         host.setUserDefault(defaultProfile.llmTemperatureValue, forKey: "llmTemperatureValue")
+        host.setUserDefault(defaultProfile.llmAPIModeRaw, forKey: "llmAPIMode")
+        host.setUserDefault(defaultProfile.reasoningEffortRaw, forKey: "reasoningEffort")
         if let data = try? JSONEncoder().encode(defaultProfile.fetchedModels) {
             host.setUserDefault(data, forKey: "fetchedModels")
         }
@@ -1166,7 +1286,7 @@ final class OpenAICompatiblePlugin: NSObject,
         thinkingEnabled: Bool,
         apiVersion: String
     ) async throws -> String {
-        let path = "/v1/chat/completions"
+        let path = OpenAICompatibleLLMAPI.chatCompletions.path
         guard let url = Self.requestURL(baseURL: baseURL, path: path, apiVersion: apiVersion) else {
             throw PluginChatError.apiError("Invalid URL: \(baseURL)\(path)")
         }
@@ -1223,13 +1343,13 @@ final class OpenAICompatiblePlugin: NSObject,
                 ["role": "system", "content": systemPrompt],
                 ["role": "user", "content": userText],
             ],
-            "thinking": [
-                "type": thinkingEnabled ? "enabled" : "disabled"
-            ],
         ]
         requestBody[outputTokenParameter.rawValue] = 4096
         if let temperature {
             requestBody["temperature"] = temperature
+        }
+        if thinkingEnabled {
+            requestBody["thinking"] = ["type": "enabled"]
         }
 
         var request = URLRequest(url: url)
@@ -1265,6 +1385,110 @@ final class OpenAICompatiblePlugin: NSObject,
         }
 
         return content.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func processResponse(
+        apiKey: String,
+        baseURL: String,
+        model: String,
+        systemPrompt: String,
+        userText: String,
+        temperature: Double?,
+        reasoningEffort: String?,
+        requestTimeout: TimeInterval,
+        apiVersion: String
+    ) async throws -> String {
+        let path = OpenAICompatibleLLMAPI.responses.path
+        guard let url = Self.requestURL(baseURL: baseURL, path: path, apiVersion: apiVersion) else {
+            throw PluginChatError.apiError("Invalid URL: \(baseURL)\(path)")
+        }
+
+        let instructions = systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? "You are a helpful assistant."
+            : systemPrompt
+        var requestBody: [String: Any] = [
+            "model": model,
+            "instructions": instructions,
+            "input": [
+                [
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        [
+                            "type": "input_text",
+                            "text": userText,
+                        ],
+                    ],
+                ],
+            ],
+            "store": false,
+        ]
+        if let reasoningEffort {
+            requestBody["reasoning"] = ["effort": reasoningEffort]
+        }
+        if let temperature {
+            requestBody["temperature"] = temperature
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        Self.applyAuthentication(to: &request, apiKey: apiKey)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = requestTimeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: requestBody)
+
+        let (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: requestTimeout)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginChatError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            return try Self.parseResponsesText(from: data)
+        case 401:
+            throw PluginChatError.invalidApiKey
+        case 429:
+            throw PluginChatError.rateLimited
+        default:
+            throw PluginChatError.apiError(Self.chatErrorMessage(from: data, statusCode: httpResponse.statusCode))
+        }
+    }
+
+    static func parseResponsesText(from data: Data) throws -> String {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw PluginChatError.apiError("Failed to parse response")
+        }
+
+        if let outputText = json["output_text"] as? String {
+            let trimmed = outputText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
+
+        if let output = json["output"] as? [[String: Any]] {
+            let textParts = output.flatMap { item -> [String] in
+                guard let content = item["content"] as? [[String: Any]] else { return [] }
+                return content.compactMap { contentItem in
+                    let type = contentItem["type"] as? String
+                    guard type == nil || type == "output_text" || type == "text" else { return nil }
+                    if let text = contentItem["text"] as? String {
+                        return text
+                    }
+                    if let text = contentItem["text"] as? [String: Any] {
+                        return text["value"] as? String
+                    }
+                    return nil
+                }
+            }
+
+            let text = textParts.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+            if !text.isEmpty {
+                return text
+            }
+        }
+
+        throw PluginChatError.apiError("Failed to parse response text")
     }
 
     private func performVersionedTranscriptionRequest(
@@ -1635,6 +1859,8 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var thinkingEnabled = false
     @State private var chatTimeoutInput = ""
     @State private var transcriptionTransport: OpenAICompatibleTranscriptTransport = .auto
+    @State private var llmAPI: OpenAICompatibleLLMAPI = .chatCompletions
+    @State private var reasoningEffort: OpenAICompatibleReasoningEffort = .providerDefault
 
     private let bundle = pluginModuleBundle
 
@@ -1736,7 +1962,11 @@ private struct OpenAICompatibleSettingsView: View {
                     serverSection
                     modelSection
                     temperatureSection
-                    thinkingModeSection
+                    if llmAPI == .chatCompletions {
+                        thinkingModeSection
+                    } else {
+                        reasoningEffortSection
+                    }
                     timeoutSection
 
                     Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -1886,7 +2116,37 @@ private struct OpenAICompatibleSettingsView: View {
                 manualModelSection
             }
 
+            llmAPISection
             transportSection
+        }
+    }
+
+    private var llmAPISection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("LLM API", bundle: bundle)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Picker("LLM API", selection: $llmAPI) {
+                Text("Chat Completions", bundle: bundle).tag(OpenAICompatibleLLMAPI.chatCompletions)
+                Text("Responses", bundle: bundle).tag(OpenAICompatibleLLMAPI.responses)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .onChange(of: llmAPI) {
+                guard let selectedProfile else { return }
+                plugin.setLLMAPI(llmAPI, for: selectedProfile.id)
+                reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+            }
+
+            Text(
+                llmAPI == .chatCompletions
+                    ? "Uses /v1/chat/completions for broad compatibility with existing providers."
+                    : "Uses /v1/responses with OpenAI-compatible input, output, and reasoning fields.",
+                bundle: bundle
+            )
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
     }
 
@@ -2044,6 +2304,12 @@ private struct OpenAICompatibleSettingsView: View {
                         reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
                     }
             }
+
+            if llmAPI == .responses, reasoningEffort != .providerDefault {
+                Text("Temperature overrides are omitted when Responses reasoning effort is configured.", bundle: bundle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 
@@ -2052,7 +2318,7 @@ private struct OpenAICompatibleSettingsView: View {
             Divider()
 
             Toggle(isOn: $thinkingEnabled) {
-                Text("Thinking Mode", bundle: bundle)
+                Text("Provider Thinking Extension", bundle: bundle)
                     .font(.headline)
             }
             .onChange(of: thinkingEnabled) {
@@ -2060,6 +2326,35 @@ private struct OpenAICompatibleSettingsView: View {
                 plugin.setThinkingEnabled(thinkingEnabled, for: selectedProfile.id)
                 reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
             }
+
+            Text("Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private var reasoningEffortSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+
+            Text("Reasoning Effort", bundle: bundle)
+                .font(.headline)
+
+            Picker("Reasoning Effort", selection: $reasoningEffort) {
+                ForEach(OpenAICompatibleReasoningEffort.allCases, id: \.self) { effort in
+                    Text(String(localized: String.LocalizationValue(effort.displayName), bundle: bundle))
+                        .tag(effort)
+                }
+            }
+            .onChange(of: reasoningEffort) {
+                guard let selectedProfile else { return }
+                plugin.setReasoningEffort(reasoningEffort, for: selectedProfile.id)
+                reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+            }
+
+            Text("Provider Default omits reasoning. Other values send reasoning: { effort: ... } to /v1/responses.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
     }
 
@@ -2118,6 +2413,8 @@ private struct OpenAICompatibleSettingsView: View {
         thinkingEnabled = profile.thinkingEnabled
         chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
         transcriptionTransport = profile.transcriptionTransport
+        llmAPI = profile.llmAPI
+        reasoningEffort = profile.reasoningEffort
         connectionResult = nil
     }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -155,6 +155,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var llmTemperatureValue: Double
     var fetchedModels: [FetchedModel]
     var chatRequestTimeoutSeconds: TimeInterval?
+    var thinkingEnabled: Bool
     var transcriptionTransportRaw: String
     var llmAPIModeRaw: String
     var reasoningEffortRaw: String
@@ -174,6 +175,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         case llmTemperatureValue
         case fetchedModels
         case chatRequestTimeoutSeconds
+        case thinkingEnabled
         case transcriptionTransportRaw
         case llmAPIModeRaw
         case reasoningEffortRaw
@@ -190,6 +192,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
+        thinkingEnabled: Bool = false,
         transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
         llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
         reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
@@ -204,6 +207,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.llmTemperatureValue = llmTemperatureValue
         self.fetchedModels = fetchedModels
         self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
+        self.thinkingEnabled = thinkingEnabled
         self.transcriptionTransportRaw = transcriptionTransportRaw
         self.llmAPIModeRaw = llmAPIModeRaw
         self.reasoningEffortRaw = reasoningEffortRaw
@@ -221,6 +225,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue = try container.decode(Double.self, forKey: .llmTemperatureValue)
         fetchedModels = try container.decode([FetchedModel].self, forKey: .fetchedModels)
         chatRequestTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .chatRequestTimeoutSeconds)
+        thinkingEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingEnabled) ?? false
         // Profiles saved before realtime support existed have no stored value;
         // default to `auto` so previously-working batch models keep working
         // and only the known realtime model IDs switch transport.
@@ -281,6 +286,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
+        thinkingEnabled: Bool = false,
         transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
         llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
         reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
@@ -296,6 +302,7 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             llmTemperatureValue: llmTemperatureValue,
             fetchedModels: fetchedModels,
             chatRequestTimeoutSeconds: chatRequestTimeoutSeconds,
+            thinkingEnabled: thinkingEnabled,
             transcriptionTransportRaw: transcriptionTransportRaw,
             llmAPIModeRaw: llmAPIModeRaw,
             reasoningEffortRaw: reasoningEffortRaw
@@ -535,6 +542,10 @@ final class OpenAICompatiblePlugin: NSObject,
         setLLMTemperatureValue(value, for: providerId)
     }
 
+    func setThinkingEnabled(_ enabled: Bool) {
+        setThinkingEnabled(enabled, for: providerId)
+    }
+
     // MARK: - Settings View
 
     var settingsView: AnyView? {
@@ -672,6 +683,12 @@ final class OpenAICompatiblePlugin: NSObject,
         )
         updateProfile(profileId) { profile in
             profile.chatRequestTimeoutSeconds = clamped
+        }
+    }
+
+    func setThinkingEnabled(_ enabled: Bool, for profileId: String) {
+        updateProfile(profileId) { profile in
+            profile.thinkingEnabled = enabled
         }
     }
 
@@ -951,6 +968,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: profile.resolvedChatRequestTimeout,
+                thinkingEnabled: profile.thinkingEnabled,
                 apiVersion: profile.apiVersion
             )
         case .responses:
@@ -1265,6 +1283,7 @@ final class OpenAICompatiblePlugin: NSObject,
         userText: String,
         temperature: Double?,
         requestTimeout: TimeInterval,
+        thinkingEnabled: Bool,
         apiVersion: String
     ) async throws -> String {
         let path = OpenAICompatibleLLMAPI.chatCompletions.path
@@ -1282,6 +1301,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: requestTimeout,
+                thinkingEnabled: thinkingEnabled,
                 outputTokenParameter: outputTokenParameter
             )
         } catch let error as PluginChatError {
@@ -1300,6 +1320,7 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: requestTimeout,
+                thinkingEnabled: thinkingEnabled,
                 outputTokenParameter: fallback
             )
         }
@@ -1313,6 +1334,7 @@ final class OpenAICompatiblePlugin: NSObject,
         userText: String,
         temperature: Double?,
         requestTimeout: TimeInterval,
+        thinkingEnabled: Bool,
         outputTokenParameter: OutputTokenParameter
     ) async throws -> String {
         var requestBody: [String: Any] = [
@@ -1325,6 +1347,9 @@ final class OpenAICompatiblePlugin: NSObject,
         requestBody[outputTokenParameter.rawValue] = 4096
         if let temperature {
             requestBody["temperature"] = temperature
+        }
+        if thinkingEnabled {
+            requestBody["thinking"] = ["type": "enabled"]
         }
 
         var request = URLRequest(url: url)
@@ -1831,6 +1856,7 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var manualLLMModel = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
+    @State private var thinkingEnabled = false
     @State private var chatTimeoutInput = ""
     @State private var transcriptionTransport: OpenAICompatibleTranscriptTransport = .auto
     @State private var llmAPI: OpenAICompatibleLLMAPI = .chatCompletions
@@ -1936,7 +1962,9 @@ private struct OpenAICompatibleSettingsView: View {
                     serverSection
                     modelSection
                     temperatureSection
-                    if llmAPI == .responses {
+                    if llmAPI == .chatCompletions {
+                        thinkingModeSection
+                    } else {
                         reasoningEffortSection
                     }
                     timeoutSection
@@ -2285,6 +2313,26 @@ private struct OpenAICompatibleSettingsView: View {
         }
     }
 
+    private var thinkingModeSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Divider()
+
+            Toggle(isOn: $thinkingEnabled) {
+                Text("Provider Thinking Extension", bundle: bundle)
+                    .font(.headline)
+            }
+            .onChange(of: thinkingEnabled) {
+                guard let selectedProfile else { return }
+                plugin.setThinkingEnabled(thinkingEnabled, for: selectedProfile.id)
+                reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
+            }
+
+            Text("Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+
     private var reasoningEffortSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Divider()
@@ -2362,6 +2410,7 @@ private struct OpenAICompatibleSettingsView: View {
         manualLLMModel = profile.selectedLLMModelId
         llmTemperatureMode = PluginLLMTemperatureMode(rawValue: profile.llmTemperatureModeRaw) ?? .providerDefault
         llmTemperatureValue = profile.llmTemperatureValue
+        thinkingEnabled = profile.thinkingEnabled
         chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
         transcriptionTransport = profile.transcriptionTransport
         llmAPI = profile.llmAPI

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -155,7 +155,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
     var llmTemperatureValue: Double
     var fetchedModels: [FetchedModel]
     var chatRequestTimeoutSeconds: TimeInterval?
-    var thinkingEnabled: Bool
     var transcriptionTransportRaw: String
     var llmAPIModeRaw: String
     var reasoningEffortRaw: String
@@ -175,7 +174,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         case llmTemperatureValue
         case fetchedModels
         case chatRequestTimeoutSeconds
-        case thinkingEnabled
         case transcriptionTransportRaw
         case llmAPIModeRaw
         case reasoningEffortRaw
@@ -192,7 +190,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
-        thinkingEnabled: Bool = false,
         transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
         llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
         reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
@@ -207,7 +204,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         self.llmTemperatureValue = llmTemperatureValue
         self.fetchedModels = fetchedModels
         self.chatRequestTimeoutSeconds = chatRequestTimeoutSeconds
-        self.thinkingEnabled = thinkingEnabled
         self.transcriptionTransportRaw = transcriptionTransportRaw
         self.llmAPIModeRaw = llmAPIModeRaw
         self.reasoningEffortRaw = reasoningEffortRaw
@@ -225,7 +221,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue = try container.decode(Double.self, forKey: .llmTemperatureValue)
         fetchedModels = try container.decode([FetchedModel].self, forKey: .fetchedModels)
         chatRequestTimeoutSeconds = try container.decodeIfPresent(TimeInterval.self, forKey: .chatRequestTimeoutSeconds)
-        thinkingEnabled = try container.decodeIfPresent(Bool.self, forKey: .thinkingEnabled) ?? false
         // Profiles saved before realtime support existed have no stored value;
         // default to `auto` so previously-working batch models keep working
         // and only the known realtime model IDs switch transport.
@@ -286,7 +281,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
         llmTemperatureValue: Double = 0.3,
         fetchedModels: [FetchedModel] = [],
         chatRequestTimeoutSeconds: TimeInterval? = nil,
-        thinkingEnabled: Bool = false,
         transcriptionTransportRaw: String = OpenAICompatibleTranscriptTransport.auto.rawValue,
         llmAPIModeRaw: String = OpenAICompatibleLLMAPI.chatCompletions.rawValue,
         reasoningEffortRaw: String = OpenAICompatibleReasoningEffort.providerDefault.rawValue
@@ -302,7 +296,6 @@ struct OpenAICompatibleProfile: Codable, Equatable, Identifiable, Sendable {
             llmTemperatureValue: llmTemperatureValue,
             fetchedModels: fetchedModels,
             chatRequestTimeoutSeconds: chatRequestTimeoutSeconds,
-            thinkingEnabled: thinkingEnabled,
             transcriptionTransportRaw: transcriptionTransportRaw,
             llmAPIModeRaw: llmAPIModeRaw,
             reasoningEffortRaw: reasoningEffortRaw
@@ -542,10 +535,6 @@ final class OpenAICompatiblePlugin: NSObject,
         setLLMTemperatureValue(value, for: providerId)
     }
 
-    func setThinkingEnabled(_ enabled: Bool) {
-        setThinkingEnabled(enabled, for: providerId)
-    }
-
     // MARK: - Settings View
 
     var settingsView: AnyView? {
@@ -683,12 +672,6 @@ final class OpenAICompatiblePlugin: NSObject,
         )
         updateProfile(profileId) { profile in
             profile.chatRequestTimeoutSeconds = clamped
-        }
-    }
-
-    func setThinkingEnabled(_ enabled: Bool, for profileId: String) {
-        updateProfile(profileId) { profile in
-            profile.thinkingEnabled = enabled
         }
     }
 
@@ -968,7 +951,6 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: profile.resolvedChatRequestTimeout,
-                thinkingEnabled: profile.thinkingEnabled,
                 apiVersion: profile.apiVersion
             )
         case .responses:
@@ -1283,7 +1265,6 @@ final class OpenAICompatiblePlugin: NSObject,
         userText: String,
         temperature: Double?,
         requestTimeout: TimeInterval,
-        thinkingEnabled: Bool,
         apiVersion: String
     ) async throws -> String {
         let path = OpenAICompatibleLLMAPI.chatCompletions.path
@@ -1301,7 +1282,6 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: requestTimeout,
-                thinkingEnabled: thinkingEnabled,
                 outputTokenParameter: outputTokenParameter
             )
         } catch let error as PluginChatError {
@@ -1320,7 +1300,6 @@ final class OpenAICompatiblePlugin: NSObject,
                 userText: userText,
                 temperature: temperature,
                 requestTimeout: requestTimeout,
-                thinkingEnabled: thinkingEnabled,
                 outputTokenParameter: fallback
             )
         }
@@ -1334,7 +1313,6 @@ final class OpenAICompatiblePlugin: NSObject,
         userText: String,
         temperature: Double?,
         requestTimeout: TimeInterval,
-        thinkingEnabled: Bool,
         outputTokenParameter: OutputTokenParameter
     ) async throws -> String {
         var requestBody: [String: Any] = [
@@ -1347,9 +1325,6 @@ final class OpenAICompatiblePlugin: NSObject,
         requestBody[outputTokenParameter.rawValue] = 4096
         if let temperature {
             requestBody["temperature"] = temperature
-        }
-        if thinkingEnabled {
-            requestBody["thinking"] = ["type": "enabled"]
         }
 
         var request = URLRequest(url: url)
@@ -1856,7 +1831,6 @@ private struct OpenAICompatibleSettingsView: View {
     @State private var manualLLMModel = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
-    @State private var thinkingEnabled = false
     @State private var chatTimeoutInput = ""
     @State private var transcriptionTransport: OpenAICompatibleTranscriptTransport = .auto
     @State private var llmAPI: OpenAICompatibleLLMAPI = .chatCompletions
@@ -1962,9 +1936,7 @@ private struct OpenAICompatibleSettingsView: View {
                     serverSection
                     modelSection
                     temperatureSection
-                    if llmAPI == .chatCompletions {
-                        thinkingModeSection
-                    } else {
+                    if llmAPI == .responses {
                         reasoningEffortSection
                     }
                     timeoutSection
@@ -2313,26 +2285,6 @@ private struct OpenAICompatibleSettingsView: View {
         }
     }
 
-    private var thinkingModeSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Divider()
-
-            Toggle(isOn: $thinkingEnabled) {
-                Text("Provider Thinking Extension", bundle: bundle)
-                    .font(.headline)
-            }
-            .onChange(of: thinkingEnabled) {
-                guard let selectedProfile else { return }
-                plugin.setThinkingEnabled(thinkingEnabled, for: selectedProfile.id)
-                reloadProfiles(selecting: selectedProfile.id, preserveInputs: true)
-            }
-
-            Text("Adds the nonstandard Chat Completions thinking field only when enabled. Leave off unless your provider documents support.", bundle: bundle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-    }
-
     private var reasoningEffortSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             Divider()
@@ -2410,7 +2362,6 @@ private struct OpenAICompatibleSettingsView: View {
         manualLLMModel = profile.selectedLLMModelId
         llmTemperatureMode = PluginLLMTemperatureMode(rawValue: profile.llmTemperatureModeRaw) ?? .providerDefault
         llmTemperatureValue = profile.llmTemperatureValue
-        thinkingEnabled = profile.thinkingEnabled
         chatTimeoutInput = String(Int(profile.resolvedChatRequestTimeout))
         transcriptionTransport = profile.transcriptionTransport
         llmAPI = profile.llmAPI

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -28,6 +28,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         plugin.selectModel("whisper-1")
         plugin.selectLLMModel("gpt-4.1-mini")
+        plugin.setThinkingEnabled(true)
         plugin.deactivate()
 
         let reloaded = OpenAICompatiblePlugin()
@@ -35,6 +36,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(reloaded.selectedModelId, "whisper-1")
         XCTAssertEqual(reloaded.selectedLLMModelId, "gpt-4.1-mini")
+        XCTAssertEqual(reloaded.profileSnapshot(for: reloaded.providerId)?.thinkingEnabled, true)
     }
 
     func testLegacyConfigurationMigratesIntoDefaultProfile() throws {
@@ -67,6 +69,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.selectedLLMModelId, "chat-legacy")
         XCTAssertEqual(profile.llmTemperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
         XCTAssertEqual(profile.llmTemperatureValue, 0.7)
+        XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.llmAPI, .chatCompletions)
         XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.fetchedModels.map(\.id), ["legacy-model"])
@@ -99,7 +102,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(host.userDefault(forKey: "apiVersion") as? String, "preview")
     }
 
-    func testSavedProfilesIgnoreLegacyThinkingMode() throws {
+    func testSavedProfilesWithoutThinkingModeDecodeAsDisabled() throws {
         let savedProfiles = Data(
             """
             [
@@ -112,8 +115,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
                 "llmTemperatureModeRaw": "providerDefault",
                 "llmTemperatureValue": 0.3,
                 "fetchedModels": [],
-                "chatRequestTimeoutSeconds": 45,
-                "thinkingEnabled": true
+                "chatRequestTimeoutSeconds": 45
               }
             ]
             """.utf8
@@ -125,11 +127,42 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
         XCTAssertEqual(profile.apiVersion, "")
+        XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.llmAPI, .chatCompletions)
         XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.resolvedChatRequestTimeout, 45)
-        let encoded = try JSONEncoder().encode(plugin.profileSnapshots)
-        XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("thinkingEnabled"))
+        XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
+    }
+
+    func testSavedChatCompletionsThinkingModeSurvivesActivationPersistence() throws {
+        let savedProfiles = Data(
+            """
+            [
+              {
+                "id": "openai-compatible",
+                "name": "OpenAI Compatible",
+                "baseURL": "https://legacy-profile.test",
+                "selectedModelId": "",
+                "selectedLLMModelId": "deepseek-reasoner",
+                "llmTemperatureModeRaw": "providerDefault",
+                "llmTemperatureValue": 0.3,
+                "fetchedModels": [],
+                "thinkingEnabled": true
+              }
+            ]
+            """.utf8
+        )
+        let host = try PluginTestHostServices(defaults: ["profiles": savedProfiles])
+        let plugin = OpenAICompatiblePlugin()
+
+        plugin.activate(host: host)
+        plugin.deactivate()
+
+        let persistedProfiles = try XCTUnwrap(host.userDefault(forKey: "profiles") as? Data)
+        let decodedProfiles = try JSONDecoder().decode([OpenAICompatibleProfile].self, from: persistedProfiles)
+        let profile = try XCTUnwrap(decodedProfiles.first)
+        XCTAssertEqual(profile.llmAPI, .chatCompletions)
+        XCTAssertTrue(profile.thinkingEnabled)
     }
 
     func testAdditionalProfilesExposeIndependentTranscriptionAndLLMRoles() throws {
@@ -624,6 +657,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.selectLLMModel("inception-chat", for: inception.id)
         plugin.setLLMTemperatureMode(.custom, for: inception.id)
         plugin.setLLMTemperatureValue(0.9, for: inception.id)
+        plugin.setThinkingEnabled(true, for: inception.id)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -676,7 +710,8 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(inceptionJSON["max_tokens"] as? Int, 4096)
         XCTAssertNil(inceptionJSON["max_completion_tokens"])
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
-        XCTAssertNil(inceptionJSON["thinking"])
+        let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
+        XCTAssertEqual(inceptionThinking["type"], "enabled")
     }
 
     func testResponsesModeUsesProfileURLAuthTimeoutAndOpenAIRequestShape() async throws {
@@ -691,6 +726,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.activate(host: host)
         plugin.setApiVersion("preview", for: plugin.providerId)
         plugin.setLLMAPI(.responses, for: plugin.providerId)
+        plugin.setThinkingEnabled(true)
         plugin.setChatRequestTimeout(75, for: plugin.providerId)
 
         let store = PluginHTTPClientSessionStore()
@@ -890,6 +926,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.activate(host: host)
         plugin.setLLMTemperatureMode(.custom)
         plugin.setLLMTemperatureValue(0.4)
+        plugin.setThinkingEnabled(true)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -923,7 +960,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(firstJSON["model"] as? String, "future-chat")
         XCTAssertEqual(firstJSON["max_tokens"] as? Int, 4096)
         XCTAssertNil(firstJSON["max_completion_tokens"])
-        XCTAssertNil(firstJSON["thinking"])
 
         let retryBody = try XCTUnwrap(requests[1].httpBody)
         let retryJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: retryBody) as? [String: Any])
@@ -931,7 +967,8 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(retryJSON["max_completion_tokens"] as? Int, 4096)
         XCTAssertNil(retryJSON["max_tokens"])
         XCTAssertEqual(retryJSON["temperature"] as? Double, 0.4)
-        XCTAssertNil(retryJSON["thinking"])
+        let retryThinking = try XCTUnwrap(retryJSON["thinking"] as? [String: String])
+        XCTAssertEqual(retryThinking["type"], "enabled")
     }
 
     func testFallbackOutputTokenParameterRequiresBothParameterNames() {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -28,7 +28,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         plugin.selectModel("whisper-1")
         plugin.selectLLMModel("gpt-4.1-mini")
-        plugin.setThinkingEnabled(true)
         plugin.deactivate()
 
         let reloaded = OpenAICompatiblePlugin()
@@ -36,7 +35,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         XCTAssertEqual(reloaded.selectedModelId, "whisper-1")
         XCTAssertEqual(reloaded.selectedLLMModelId, "gpt-4.1-mini")
-        XCTAssertEqual(reloaded.profileSnapshot(for: reloaded.providerId)?.thinkingEnabled, true)
     }
 
     func testLegacyConfigurationMigratesIntoDefaultProfile() throws {
@@ -69,7 +67,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.selectedLLMModelId, "chat-legacy")
         XCTAssertEqual(profile.llmTemperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
         XCTAssertEqual(profile.llmTemperatureValue, 0.7)
-        XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.llmAPI, .chatCompletions)
         XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.fetchedModels.map(\.id), ["legacy-model"])
@@ -102,7 +99,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(host.userDefault(forKey: "apiVersion") as? String, "preview")
     }
 
-    func testSavedProfilesWithoutThinkingModeDecodeAsDisabled() throws {
+    func testSavedProfilesIgnoreLegacyThinkingMode() throws {
         let savedProfiles = Data(
             """
             [
@@ -115,7 +112,8 @@ final class OpenAICompatiblePluginTests: XCTestCase {
                 "llmTemperatureModeRaw": "providerDefault",
                 "llmTemperatureValue": 0.3,
                 "fetchedModels": [],
-                "chatRequestTimeoutSeconds": 45
+                "chatRequestTimeoutSeconds": 45,
+                "thinkingEnabled": true
               }
             ]
             """.utf8
@@ -127,11 +125,11 @@ final class OpenAICompatiblePluginTests: XCTestCase {
 
         let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
         XCTAssertEqual(profile.apiVersion, "")
-        XCTAssertFalse(profile.thinkingEnabled)
         XCTAssertEqual(profile.llmAPI, .chatCompletions)
         XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.resolvedChatRequestTimeout, 45)
-        XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
+        let encoded = try JSONEncoder().encode(plugin.profileSnapshots)
+        XCTAssertFalse(String(decoding: encoded, as: UTF8.self).contains("thinkingEnabled"))
     }
 
     func testAdditionalProfilesExposeIndependentTranscriptionAndLLMRoles() throws {
@@ -626,7 +624,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.selectLLMModel("inception-chat", for: inception.id)
         plugin.setLLMTemperatureMode(.custom, for: inception.id)
         plugin.setLLMTemperatureValue(0.9, for: inception.id)
-        plugin.setThinkingEnabled(true, for: inception.id)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -679,8 +676,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(inceptionJSON["max_tokens"] as? Int, 4096)
         XCTAssertNil(inceptionJSON["max_completion_tokens"])
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
-        let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
-        XCTAssertEqual(inceptionThinking["type"], "enabled")
+        XCTAssertNil(inceptionJSON["thinking"])
     }
 
     func testResponsesModeUsesProfileURLAuthTimeoutAndOpenAIRequestShape() async throws {
@@ -894,7 +890,6 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         plugin.activate(host: host)
         plugin.setLLMTemperatureMode(.custom)
         plugin.setLLMTemperatureValue(0.4)
-        plugin.setThinkingEnabled(true)
 
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -928,6 +923,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(firstJSON["model"] as? String, "future-chat")
         XCTAssertEqual(firstJSON["max_tokens"] as? Int, 4096)
         XCTAssertNil(firstJSON["max_completion_tokens"])
+        XCTAssertNil(firstJSON["thinking"])
 
         let retryBody = try XCTUnwrap(requests[1].httpBody)
         let retryJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: retryBody) as? [String: Any])
@@ -935,8 +931,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(retryJSON["max_completion_tokens"] as? Int, 4096)
         XCTAssertNil(retryJSON["max_tokens"])
         XCTAssertEqual(retryJSON["temperature"] as? Double, 0.4)
-        let retryThinking = try XCTUnwrap(retryJSON["thinking"] as? [String: String])
-        XCTAssertEqual(retryThinking["type"], "enabled")
+        XCTAssertNil(retryJSON["thinking"])
     }
 
     func testFallbackOutputTokenParameterRequiresBothParameterNames() {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/Tests/OpenAICompatiblePluginTests.swift
@@ -70,6 +70,8 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(profile.llmTemperatureModeRaw, PluginLLMTemperatureMode.custom.rawValue)
         XCTAssertEqual(profile.llmTemperatureValue, 0.7)
         XCTAssertFalse(profile.thinkingEnabled)
+        XCTAssertEqual(profile.llmAPI, .chatCompletions)
+        XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.fetchedModels.map(\.id), ["legacy-model"])
         XCTAssertEqual(plugin.apiKey(for: profile.id), "legacy-token")
         XCTAssertNotNil(host.userDefault(forKey: "profiles") as? Data)
@@ -126,6 +128,8 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         let profile = try XCTUnwrap(plugin.profileSnapshot(for: plugin.providerId))
         XCTAssertEqual(profile.apiVersion, "")
         XCTAssertFalse(profile.thinkingEnabled)
+        XCTAssertEqual(profile.llmAPI, .chatCompletions)
+        XCTAssertEqual(profile.reasoningEffort, .providerDefault)
         XCTAssertEqual(profile.resolvedChatRequestTimeout, 45)
         XCTAssertNoThrow(try JSONEncoder().encode(plugin.profileSnapshots))
     }
@@ -667,8 +671,7 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(defaultJSON["model"] as? String, "default-chat")
         XCTAssertEqual(defaultJSON["max_tokens"] as? Int, 4096)
         XCTAssertEqual(defaultJSON["temperature"] as? Double, 0.2)
-        let defaultThinking = try XCTUnwrap(defaultJSON["thinking"] as? [String: String])
-        XCTAssertEqual(defaultThinking["type"], "disabled")
+        XCTAssertNil(defaultJSON["thinking"])
 
         let inceptionBody = try XCTUnwrap(requests[1].httpBody)
         let inceptionJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: inceptionBody) as? [String: Any])
@@ -678,6 +681,205 @@ final class OpenAICompatiblePluginTests: XCTestCase {
         XCTAssertEqual(inceptionJSON["temperature"] as? Double, 0.9)
         let inceptionThinking = try XCTUnwrap(inceptionJSON["thinking"] as? [String: String])
         XCTAssertEqual(inceptionThinking["type"], "enabled")
+    }
+
+    func testResponsesModeUsesProfileURLAuthTimeoutAndOpenAIRequestShape() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test/openai?tenant=contoso",
+                "selectedLLMModel": "gpt-5-compatible",
+            ],
+            secrets: ["api-key": "secret-token"]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setApiVersion("preview", for: plugin.providerId)
+        plugin.setLLMAPI(.responses, for: plugin.providerId)
+        plugin.setChatRequestTimeout(75, for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"output_text":"  processed response  "}"#.utf8),
+                    Self.httpResponse(
+                        url: "https://example.test/openai/v1/responses?tenant=contoso&api-version=preview",
+                        statusCode: 200
+                    )
+                )
+            ])
+        }
+
+        let result = try await plugin.process(
+            systemPrompt: "Fix the text",
+            userText: "hello",
+            model: nil,
+            temperatureDirective: .custom(0.8)
+        )
+
+        XCTAssertEqual(result, "processed response")
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/openai/v1/responses")
+        XCTAssertEqual(
+            URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?.queryItems,
+            [
+                URLQueryItem(name: "tenant", value: "contoso"),
+                URLQueryItem(name: "api-version", value: "preview"),
+            ]
+        )
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer " + "secret-token")
+        XCTAssertEqual(request.timeoutInterval, 75)
+
+        let body = try XCTUnwrap(request.httpBody)
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+        XCTAssertEqual(json["model"] as? String, "gpt-5-compatible")
+        XCTAssertEqual(json["instructions"] as? String, "Fix the text")
+        XCTAssertEqual(json["store"] as? Bool, false)
+        XCTAssertEqual(json["temperature"] as? Double, 0.8)
+        XCTAssertNil(json["reasoning"])
+        XCTAssertNil(json["thinking"])
+        XCTAssertNil(json["messages"])
+
+        let input = try XCTUnwrap(json["input"] as? [[String: Any]])
+        XCTAssertEqual(input.first?["type"] as? String, "message")
+        XCTAssertEqual(input.first?["role"] as? String, "user")
+        let content = try XCTUnwrap(input.first?["content"] as? [[String: Any]])
+        XCTAssertEqual(content.first?["type"] as? String, "input_text")
+        XCTAssertEqual(content.first?["text"] as? String, "hello")
+    }
+
+    func testResponsesModeSendsConfiguredReasoningLevelsAndOmitsTemperature() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedLLMModel": "reasoning-model",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setLLMAPI(.responses, for: plugin.providerId)
+        plugin.setLLMTemperatureMode(.custom)
+        plugin.setLLMTemperatureValue(0.6)
+
+        let efforts: [OpenAICompatibleReasoningEffort] = [.low, .medium, .high, .xhigh, .max]
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: efforts.map { _ in
+                .success(
+                    Data(#"{"output_text":"ok"}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/responses", statusCode: 200)
+                )
+            })
+        }
+
+        for effort in efforts {
+            plugin.setReasoningEffort(effort, for: plugin.providerId)
+            let result = try await plugin.process(
+                systemPrompt: "",
+                userText: "hello",
+                model: nil,
+                temperatureDirective: .custom(1.1)
+            )
+            XCTAssertEqual(result, "ok")
+        }
+
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, efforts.count)
+        for (request, effort) in zip(requests, efforts) {
+            let body = try XCTUnwrap(request.httpBody)
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: body) as? [String: Any])
+            let reasoning = try XCTUnwrap(json["reasoning"] as? [String: String])
+            XCTAssertEqual(reasoning["effort"], effort.rawValue)
+            XCTAssertNil(json["temperature"])
+            XCTAssertEqual(json["instructions"] as? String, "You are a helpful assistant.")
+        }
+    }
+
+    func testResponsesModeParsesOutputContentFallbacks() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedLLMModel": "responses-model",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setLLMAPI(.responses, for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        #"""
+                        {
+                          "output": [
+                            {"type":"reasoning","content":[{"type":"reasoning_text","text":"hidden"}]},
+                            {"type":"message","content":[
+                              {"type":"output_text","text":"First "},
+                              {"type":"text","text":{"value":"part"}}
+                            ]}
+                          ]
+                        }
+                        """#.utf8
+                    ),
+                    Self.httpResponse(url: "https://example.test/v1/responses", statusCode: 200)
+                )
+            ])
+        }
+
+        let result = try await plugin.process(systemPrompt: "Fix", userText: "hello", model: nil)
+
+        XCTAssertEqual(result, "First part")
+    }
+
+    func testResponsesModeSurfacesCompatibleErrorMessage() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "baseURL": "https://example.test",
+                "selectedLLMModel": "missing-model",
+            ]
+        )
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        plugin.setLLMAPI(.responses, for: plugin.providerId)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"responses model not found"}}"#.utf8),
+                    Self.httpResponse(url: "https://example.test/v1/responses", statusCode: 404)
+                )
+            ])
+        }
+
+        do {
+            _ = try await plugin.process(systemPrompt: "Fix", userText: "hello", model: nil)
+            XCTFail("Expected apiError")
+        } catch PluginChatError.apiError(let message) {
+            XCTAssertEqual(message, "responses model not found")
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testLLMAPIAndReasoningEffortPersistPerProfile() throws {
+        let host = try PluginTestHostServices(defaults: ["baseURL": "https://default.test"])
+        let plugin = OpenAICompatiblePlugin()
+        plugin.activate(host: host)
+        let custom = plugin.addProfile(named: "Responses Server")
+        plugin.setBaseURL("https://responses.test", for: custom.id)
+        plugin.setLLMAPI(.responses, for: custom.id)
+        plugin.setReasoningEffort(.max, for: custom.id)
+
+        let reloaded = OpenAICompatiblePlugin()
+        reloaded.activate(host: host)
+
+        XCTAssertEqual(reloaded.profileSnapshot(for: reloaded.providerId)?.llmAPI, .chatCompletions)
+        XCTAssertEqual(reloaded.profileSnapshot(for: reloaded.providerId)?.reasoningEffort, .providerDefault)
+        XCTAssertEqual(reloaded.profileSnapshot(for: custom.id)?.llmAPI, .responses)
+        XCTAssertEqual(reloaded.profileSnapshot(for: custom.id)?.reasoningEffort, .max)
     }
 
     func testProcessRetriesWithMaxCompletionTokensWhenProviderRequestsIt() async throws {

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -81,7 +81,7 @@ Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional Hug
 
 Bundled experimental local TTS plugins such as Supertonic store optional HuggingFace tokens the same way, but model weights are not bundled in the plugin ZIP. Supertonic downloads `Supertone/supertonic-3` assets only after the user accepts the OpenRAIL-M model license in plugin settings. That model-license confirmation is scoped to the model download and does not change TypeWhisper app licensing.
 
-Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
+Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. OpenAI Compatible profiles can independently use the broadly supported `/v1/chat/completions` endpoint or the OpenAI-style `/v1/responses` endpoint. Responses profiles support optional reasoning effort (`low`, `medium`, `high`, `xhigh`, or `max`); Chat Completions profiles retain an opt-in provider-specific thinking extension. Existing profiles default to Chat Completions. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
 
 ## Example
 

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -81,7 +81,7 @@ Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional Hug
 
 Bundled experimental local TTS plugins such as Supertonic store optional HuggingFace tokens the same way, but model weights are not bundled in the plugin ZIP. Supertonic downloads `Supertone/supertonic-3` assets only after the user accepts the OpenRAIL-M model license in plugin settings. That model-license confirmation is scoped to the model download and does not change TypeWhisper app licensing.
 
-Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. OpenAI Compatible profiles can independently use the broadly supported `/v1/chat/completions` endpoint or the OpenAI-style `/v1/responses` endpoint. Responses profiles support optional reasoning effort (`low`, `medium`, `high`, `xhigh`, or `max`); Chat Completions profiles retain an opt-in provider-specific thinking extension. Existing profiles default to Chat Completions. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
+Bundled cloud plugins include Groq, OpenAI, OpenAI Compatible, and xAI/Grok. The xAI/Grok bundle is a combined `LLMProviderPlugin`, `TranscriptionEnginePlugin`, `LiveTranscriptionCapablePlugin`, and `TTSProviderPlugin` implementation for Grok text generation, STT, and TTS.
 
 ## Example
 


### PR DESCRIPTION
## Summary

- add a per-profile LLM API selector for Chat Completions or OpenAI-compatible Responses endpoints, defaulting existing profiles to Chat Completions
- support optional Responses reasoning effort (`low`, `medium`, `high`, `xhigh`, and `max`) with mode-aware temperature and provider thinking behavior
- use profile base URLs, API versions, authentication, models, and timeouts for Responses requests, including strict `type: message` input items
- parse top-level and nested Responses output text, localize the new settings, document the behavior, and cover migration and both API modes with targeted tests

## Test Plan

- [x] Ran `scripts/pr-preflight.sh origin/main`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features
- [x] Ran `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -quiet`
- [x] Tested `/v1/responses` end-to-end from the production TypeWhisper app with the development plugin against a local OpenAI-compatible proxy using `gpt-5.6-luna` and low reasoning effort


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Choose between Chat Completions and Responses API modes for each profile.
  * Configure reasoning effort levels independently per profile.
  * Improved response handling and clearer error reporting.
* **Bug Fixes**
  * Preserved compatibility with existing profiles and legacy Thinking Mode settings.
  * Chat Completions requests no longer send thinking options unless enabled.
* **Localization**
  * Added German, Japanese, and Simplified Chinese translations for API, reasoning, endpoint, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->