### PR TITLE
Add calendar metadata to meeting transcripts

### DIFF
--- a/TypeWhisper/Models/CalendarMeetingAutomationModels.swift
+++ b/TypeWhisper/Models/CalendarMeetingAutomationModels.swift
@@ -88,6 +88,52 @@ struct CalendarMeetingCanonicalLink: Codable, Hashable, Sendable, Identifiable {
     var id: String { "\(provider.rawValue):\(identity)" }
 }
 
+enum CalendarMeetingParticipantStatus: String, Codable, Sendable {
+    case accepted
+    case tentative
+    case pending
+    case declined
+    case delegated
+    case completed
+    case inProcess
+    case unknown
+}
+
+struct CalendarMeetingParticipant: Codable, Equatable, Sendable {
+    let name: String?
+    let emailAddress: String?
+    let status: CalendarMeetingParticipantStatus
+    let isCurrentUser: Bool
+}
+
+struct CalendarMeetingTranscriptMetadata: Codable, Equatable, Sendable {
+    let eventIdentifier: String
+    let title: String
+    let startDate: Date
+    let endDate: Date
+    let location: String?
+    let organizer: CalendarMeetingParticipant?
+    let attendees: [CalendarMeetingParticipant]
+}
+
+struct RecordingTranscriptDocument: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let text: String?
+    let calendarEvent: CalendarMeetingTranscriptMetadata
+
+    init(
+        schemaVersion: Int = currentSchemaVersion,
+        text: String?,
+        calendarEvent: CalendarMeetingTranscriptMetadata
+    ) {
+        self.schemaVersion = schemaVersion
+        self.text = text
+        self.calendarEvent = calendarEvent
+    }
+}
+
 struct CalendarMeetingOccurrence: Identifiable, Equatable, Sendable {
     let eventIdentifier: String
     let occurrenceStart: Date
@@ -97,6 +143,7 @@ struct CalendarMeetingOccurrence: Identifiable, Equatable, Sendable {
     let calendarID: String
     let participationStatus: CalendarMeetingParticipationStatus
     let meetingLinks: [CalendarMeetingCanonicalLink]
+    let transcriptMetadata: CalendarMeetingTranscriptMetadata
     let occurrenceDigest: String
 
     var id: String { occurrenceDigest }
@@ -109,7 +156,10 @@ struct CalendarMeetingOccurrence: Identifiable, Equatable, Sendable {
         title: String,
         calendarID: String,
         participationStatus: CalendarMeetingParticipationStatus,
-        meetingLinks: [CalendarMeetingCanonicalLink]
+        meetingLinks: [CalendarMeetingCanonicalLink],
+        location: String? = nil,
+        organizer: CalendarMeetingParticipant? = nil,
+        attendees: [CalendarMeetingParticipant] = []
     ) {
         self.eventIdentifier = eventIdentifier
         self.occurrenceStart = occurrenceStart
@@ -119,6 +169,15 @@ struct CalendarMeetingOccurrence: Identifiable, Equatable, Sendable {
         self.calendarID = calendarID
         self.participationStatus = participationStatus
         self.meetingLinks = meetingLinks
+        transcriptMetadata = CalendarMeetingTranscriptMetadata(
+            eventIdentifier: eventIdentifier,
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            location: location,
+            organizer: organizer,
+            attendees: attendees
+        )
         occurrenceDigest = CalendarMeetingOccurrenceDigest.make(
             eventIdentifier: eventIdentifier,
             occurrenceStart: occurrenceStart

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -35486,6 +35486,62 @@
         }
       }
     },
+    "calendarMeeting.settings.configureTranscription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recorder konfigurieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configure Recorder"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "レコーダーを設定"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "配置录音器"
+          }
+        }
+      }
+    },
+    "calendarMeeting.settings.transcriptionHelp" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erstellt nach kalendergestarteten Aufnahmen ein Transkript. Kalender-Metadaten werden unabhängig davon lokal neben der Aufnahme gespeichert."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creates a transcript after calendar-started recordings. Calendar metadata is stored locally alongside the recording either way."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "カレンダーから開始した録音の終了後に文字起こしを作成します。カレンダーのメタデータは、この設定に関係なく録音とともにローカルに保存されます。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "为日历启动的录音生成转录。无论此设置如何，日历元数据都会与录音一起存储在本机。"
+          }
+        }
+      }
+    },
     "calendarMeeting.settings.startMode" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -35525,7 +35525,7 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Creates a transcript after calendar-started recordings. Calendar metadata is stored locally alongside the recording either way."
+            "value" : "Creates a transcript after a calendar-started recording ends. Calendar metadata is stored locally alongside the recording either way."
           }
         },
         "ja" : {
@@ -35537,7 +35537,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "为日历启动的录音生成转录。无论此设置如何，日历元数据都会与录音一起存储在本机。"
+            "value" : "在日历启动的录音结束后生成转录。无论此设置如何，日历元数据都会与录音一起存储在本机。"
           }
         }
       }

--- a/TypeWhisper/Services/CalendarMeetingAutomationController.swift
+++ b/TypeWhisper/Services/CalendarMeetingAutomationController.swift
@@ -940,11 +940,12 @@ final class CalendarMeetingAutomationController: ObservableObject {
 
             let preferredBaseName = CalendarMeetingRecordingFilename.preferredBaseName(
                 title: occurrence.title,
-                date: self.nowProvider()
+                date: occurrence.startDate
             )
             do {
                 let handle = try await self.recorderViewModel.startCalendarMeetingRecording(
-                    preferredBaseName: preferredBaseName
+                    preferredBaseName: preferredBaseName,
+                    transcriptMetadata: occurrence.transcriptMetadata
                 )
                 guard generation == self.recordingStartGeneration,
                       self.hasPremiumAccess,

--- a/TypeWhisper/Services/CalendarMeetingRecordingFilename.swift
+++ b/TypeWhisper/Services/CalendarMeetingRecordingFilename.swift
@@ -6,12 +6,12 @@ enum CalendarMeetingRecordingFilename {
     private static let maximumFilenameUTF8Bytes = 255
 
     static func preferredBaseName(title: String, date: Date = Date()) -> String {
-        let timestamp = timestampString(for: date)
+        let datePrefix = datePrefixString(for: date)
         let sanitizedTitle = sanitizeTitle(title)
         if sanitizedTitle.isEmpty {
-            return "Recording \(timestamp)"
+            return "\(datePrefix) - Recording"
         }
-        return "\(sanitizedTitle) — \(timestamp)"
+        return "\(datePrefix) - \(sanitizedTitle)"
     }
 
     static func sanitizedBaseName(_ value: String, fallbackDate: Date = Date()) -> String {
@@ -94,6 +94,15 @@ enum CalendarMeetingRecordingFilename {
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = .autoupdatingCurrent
         formatter.dateFormat = "yyyy-MM-dd HH.mm.ss"
+        return formatter.string(from: date)
+    }
+
+    private static func datePrefixString(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = .autoupdatingCurrent
+        formatter.dateFormat = "yyyyMMdd"
         return formatter.string(from: date)
     }
 }

--- a/TypeWhisper/Services/EventKitCalendarMeetingProvider.swift
+++ b/TypeWhisper/Services/EventKitCalendarMeetingProvider.swift
@@ -176,8 +176,59 @@ actor EventKitCalendarMeetingProvider: CalendarMeetingEventProviding {
             title: event.title ?? "",
             calendarID: event.calendar.calendarIdentifier,
             participationStatus: participationStatus,
-            meetingLinks: links
+            meetingLinks: links,
+            location: Self.normalized(event.location),
+            organizer: event.organizer.map(Self.participantMetadata),
+            attendees: (event.attendees ?? []).map(Self.participantMetadata)
         )
+    }
+
+    private static func participantMetadata(
+        _ participant: EKParticipant
+    ) -> CalendarMeetingParticipant {
+        CalendarMeetingParticipant(
+            name: normalized(participant.name),
+            emailAddress: emailAddress(from: participant.url),
+            status: participantStatusMetadata(participant.participantStatus),
+            isCurrentUser: participant.isCurrentUser
+        )
+    }
+
+    private static func emailAddress(from url: URL) -> String? {
+        guard url.scheme?.lowercased() == "mailto" else { return nil }
+        var address = String(url.absoluteString.dropFirst("mailto:".count))
+        if address.hasPrefix("//") {
+            address.removeFirst(2)
+        }
+        address = address
+            .split(whereSeparator: { $0 == "?" || $0 == "#" })
+            .first
+            .map(String.init) ?? ""
+        return normalized(address.removingPercentEncoding ?? address)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+
+    private static func participantStatusMetadata(
+        _ status: EKParticipantStatus
+    ) -> CalendarMeetingParticipantStatus {
+        switch status {
+        case .accepted: .accepted
+        case .tentative: .tentative
+        case .pending: .pending
+        case .declined: .declined
+        case .delegated: .delegated
+        case .completed: .completed
+        case .inProcess: .inProcess
+        case .unknown: .unknown
+        @unknown default: .unknown
+        }
     }
 
     nonisolated static func mapAuthorization(

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -476,7 +476,8 @@ final class AudioRecorderViewModel: ObservableObject {
                     micEnabled: micEnabled,
                     systemAudioEnabled: systemAudioEnabled,
                     apiSessionID: nil,
-                    preferredBaseName: nil
+                    preferredBaseName: nil,
+                    transcriptMetadata: nil
                 )
             } catch {
                 errorMessage = error.localizedDescription
@@ -493,7 +494,8 @@ final class AudioRecorderViewModel: ObservableObject {
         micEnabled requestedMicEnabled: Bool,
         systemAudioEnabled requestedSystemAudioEnabled: Bool,
         apiSessionID: UUID?,
-        preferredBaseName: String?
+        preferredBaseName: String?,
+        transcriptMetadata: CalendarMeetingTranscriptMetadata?
     ) async throws -> URL {
         guard retranscribingRecordingURL == nil else {
             throw RecorderAPIError.retranscribing
@@ -515,7 +517,7 @@ final class AudioRecorderViewModel: ObservableObject {
         errorMessage = nil
         systemAudioWarningMessage = nil
         partialText = ""
-        activeCalendarMeetingTranscriptMetadata = nil
+        activeCalendarMeetingTranscriptMetadata = transcriptMetadata
         reconcileSelectionWithAvailablePlugins()
         state = .recording
         let microphoneSelection = requestedMicEnabled
@@ -541,6 +543,7 @@ final class AudioRecorderViewModel: ObservableObject {
             }
             state = .idle
             currentOutputURL = nil
+            activeCalendarMeetingTranscriptMetadata = nil
             if let apiSessionID {
                 activeRecorderAPISessionID = nil
                 recorderAPISessions.removeValue(forKey: apiSessionID)
@@ -716,7 +719,8 @@ final class AudioRecorderViewModel: ObservableObject {
             micEnabled: resolvedMicEnabled,
             systemAudioEnabled: resolvedSystemAudioEnabled,
             apiSessionID: sessionID,
-            preferredBaseName: nil
+            preferredBaseName: nil,
+            transcriptMetadata: nil
         )
         return sessionID
     }
@@ -750,7 +754,8 @@ final class AudioRecorderViewModel: ObservableObject {
             micEnabled: micEnabled,
             systemAudioEnabled: systemAudioEnabled,
             apiSessionID: nil,
-            preferredBaseName: preferredBaseName
+            preferredBaseName: preferredBaseName,
+            transcriptMetadata: transcriptMetadata
         )
         guard state == .recording else {
             activeCalendarMeetingHandle = nil
@@ -758,7 +763,6 @@ final class AudioRecorderViewModel: ObservableObject {
         }
         let handle = CalendarMeetingRecordingHandle(id: UUID(), outputURL: outputURL)
         activeCalendarMeetingHandle = handle
-        activeCalendarMeetingTranscriptMetadata = transcriptMetadata
         return handle
     }
 
@@ -821,15 +825,24 @@ final class AudioRecorderViewModel: ObservableObject {
         guard !isRetranscribing(item) else { return }
 
         do {
-            try FileManager.default.removeItem(at: item.url)
-            // Also delete sidecar transcript
-            let txtURL = item.url.deletingPathExtension().appendingPathExtension("txt")
-            try? FileManager.default.removeItem(at: txtURL)
-            try? FileManager.default.removeItem(at: transcriptDocumentURL(for: item.url))
-            clearTranscriptionFailure(for: item.url)
+            try removeRecordingFileIfPresent(at: transcriptURL(for: item.url))
+            try removeRecordingFileIfPresent(at: transcriptDocumentURL(for: item.url))
+            try removeRecordingFileIfPresent(at: transcriptionFailureURL(for: item.url))
+            try removeRecordingFileIfPresent(at: item.url)
+            transientTranscriptionFailures.removeValue(
+                forKey: transcriptionFailureKey(for: item.url)
+            )
             recordings.removeAll { $0.id == item.id }
         } catch {
             errorMessage = error.localizedDescription
+        }
+    }
+
+    private func removeRecordingFileIfPresent(at url: URL) throws {
+        do {
+            try FileManager.default.removeItem(at: url)
+        } catch let error as CocoaError where error.code == .fileNoSuchFile {
+            return
         }
     }
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -75,6 +75,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let prompt: String?
         let dictionaryTermHints: [PluginDictionaryTermHint]
         let liveSessionResult: TranscriptionResult?
+        let calendarEvent: CalendarMeetingTranscriptMetadata?
     }
 
     struct RecordingTranscriptionFailure: Codable, Equatable, Sendable {
@@ -126,7 +127,26 @@ final class AudioRecorderViewModel: ObservableObject {
         let fileSize: Int64
         let transcript: String?
         let transcriptionFailure: RecordingTranscriptionFailure?
+        let calendarEvent: CalendarMeetingTranscriptMetadata?
         var fileName: String { url.lastPathComponent }
+
+        init(
+            url: URL,
+            date: Date,
+            duration: TimeInterval,
+            fileSize: Int64,
+            transcript: String?,
+            transcriptionFailure: RecordingTranscriptionFailure?,
+            calendarEvent: CalendarMeetingTranscriptMetadata? = nil
+        ) {
+            self.url = url
+            self.date = date
+            self.duration = duration
+            self.fileSize = fileSize
+            self.transcript = transcript
+            self.transcriptionFailure = transcriptionFailure
+            self.calendarEvent = calendarEvent
+        }
     }
 
     @Published var state: RecorderState = .idle
@@ -231,6 +251,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
     private var currentOutputURL: URL?
     private var activeCalendarMeetingHandle: CalendarMeetingRecordingHandle?
+    private var activeCalendarMeetingTranscriptMetadata: CalendarMeetingTranscriptMetadata?
     private var activeRecorderAPISessionID: UUID?
     private var recorderAPISessions: [UUID: RecorderAPISessionSnapshot] = [:]
     private var transientTranscriptionFailures: [String: RecordingTranscriptionFailure] = [:]
@@ -494,6 +515,7 @@ final class AudioRecorderViewModel: ObservableObject {
         errorMessage = nil
         systemAudioWarningMessage = nil
         partialText = ""
+        activeCalendarMeetingTranscriptMetadata = nil
         reconcileSelectionWithAvailablePlugins()
         state = .recording
         let microphoneSelection = requestedMicEnabled
@@ -551,6 +573,8 @@ final class AudioRecorderViewModel: ObservableObject {
 
     private func stopRecording(apiSessionID: UUID?) {
         activeCalendarMeetingHandle = nil
+        let calendarEvent = activeCalendarMeetingTranscriptMetadata
+        activeCalendarMeetingTranscriptMetadata = nil
         let recordingDuration = duration
         let shouldTranscribe = transcriptionEnabled
 
@@ -568,6 +592,20 @@ final class AudioRecorderViewModel: ObservableObject {
             )
             async let finalizedURLTask = recorderService.finalizeRecording(stoppedRecording)
             let (liveSessionResult, url) = await (liveSessionResultTask, finalizedURLTask)
+
+            if let url, let calendarEvent {
+                do {
+                    try saveTranscriptDocument(
+                        text: nil,
+                        calendarEvent: calendarEvent,
+                        for: url
+                    )
+                } catch {
+                    logger.error(
+                        "Failed to save calendar transcript metadata: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
 
             let finalTranscriptionRequest: FinalTranscriptionRequest?
             if shouldTranscribe, let url {
@@ -592,7 +630,8 @@ final class AudioRecorderViewModel: ObservableObject {
                     modelOverrideId: selectedModel,
                     prompt: dictionaryPrompt,
                     dictionaryTermHints: dictionaryTermHints,
-                    liveSessionResult: liveSessionResult
+                    liveSessionResult: liveSessionResult,
+                    calendarEvent: calendarEvent
                 )
                 if let apiSessionID {
                     markRecorderAPISessionFinalizing(id: apiSessionID, outputURL: url)
@@ -704,7 +743,8 @@ final class AudioRecorderViewModel: ObservableObject {
     // MARK: - Calendar Meeting Automation
 
     func startCalendarMeetingRecording(
-        preferredBaseName: String
+        preferredBaseName: String,
+        transcriptMetadata: CalendarMeetingTranscriptMetadata? = nil
     ) async throws -> CalendarMeetingRecordingHandle {
         let outputURL = try await beginRecording(
             micEnabled: micEnabled,
@@ -718,6 +758,7 @@ final class AudioRecorderViewModel: ObservableObject {
         }
         let handle = CalendarMeetingRecordingHandle(id: UUID(), outputURL: outputURL)
         activeCalendarMeetingHandle = handle
+        activeCalendarMeetingTranscriptMetadata = transcriptMetadata
         return handle
     }
 
@@ -784,6 +825,7 @@ final class AudioRecorderViewModel: ObservableObject {
             // Also delete sidecar transcript
             let txtURL = item.url.deletingPathExtension().appendingPathExtension("txt")
             try? FileManager.default.removeItem(at: txtURL)
+            try? FileManager.default.removeItem(at: transcriptDocumentURL(for: item.url))
             clearTranscriptionFailure(for: item.url)
             recordings.removeAll { $0.id == item.id }
         } catch {
@@ -832,7 +874,8 @@ final class AudioRecorderViewModel: ObservableObject {
                 modelOverrideId: self.selectedModel,
                 prompt: self.dictionaryService.getTermsForPrompt(providerId: providerId),
                 dictionaryTermHints: self.dictionaryService.getTermHints(providerId: providerId),
-                liveSessionResult: nil
+                liveSessionResult: nil,
+                calendarEvent: item.calendarEvent
             )
 
             _ = await self.runRetranscription(request)
@@ -902,7 +945,17 @@ final class AudioRecorderViewModel: ObservableObject {
                 let size = (attrs[.size] as? Int64) ?? 0
                 let duration = audioDuration(for: url)
                 let transcriptURL = url.deletingPathExtension().appendingPathExtension("txt")
-                let transcript = try? String(contentsOf: transcriptURL, encoding: .utf8)
+                let transcriptDocumentURL = url
+                    .deletingPathExtension()
+                    .appendingPathExtension("transcript.json")
+                let transcriptDocument = (try? Data(contentsOf: transcriptDocumentURL))
+                    .flatMap { data -> RecordingTranscriptDocument? in
+                        let decoder = JSONDecoder()
+                        decoder.dateDecodingStrategy = .iso8601
+                        return try? decoder.decode(RecordingTranscriptDocument.self, from: data)
+                    }
+                let transcript = (try? String(contentsOf: transcriptURL, encoding: .utf8))
+                    ?? transcriptDocument?.text
                 let failureURL = url.appendingPathExtension("transcription-failure.json")
                 let persistedFailure = (try? Data(contentsOf: failureURL))
                     .flatMap { try? JSONDecoder().decode(RecordingTranscriptionFailure.self, from: $0) }
@@ -913,7 +966,8 @@ final class AudioRecorderViewModel: ObservableObject {
                     duration: duration,
                     fileSize: size,
                     transcript: transcript,
-                    transcriptionFailure: persistedFailure ?? transientFailures[failureKey]
+                    transcriptionFailure: persistedFailure ?? transientFailures[failureKey],
+                    calendarEvent: transcriptDocument?.calendarEvent
                 )
             }
             .sorted { $0.date > $1.date }
@@ -1117,7 +1171,8 @@ final class AudioRecorderViewModel: ObservableObject {
             modelOverrideId: selectedModel,
             prompt: nil,
             dictionaryTermHints: [],
-            liveSessionResult: nil
+            liveSessionResult: nil,
+            calendarEvent: nil
         )
         let failure = makeTranscriptionFailure(
             phase: phase,
@@ -1134,10 +1189,41 @@ final class AudioRecorderViewModel: ObservableObject {
         audioURL.deletingPathExtension().appendingPathExtension("txt")
     }
 
-    private func saveTranscript(_ text: String, for audioURL: URL) throws {
+    private func saveTranscript(
+        _ text: String,
+        for audioURL: URL,
+        calendarEvent: CalendarMeetingTranscriptMetadata?
+    ) throws {
         let txtURL = transcriptURL(for: audioURL)
         try text.write(to: txtURL, atomically: true, encoding: .utf8)
+        if let calendarEvent {
+            try saveTranscriptDocument(
+                text: text,
+                calendarEvent: calendarEvent,
+                for: audioURL
+            )
+        }
         clearTranscriptionFailure(for: audioURL)
+    }
+
+    private func transcriptDocumentURL(for audioURL: URL) -> URL {
+        audioURL.deletingPathExtension().appendingPathExtension("transcript.json")
+    }
+
+    private func saveTranscriptDocument(
+        text: String?,
+        calendarEvent: CalendarMeetingTranscriptMetadata,
+        for audioURL: URL
+    ) throws {
+        let document = RecordingTranscriptDocument(
+            text: text,
+            calendarEvent: calendarEvent
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(document)
+        try data.write(to: transcriptDocumentURL(for: audioURL), options: .atomic)
     }
 
     private func loadTranscript(for audioURL: URL) -> String? {
@@ -1151,7 +1237,11 @@ final class AudioRecorderViewModel: ObservableObject {
         request: FinalTranscriptionRequest
     ) -> FinalTranscriptionOutcome {
         do {
-            try saveTranscript(text, for: audioURL)
+            try saveTranscript(
+                text,
+                for: audioURL,
+                calendarEvent: request.calendarEvent
+            )
             return .transcriptSaved
         } catch {
             logger.error("Failed to save transcript: \(error.localizedDescription)")

--- a/TypeWhisper/Views/CalendarMeetingSettingsSection.swift
+++ b/TypeWhisper/Views/CalendarMeetingSettingsSection.swift
@@ -3,6 +3,15 @@ import SwiftUI
 @MainActor
 struct CalendarMeetingSettingsSection: View {
     @ObservedObject var controller: CalendarMeetingAutomationController
+    @ObservedObject private var recorderViewModel: AudioRecorderViewModel
+
+    init(
+        controller: CalendarMeetingAutomationController,
+        recorderViewModel: AudioRecorderViewModel = .shared
+    ) {
+        self.controller = controller
+        self.recorderViewModel = recorderViewModel
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
@@ -37,6 +46,50 @@ struct CalendarMeetingSettingsSection: View {
                     Text(String(localized: "calendarMeeting.settings.startModeHelp"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                }
+            }
+
+            SettingsCard {
+                VStack(alignment: .leading, spacing: 10) {
+                    Text(String(localized: "recorder.transcription"))
+                        .font(.headline)
+
+                    Toggle(
+                        String(localized: "recorder.createTranscriptAfterRecording"),
+                        isOn: $recorderViewModel.transcriptionEnabled
+                    )
+                    .toggleStyle(.switch)
+                    .disabled(recorderViewModel.state != .idle)
+                    .accessibilityIdentifier("calendarMeeting.transcriptionEnabled")
+
+                    Text(String(localized: "calendarMeeting.settings.transcriptionHelp"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if recorderViewModel.transcriptionEnabled {
+                        Divider()
+
+                        LabeledContent(String(localized: "recorder.effectiveEngine")) {
+                            Text(
+                                recorderViewModel.activeEngineName
+                                    ?? String(localized: "recorder.noEngineSelected")
+                            )
+                        }
+
+                        LabeledContent(String(localized: "recorder.effectiveModel")) {
+                            Text(
+                                recorderViewModel.activeModelName
+                                    ?? String(localized: "watchFolder.model.default")
+                            )
+                        }
+
+                        Button(String(localized: "calendarMeeting.settings.configureTranscription")) {
+                            SettingsNavigationCoordinator.shared.navigate(to: .recorder)
+                            ManagedAppWindowOpener.shared.open(id: "settings")
+                        }
+                        .buttonStyle(.link)
+                        .accessibilityIdentifier("calendarMeeting.configureTranscription")
+                    }
                 }
             }
 

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -558,6 +558,47 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: documentURL.path))
     }
 
+    func testDeleteRecordingRetainsAudioWhenCalendarMetadataCannotBeDeleted() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory)
+        )
+        viewModel.transcriptionEnabled = false
+        viewModel.livePreviewEnabled = false
+
+        let handle = try await viewModel.startCalendarMeetingRecording(
+            preferredBaseName: "Protected metadata",
+            transcriptMetadata: makeCalendarMeetingTranscriptMetadata(title: "Protected metadata")
+        )
+        try viewModel.stopCalendarMeetingRecording(handle: handle)
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        let documentURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.json")
+        try FileManager.default.setAttributes(
+            [.immutable: true],
+            ofItemAtPath: documentURL.path
+        )
+        defer {
+            try? FileManager.default.setAttributes(
+                [.immutable: false],
+                ofItemAtPath: documentURL.path
+            )
+        }
+
+        viewModel.deleteRecording(recording)
+
+        XCTAssertTrue(FileManager.default.fileExists(atPath: handle.outputURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: documentURL.path))
+        XCTAssertEqual(viewModel.recordings.map(\.id), [recording.id])
+        XCTAssertNotNil(viewModel.errorMessage)
+    }
+
     func testFinalTranscriptionDoesNotForceGlobalDefaultModelAsRecorderOverride() async throws {
         try preserveStandardDefaults()
         let defaults = try makeDefaults()

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -482,8 +482,10 @@ final class AudioRecorderViewModelTests: XCTestCase {
         viewModel.transcriptionEnabled = true
         viewModel.livePreviewEnabled = false
 
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "RC2 Meeting")
         let handle = try await viewModel.startCalendarMeetingRecording(
-            preferredBaseName: "RC2 Meeting"
+            preferredBaseName: "RC2 Meeting",
+            transcriptMetadata: metadata
         )
         try viewModel.stopCalendarMeetingRecording(handle: handle)
 
@@ -498,7 +500,62 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(request.audioSampleCount, finalizedFileSamples.count)
         XCTAssertEqual(request.firstAudioSample, finalizedFileSamples.first)
         XCTAssertNotEqual(request.audioSampleCount, captureSamples.count)
-        XCTAssertEqual(viewModel.recordings.first?.transcript, "complete meeting transcript")
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertEqual(recording.transcript, "complete meeting transcript")
+        XCTAssertEqual(recording.calendarEvent, metadata)
+
+        let documentURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.json")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let document = try decoder.decode(
+            RecordingTranscriptDocument.self,
+            from: Data(contentsOf: documentURL)
+        )
+        XCTAssertEqual(document.schemaVersion, RecordingTranscriptDocument.currentSchemaVersion)
+        XCTAssertEqual(document.text, "complete meeting transcript")
+        XCTAssertEqual(document.calendarEvent, metadata)
+    }
+
+    func testCalendarMetadataPersistsWithoutTranscriptionAndIsDeletedWithRecording() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory)
+        )
+        viewModel.transcriptionEnabled = false
+        viewModel.livePreviewEnabled = false
+
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "Planning")
+        let handle = try await viewModel.startCalendarMeetingRecording(
+            preferredBaseName: "Planning",
+            transcriptMetadata: metadata
+        )
+        try viewModel.stopCalendarMeetingRecording(handle: handle)
+
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertNil(recording.transcript)
+        XCTAssertEqual(recording.calendarEvent, metadata)
+
+        let documentURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.json")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let document = try decoder.decode(
+            RecordingTranscriptDocument.self,
+            from: Data(contentsOf: documentURL)
+        )
+        XCTAssertNil(document.text)
+        XCTAssertEqual(document.calendarEvent, metadata)
+
+        viewModel.deleteRecording(recording)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: handle.outputURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: documentURL.path))
     }
 
     func testFinalTranscriptionDoesNotForceGlobalDefaultModelAsRecorderOverride() async throws {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -27,6 +27,30 @@ private actor RecorderStopFinalizationGate {
     }
 }
 
+private actor RecorderStartGate {
+    private var continuation: CheckedContinuation<URL, Never>?
+    private var started = false
+    private var outputURL: URL?
+
+    func wait(outputURL: URL) async -> URL {
+        started = true
+        self.outputURL = outputURL
+        return await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func hasStarted() -> Bool {
+        started
+    }
+
+    func resume() {
+        guard let continuation, let outputURL else { return }
+        continuation.resume(returning: outputURL)
+        self.continuation = nil
+    }
+}
+
 private final class BlockingRecordingsLoader: @unchecked Sendable {
     let started = DispatchSemaphore(value: 0)
     let release = DispatchSemaphore(value: 0)
@@ -513,9 +537,99 @@ final class AudioRecorderViewModelTests: XCTestCase {
             RecordingTranscriptDocument.self,
             from: Data(contentsOf: documentURL)
         )
-        XCTAssertEqual(document.schemaVersion, RecordingTranscriptDocument.currentSchemaVersion)
+        XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertEqual(document.text, "complete meeting transcript")
         XCTAssertEqual(document.calendarEvent, metadata)
+    }
+
+    func testCalendarMetadataPersistsWhenFinalTranscriptionFails() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .failure("provider unavailable"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let viewModel = makeFinalTranscriptionViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recordingsDirectory: recordingsDirectory
+        )
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "Failed meeting")
+
+        let handle = try await viewModel.startCalendarMeetingRecording(
+            preferredBaseName: "Failed meeting",
+            transcriptMetadata: metadata
+        )
+        try viewModel.stopCalendarMeetingRecording(handle: handle)
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertNil(recording.transcript)
+        XCTAssertEqual(recording.calendarEvent, metadata)
+        XCTAssertEqual(recording.transcriptionFailure?.phase, .finalTranscription)
+
+        let documentURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.json")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let document = try decoder.decode(
+            RecordingTranscriptDocument.self,
+            from: Data(contentsOf: documentURL)
+        )
+        XCTAssertEqual(document.schemaVersion, 1)
+        XCTAssertNil(document.text)
+        XCTAssertEqual(document.calendarEvent, metadata)
+    }
+
+    func testManualStopDuringCalendarStartupPersistsMetadata() async throws {
+        try preserveStandardDefaults()
+        let defaults = try makeDefaults()
+        let recordingsDirectory = makeTemporaryDirectory()
+        let recorderService = AudioRecorderService()
+        recorderService.recordingsDirectoryOverride = recordingsDirectory
+        let startGate = RecorderStartGate()
+        recorderService.startRecordingOverride = { _, _, _, outputURL, _ in
+            try Data("starting".utf8).write(to: outputURL)
+            return await startGate.wait(outputURL: outputURL)
+        }
+        recorderService.stopRecordingOverride = { outputURL in
+            try Data("recorded".utf8).write(to: outputURL)
+            return outputURL
+        }
+        let viewModel = makeViewModel(defaults: defaults, recorderService: recorderService)
+        viewModel.transcriptionEnabled = false
+        viewModel.livePreviewEnabled = false
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "Startup race")
+
+        let startTask = Task {
+            try await viewModel.startCalendarMeetingRecording(
+                preferredBaseName: "Startup race",
+                transcriptMetadata: metadata
+            )
+        }
+        for _ in 0..<100 where !(await startGate.hasStarted()) {
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        let startupDidSuspend = await startGate.hasStarted()
+        XCTAssertTrue(startupDidSuspend)
+        XCTAssertEqual(viewModel.state, .recording)
+
+        viewModel.stopRecording()
+        await startGate.resume()
+        do {
+            _ = try await startTask.value
+            XCTFail("Expected startup to observe the manual stop")
+        } catch let error as AudioRecorderViewModel.RecorderAPIError {
+            guard case .notRecording = error else {
+                return XCTFail("Expected notRecording, got \(error)")
+            }
+        }
+
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+        let recording = try XCTUnwrap(viewModel.recordings.first)
+        XCTAssertEqual(recording.calendarEvent, metadata)
+        XCTAssertNil(recording.transcript)
     }
 
     func testCalendarMetadataPersistsWithoutTranscriptionAndIsDeletedWithRecording() async throws {
@@ -550,6 +664,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
             RecordingTranscriptDocument.self,
             from: Data(contentsOf: documentURL)
         )
+        XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertNil(document.text)
         XCTAssertEqual(document.calendarEvent, metadata)
 
@@ -688,8 +803,16 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let audioURL = recordingsDirectory.appendingPathComponent("Meeting.m4a")
         let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
         let failureURL = failureSidecarURL(for: audioURL)
+        let documentURL = audioURL.deletingPathExtension().appendingPathExtension("transcript.json")
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "Meeting")
         try Data("audio".utf8).write(to: audioURL)
         try "old transcript".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(RecordingTranscriptDocument(
+            text: "old transcript",
+            calendarEvent: metadata
+        )).write(to: documentURL, options: .atomic)
         let oldFailure = AudioRecorderViewModel.RecordingTranscriptionFailure(
             phase: .finalTranscription,
             providerError: "old failure",
@@ -729,7 +852,18 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: failureURL.path))
         XCTAssertEqual(viewModel.recordings.first?.transcript, "fresh retranscription")
         XCTAssertNil(viewModel.recordings.first?.transcriptionFailure)
+        XCTAssertEqual(viewModel.recordings.first?.calendarEvent, metadata)
         XCTAssertTrue(viewModel.canToggleRecording)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let document = try decoder.decode(
+            RecordingTranscriptDocument.self,
+            from: Data(contentsOf: documentURL)
+        )
+        XCTAssertEqual(document.schemaVersion, 1)
+        XCTAssertEqual(document.text, "fresh retranscription")
+        XCTAssertEqual(document.calendarEvent, metadata)
 
         let plugin = try XCTUnwrap(
             PluginManager.shared.transcriptionEngine(for: "assemblyai") as? AudioRecorderMockTranscriptionPlugin

--- a/TypeWhisperTests/CalendarMeetingRecordingTests.swift
+++ b/TypeWhisperTests/CalendarMeetingRecordingTests.swift
@@ -11,10 +11,30 @@ final class CalendarMeetingRecordingTests: XCTestCase {
             date: date
         )
 
-        XCTAssertTrue(value.hasPrefix("Café Team Weekly Sync — "))
+        XCTAssertTrue(value.hasSuffix(" - Café Team Weekly Sync"))
+        XCTAssertNotNil(value.range(of: #"^\d{8} - "#, options: .regularExpression))
         XCTAssertFalse(value.contains("/"))
         XCTAssertFalse(value.contains(":"))
         XCTAssertFalse(value.contains("\n"))
+    }
+
+    func testPreferredNamePrefixesEventStartDateForSorting() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        let date = try XCTUnwrap(calendar.date(from: DateComponents(
+            year: 2026,
+            month: 8,
+            day: 9,
+            hour: 12
+        )))
+
+        XCTAssertEqual(
+            CalendarMeetingRecordingFilename.preferredBaseName(
+                title: "Event title",
+                date: date
+            ),
+            "20260809 - Event title"
+        )
     }
 
     func testEmptyTitleFallsBackAndTitleIsLimitedToOneHundredTwentyGraphemes() {
@@ -22,11 +42,11 @@ final class CalendarMeetingRecordingTests: XCTestCase {
         XCTAssertTrue(CalendarMeetingRecordingFilename.preferredBaseName(
             title: " .  \n ",
             date: date
-        ).hasPrefix("Recording "))
+        ).hasSuffix(" - Recording"))
 
         let longTitle = String(repeating: "A", count: 140)
         let result = CalendarMeetingRecordingFilename.preferredBaseName(title: longTitle, date: date)
-        let title = result.components(separatedBy: " — ").first ?? ""
+        let title = result.components(separatedBy: " - ").last ?? ""
         XCTAssertEqual(title.count, 120)
     }
 
@@ -36,7 +56,7 @@ final class CalendarMeetingRecordingTests: XCTestCase {
             title: String(repeating: "会", count: 140),
             date: date
         )
-        let title = preferredBaseName.components(separatedBy: " — ").first ?? ""
+        let title = preferredBaseName.components(separatedBy: " - ").last ?? ""
         XCTAssertLessThanOrEqual(title.utf8.count, 200)
 
         let result = CalendarMeetingRecordingFilename.availableURL(

--- a/TypeWhisperTests/CalendarMeetingRecordingTests.swift
+++ b/TypeWhisperTests/CalendarMeetingRecordingTests.swift
@@ -20,7 +20,7 @@ final class CalendarMeetingRecordingTests: XCTestCase {
 
     func testPreferredNamePrefixesEventStartDateForSorting() throws {
         var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+        calendar.timeZone = .autoupdatingCurrent
         let date = try XCTUnwrap(calendar.date(from: DateComponents(
             year: 2026,
             month: 8,

--- a/TypeWhisperTests/MeetingLinkParserTests.swift
+++ b/TypeWhisperTests/MeetingLinkParserTests.swift
@@ -140,3 +140,35 @@ func makeCalendarMeetingTestOccurrence(
         meetingLinks: links
     )
 }
+
+func makeCalendarMeetingTranscriptMetadata(
+    eventIdentifier: String = "event-1",
+    title: String = "Planning",
+    startDate: Date = Date(timeIntervalSince1970: 2_000_000_000),
+    endDate: Date = Date(timeIntervalSince1970: 2_000_003_600),
+    location: String? = "Conference Room",
+    organizer: CalendarMeetingParticipant? = CalendarMeetingParticipant(
+        name: "Ada Organizer",
+        emailAddress: "ada@example.com",
+        status: .accepted,
+        isCurrentUser: false
+    ),
+    attendees: [CalendarMeetingParticipant] = [
+        CalendarMeetingParticipant(
+            name: "Marco Attendee",
+            emailAddress: "marco@example.com",
+            status: .accepted,
+            isCurrentUser: true
+        )
+    ]
+) -> CalendarMeetingTranscriptMetadata {
+    CalendarMeetingTranscriptMetadata(
+        eventIdentifier: eventIdentifier,
+        title: title,
+        startDate: startDate,
+        endDate: endDate,
+        location: location,
+        organizer: organizer,
+        attendees: attendees
+    )
+}


### PR DESCRIPTION
## Summary

- capture calendar event metadata for calendar-started recordings, including title, start/end time, location, organizer, and attendees
- store the metadata in a versioned `.transcript.json` sidecar next to the recording, while retaining the existing plain-text transcript
- name calendar recordings with a sortable date and event title
- expose the existing post-recording transcription setting directly in Meeting Automation
- preserve calendar metadata when transcription is disabled, fails, or is run again later

## Issue context

Issue #1082 requests calendar context in meeting transcripts so downstream AI workflows can produce more accurate meeting minutes, together with sortable filenames based on the event title.

Previously, the calendar automation flow used the event only to decide when to record. The recorder did not receive detached event metadata, saved only an optional plain-text transcript, and generated generic timestamp-based filenames. The transcription preference was also only visible in the separate Recorder settings.

This change carries a detached, Codable calendar snapshot through the recording flow and writes it locally alongside the audio. The new JSON sidecar uses schema version 1 and includes transcript text when available.

Closes #1082

## Test plan

- `git diff --check`
- `xcodebuild -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -derivedDataPath /Users/marco/Projects/typewhisper-mac-dev/DerivedData -allowProvisioningUpdates APP_GROUP_ID=2D8ALY3LCL.com.typewhisper.mac DEVELOPMENT_TEAM=2D8ALY3LCL CODE_SIGN_STYLE=Automatic 'CODE_SIGN_IDENTITY=Apple Development' -parallel-testing-enabled NO test -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/CalendarMeetingRecordingTests -only-testing:TypeWhisperTests/CalendarMeetingEventProviderTests -only-testing:TypeWhisperTests/CalendarMeetingAutomationControllerTests -only-testing:TypeWhisperTests/CalendarMeetingAutomationPolicyTests -only-testing:TypeWhisperTests/MeetingLinkParserTests` — 102 passed
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-a5d40fb5` — signed Dev build succeeded and launched
- manually completed a calendar-started recording with transcription disabled; verified the WAV and metadata-only JSON sidecar
- manually completed a calendar-started recording with transcription enabled; verified the WAV, plain-text transcript, and JSON sidecar containing matching transcript text and calendar metadata


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar recordings now retain meeting details, including location, organizer, attendees, and meeting links.
  * Transcription metadata is preserved through recording, retranscription, and transcript storage.
  * Added calendar transcription settings with localized help text in English, German, Japanese, and Simplified Chinese.

* **Improvements**
  * Recording filenames now use the meeting date followed by the title, with a clear fallback for untitled meetings.
  * Calendar details remain available when transcription is disabled and are removed when recordings are deleted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->