### PR TITLE
Fix incomplete meeting recorder transcriptions

### DIFF
--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -575,9 +575,17 @@ final class AudioRecorderViewModel: ObservableObject {
                 let providerId = effectiveProviderId
                 let dictionaryPrompt = dictionaryService.getTermsForPrompt(providerId: providerId)
                 let dictionaryTermHints = dictionaryService.getTermHints(providerId: providerId)
+                let finalSamples = if liveSessionResult == nil {
+                    await finalizedRecordingSamples(
+                        from: url,
+                        fallback: stoppedRecording.transcriptionSamples
+                    )
+                } else {
+                    stoppedRecording.transcriptionSamples
+                }
                 finalTranscriptionRequest = FinalTranscriptionRequest(
                     outputURL: url,
-                    buffer: stoppedRecording.transcriptionSamples,
+                    buffer: finalSamples,
                     languageSelection: languageSelection,
                     task: selectedTask,
                     providerId: providerId,
@@ -631,6 +639,27 @@ final class AudioRecorderViewModel: ObservableObject {
                     failRecorderAPISession(id: apiSessionID, error: "Failed to finalize recording")
                 }
             }
+        }
+    }
+
+    private func finalizedRecordingSamples(
+        from outputURL: URL,
+        fallback captureSamples: [Float]
+    ) async -> [Float] {
+        do {
+            let samples = try await audioSamplesLoader(outputURL)
+            guard !samples.isEmpty else {
+                logger.warning(
+                    "Finalized recording contained no transcription samples; using capture buffer"
+                )
+                return captureSamples
+            }
+            return samples
+        } catch {
+            logger.warning(
+                "Could not load finalized recording for transcription; using capture buffer: \(error.localizedDescription, privacy: .public)"
+            )
+            return captureSamples
         }
     }
 

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -450,6 +450,57 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertNil(recording.transcriptionFailure)
     }
 
+    func testCalendarMeetingFinalTranscriptionUsesFinalizedRecordingSamples() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .success("complete meeting transcript"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let captureSamples = Array(
+            repeating: Float(0.1),
+            count: Int(AudioRecorderService.transcriptionSampleRate)
+        )
+        let finalizedFileSamples = Array(
+            repeating: Float(0.6),
+            count: Int(AudioRecorderService.transcriptionSampleRate * 2)
+        )
+        let recorderService = makeRecorderService(
+            recordingsDirectory: recordingsDirectory,
+            samples: captureSamples
+        )
+        var loadedURL: URL?
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: recorderService,
+            audioSamplesLoader: { url in
+                loadedURL = url
+                return finalizedFileSamples
+            }
+        )
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let handle = try await viewModel.startCalendarMeetingRecording(
+            preferredBaseName: "RC2 Meeting"
+        )
+        try viewModel.stopCalendarMeetingRecording(handle: handle)
+
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        XCTAssertEqual(loadedURL?.standardizedFileURL, handle.outputURL.standardizedFileURL)
+        let plugin = try XCTUnwrap(
+            PluginManager.shared.transcriptionEngine(for: "groq")
+                as? AudioRecorderMockTranscriptionPlugin
+        )
+        let request = try XCTUnwrap(plugin.lastRequest)
+        XCTAssertEqual(request.audioSampleCount, finalizedFileSamples.count)
+        XCTAssertEqual(request.firstAudioSample, finalizedFileSamples.first)
+        XCTAssertNotEqual(request.audioSampleCount, captureSamples.count)
+        XCTAssertEqual(viewModel.recordings.first?.transcript, "complete meeting transcript")
+    }
+
     func testFinalTranscriptionDoesNotForceGlobalDefaultModelAsRecorderOverride() async throws {
         try preserveStandardDefaults()
         let defaults = try makeDefaults()
@@ -1409,6 +1460,8 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         let language: String?
         let translate: Bool
         let prompt: String?
+        let audioSampleCount: Int
+        let firstAudioSample: Float?
     }
 
     enum TranscriptionBehavior {
@@ -1468,7 +1521,13 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
-        lastRequest = Request(language: language, translate: translate, prompt: prompt)
+        lastRequest = Request(
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            audioSampleCount: audio.samples.count,
+            firstAudioSample: audio.samples.first
+        )
         return switch behavior {
         case .success(let text):
             PluginTranscriptionResult(text: text)

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -7252,7 +7252,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
         let audioFileService = AudioFileService()
         let audioRecordingService = AudioRecordingService(
-            bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer
+            bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer,
+            defaultInputController: APIFakeAudioInputDeviceDefaultController(defaultInputDeviceID: nil),
+            inputTransportResolver: FakeAudioDeviceTransportResolver(transports: [:])
         )
         let audioRecorderService = AudioRecorderService()
         audioRecorderService.recordingsDirectoryOverride = appSupportDirectory.appendingPathComponent("recordings")
@@ -7578,6 +7580,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         let audioRecordingService = AudioRecordingService(
             bluetoothInputRouteStabilizer: audioRecordingBluetoothInputRouteStabilizer,
+            defaultInputController: APIFakeAudioInputDeviceDefaultController(defaultInputDeviceID: nil),
+            inputTransportResolver: FakeAudioDeviceTransportResolver(transports: [:]),
             recoveryAudioStore: audioRecordingRecoveryAudioStore
         )
         let hotkeyService = HotkeyService()


### PR DESCRIPTION
## Summary

- transcribe finalized meeting recordings from the saved audio file instead of the transient capture buffer
- fall back to the capture buffer when the finalized file cannot be loaded
- preserve the existing live-transcription result path to avoid duplicate provider requests
- add a regression test covering the calendar meeting recorder flow
- isolate API and dictation integration fixtures from real CoreAudio input prewarming

## Issue context

In #1091, an automatically detected Microsoft Teams meeting produced a complete saved recording, but the transcript under Recorder omitted most of the meeting. Transcribing the same saved file manually produced a substantially more complete result.

The recorder's batch transcription path used the separately accumulated in-memory transcription samples, while manual file transcription decoded the finalized recording. If those inputs diverged, the automatic transcript could be incomplete even though the saved recording was intact. This change makes both paths use the finalized recording as their source of truth.

Closes #1091

## User impact

Automatic meeting recordings processed by batch engines such as Whisper Large V3 now transcribe the same finalized audio that users can transcribe manually from the saved file.

## Test plan

- [x] Regression test:
  ```shell
  xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testCalendarMeetingFinalTranscriptionUsesFinalizedRecordingSamples CODE_SIGNING_ALLOWED=NO
  ```
- [x] Focused recorder and meeting automation suites:
  ```shell
  xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/CalendarMeetingAutomationControllerTests -only-testing:TypeWhisperTests/RecorderTranscriptionBufferTests CODE_SIGNING_ALLOWED=NO
  ```
- [x] Complete integration test suite:
  ```shell
  xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests CODE_SIGNING_ALLOWED=NO
  ```
- [x] Plugin SDK tests (585 tests):
  ```shell
  swift test --package-path TypeWhisperPluginSDK --skip-update
  ```
- [x] Signed development build and launch:
  ```shell
  /Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-ce05755c
  codesign --verify --deep --strict --verbose=2 /Users/marco/Projects/typewhisper-mac-dev/Build/TypeWhisper.app
  ```
- [x] Diff validation:
  ```shell
  git diff --check origin/main...HEAD
  ```

## Validation notes

An earlier full macOS test run completed 1,226 tests before API integration tests spent minutes in real CoreAudio input prewarming. The API and dictation test fixtures now use fake input controllers and transport resolvers; the complete `TypeWhisperIntegrationTests` suite passes locally in about 22 seconds, including both previously slow API tests. The repository preflight additionally reports two pre-existing incomplete Simplified Chinese AirPods localizations; the localization catalog is byte-identical to `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Final transcriptions now use audio from the completed recording when live transcription results are unavailable.
  * Added a fallback to captured audio when the finalized recording cannot be loaded or contains no usable data.

* **Tests**
  * Added coverage confirming finalized recording audio is used for meeting transcriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->