### PR TITLE
Add live transcript updates to active text fields

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -13,6 +13,7 @@ enum UserDefaultsKeys {
     static let indicatorStyle = "indicatorStyle"
     static let indicatorVisibleInScreenCaptures = "indicatorVisibleInScreenCaptures"
     static let indicatorTranscriptPreviewEnabled = "indicatorTranscriptPreviewEnabled"
+    static let liveFieldTranscriptEnabled = "liveFieldTranscriptEnabled"
     static let indicatorTranscriptPreviewFontSizeOffset = "indicatorTranscriptPreviewFontSizeOffset"
     static let livePreviewEngineId = "livePreviewEngineId"
     static let preserveClipboard = "preserveClipboard"

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -26422,6 +26422,28 @@
         }
       }
     },
+    "Show live transcript in the active text field" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Live-Transkript im aktiven Textfeld anzeigen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクティブなテキストフィールドにライブ文字起こしを表示"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在当前文本字段中显示实时转录"
+          }
+        }
+      }
+    },
     "Show live transcript preview" : {
       "localizations" : {
         "de" : {
@@ -27509,6 +27531,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "周日"
+          }
+        }
+      }
+    },
+    "Supported text fields are updated while you speak. TypeWhisper uses the transcript overlay when direct updates are unavailable." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unterstützte Textfelder werden während des Sprechens aktualisiert. Wenn direkte Aktualisierungen nicht verfügbar sind, verwendet TypeWhisper die Transkriptvorschau."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "対応するテキストフィールドは話している間に更新されます。直接更新できない場合、TypeWhisperは文字起こしオーバーレイを使用します。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持的文本字段会在您说话时更新。无法直接更新时，TypeWhisper 会使用转录浮层。"
           }
         }
       }
@@ -29027,6 +29071,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "无法验证“通过 Apple 登录”的响应。"
+          }
+        }
+      }
+    },
+    "The text field changed. The final transcript is available in Recent Transcriptions." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Das Textfeld wurde geändert. Das endgültige Transkript ist unter „Letzte Transkriptionen“ verfügbar."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストフィールドが変更されました。最終的な文字起こしは「最近の文字起こし」で確認できます。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "文本字段已更改。最终转录可在“最近的转录”中查看。"
           }
         }
       }

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -27535,24 +27535,24 @@
         }
       }
     },
-    "Supported text fields are updated while you speak. TypeWhisper uses the transcript overlay when direct updates are unavailable." : {
+    "Supported text fields are updated while you speak. TypeWhisper inserts the final transcript normally when direct updates are unavailable." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unterstützte Textfelder werden während des Sprechens aktualisiert. Wenn direkte Aktualisierungen nicht verfügbar sind, verwendet TypeWhisper die Transkriptvorschau."
+            "value" : "Unterstützte Textfelder werden während des Sprechens aktualisiert. Wenn direkte Aktualisierungen nicht verfügbar sind, fügt TypeWhisper das endgültige Transkript wie gewohnt ein."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "対応するテキストフィールドは話している間に更新されます。直接更新できない場合、TypeWhisperは文字起こしオーバーレイを使用します。"
+            "value" : "対応するテキストフィールドは話している間に更新されます。直接更新できない場合、TypeWhisperは最終的な文字起こしを通常どおり挿入します。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持的文本字段会在您说话时更新。无法直接更新时，TypeWhisper 会使用转录浮层。"
+            "value" : "支持的文本字段会在您说话时更新。无法直接更新时，TypeWhisper 会照常插入最终转录。"
           }
         }
       }

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -173,6 +173,7 @@ enum SettingsBackupExporter {
         var indicatorStyle: String? = nil
         var indicatorVisibleInScreenCaptures: Bool? = nil
         var indicatorTranscriptPreviewEnabled: Bool? = nil
+        var liveFieldTranscriptEnabled: Bool? = nil
         var indicatorTranscriptPreviewFontSizeOffset: Int? = nil
         var preserveClipboard: Bool? = nil
         var mediaPauseEnabled: Bool? = nil
@@ -220,6 +221,7 @@ enum SettingsBackupExporter {
             if indicatorStyle != nil { count += 1 }
             if indicatorVisibleInScreenCaptures != nil { count += 1 }
             if indicatorTranscriptPreviewEnabled != nil { count += 1 }
+            if liveFieldTranscriptEnabled != nil { count += 1 }
             if indicatorTranscriptPreviewFontSizeOffset != nil { count += 1 }
             if preserveClipboard != nil { count += 1 }
             if mediaPauseEnabled != nil { count += 1 }
@@ -565,6 +567,7 @@ enum SettingsBackupExporter {
                 indicatorStyle: userDefaults.string(forKey: UserDefaultsKeys.indicatorStyle),
                 indicatorVisibleInScreenCaptures: userDefaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
                 indicatorTranscriptPreviewEnabled: userDefaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled) as? Bool,
+                liveFieldTranscriptEnabled: userDefaults.object(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled) as? Bool,
                 indicatorTranscriptPreviewFontSizeOffset: userDefaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset) as? Int,
                 preserveClipboard: userDefaults.object(forKey: UserDefaultsKeys.preserveClipboard) as? Bool,
                 mediaPauseEnabled: userDefaults.object(forKey: UserDefaultsKeys.mediaPauseEnabled) as? Bool,
@@ -841,6 +844,7 @@ enum SettingsBackupExporter {
         apply(preferences.indicatorStyle, forKey: UserDefaultsKeys.indicatorStyle)
         apply(preferences.indicatorVisibleInScreenCaptures, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
         apply(preferences.indicatorTranscriptPreviewEnabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+        apply(preferences.liveFieldTranscriptEnabled, forKey: UserDefaultsKeys.liveFieldTranscriptEnabled)
         apply(preferences.indicatorTranscriptPreviewFontSizeOffset, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         apply(preferences.preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard)
         apply(preferences.mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled)

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -627,6 +627,7 @@ enum SettingsBackupExporter {
         historyService: HistoryService,
         usageStatisticsService: UsageStatisticsService,
         userDefaults: UserDefaults = .standard,
+        liveFieldTranscriptEnabledDidChange: ((Bool) -> Void)? = nil,
         recoveryRetentionPolicyDidChange: ((DictationRecoveryRetentionPolicy) -> Void)? = nil
     ) async -> ImportResult {
         var result = ImportResult()
@@ -845,6 +846,9 @@ enum SettingsBackupExporter {
         apply(preferences.indicatorVisibleInScreenCaptures, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
         apply(preferences.indicatorTranscriptPreviewEnabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
         apply(preferences.liveFieldTranscriptEnabled, forKey: UserDefaultsKeys.liveFieldTranscriptEnabled)
+        if let liveFieldTranscriptEnabled = preferences.liveFieldTranscriptEnabled {
+            liveFieldTranscriptEnabledDidChange?(liveFieldTranscriptEnabled)
+        }
         apply(preferences.indicatorTranscriptPreviewFontSizeOffset, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         apply(preferences.preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard)
         apply(preferences.mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled)

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -45,6 +45,8 @@ private func installLiveFieldApplicationActivationObserver(
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
+    private static let liveFieldMessagingTimeout: Float = 0.05
+
     private let browserURLResolver: BrowserURLResolver
     private let syntheticPastePreferredBundleIdentifiers: Set<String> = [
         "com.apple.Terminal",
@@ -72,6 +74,7 @@ final class TextInsertionService {
     var liveFieldTargetEligibilityOverride: ((AXUIElement) -> Bool)?
     var liveFieldApplicationEligibilityOverride: ((String) -> Bool)?
     var liveFieldElectronApplicationOverride: ((String) -> Bool)?
+    var setMessagingTimeoutOverride: ((AXUIElement, Float) -> Void)?
     var setSelectedRangeOverride: ((AXUIElement, NSRange) -> Bool)?
     var textSelectionOverride: (() -> TextSelection?)?
     var insertTextAtOverride: ((AXUIElement, String) -> Bool)?
@@ -279,23 +282,27 @@ final class TextInsertionService {
     }
 
     /// Returns the focused text element (even without selection), for later insertion.
-    func getFocusedTextElement() -> AXUIElement? {
+    func getFocusedTextElement(messagingTimeout: Float? = nil) -> AXUIElement? {
         if let focusedTextElementOverride {
-            return focusedTextElementOverride()
+            guard let element = focusedTextElementOverride() else { return nil }
+            applyMessagingTimeout(messagingTimeout, to: element)
+            return element
         }
         guard isAccessibilityGranted else { return nil }
 
         let systemWide = AXUIElementCreateSystemWide()
+        applyMessagingTimeout(messagingTimeout, to: systemWide)
         var focusedElement: AnyObject?
         guard AXUIElementCopyAttributeValue(systemWide, kAXFocusedUIElementAttribute as CFString, &focusedElement) == .success else {
             return nil
         }
 
         guard let element = axElement(from: focusedElement) else { return nil }
-        if isLiveFieldTextRole(element), selectedRangeAttribute(from: element) != nil {
+        applyMessagingTimeout(messagingTimeout, to: element)
+        if isLiveFieldTextRole(element) {
             return element
         }
-        return findEditableTextDescendant(of: element)
+        return findEditableTextDescendant(of: element, messagingTimeout: messagingTimeout)
     }
 
     /// Replaces the selected text on a previously captured AXUIElement.
@@ -396,7 +403,9 @@ final class TextInsertionService {
             logger.debug("Live field target rejected: app requires normal final insertion")
             return nil
         }
-        guard let state = captureFocusedTextState() else {
+        guard let state = captureFocusedTextState(
+            messagingTimeout: Self.liveFieldMessagingTimeout
+        ) else {
             logger.debug("Live field target rejected: no readable focused text element")
             return nil
         }
@@ -472,23 +481,31 @@ final class TextInsertionService {
             return .detached
         }
 
-        if var resultingState = captureFocusedTextState(),
+        if var resultingState = captureFocusedTextState(
+            messagingTimeout: Self.liveFieldMessagingTimeout
+        ),
            captureActiveApp().bundleId == target.applicationBundleIdentifier,
            resultingState.value == expectedValue,
            resultingState.selectedRange != expectedCaret {
             _ = setSelectedRange(expectedCaret, on: resultingState.element)
-            resultingState = captureFocusedTextState() ?? resultingState
+            resultingState = captureFocusedTextState(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+            ) ?? resultingState
         }
 
         guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
-              let resultingState = captureFocusedTextState(),
+              let resultingState = captureFocusedTextState(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+              ),
               resultingState.value == expectedValue,
               resultingState.selectedRange == expectedCaret,
               resultingState.selectedText?.isEmpty != false,
               resultingState.element == target.element
                 || isEligibleLiveFieldTarget(resultingState.element) else {
             _ = setSelectedRange(target.expectedCaret, on: target.element)
-            if let unchangedState = captureFocusedTextState(),
+            if let unchangedState = captureFocusedTextState(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+            ),
                unchangedState.element == target.element,
                unchangedState.value == target.expectedValue,
                unchangedState.selectedRange == target.expectedCaret,
@@ -971,13 +988,17 @@ final class TextInsertionService {
         findSelectionInDescendants(of: root, maxDepth: 6, maxNodes: 80)
     }
 
-    private func findEditableTextDescendant(of root: AXUIElement) -> AXUIElement? {
+    private func findEditableTextDescendant(
+        of root: AXUIElement,
+        messagingTimeout: Float? = nil
+    ) -> AXUIElement? {
         var queue: [(element: AXUIElement, depth: Int)] = childElements(of: root).map { ($0, 1) }
         var visited = 0
 
         while !queue.isEmpty && visited < 80 {
             let current = queue.removeFirst()
             visited += 1
+            applyMessagingTimeout(messagingTimeout, to: current.element)
 
             if isLiveFieldTextRole(current.element),
                selectedRangeAttribute(from: current.element) != nil {
@@ -1135,12 +1156,16 @@ final class TextInsertionService {
         return text.isEmpty ? nil : text
     }
 
-    private func captureFocusedTextState() -> FocusedTextState? {
-        guard let element = getFocusedTextElement() else { return nil }
-        return captureFocusedTextState(for: element)
+    private func captureFocusedTextState(messagingTimeout: Float? = nil) -> FocusedTextState? {
+        guard let element = getFocusedTextElement(messagingTimeout: messagingTimeout) else { return nil }
+        return captureFocusedTextState(for: element, messagingTimeout: messagingTimeout)
     }
 
-    private func captureFocusedTextState(for element: AXUIElement) -> FocusedTextState? {
+    private func captureFocusedTextState(
+        for element: AXUIElement,
+        messagingTimeout: Float? = nil
+    ) -> FocusedTextState? {
+        applyMessagingTimeout(messagingTimeout, to: element)
         if let focusedTextStateOverride {
             guard let snapshot = focusedTextStateOverride(element) else { return nil }
             return FocusedTextState(
@@ -1213,7 +1238,9 @@ final class TextInsertionService {
 
     private func verifiedLiveFieldState(for target: inout LiveFieldTarget) -> FocusedTextState? {
         guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
-              let state = captureFocusedTextState(),
+              let state = captureFocusedTextState(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+              ),
               state.value == target.expectedValue,
               state.selectedRange == target.expectedCaret,
               state.selectedText?.isEmpty != false else {
@@ -1235,6 +1262,15 @@ final class TextInsertionService {
             selectedText: nil,
             selectedRange: target.expectedCaret
         )
+    }
+
+    private func applyMessagingTimeout(_ timeout: Float?, to element: AXUIElement) {
+        guard let timeout, timeout > 0 else { return }
+        if let setMessagingTimeoutOverride {
+            setMessagingTimeoutOverride(element, timeout)
+        } else {
+            _ = AXUIElementSetMessagingTimeout(element, timeout)
+        }
     }
 
     private func applicationSupportsVerifiedLiveFieldUpdates(

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -7,6 +7,41 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "TextInsertionService")
 
+private final class LiveFieldApplicationActivationObservation: @unchecked Sendable {
+    private let notificationCenter: NotificationCenter
+    private let token: NSObjectProtocol
+
+    init(notificationCenter: NotificationCenter, token: NSObjectProtocol) {
+        self.notificationCenter = notificationCenter
+        self.token = token
+    }
+
+    deinit {
+        notificationCenter.removeObserver(token)
+    }
+}
+
+private func installLiveFieldApplicationActivationObserver(
+    onActivation: @escaping @MainActor (String?) -> Void
+) -> LiveFieldApplicationActivationObservation {
+    let notificationCenter = NSWorkspace.shared.notificationCenter
+    let token = notificationCenter.addObserver(
+        forName: NSWorkspace.didActivateApplicationNotification,
+        object: nil,
+        queue: .main
+    ) { notification in
+        let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+        let bundleIdentifier = application?.bundleIdentifier
+        Task { @MainActor in
+            onActivation(bundleIdentifier)
+        }
+    }
+    return LiveFieldApplicationActivationObservation(
+        notificationCenter: notificationCenter,
+        token: token
+    )
+}
+
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
@@ -33,6 +68,11 @@ final class TextInsertionService {
     var pasteboardProvider: () -> NSPasteboard = { .general }
     var focusedTextElementOverride: (() -> AXUIElement?)?
     var focusedTextStateOverride: ((AXUIElement) -> FocusedTextSnapshot?)?
+    var focusedTextPlaceholderOverride: ((AXUIElement) -> String?)?
+    var liveFieldTargetEligibilityOverride: ((AXUIElement) -> Bool)?
+    var liveFieldApplicationEligibilityOverride: ((String) -> Bool)?
+    var liveFieldElectronApplicationOverride: ((String) -> Bool)?
+    var setSelectedRangeOverride: ((AXUIElement, NSRange) -> Bool)?
     var textSelectionOverride: (() -> TextSelection?)?
     var insertTextAtOverride: ((AXUIElement, String) -> Bool)?
     var pasteSimulatorOverride: (() -> Void)?
@@ -177,6 +217,26 @@ final class TextInsertionService {
         let selectedRange: NSRange?
     }
 
+    struct LiveFieldTarget: @unchecked Sendable {
+        let applicationBundleIdentifier: String
+        fileprivate var element: AXUIElement
+        let originalInsertionContext: InsertionContext
+        fileprivate var expectedValue: String
+        fileprivate var expectedCaret: NSRange
+        fileprivate var ownedRange: NSRange
+        fileprivate var provisionalText: String
+        fileprivate(set) var hasAttemptedMutation = false
+
+        var hasProvisionalText: Bool {
+            !provisionalText.isEmpty
+        }
+    }
+
+    enum LiveFieldMutationResult {
+        case applied(FocusedTextObservation)
+        case detached
+    }
+
     func getSelectedText() -> String? {
         if let selectedTextOverride {
             return selectedTextOverride()
@@ -231,14 +291,11 @@ final class TextInsertionService {
             return nil
         }
 
-        let element = focusedElement as! AXUIElement
-        var roleValue: AnyObject?
-        guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleValue) == .success,
-              let role = roleValue as? String else { return nil }
-
-        let textRoles = ["AXTextField", "AXTextArea", "AXComboBox", "AXSearchField", "AXWebArea"]
-        guard textRoles.contains(role) else { return nil }
-        return element
+        guard let element = axElement(from: focusedElement) else { return nil }
+        if isLiveFieldTextRole(element), selectedRangeAttribute(from: element) != nil {
+            return element
+        }
+        return findEditableTextDescendant(of: element)
     }
 
     /// Replaces the selected text on a previously captured AXUIElement.
@@ -320,6 +377,138 @@ final class TextInsertionService {
             previousCharacter: previousCharacter,
             nextCharacter: nextCharacter
         )
+    }
+
+    func captureLiveFieldTarget(expectedBundleIdentifier: String?) -> LiveFieldTarget? {
+        guard isAccessibilityGranted else {
+            logger.debug("Live field target rejected: Accessibility is not granted")
+            return nil
+        }
+        guard let expectedBundleIdentifier else {
+            logger.debug("Live field target rejected: target app has no bundle identifier")
+            return nil
+        }
+        guard captureActiveApp().bundleId == expectedBundleIdentifier else {
+            logger.debug("Live field target rejected: active app changed before capture")
+            return nil
+        }
+        guard applicationSupportsVerifiedLiveFieldUpdates(expectedBundleIdentifier) else {
+            logger.debug("Live field target rejected: app requires normal final insertion")
+            return nil
+        }
+        guard let state = captureFocusedTextState() else {
+            logger.debug("Live field target rejected: no readable focused text element")
+            return nil
+        }
+        guard let value = state.value else {
+            logger.debug("Live field target rejected: focused element has no readable value")
+            return nil
+        }
+        guard let selectedRange = state.selectedRange else {
+            logger.debug("Live field target rejected: focused element has no selected-text range")
+            return nil
+        }
+        guard selectedRange.length == 0,
+              state.selectedText?.isEmpty != false else {
+            logger.debug("Live field target rejected: selection is not empty")
+            return nil
+        }
+        guard Range(selectedRange, in: value) != nil else {
+            logger.debug("Live field target rejected: selection is outside the readable value")
+            return nil
+        }
+        guard isEligibleLiveFieldTarget(state.element) else {
+            logger.debug("Live field target rejected: focused element is not eligible")
+            return nil
+        }
+
+        let insertionContext = insertionContext(
+            value: value,
+            selectedText: state.selectedText,
+            selectedRange: selectedRange
+        )
+        return LiveFieldTarget(
+            applicationBundleIdentifier: expectedBundleIdentifier,
+            element: state.element,
+            originalInsertionContext: insertionContext,
+            expectedValue: value,
+            expectedCaret: selectedRange,
+            ownedRange: selectedRange,
+            provisionalText: ""
+        )
+    }
+
+    func replaceLiveFieldText(
+        _ text: String,
+        in target: inout LiveFieldTarget
+    ) -> LiveFieldMutationResult {
+        guard let currentState = verifiedLiveFieldState(for: &target) else {
+            return .detached
+        }
+
+        if text == target.provisionalText {
+            return .applied(observation(from: currentState))
+        }
+
+        let expectedValue = (target.expectedValue as NSString).replacingCharacters(
+            in: target.ownedRange,
+            with: text
+        )
+        let replacementLength = (text as NSString).length
+        let expectedCaret = NSRange(
+            location: target.ownedRange.location + replacementLength,
+            length: 0
+        )
+        let expectedOwnedRange = NSRange(
+            location: target.ownedRange.location,
+            length: replacementLength
+        )
+
+        guard setSelectedRange(target.ownedRange, on: target.element) else {
+            return .detached
+        }
+        guard insertTextAt(element: target.element, text: text) else {
+            _ = setSelectedRange(target.expectedCaret, on: target.element)
+            return .detached
+        }
+
+        if var resultingState = captureFocusedTextState(),
+           captureActiveApp().bundleId == target.applicationBundleIdentifier,
+           resultingState.value == expectedValue,
+           resultingState.selectedRange != expectedCaret {
+            _ = setSelectedRange(expectedCaret, on: resultingState.element)
+            resultingState = captureFocusedTextState() ?? resultingState
+        }
+
+        guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
+              let resultingState = captureFocusedTextState(),
+              resultingState.value == expectedValue,
+              resultingState.selectedRange == expectedCaret,
+              resultingState.selectedText?.isEmpty != false,
+              resultingState.element == target.element
+                || isEligibleLiveFieldTarget(resultingState.element) else {
+            _ = setSelectedRange(target.expectedCaret, on: target.element)
+            if let unchangedState = captureFocusedTextState(),
+               unchangedState.element == target.element,
+               unchangedState.value == target.expectedValue,
+               unchangedState.selectedRange == target.expectedCaret,
+               unchangedState.selectedText?.isEmpty != false {
+                return .detached
+            }
+
+            // AX reported a successful write but the resulting state is not
+            // provably unchanged. Text may be present, so paste is unsafe.
+            target.hasAttemptedMutation = true
+            return .detached
+        }
+
+        target.hasAttemptedMutation = true
+        target.element = resultingState.element
+        target.expectedValue = expectedValue
+        target.expectedCaret = expectedCaret
+        target.ownedRange = expectedOwnedRange
+        target.provisionalText = text
+        return .applied(observation(from: resultingState))
     }
 
     func captureFocusedTextObservation() -> FocusedTextObservation? {
@@ -782,6 +971,29 @@ final class TextInsertionService {
         findSelectionInDescendants(of: root, maxDepth: 6, maxNodes: 80)
     }
 
+    private func findEditableTextDescendant(of root: AXUIElement) -> AXUIElement? {
+        var queue: [(element: AXUIElement, depth: Int)] = childElements(of: root).map { ($0, 1) }
+        var visited = 0
+
+        while !queue.isEmpty && visited < 80 {
+            let current = queue.removeFirst()
+            visited += 1
+
+            if isLiveFieldTextRole(current.element),
+               selectedRangeAttribute(from: current.element) != nil {
+                return current.element
+            }
+
+            if current.depth < 6 {
+                queue.append(contentsOf: childElements(of: current.element).map {
+                    ($0, current.depth + 1)
+                })
+            }
+        }
+
+        return nil
+    }
+
     private func findSelectionInDescendants(
         of root: AXUIElement,
         maxDepth: Int,
@@ -933,24 +1145,200 @@ final class TextInsertionService {
             guard let snapshot = focusedTextStateOverride(element) else { return nil }
             return FocusedTextState(
                 element: element,
-                value: snapshot.value,
+                value: normalizedTextValue(
+                    snapshot.value,
+                    placeholder: focusedTextPlaceholderOverride?(element),
+                    selectedRange: snapshot.selectedRange
+                ),
                 selectedText: snapshot.selectedText,
                 selectedRange: snapshot.selectedRange
             )
         }
 
+        let selectedRange = selectedRangeAttribute(from: element)
         return FocusedTextState(
             element: element,
-            value: stringAttribute(kAXValueAttribute as CFString, from: element),
+            value: normalizedTextValue(
+                stringAttribute(kAXValueAttribute as CFString, from: element),
+                placeholder: stringAttribute(kAXPlaceholderValueAttribute as CFString, from: element),
+                selectedRange: selectedRange
+            ),
             selectedText: stringAttribute(kAXSelectedTextAttribute as CFString, from: element),
-            selectedRange: selectedRangeAttribute(from: element)
+            selectedRange: selectedRange
         )
+    }
+
+    private func normalizedTextValue(
+        _ value: String?,
+        placeholder: String?,
+        selectedRange: NSRange?
+    ) -> String? {
+        guard let value,
+              let placeholder,
+              !placeholder.isEmpty,
+              value == placeholder,
+              selectedRange == NSRange(location: 0, length: 0) else {
+            return value
+        }
+
+        // Chromium/Electron content-editable fields can expose their visible
+        // placeholder through AXValue. It disappears on the first real write,
+        // so treating it as document content would make verification detach.
+        return ""
+    }
+
+    private func insertionContext(
+        value: String,
+        selectedText: String?,
+        selectedRange: NSRange
+    ) -> InsertionContext {
+        let stringRange = Range(selectedRange, in: value)
+        let previousCharacter = stringRange.flatMap { range in
+            range.lowerBound > value.startIndex
+                ? value[value.index(before: range.lowerBound)]
+                : nil
+        }
+        let nextCharacter = stringRange.flatMap { range in
+            range.upperBound < value.endIndex ? value[range.upperBound] : nil
+        }
+
+        return InsertionContext(
+            value: value,
+            selectedRange: selectedRange,
+            selectedText: selectedText,
+            previousCharacter: previousCharacter,
+            nextCharacter: nextCharacter
+        )
+    }
+
+    private func verifiedLiveFieldState(for target: inout LiveFieldTarget) -> FocusedTextState? {
+        guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
+              let state = captureFocusedTextState(),
+              state.value == target.expectedValue,
+              state.selectedRange == target.expectedCaret,
+              state.selectedText?.isEmpty != false else {
+            return nil
+        }
+
+        if state.element != target.element {
+            guard target.hasProvisionalText,
+                  isEligibleLiveFieldTarget(state.element),
+                  (target.expectedValue as NSString).substring(with: target.ownedRange)
+                    == target.provisionalText else {
+                return nil
+            }
+            target.element = state.element
+        }
+        return FocusedTextState(
+            element: state.element,
+            value: target.expectedValue,
+            selectedText: nil,
+            selectedRange: target.expectedCaret
+        )
+    }
+
+    private func applicationSupportsVerifiedLiveFieldUpdates(
+        _ bundleIdentifier: String
+    ) -> Bool {
+        if let liveFieldApplicationEligibilityOverride {
+            return liveFieldApplicationEligibilityOverride(bundleIdentifier)
+        }
+
+        return !isElectronApplication(bundleIdentifier)
+    }
+
+    private func isElectronApplication(_ bundleIdentifier: String) -> Bool {
+        if let liveFieldElectronApplicationOverride {
+            return liveFieldElectronApplicationOverride(bundleIdentifier)
+        }
+
+        let runningApplication = NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleIdentifier)
+            .first
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        let application = runningApplication
+            ?? (frontmostApplication?.bundleIdentifier == bundleIdentifier
+                ? frontmostApplication
+                : nil)
+        guard let bundleURL = application?.bundleURL else {
+            return false
+        }
+
+        let electronFrameworkURL = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Frameworks", isDirectory: true)
+            .appendingPathComponent("Electron Framework.framework", isDirectory: true)
+        return FileManager.default.fileExists(atPath: electronFrameworkURL.path)
+    }
+
+    private func observation(from state: FocusedTextState) -> FocusedTextObservation {
+        FocusedTextObservation(
+            element: state.element,
+            value: state.value ?? "",
+            selectedText: state.selectedText,
+            selectedRange: state.selectedRange
+        )
+    }
+
+    private func isEligibleLiveFieldTarget(_ element: AXUIElement) -> Bool {
+        if let liveFieldTargetEligibilityOverride {
+            return liveFieldTargetEligibilityOverride(element)
+        }
+
+        guard isLiveFieldTextRole(element) else { return false }
+
+        var selectedTextSettable = DarwinBoolean(false)
+        var selectedRangeSettable = DarwinBoolean(false)
+        guard AXUIElementIsAttributeSettable(
+            element,
+            kAXSelectedTextAttribute as CFString,
+            &selectedTextSettable
+        ) == .success,
+        AXUIElementIsAttributeSettable(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            &selectedRangeSettable
+        ) == .success else {
+            return false
+        }
+        return selectedTextSettable.boolValue && selectedRangeSettable.boolValue
+    }
+
+    private func isLiveFieldTextRole(_ element: AXUIElement) -> Bool {
+        var roleValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXRoleAttribute as CFString,
+            &roleValue
+        ) == .success,
+        let role = roleValue as? String else {
+            return false
+        }
+        return ["AXTextField", "AXTextArea", "AXComboBox", "AXSearchField", "AXWebArea"]
+            .contains(role)
+    }
+
+    private func setSelectedRange(_ range: NSRange, on element: AXUIElement) -> Bool {
+        if let setSelectedRangeOverride {
+            return setSelectedRangeOverride(element, range)
+        }
+
+        var cfRange = CFRange(location: range.location, length: range.length)
+        guard let rangeValue = AXValueCreate(.cfRange, &cfRange) else { return false }
+        return AXUIElementSetAttributeValue(
+            element,
+            kAXSelectedTextRangeAttribute as CFString,
+            rangeValue
+        ) == .success
     }
 
     private func stringAttribute(_ attribute: CFString, from element: AXUIElement) -> String? {
         var value: AnyObject?
         guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else { return nil }
-        return value as? String
+        if let string = value as? String {
+            return string
+        }
+        return (value as? NSAttributedString)?.string
     }
 
     private func selectedRangeAttribute(from element: AXUIElement) -> NSRange? {
@@ -972,4 +1360,149 @@ final class TextInsertionService {
         return NSRange(location: range.location, length: range.length)
     }
 
+}
+
+@MainActor
+final class LiveFieldTranscriptSession {
+    enum State: Equatable {
+        case active
+        case detached
+        case finalized
+        case cancelled
+    }
+
+    enum CompletionResult {
+        case applied(TextInsertionService.FocusedTextObservation)
+        case detached(hadAttemptedMutation: Bool)
+    }
+
+    let sessionID: UUID
+    private(set) var state: State = .active
+    private(set) var target: TextInsertionService.LiveFieldTarget
+
+    private let textInsertionService: TextInsertionService
+    private let updateInterval: Duration
+    private var pendingText: String?
+    private var updateTask: Task<Void, Never>?
+    private var applicationActivationObservation: LiveFieldApplicationActivationObservation?
+
+    init(
+        sessionID: UUID,
+        target: TextInsertionService.LiveFieldTarget,
+        textInsertionService: TextInsertionService,
+        updateInterval: Duration = .milliseconds(120)
+    ) {
+        self.sessionID = sessionID
+        self.target = target
+        self.textInsertionService = textInsertionService
+        self.updateInterval = updateInterval
+        self.applicationActivationObservation = installLiveFieldApplicationActivationObserver { [weak self] bundleIdentifier in
+            self?.handleApplicationActivation(bundleIdentifier: bundleIdentifier)
+        }
+    }
+
+    deinit {
+        updateTask?.cancel()
+    }
+
+    var originalInsertionContext: TextInsertionService.InsertionContext {
+        target.originalInsertionContext
+    }
+
+    var hasAttemptedMutation: Bool {
+        target.hasAttemptedMutation
+    }
+
+    var hasProvisionalText: Bool {
+        target.hasProvisionalText
+    }
+
+    func receivePartial(_ text: String) {
+        guard state == .active,
+              !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return
+        }
+
+        pendingText = text
+        schedulePendingUpdateIfNeeded()
+    }
+
+    func finalize(with text: String) -> CompletionResult {
+        cancelPendingUpdate()
+        guard state == .active else {
+            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+        }
+
+        switch textInsertionService.replaceLiveFieldText(text, in: &target) {
+        case .applied(let observation):
+            state = .finalized
+            return .applied(observation)
+        case .detached:
+            state = .detached
+            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+        }
+    }
+
+    func cancel() -> CompletionResult {
+        cancelPendingUpdate()
+        guard state == .active else {
+            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+        }
+
+        switch textInsertionService.replaceLiveFieldText("", in: &target) {
+        case .applied(let observation):
+            state = .cancelled
+            return .applied(observation)
+        case .detached:
+            state = .detached
+            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+        }
+    }
+
+    func keepProvisionalText() {
+        cancelPendingUpdate()
+        guard state == .active else { return }
+        state = .finalized
+    }
+
+    private func schedulePendingUpdateIfNeeded() {
+        guard updateTask == nil else { return }
+        updateTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await Task.sleep(for: updateInterval)
+            guard !Task.isCancelled else { return }
+            applyPendingUpdate()
+        }
+    }
+
+    private func applyPendingUpdate() {
+        updateTask = nil
+        guard state == .active, let pendingText else { return }
+        self.pendingText = nil
+
+        switch textInsertionService.replaceLiveFieldText(pendingText, in: &target) {
+        case .applied:
+            if self.pendingText != nil {
+                schedulePendingUpdateIfNeeded()
+            }
+        case .detached:
+            state = .detached
+            self.pendingText = nil
+        }
+    }
+
+    private func cancelPendingUpdate() {
+        updateTask?.cancel()
+        updateTask = nil
+        pendingText = nil
+    }
+
+    private func handleApplicationActivation(bundleIdentifier: String?) {
+        guard state == .active,
+              bundleIdentifier != target.applicationBundleIdentifier else {
+            return
+        }
+        cancelPendingUpdate()
+        state = .detached
+    }
 }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -200,6 +200,9 @@ final class DictationViewModel: ObservableObject {
     @Published var indicatorTranscriptPreviewEnabled: Bool {
         didSet { Self.persistIndicatorTranscriptPreviewEnabled(indicatorTranscriptPreviewEnabled) }
     }
+    @Published var liveFieldTranscriptEnabled: Bool {
+        didSet { Self.persistLiveFieldTranscriptEnabled(liveFieldTranscriptEnabled) }
+    }
     @Published var indicatorVisibleInScreenCaptures: Bool {
         didSet { Self.persistIndicatorVisibleInScreenCaptures(indicatorVisibleInScreenCaptures) }
     }
@@ -361,6 +364,7 @@ final class DictationViewModel: ObservableObject {
     /// dictation engine. When false (a distinct preview engine), the live session's
     /// text is display-only and must never be promoted to the final transcription.
     private var lastPreviewFollowsDictationEngine = true
+    private var liveFieldTranscriptSession: LiveFieldTranscriptSession?
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
     private var pendingHotkeyDictationStart: PendingHotkeyDictationStart?
@@ -514,6 +518,7 @@ final class DictationViewModel: ObservableObject {
         self.audioDuckingLevel = UserDefaults.standard.object(forKey: UserDefaultsKeys.audioDuckingLevel) as? Double ?? 0.2
         self.soundFeedbackEnabled = UserDefaults.standard.object(forKey: UserDefaultsKeys.soundFeedbackEnabled) as? Bool ?? true
         self.indicatorTranscriptPreviewEnabled = Self.loadIndicatorTranscriptPreviewEnabled()
+        self.liveFieldTranscriptEnabled = Self.loadLiveFieldTranscriptEnabled()
         self.indicatorVisibleInScreenCaptures = Self.loadIndicatorVisibleInScreenCaptures()
         self.indicatorTranscriptPreviewFontSizeOffset = Self.loadIndicatorTranscriptPreviewFontSizeOffset()
         self.livePreviewEngineId = Self.loadLivePreviewEngineId()
@@ -540,6 +545,10 @@ final class DictationViewModel: ObservableObject {
 
         streamingHandler.onPartialTextUpdate = { [weak self] text in
             guard let self else { return }
+            if let liveFieldTranscriptSession = self.liveFieldTranscriptSession,
+               liveFieldTranscriptSession.sessionID == self.activeDictationSessionID {
+                liveFieldTranscriptSession.receivePartial(text)
+            }
             if self.partialText != text {
                 self.partialText = text
                 let elapsed = self.recordingStartTime.map { Date().timeIntervalSince($0) } ?? 0
@@ -600,6 +609,14 @@ final class DictationViewModel: ObservableObject {
 
     nonisolated static func persistIndicatorTranscriptPreviewEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
         defaults.set(enabled, forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
+    }
+
+    nonisolated static func loadLiveFieldTranscriptEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled) as? Bool ?? false
+    }
+
+    nonisolated static func persistLiveFieldTranscriptEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: UserDefaultsKeys.liveFieldTranscriptEnabled)
     }
 
     nonisolated static func loadIndicatorVisibleInScreenCaptures(defaults: UserDefaults = .standard) -> Bool {
@@ -934,6 +951,7 @@ final class DictationViewModel: ObservableObject {
         }
         clearRecordingStartCueState()
         clearDeferredRecordingContext()
+        cancelLiveFieldTranscriptSession()
         restoreRecordingSideEffects()
         streamingHandler.stop()
         stopRecordingTimer()
@@ -1130,6 +1148,7 @@ final class DictationViewModel: ObservableObject {
             showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         case .processing:
             cancelActiveDictationSessionIfNeeded(message: cancelledMessage)
+            cancelLiveFieldTranscriptSession()
             stopFinalizationTask?.cancel()
             stopFinalizationTask = nil
             streamingHandler.stop()
@@ -1170,6 +1189,7 @@ final class DictationViewModel: ObservableObject {
         indicatorFeedbackLifetime.cancel()
         clearCancelWarning()
         pendingPushToTalkDiscardMessage = nil
+        cancelLiveFieldTranscriptSession()
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         urlResolutionTask?.cancel()
@@ -1367,7 +1387,12 @@ final class DictationViewModel: ObservableObject {
         updateRecordingStartCuePayload(activeApp: activeApp)
         let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
 
-        startLiveStreaming(allowLiveTranscription: indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0)
+        beginLiveFieldTranscriptSessionIfEligible(sessionID: sessionID, activeApp: activeApp)
+        startLiveStreaming(
+            allowLiveTranscription: indicatorTranscriptPreviewEnabled
+                || liveFieldTranscriptEnabled
+                || externalStreamingDisplayCount > 0
+        )
         scheduleDeferredRecordingMetadataCapture(
             activeApp: activeApp,
             forcedWorkflowId: forcedWorkflowId
@@ -1581,6 +1606,7 @@ final class DictationViewModel: ObservableObject {
         restoreRecordingSideEffects()
         if let discardMessage = pendingPushToTalkDiscardMessage {
             pendingPushToTalkDiscardMessage = nil
+            cancelLiveFieldTranscriptSession()
             streamingHandler.stop()
             lastStreamingParams = nil
             stopRecordingTimer()
@@ -1671,6 +1697,7 @@ final class DictationViewModel: ObservableObject {
 
         switch decision {
         case .discardTooShort:
+            cancelLiveFieldTranscriptSession()
             audioRecordingService.discardActiveRecoveryRecording()
             let errorMessage = String(localized: "Too short, hold the hotkey a bit longer")
             if let sessionID {
@@ -1683,6 +1710,7 @@ final class DictationViewModel: ObservableObject {
             )
             return
         case .discardNoSpeech:
+            cancelLiveFieldTranscriptSession()
             audioRecordingService.discardActiveRecoveryRecording()
             logger.info("Peak level too low (\(String(format: "%.4f", peakLevel))) - no speech detected")
             let errorMessage = String(localized: "No speech detected")
@@ -1768,6 +1796,7 @@ final class DictationViewModel: ObservableObject {
 
                 var text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard !text.isEmpty else {
+                    handleLiveFieldTranscriptionFailure(stablePreviewText: previewText)
                     logger.info("Transcription returned empty text (duration: \(String(format: "%.2f", result.duration))s, engine: \(result.engineUsed))")
                     audioRecordingService.preserveActiveRecoveryRecording()
                     let errorMessage = String(localized: "No speech recognized")
@@ -1849,15 +1878,19 @@ final class DictationViewModel: ObservableObject {
                 // Route to action plugin or insert text
                 if let actionPluginId = self.effectiveActionPluginId,
                    let actionPlugin = PluginManager.shared.actionPlugin(for: actionPluginId) {
+                    cancelLiveFieldTranscriptSession()
                     try await executeActionPlugin(
                         actionPlugin, pluginId: actionPluginId, text: text,
                         activeApp: activeApp, language: language, originalText: result.text
                     )
                 } else {
                     let contextualInsertionEnabled = DictationInsertionTextFormatter.contextualInsertionEnabled()
-                    let insertionContext = contextualInsertionEnabled
-                        ? textInsertionService.captureInsertionContext()
-                        : nil
+                    let insertionContext: TextInsertionService.InsertionContext? = if contextualInsertionEnabled {
+                        liveFieldTranscriptSession?.originalInsertionContext
+                            ?? textInsertionService.captureInsertionContext()
+                    } else {
+                        nil
+                    }
                     let insertionText = DictationInsertionTextFormatter.textForInsertion(
                         text,
                         insertionContext: insertionContext,
@@ -1867,31 +1900,64 @@ final class DictationViewModel: ObservableObject {
                         shouldTrackTargetAppCorrectionLearning
                             || improveTypeWhisperCaptureEnabled
                     ) && resolvedOutputFormat == nil
-                    let learningPreInsertionObservation = shouldObservePostInsertionEdits
-                        ? textInsertionService.captureFocusedTextObservation()
-                        : nil
-                    let insertionResult = try await textInsertionService.insertText(
-                        insertionText,
-                        preserveClipboard: preserveClipboard,
-                        autoEnter: self.effectiveAutoEnterEnabled,
-                        outputFormat: resolvedOutputFormat
-                    )
-                    logger.info("Stop timing: text inserted elapsedMs=\(stopElapsedMs(), privacy: .public)")
-                    if case .pasted(.unverified(let reason)) = insertionResult {
-                        logger.info(
-                            "Text insertion paste could not be verified; continuing with clipboard paste fallback. reason=\(reason.rawValue, privacy: .public), app=\(activeApp.bundleId ?? "nil", privacy: .public)"
+                    var didInsertText = false
+                    var shouldUseNormalInsertion = true
+
+                    if resolvedOutputFormat == nil,
+                       let liveFieldTranscriptSession {
+                        switch liveFieldTranscriptSession.finalize(with: insertionText) {
+                        case .applied(let finalObservation):
+                            shouldUseNormalInsertion = false
+                            didInsertText = true
+                            targetAppCorrectionBaseline = shouldObservePostInsertionEdits
+                                ? finalObservation
+                                : nil
+                            insertedTextForCorrectionTracking = insertionText
+                            if self.effectiveAutoEnterEnabled {
+                                try? await Task.sleep(for: .milliseconds(50))
+                                textInsertionService.simulateReturn()
+                            }
+                        case .detached(let hadAttemptedMutation):
+                            shouldUseNormalInsertion = !hadAttemptedMutation
+                            if hadAttemptedMutation {
+                                showLiveFieldRecoveryFeedback()
+                            }
+                        }
+                        self.liveFieldTranscriptSession = nil
+                    } else if liveFieldTranscriptSession != nil {
+                        shouldUseNormalInsertion = prepareLiveFieldSessionForNormalInsertion()
+                    }
+
+                    if shouldUseNormalInsertion {
+                        let learningPreInsertionObservation = shouldObservePostInsertionEdits
+                            ? textInsertionService.captureFocusedTextObservation()
+                            : nil
+                        let insertionResult = try await textInsertionService.insertText(
+                            insertionText,
+                            preserveClipboard: preserveClipboard,
+                            autoEnter: self.effectiveAutoEnterEnabled,
+                            outputFormat: resolvedOutputFormat
                         )
+                        if case .pasted(.unverified(let reason)) = insertionResult {
+                            logger.info(
+                                "Text insertion paste could not be verified; continuing with clipboard paste fallback. reason=\(reason.rawValue, privacy: .public), app=\(activeApp.bundleId ?? "nil", privacy: .public)"
+                            )
+                        }
+                        targetAppCorrectionBaseline = learningPreInsertionObservation.flatMap {
+                            textInsertionService.recaptureFocusedTextObservation(matching: $0)
+                        }
+                        insertedTextForCorrectionTracking = insertionText
+                        didInsertText = true
                     }
-                    let learningBaselineObservation = learningPreInsertionObservation.flatMap {
-                        textInsertionService.recaptureFocusedTextObservation(matching: $0)
+
+                    if didInsertText {
+                        logger.info("Stop timing: text inserted elapsedMs=\(stopElapsedMs(), privacy: .public)")
+                        EventBus.shared.emit(.textInserted(TextInsertedPayload(
+                            text: insertionText,
+                            appName: activeApp.name,
+                            bundleIdentifier: activeApp.bundleId
+                        )))
                     }
-                    targetAppCorrectionBaseline = learningBaselineObservation
-                    insertedTextForCorrectionTracking = insertionText
-                    EventBus.shared.emit(.textInserted(TextInsertedPayload(
-                        text: insertionText,
-                        appName: activeApp.name,
-                        bundleIdentifier: activeApp.bundleId
-                    )))
                 }
 
                 if let insertedTextForCorrectionTracking {
@@ -1983,6 +2049,7 @@ final class DictationViewModel: ObservableObject {
                 }
             } catch {
                 guard !Task.isCancelled else { return }
+                handleLiveFieldTranscriptionFailure(stablePreviewText: previewText)
                 audioRecordingService.preserveActiveRecoveryRecording()
                 EventBus.shared.emit(.transcriptionFailed(TranscriptionFailedPayload(
                     error: error.localizedDescription,
@@ -2175,6 +2242,7 @@ final class DictationViewModel: ObservableObject {
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         lastStreamingParams = nil
+        liveFieldTranscriptSession = nil
         isStopInFlight = false
         activeDictationSessionID = nil
         pendingPushToTalkDiscardMessage = nil
@@ -2314,6 +2382,73 @@ final class DictationViewModel: ObservableObject {
         )
     }
 
+    private func beginLiveFieldTranscriptSessionIfEligible(
+        sessionID: UUID,
+        activeApp: (name: String?, bundleId: String?, url: String?)
+    ) {
+        liveFieldTranscriptSession = nil
+        guard liveFieldTranscriptEnabled,
+              effectiveActionPluginId == nil,
+              resolvedEffectiveOutputFormat(for: activeApp) == nil,
+              let target = textInsertionService.captureLiveFieldTarget(
+                expectedBundleIdentifier: activeApp.bundleId
+              ) else {
+            return
+        }
+
+        liveFieldTranscriptSession = LiveFieldTranscriptSession(
+            sessionID: sessionID,
+            target: target,
+            textInsertionService: textInsertionService
+        )
+    }
+
+    private func cancelLiveFieldTranscriptSession() {
+        guard let liveFieldTranscriptSession else { return }
+        _ = liveFieldTranscriptSession.cancel()
+        self.liveFieldTranscriptSession = nil
+    }
+
+    private func prepareLiveFieldSessionForNormalInsertion() -> Bool {
+        guard let liveFieldTranscriptSession else { return true }
+        defer { self.liveFieldTranscriptSession = nil }
+
+        switch liveFieldTranscriptSession.cancel() {
+        case .applied:
+            return true
+        case .detached(let hadAttemptedMutation):
+            if hadAttemptedMutation {
+                showLiveFieldRecoveryFeedback()
+                return false
+            }
+            return true
+        }
+    }
+
+    private func handleLiveFieldTranscriptionFailure(stablePreviewText: String) {
+        guard let liveFieldTranscriptSession else { return }
+        let hasUsableVisiblePartial = liveFieldTranscriptSession.hasProvisionalText
+            && StreamingHandler.isSubstantiveStablePreview(
+                stablePreviewText.trimmingCharacters(in: .whitespacesAndNewlines)
+            )
+        if hasUsableVisiblePartial {
+            liveFieldTranscriptSession.keepProvisionalText()
+            self.liveFieldTranscriptSession = nil
+        } else {
+            cancelLiveFieldTranscriptSession()
+        }
+    }
+
+    private func showLiveFieldRecoveryFeedback() {
+        showNotchFeedback(
+            message: String(localized: "The text field changed. The final transcript is available in Recent Transcriptions."),
+            icon: "text.badge.xmark",
+            duration: 3.0,
+            isError: true,
+            errorCategory: "insertion"
+        )
+    }
+
     /// Whether an engine is usable as the live preview engine: auth-available and
     /// either currently configured or restorable on demand (an installed local
     /// engine whose model was auto-unloaded restores at session start via
@@ -2376,7 +2511,9 @@ final class DictationViewModel: ObservableObject {
         )
         guard newParams != previous else { return }
         logger.info("Streaming params changed after URL resolution, restarting live session")
-        let allowLive = indicatorTranscriptPreviewEnabled || externalStreamingDisplayCount > 0
+        let allowLive = indicatorTranscriptPreviewEnabled
+            || liveFieldTranscriptEnabled
+            || externalStreamingDisplayCount > 0
         startLiveStreaming(allowLiveTranscription: allowLive)
     }
 

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -229,6 +229,13 @@ struct AdvancedSettingsView: View {
                     )
                 }
 
+                Toggle(isOn: $dictation.liveFieldTranscriptEnabled) {
+                    SettingsInfoLabel(
+                        title: String(localized: "Show live transcript in the active text field"),
+                        info: String(localized: "Supported text fields are updated while you speak. TypeWhisper uses the transcript overlay when direct updates are unavailable.")
+                    )
+                }
+
                 Toggle(isOn: $dictation.microphoneBoostEnabled) {
                     SettingsInfoLabel(
                         title: localizedAppText("Whisper Mode (AGC)", de: "Whisper-Modus (AGC)"),

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -232,7 +232,7 @@ struct AdvancedSettingsView: View {
                 Toggle(isOn: $dictation.liveFieldTranscriptEnabled) {
                     SettingsInfoLabel(
                         title: String(localized: "Show live transcript in the active text field"),
-                        info: String(localized: "Supported text fields are updated while you speak. TypeWhisper uses the transcript overlay when direct updates are unavailable.")
+                        info: String(localized: "Supported text fields are updated while you speak. TypeWhisper inserts the final transcript normally when direct updates are unavailable.")
                     )
                 }
 
@@ -665,6 +665,9 @@ struct AdvancedSettingsView: View {
             pluginRegistryService: container.pluginRegistryService,
             historyService: container.historyService,
             usageStatisticsService: container.usageStatisticsService,
+            liveFieldTranscriptEnabledDidChange: { enabled in
+                dictation.liveFieldTranscriptEnabled = enabled
+            },
             recoveryRetentionPolicyDidChange: { policy in
                 _ = container.audioRecordingService.updateRecoveryRetentionPolicy(policy)
             }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -47,6 +47,20 @@ final class DictationViewModelIndicatorSettingsTests: XCTestCase {
         XCTAssertFalse(DictationViewModel.loadIndicatorTranscriptPreviewEnabled(defaults: defaults))
     }
 
+    func testLiveFieldTranscriptDefaultsToDisabled() {
+        XCTAssertFalse(DictationViewModel.loadLiveFieldTranscriptEnabled(defaults: defaults))
+    }
+
+    func testLiveFieldTranscriptPersistsWhenEnabled() {
+        DictationViewModel.persistLiveFieldTranscriptEnabled(true, defaults: defaults)
+
+        XCTAssertEqual(
+            defaults.object(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled) as? Bool,
+            true
+        )
+        XCTAssertTrue(DictationViewModel.loadLiveFieldTranscriptEnabled(defaults: defaults))
+    }
+
     func testMissingIndicatorTranscriptPreviewKeyFallsBackToTrue() {
         defaults.removeObject(forKey: UserDefaultsKeys.indicatorTranscriptPreviewEnabled)
 

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -450,6 +450,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.userDefaults.set(3, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         source.userDefaults.set("overlay", forKey: UserDefaultsKeys.indicatorStyle)
         source.userDefaults.set(false, forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures)
+        source.userDefaults.set(true, forKey: UserDefaultsKeys.liveFieldTranscriptEnabled)
         source.userDefaults.set(true, forKey: UserDefaultsKeys.recorderSystemAudioEnabled)
         source.userDefaults.set(7, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
         // Deliberately excluded: engine/model selections must not be exported.
@@ -474,6 +475,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         XCTAssertEqual(backup.preferences.indicatorTranscriptPreviewFontSizeOffset, 3)
         XCTAssertEqual(backup.preferences.indicatorStyle, "overlay")
         XCTAssertEqual(backup.preferences.indicatorVisibleInScreenCaptures, false)
+        XCTAssertEqual(backup.preferences.liveFieldTranscriptEnabled, true)
         XCTAssertEqual(backup.preferences.recorderSystemAudioEnabled, true)
         XCTAssertEqual(backup.preferences.dictationRecoveryRetentionDays, 7)
 
@@ -497,7 +499,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         )
 
         XCTAssertTrue(result.updateChannelApplied)
-        XCTAssertGreaterThanOrEqual(result.preferencesApplied, 7)
+        XCTAssertGreaterThanOrEqual(result.preferencesApplied, 8)
         XCTAssertEqual(destination.userDefaults.string(forKey: UserDefaultsKeys.updateChannel), AppConstants.ReleaseChannel.daily.rawValue)
         XCTAssertEqual(destination.userDefaults.string(forKey: UserDefaultsKeys.selectedLanguage), "de")
         XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.translationEnabled), true)
@@ -507,6 +509,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             destination.userDefaults.object(forKey: UserDefaultsKeys.indicatorVisibleInScreenCaptures) as? Bool,
             false
         )
+        XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled), true)
         XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays), 7)
         XCTAssertEqual(appliedRecoveryRetentionPolicy, .sevenDays)
         XCTAssertNil(destination.userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine))

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -482,6 +482,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         let destination = try makeFixture()
         defer { teardown(destination) }
         var appliedRecoveryRetentionPolicy: DictationRecoveryRetentionPolicy?
+        var appliedLiveFieldTranscriptEnabled: Bool?
 
         let result = await SettingsBackupExporter.importBackup(
             backup,
@@ -495,6 +496,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             historyService: destination.historyService,
             usageStatisticsService: destination.usageStatisticsService,
             userDefaults: destination.userDefaults,
+            liveFieldTranscriptEnabledDidChange: { appliedLiveFieldTranscriptEnabled = $0 },
             recoveryRetentionPolicyDidChange: { appliedRecoveryRetentionPolicy = $0 }
         )
 
@@ -510,6 +512,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             false
         )
         XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled), true)
+        XCTAssertEqual(appliedLiveFieldTranscriptEnabled, true)
         XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays), 7)
         XCTAssertEqual(appliedRecoveryRetentionPolicy, .sevenDays)
         XCTAssertNil(destination.userDefaults.string(forKey: UserDefaultsKeys.fileTranscriptionEngine))

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -3902,6 +3902,380 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveFieldSessionRevisesOneOwnedRangeAndFinalizesInPlace() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        var value = "Before  after"
+        var selectedRange = NSRange(location: 7, length: 0)
+        var writes: [String] = []
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, text in
+            writes.append(text)
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+
+        session.receivePartial("Hello")
+        try await Task.sleep(for: .milliseconds(10))
+        session.receivePartial("Hello world")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(value, "Before Hello world after")
+        XCTAssertEqual(writes, ["Hello", "Hello world"])
+        XCTAssertEqual(session.state, .active)
+
+        let result = session.finalize(with: "Final text")
+        guard case .applied(let observation) = result else {
+            return XCTFail("Expected final live-field replacement")
+        }
+        XCTAssertEqual(value, "Before Final text after")
+        XCTAssertEqual(observation.value, value)
+        XCTAssertEqual(selectedRange, NSRange(location: 17, length: 0))
+        XCTAssertEqual(session.state, .finalized)
+    }
+
+    @MainActor
+    func testLiveFieldSessionDetachesAfterUserChangesText() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        var value = ""
+        var selectedRange = NSRange(location: 0, length: 0)
+        var writeCount = 0
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("TextEdit", "com.apple.TextEdit", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, text in
+            writeCount += 1
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.TextEdit")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("Hello")
+        try await Task.sleep(for: .milliseconds(10))
+
+        value += "!"
+        selectedRange = NSRange(location: 6, length: 0)
+        session.receivePartial("Hello world")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(session.state, .detached)
+        XCTAssertEqual(value, "Hello!")
+        XCTAssertEqual(writeCount, 1)
+
+        let result = session.finalize(with: "Final")
+        guard case .detached(let hadAttemptedMutation) = result else {
+            return XCTFail("Expected detached finalization")
+        }
+        XCTAssertTrue(hadAttemptedMutation)
+        XCTAssertEqual(value, "Hello!")
+        XCTAssertEqual(writeCount, 1)
+    }
+
+    @MainActor
+    func testLiveFieldSessionCancellationRemovesOnlyOwnedText() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        var value = "Start end"
+        var selectedRange = NSRange(location: 6, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Mail", "com.apple.mail", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, text in
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.mail")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("draft ")
+        try await Task.sleep(for: .milliseconds(10))
+
+        guard case .applied = session.cancel() else {
+            return XCTFail("Expected cancellation cleanup")
+        }
+        XCTAssertEqual(value, "Start end")
+        XCTAssertEqual(selectedRange, NSRange(location: 6, length: 0))
+        XCTAssertEqual(session.state, .cancelled)
+    }
+
+    @MainActor
+    func testLiveFieldTargetRejectsNonEmptySelection() {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: "Selected", selectedText: "Selected", selectedRange: NSRange(location: 0, length: 8))
+        }
+
+        XCTAssertNil(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+    }
+
+    @MainActor
+    func testLiveFieldTargetRejectsElectronApplication() {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Electron App", "com.example.electron", nil) }
+        service.liveFieldElectronApplicationOverride = { _ in true }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+        }
+
+        XCTAssertNil(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.example.electron")
+        )
+    }
+
+    @MainActor
+    func testLiveFieldSessionTreatsExposedPlaceholderAsEmptyText() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        let placeholder = "Ask anything or type @ to add context"
+        var value = placeholder
+        var selectedRange = NSRange(location: 0, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        service.focusedTextElementOverride = { element }
+        service.focusedTextPlaceholderOverride = { _ in value == placeholder ? placeholder : nil }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, text in
+            value = text
+            selectedRange = NSRange(location: (text as NSString).length, length: 0)
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.t3.code")
+        )
+        XCTAssertEqual(target.originalInsertionContext.value, "")
+
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("Hello from TypeWhisper")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(session.state, .active)
+        XCTAssertEqual(value, "Hello from TypeWhisper")
+        guard case .applied = session.finalize(with: "Final transcript") else {
+            return XCTFail("Expected placeholder-backed field to finalize in place")
+        }
+        XCTAssertEqual(value, "Final transcript")
+    }
+
+    @MainActor
+    func testLiveFieldSessionAllowsFallbackWhenInitialAXWriteFails() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        var selectedRange = NSRange(location: 0, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: "", selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, _ in false }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.t3.code")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("Hello")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(session.state, .detached)
+        guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
+            return XCTFail("Expected the failed inline session to detach")
+        }
+        XCTAssertFalse(hadAttemptedMutation)
+    }
+
+    @MainActor
+    func testLiveFieldSessionAllowsFallbackWhenAXSuccessLeavesFieldUnchanged() async throws {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        var selectedRange = NSRange(location: 0, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: "", selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, _ in true }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.t3.code")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("Hello")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(session.state, .detached)
+        guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
+            return XCTFail("Expected ignored AX success to detach")
+        }
+        XCTAssertFalse(hadAttemptedMutation)
+    }
+
+    @MainActor
+    func testLiveFieldSessionRebindsToRecreatedWebEditorElement() async throws {
+        let service = TextInsertionService()
+        var element = AXUIElementCreateSystemWide()
+        var value = ""
+        var selectedRange = NSRange(location: 0, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { _ in
+            (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { _, text in
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
+            element = AXUIElementCreateSystemWide()
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.t3.code")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+        session.receivePartial("Hello")
+        try await Task.sleep(for: .milliseconds(10))
+        session.receivePartial("Hello from Electron")
+        try await Task.sleep(for: .milliseconds(10))
+
+        XCTAssertEqual(session.state, .active)
+        XCTAssertEqual(value, "Hello from Electron")
+        guard case .applied = session.finalize(with: "Final transcript") else {
+            return XCTFail("Expected recreated Electron element to finalize")
+        }
+        XCTAssertEqual(value, "Final transcript")
+    }
+
+    @MainActor
     func testGetTextSelectionDerivesSelectedTextFromFocusedValueAndRange() {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -3902,6 +3902,20 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    private func waitForLiveFieldUpdate(
+        _ description: String,
+        condition: () -> Bool
+    ) async throws {
+        for _ in 0..<100 {
+            if condition() {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+        XCTFail("Timed out waiting for live-field update: \(description)")
+    }
+
+    @MainActor
     func testLiveFieldSessionRevisesOneOwnedRangeAndFinalizesInPlace() async throws {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()
@@ -3941,9 +3955,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         )
 
         session.receivePartial("Hello")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("first partial") { writes == ["Hello"] }
         session.receivePartial("Hello world")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("revised partial") {
+            value == "Before Hello world after"
+        }
 
         XCTAssertEqual(value, "Before Hello world after")
         XCTAssertEqual(writes, ["Hello", "Hello world"])
@@ -3998,12 +4014,14 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("Hello")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("initial partial") { writeCount == 1 }
 
         value += "!"
         selectedRange = NSRange(location: 6, length: 0)
         session.receivePartial("Hello world")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("detach after external edit") {
+            session.state == .detached
+        }
 
         XCTAssertEqual(session.state, .detached)
         XCTAssertEqual(value, "Hello!")
@@ -4055,7 +4073,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("draft ")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("cancellable partial") { value == "Start draft end" }
 
         guard case .applied = session.cancel() else {
             return XCTFail("Expected cancellation cleanup")
@@ -4122,8 +4140,14 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             return true
         }
         service.insertTextAtOverride = { _, text in
-            value = text
-            selectedRange = NSRange(location: (text as NSString).length, length: 0)
+            if value == placeholder {
+                value = ""
+            }
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
             return true
         }
 
@@ -4139,7 +4163,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("Hello from TypeWhisper")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("placeholder replacement") {
+            value == "Hello from TypeWhisper"
+        }
 
         XCTAssertEqual(session.state, .active)
         XCTAssertEqual(value, "Hello from TypeWhisper")
@@ -4178,7 +4204,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("Hello")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("failed AX write fallback") {
+            session.state == .detached
+        }
 
         XCTAssertEqual(session.state, .detached)
         guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
@@ -4216,7 +4244,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("Hello")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("ignored AX write fallback") {
+            session.state == .detached
+        }
 
         XCTAssertEqual(session.state, .detached)
         guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
@@ -4228,14 +4258,21 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     @MainActor
     func testLiveFieldSessionRebindsToRecreatedWebEditorElement() async throws {
         let service = TextInsertionService()
-        var element = AXUIElementCreateSystemWide()
+        let originalElement = AXUIElementCreateSystemWide()
+        let recreatedElement = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
+        XCTAssertFalse(CFEqual(originalElement, recreatedElement))
+        var element = originalElement
         var value = ""
         var selectedRange = NSRange(location: 0, length: 0)
+        var timeoutApplications: [(element: AXUIElement, timeout: Float)] = []
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.setMessagingTimeoutOverride = { element, timeout in
+            timeoutApplications.append((element, timeout))
+        }
         service.focusedTextStateOverride = { _ in
             (value: value, selectedText: nil, selectedRange: selectedRange)
         }
@@ -4249,7 +4286,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 location: selectedRange.location + (text as NSString).length,
                 length: 0
             )
-            element = AXUIElementCreateSystemWide()
+            element = recreatedElement
             return true
         }
 
@@ -4263,12 +4300,19 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             updateInterval: .milliseconds(1)
         )
         session.receivePartial("Hello")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("first recreated-element partial") {
+            value == "Hello"
+        }
         session.receivePartial("Hello from Electron")
-        try await Task.sleep(for: .milliseconds(10))
+        try await waitForLiveFieldUpdate("second recreated-element partial") {
+            value == "Hello from Electron"
+        }
 
         XCTAssertEqual(session.state, .active)
         XCTAssertEqual(value, "Hello from Electron")
+        XCTAssertTrue(timeoutApplications.allSatisfy { $0.timeout > 0 })
+        XCTAssertTrue(timeoutApplications.contains { CFEqual($0.element, originalElement) })
+        XCTAssertTrue(timeoutApplications.contains { CFEqual($0.element, recreatedElement) })
         guard case .applied = session.finalize(with: "Final transcript") else {
             return XCTFail("Expected recreated Electron element to finalize")
         }


### PR DESCRIPTION
## Summary

- add an opt-in setting that writes stable live transcript updates into the active text field
- keep one verified, TypeWhisper-owned provisional range so revised partials replace in place without duplication
- finalize the provisional range through the existing formatting and insertion pipeline
- fail closed when focus, selection, caret, surrounding text, or application ownership changes
- exclude Electron applications from inline updates and keep their existing final paste/insertion path
- persist the preference through settings backup, apply restored values immediately, and add maintained localizations

## Why

TypeWhisper already exposes live transcript previews in its indicator, but supported text fields could not show the transcript directly while the user was speaking. Direct updates need strict ownership checks because Accessibility targets can be recreated or mutated by the target application.

This implementation only continues inline mutation when the resulting full value and caret can be synchronously verified. Electron editors are excluded after local testing showed that their Accessibility surfaces cannot provide reliable ownership verification; they continue to receive the final transcript once through the normal insertion path.

## User impact

The feature is disabled by default and can be enabled under Advanced settings. Supported native and web text fields then show stable partial text at the caret. Unsupported targets keep their normal final insertion behavior; the transcript overlay remains controlled by its separate setting.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionRevisesOneOwnedRangeAndFinalizesInPlace -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionDetachesAfterUserChangesText -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionCancellationRemovesOnlyOwnedText -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldTargetRejectsNonEmptySelection -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldTargetRejectsElectronApplication -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionTreatsExposedPlaceholderAsEmptyText -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionAllowsFallbackWhenInitialAXWriteFails -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionAllowsFallbackWhenAXSuccessLeavesFieldUnchanged -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testLiveFieldSessionRebindsToRecreatedWebEditorElement -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests/testLiveFieldTranscriptDefaultsToDisabled -only-testing:TypeWhisperTests/DictationViewModelIndicatorSettingsTests/testLiveFieldTranscriptPersistsWhenEnabled -only-testing:TypeWhisperTests/SettingsBackupExporterTests/testUpdateChannelAndPreferencesRoundTrip` (12 passed)
- `swift test --package-path TypeWhisperPluginSDK` (575 passed)
- `scripts/pr-preflight.sh origin/main` (whitespace, script, localization, and release-helper checks passed; one transient Plugin SDK test failed on the first run, and the complete 575-test SDK suite passed on rerun)
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/Projects/typewhisper-mac`
- manual smoke in Notes and browser text fields for inline replacement
- manual smoke in T3 Code for Electron final-only insertion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to display live transcription directly in the active text field while dictating.
  * Live text updates progressively and finalizes in place when supported.
  * Added safeguards and fallback behavior for incompatible fields, edits, cancellations, and target changes.
  * Added German, Japanese, and Simplified Chinese translations for related settings and messages.

* **Settings**
  * The live transcription preference is saved and included in settings backup and restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->