### PR TITLE
Fix Qwen3 transcription cutoff on long audio

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -182,45 +182,51 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             let languageName = Self.resolveLanguageName(language)
             let context = Self.contextBiasString(from: prompt)
 
-            let primaryOutput = Self.generate(
-                model: model,
-                audio: audioArray,
-                params: Self.primaryParams,
-                context: context,
-                language: languageName
-            )
-            let primaryText = Self.normalizeTranscript(primaryOutput.text)
-            let text: String
-            let outputLanguageName: String?
+            // mlx-audio-swift treats maxTokens as one shared budget across every
+            // internally generated chunk. Split here so long files receive a fresh
+            // generation budget per chunk instead of silently stopping at the cap.
+            let primaryChunks = splitAudioIntoChunks(
+                audioArray,
+                sampleRate: Self.sampleRate,
+                chunkDuration: Self.primaryParams.chunkDuration,
+                minChunkDuration: Self.primaryParams.minChunkDuration
+            ).map(\.0)
 
-            if QwenTranscriptGuard.isLikelyLooped(primaryText) {
-                let fallbackOutput = Self.generate(
-                    model: model,
-                    audio: audioArray,
-                    params: Self.fallbackParams,
-                    context: "",
-                    language: languageName
-                )
-                let fallbackText = Self.normalizeTranscript(fallbackOutput.text)
-
-                if fallbackText.isEmpty {
-                    text = primaryText
-                    outputLanguageName = primaryOutput.language
-                } else if QwenTranscriptGuard.isLikelyLooped(fallbackText) {
-                    text = QwenTranscriptGuard.preferredTranscript(primary: primaryText, fallback: fallbackText)
-                    outputLanguageName = primaryOutput.language ?? fallbackOutput.language
-                } else {
-                    text = fallbackText
-                    outputLanguageName = fallbackOutput.language
+            let transcript = try QwenChunkTranscriber.transcribe(
+                primaryChunks: primaryChunks,
+                primaryTokenLimit: Self.primaryParams.maxTokens,
+                fallbackTokenLimit: Self.fallbackParams.maxTokens,
+                makeFallbackChunks: { chunk in
+                    splitAudioIntoChunks(
+                        chunk,
+                        sampleRate: Self.sampleRate,
+                        chunkDuration: Self.fallbackParams.chunkDuration,
+                        minChunkDuration: Self.fallbackParams.minChunkDuration
+                    ).map(\.0)
+                },
+                generatePrimary: { chunk in
+                    Self.generateSingleChunk(
+                        model: model,
+                        audio: chunk,
+                        params: Self.primaryParams,
+                        context: context,
+                        language: languageName
+                    )
+                },
+                generateFallback: { chunk in
+                    Self.generateSingleChunk(
+                        model: model,
+                        audio: chunk,
+                        params: Self.fallbackParams,
+                        context: "",
+                        language: languageName
+                    )
                 }
-            } else {
-                text = primaryText
-                outputLanguageName = primaryOutput.language
-            }
+            )
 
-            let resultLanguageName = outputLanguageName ?? languageName
+            let resultLanguageName = transcript.language ?? languageName
             let cleanedText = QwenTranscriptGuard.removingLikelyTrailingArtifact(
-                from: text,
+                from: transcript.text,
                 languageName: resultLanguageName
             )
             let detectedLanguage = Self.languageCode(forQwenLanguageName: resultLanguageName) ?? language
@@ -627,21 +633,30 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         Qwen3ContextBiasFormatter.format(prompt: prompt)
     }
 
-    private static func generate(
+    private static let sampleRate = 16_000
+
+    private static func generateSingleChunk(
         model: Qwen3ASRModel,
         audio: MLXArray,
         params: STTGenerateParameters,
         context: String,
         language: String?
-    ) -> STTOutput {
-        model.generate(
+    ) -> QwenChunkGeneration {
+        let output = model.generate(
             audio: audio,
             maxTokens: params.maxTokens,
             temperature: params.temperature,
             context: context,
             language: language,
-            chunkDuration: params.chunkDuration,
+            // The plugin already split the source. Keep the upstream model from
+            // creating another set of chunks with a shared token budget.
+            chunkDuration: 1_200,
             minChunkDuration: params.minChunkDuration
+        )
+        return QwenChunkGeneration(
+            text: normalizeTranscript(output.text),
+            language: output.language,
+            generatedTokenCount: output.generationTokens
         )
     }
 
@@ -649,6 +664,133 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         text
             .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+struct QwenChunkGeneration: Equatable {
+    let text: String
+    let language: String?
+    let generatedTokenCount: Int
+}
+
+struct QwenChunkTranscript: Equatable {
+    let text: String
+    let language: String?
+}
+
+enum QwenChunkTranscriptionError: LocalizedError, Equatable {
+    case incomplete
+
+    var errorDescription: String? {
+        "Qwen3 ASR could not complete the entire audio because a chunk reached the model output limit."
+    }
+}
+
+enum QwenChunkTranscriber {
+    static func transcribe<Chunk>(
+        primaryChunks: [Chunk],
+        primaryTokenLimit: Int,
+        fallbackTokenLimit: Int,
+        makeFallbackChunks: (Chunk) -> [Chunk],
+        generatePrimary: (Chunk) -> QwenChunkGeneration,
+        generateFallback: (Chunk) -> QwenChunkGeneration
+    ) throws -> QwenChunkTranscript {
+        var chunkTexts: [String] = []
+        var chunkLanguages: [String?] = []
+
+        for chunk in primaryChunks {
+            try Task.checkCancellation()
+            let primary = generatePrimary(chunk)
+            let primaryReachedLimit = primary.generatedTokenCount >= primaryTokenLimit
+
+            guard primaryReachedLimit || QwenTranscriptGuard.isLikelyLooped(primary.text) else {
+                chunkTexts.append(primary.text)
+                chunkLanguages.append(primary.language)
+                continue
+            }
+
+            let fallback = try transcribeFallbackChunks(
+                makeFallbackChunks(chunk),
+                tokenLimit: fallbackTokenLimit,
+                generate: generateFallback
+            )
+
+            if primaryReachedLimit {
+                guard !fallback.reachedTokenLimit, !fallback.transcript.text.isEmpty else {
+                    throw QwenChunkTranscriptionError.incomplete
+                }
+                chunkTexts.append(fallback.transcript.text)
+                chunkLanguages.append(fallback.transcript.language)
+            } else if fallback.reachedTokenLimit || fallback.transcript.text.isEmpty {
+                chunkTexts.append(primary.text)
+                chunkLanguages.append(primary.language)
+            } else if QwenTranscriptGuard.isLikelyLooped(fallback.transcript.text) {
+                chunkTexts.append(
+                    QwenTranscriptGuard.preferredTranscript(
+                        primary: primary.text,
+                        fallback: fallback.transcript.text
+                    )
+                )
+                chunkLanguages.append(primary.language ?? fallback.transcript.language)
+            } else {
+                chunkTexts.append(fallback.transcript.text)
+                chunkLanguages.append(fallback.transcript.language)
+            }
+        }
+
+        return QwenChunkTranscript(
+            text: joinedTranscript(chunkTexts),
+            language: mergedLanguage(chunkLanguages)
+        )
+    }
+
+    private static func transcribeFallbackChunks<Chunk>(
+        _ chunks: [Chunk],
+        tokenLimit: Int,
+        generate: (Chunk) -> QwenChunkGeneration
+    ) throws -> (transcript: QwenChunkTranscript, reachedTokenLimit: Bool) {
+        var texts: [String] = []
+        var languages: [String?] = []
+        var reachedTokenLimit = false
+
+        for chunk in chunks {
+            try Task.checkCancellation()
+            let output = generate(chunk)
+            texts.append(output.text)
+            languages.append(output.language)
+            reachedTokenLimit = reachedTokenLimit || output.generatedTokenCount >= tokenLimit
+        }
+
+        return (
+            QwenChunkTranscript(
+                text: joinedTranscript(texts),
+                language: mergedLanguage(languages)
+            ),
+            reachedTokenLimit
+        )
+    }
+
+    private static func joinedTranscript(_ texts: [String]) -> String {
+        texts
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func mergedLanguage(_ languages: [String?]) -> String? {
+        var seen: Set<String> = []
+        var merged: [String] = []
+
+        for language in languages {
+            guard let language = language?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !language.isEmpty,
+                  seen.insert(language).inserted else {
+                continue
+            }
+            merged.append(language)
+        }
+
+        return merged.isEmpty ? nil : merged.joined(separator: ",")
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -722,8 +722,7 @@ enum QwenChunkTranscriber {
                 chunkTexts.append(fallback.transcript.text)
                 chunkLanguages.append(fallback.transcript.language)
             } else if fallback.reachedTokenLimit || fallback.transcript.text.isEmpty {
-                chunkTexts.append(primary.text)
-                chunkLanguages.append(primary.language)
+                throw QwenChunkTranscriptionError.incomplete
             } else if QwenTranscriptGuard.isLikelyLooped(fallback.transcript.text) {
                 chunkTexts.append(
                     QwenTranscriptGuard.preferredTranscript(

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -4,6 +4,91 @@ import TypeWhisperPluginSDKTesting
 @testable import Qwen3Plugin
 
 final class Qwen3PluginTests: XCTestCase {
+    func testChunkTranscriberProcessesEveryChunkWithAnIndependentTokenBudget() throws {
+        let chunks = Array(0..<24)
+        var generatedChunks: [Int] = []
+
+        let result = try QwenChunkTranscriber.transcribe(
+            primaryChunks: chunks,
+            primaryTokenLimit: 2_048,
+            fallbackTokenLimit: 1_536,
+            makeFallbackChunks: { _ in
+                XCTFail("Fallback should not run for complete primary chunks")
+                return []
+            },
+            generatePrimary: { chunk in
+                generatedChunks.append(chunk)
+                return QwenChunkGeneration(
+                    text: "chunk-\(chunk)",
+                    language: "Chinese",
+                    generatedTokenCount: 100
+                )
+            },
+            generateFallback: { _ in
+                XCTFail("Fallback should not run for complete primary chunks")
+                return QwenChunkGeneration(text: "", language: nil, generatedTokenCount: 0)
+            }
+        )
+
+        // The cumulative 2,400 generated tokens exceed the old shared 2,048-token cap.
+        XCTAssertEqual(generatedChunks, chunks)
+        XCTAssertEqual(result.text, chunks.map { "chunk-\($0)" }.joined(separator: " "))
+        XCTAssertEqual(result.language, "Chinese")
+    }
+
+    func testChunkTranscriberRetriesCappedPrimaryChunkWithSmallerFallbackChunks() throws {
+        let result = try QwenChunkTranscriber.transcribe(
+            primaryChunks: [1],
+            primaryTokenLimit: 2_048,
+            fallbackTokenLimit: 1_536,
+            makeFallbackChunks: { _ in [10, 11] },
+            generatePrimary: { _ in
+                QwenChunkGeneration(
+                    text: "partial primary",
+                    language: "Chinese",
+                    generatedTokenCount: 2_048
+                )
+            },
+            generateFallback: { chunk in
+                QwenChunkGeneration(
+                    text: "fallback-\(chunk)",
+                    language: "Chinese",
+                    generatedTokenCount: 100
+                )
+            }
+        )
+
+        XCTAssertEqual(result.text, "fallback-10 fallback-11")
+        XCTAssertEqual(result.language, "Chinese")
+    }
+
+    func testChunkTranscriberReportsIncompleteWhenFallbackAlsoHitsTokenLimit() {
+        XCTAssertThrowsError(
+            try QwenChunkTranscriber.transcribe(
+                primaryChunks: [1],
+                primaryTokenLimit: 2_048,
+                fallbackTokenLimit: 1_536,
+                makeFallbackChunks: { _ in [10] },
+                generatePrimary: { _ in
+                    QwenChunkGeneration(
+                        text: "partial primary",
+                        language: "Chinese",
+                        generatedTokenCount: 2_048
+                    )
+                },
+                generateFallback: { _ in
+                    QwenChunkGeneration(
+                        text: "partial fallback",
+                        language: "Chinese",
+                        generatedTokenCount: 1_536
+                    )
+                }
+            )
+        ) { error in
+            XCTAssertEqual(error as? QwenChunkTranscriptionError, .incomplete)
+        }
+    }
+
     func testAutoDetectDoesNotForceEnglish() {
         XCTAssertNil(Qwen3Plugin.resolveLanguageName(nil))
         XCTAssertNil(Qwen3Plugin.resolveLanguageName(""))

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Tests/Qwen3PluginTests.swift
@@ -89,6 +89,36 @@ final class Qwen3PluginTests: XCTestCase {
         }
     }
 
+    func testChunkTranscriberReportsIncompleteWhenLoopedPrimaryFallbackHitsTokenLimit() {
+        let loopedPrimary = Array(repeating: "loop", count: 16).joined(separator: " ")
+        XCTAssertTrue(QwenTranscriptGuard.isLikelyLooped(loopedPrimary))
+
+        XCTAssertThrowsError(
+            try QwenChunkTranscriber.transcribe(
+                primaryChunks: [1],
+                primaryTokenLimit: 2_048,
+                fallbackTokenLimit: 1_536,
+                makeFallbackChunks: { _ in [10] },
+                generatePrimary: { _ in
+                    QwenChunkGeneration(
+                        text: loopedPrimary,
+                        language: "Chinese",
+                        generatedTokenCount: 100
+                    )
+                },
+                generateFallback: { _ in
+                    QwenChunkGeneration(
+                        text: "partial fallback",
+                        language: "Chinese",
+                        generatedTokenCount: 1_536
+                    )
+                }
+            )
+        ) { error in
+            XCTAssertEqual(error as? QwenChunkTranscriptionError, .incomplete)
+        }
+    }
+
     func testAutoDetectDoesNotForceEnglish() {
         XCTAssertNil(Qwen3Plugin.resolveLanguageName(nil))
         XCTAssertNil(Qwen3Plugin.resolveLanguageName(""))


### PR DESCRIPTION
## Summary

- split long Qwen3 audio in the plugin so every primary chunk receives an independent generation-token budget
- retry capped or looped primary chunks as smaller fallback chunks
- fail explicitly instead of returning a silently truncated transcript when fallback generation also reaches its limit
- add regression coverage proving all chunks are processed after the old cumulative 2,048-token boundary

## Issue context

Issue #1100 reports that Qwen3 ASR silently completes with only a partial transcript for an approximately 10-minute Chinese audio file. The pinned `mlx-audio-swift` implementation applies `maxTokens` as one shared budget across all internally generated chunks and stops processing once that budget is exhausted. This change moves chunk orchestration into the plugin so the token limit applies independently to every chunk.

Closes #1100

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests` (23 tests passed)
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-b99b4340`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run Qwen3Plugin /Users/marco/.t3/worktrees/typewhisper-mac/t3code-b99b4340`
- [x] `git diff --check`
- [ ] Manual long-audio Qwen3 inference was not run because no Qwen3 model is installed in the development app container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3 transcription for longer audio by processing it in manageable chunks.
  * Added fallback handling when chunks reach token limits or trigger loop detection.
  * Reports incomplete transcriptions when fallback processing cannot finish.

* **Improvements**
  * Gives each audio chunk an independent token budget.
  * Combines chunk results more consistently and aggregates detected languages.
  * Supports cancellation during chunk processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->