### PR TITLE
Fix macOS 27 settings scroll pocket

### DIFF
--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -88,7 +88,13 @@ struct SettingsView: View {
 
     var body: some View {
         Group {
-            if #available(macOS 15, *) {
+            if #available(macOS 27, *) {
+                SettingsSidebarShell(
+                    selectedTab: $selectedTab,
+                    sections: destinationSections,
+                    detail: settingsDetail(for:)
+                )
+            } else if #available(macOS 15, *) {
                 SettingsModernShell(
                     selectedTab: $selectedTab,
                     sections: destinationSections,
@@ -492,24 +498,16 @@ private struct SettingsSidebarShell<DetailContent: View>: View {
     let detail: (SettingsTab) -> DetailContent
 
     @State private var isSidebarVisible = true
+    @State private var sidebarSearchText = ""
 
     var body: some View {
         HStack(spacing: 0) {
             if isSidebarVisible {
-                List(selection: $selectedTab) {
-                    ForEach(sections) { section in
-                        Section {
-                            ForEach(section.destinations) { destination in
-                                SettingsSidebarRow(
-                                    destination: destination,
-                                    isSelected: destination.tab == selectedTab
-                                )
-                                .tag(destination.tab)
-                            }
-                        }
-                    }
-                }
-                .listStyle(.sidebar)
+                SettingsSidebarContent(
+                    selectedTab: $selectedTab,
+                    sidebarSearchText: $sidebarSearchText,
+                    sections: sections
+                )
                 .frame(width: 240)
 
                 Divider()

--- a/TypeWhisper/Views/SettingsVisualComponents.swift
+++ b/TypeWhisper/Views/SettingsVisualComponents.swift
@@ -50,7 +50,6 @@ struct SettingsPageHeader<Actions: View>: View {
         .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.bar)
     }
 }
 

--- a/TypeWhisper/Views/SettingsVisualComponents.swift
+++ b/TypeWhisper/Views/SettingsVisualComponents.swift
@@ -50,6 +50,14 @@ struct SettingsPageHeader<Actions: View>: View {
         .padding(.horizontal, SettingsLayoutMetrics.pagePadding)
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
+        .background {
+            if #available(macOS 27, *) {
+                Color.clear
+            } else {
+                Rectangle()
+                    .fill(.bar)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- avoid the AppKit split-view path on macOS 27 and use the existing SwiftUI sidebar shell there
- reuse the searchable sidebar content in the SwiftUI shell
- keep every settings page's existing in-content header
- remove the header bar material only on macOS 27 while preserving the existing appearance on macOS 15–26

## Root cause

On macOS 27, AppKit inserts an `NSScrollPocket` above SwiftUI scroll content hosted inside the custom `NSSplitViewController`. The 52-point overlay blurs an otherwise empty region and can obscure the page header.

The workaround is scoped to macOS 27. macOS 15–26 continue using the existing AppKit split-view implementation and header material, while older systems keep the existing SwiftUI fallback.

## User impact

Settings pages no longer show the blurred empty strip at the top on macOS 27. Sidebar search, navigation, page titles, and header actions remain available. Older macOS versions retain their previous settings appearance.

## Test plan

```bash
git diff --check
/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run "$PWD"
```

Manual smoke:
- On macOS 27, open Settings and switch between Home, History, and Workflows.
- Verify that each page header is visible directly below the title bar with no blurred empty strip.
- Verify sidebar search and the Workflows "New Workflow" header action remain available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Settings interface with an improved sidebar experience on newer macOS versions.
  * Added sidebar search support for easier access to settings.

* **Style**
  * Refined the Settings page header background to better match the active macOS version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->