### PR TITLE
Bump Qwen3 plugin to 1.1.7

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -105,7 +105,7 @@ final class PluginManifestValidationTests: XCTestCase {
 
     func testMLXStoragePluginReleasesRequireHost16() throws {
         let manifestExpectations = [
-            ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.6"),
+            ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.7"),
             ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.13"),
             ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.9"),
             ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.4"),


### PR DESCRIPTION
## Summary

- bump the Qwen3 plugin manifest from 1.1.6 to 1.1.7
- keep the central MLX plugin release-version assertion in sync

## Release context

PR #1104 landed the long-audio transcription fix for #1100 after Qwen3 1.1.6 had already been published. This follow-up assigns the next release version so the fix can be built and distributed from `main`.

## Test plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter Qwen3PluginTests` (23 tests passed)
- [x] `git diff --check`
- [x] Parsed `TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json` and verified version `1.1.7`, minimum host `1.6.0`, and SDK compatibility `v1`

## Local limitation

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" -only-testing:TypeWhisperTests/PluginManifestValidationTests` stopped before test execution because this isolated worktree does not have the development-signing setup required by the app entitlements; GitHub CI remains the authoritative Xcode validation.