### PR TITLE
Fix ElevenLabs scoped API key validation

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -72,6 +72,30 @@ enum ElevenLabsTranscriptionMode: String, CaseIterable, Sendable {
     case restOnly
 }
 
+enum ElevenLabsAPIKeyValidationResult: Equatable, Sendable {
+    case valid
+    case invalid(message: String?)
+
+    var isValid: Bool {
+        if case .valid = self { return true }
+        return false
+    }
+
+    var errorMessage: String? {
+        guard case .invalid(let message) = self else { return nil }
+        return message
+    }
+}
+
+private struct ElevenLabsAPIErrorResponse: Decodable {
+    struct Detail: Decodable {
+        let message: String?
+        let status: String?
+    }
+
+    let detail: Detail?
+}
+
 @objc(ElevenLabsPlugin)
 final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.elevenlabs"
@@ -473,20 +497,41 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         return data
     }
 
-    fileprivate func validateApiKey(_ key: String) async -> Bool {
-        guard let url = URL(string: "https://api.elevenlabs.io/v1/user") else { return false }
+    fileprivate func validateApiKey(_ key: String) async -> ElevenLabsAPIKeyValidationResult {
+        guard let url = URL(string: "https://api.elevenlabs.io/v1/user") else {
+            return .invalid(message: nil)
+        }
 
         var request = URLRequest(url: url)
         request.setValue(key, forHTTPHeaderField: "xi-api-key")
         request.timeoutInterval = 10
 
         do {
-            let (_, response) = try await PluginHTTPClient.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else { return false }
-            return httpResponse.statusCode == 200
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return .invalid(message: nil)
+            }
+            return Self.apiKeyValidationResult(statusCode: httpResponse.statusCode, data: data)
         } catch {
-            return false
+            return .invalid(message: error.localizedDescription)
         }
+    }
+
+    static func apiKeyValidationResult(statusCode: Int, data: Data) -> ElevenLabsAPIKeyValidationResult {
+        guard statusCode != 200 else { return .valid }
+
+        let detail = try? JSONDecoder().decode(ElevenLabsAPIErrorResponse.self, from: data).detail
+        let message = detail?.message?.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // ElevenLabs scopes API keys per endpoint. A key restricted to Speech to Text is valid for
+        // this plugin even though the optional user-profile validation endpoint returns HTTP 401.
+        if statusCode == 401,
+           detail?.status == "missing_permissions",
+           message?.localizedCaseInsensitiveContains("user_read") == true {
+            return .valid
+        }
+
+        return .invalid(message: message?.isEmpty == false ? message : nil)
     }
 
     var settingsView: AnyView? {
@@ -522,7 +567,7 @@ private struct ElevenLabsSettingsView: View {
     let plugin: ElevenLabsPlugin
     @State private var apiKeyInput = ""
     @State private var isValidating = false
-    @State private var validationResult: Bool?
+    @State private var validationResult: ElevenLabsAPIKeyValidationResult?
     @State private var showApiKey = false
     @State private var selectedModel = ""
     @State private var transcriptionMode = ElevenLabsTranscriptionMode.automatic
@@ -563,7 +608,7 @@ private struct ElevenLabsSettingsView: View {
                     }
                     .buttonStyle(.borderless)
 
-                    if hasStoredKey && isEditingStoredKey && validationResult != false {
+                    if hasStoredKey && isEditingStoredKey && validationResult?.isValid != false {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             apiKeyInput = ""
                             validationResult = nil
@@ -591,15 +636,15 @@ private struct ElevenLabsSettingsView: View {
                     }
                 } else if let result = validationResult {
                     HStack(spacing: 4) {
-                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
-                            .foregroundStyle(result ? .green : .red)
+                        Image(systemName: result.isValid ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result.isValid ? .green : .red)
                         Text(
-                            result
+                            result.isValid
                                 ? String(localized: "Valid API Key", bundle: bundle)
-                                : String(localized: "Invalid API Key", bundle: bundle)
+                                : result.errorMessage ?? String(localized: "Invalid API Key", bundle: bundle)
                         )
                         .font(.caption)
-                        .foregroundStyle(result ? .green : .red)
+                        .foregroundStyle(result.isValid ? .green : .red)
                     }
                 }
             }
@@ -654,10 +699,10 @@ private struct ElevenLabsSettingsView: View {
                 apiKeyInput = key
                 isValidating = true
                 Task {
-                    let isValid = await plugin.validateApiKey(key)
+                    let result = await plugin.validateApiKey(key)
                     await MainActor.run {
                         isValidating = false
-                        validationResult = isValid
+                        validationResult = result
                     }
                 }
             }
@@ -674,13 +719,13 @@ private struct ElevenLabsSettingsView: View {
         validationResult = nil
 
         Task {
-            let isValid = await plugin.validateApiKey(trimmedKey)
+            let result = await plugin.validateApiKey(trimmedKey)
             await MainActor.run {
-                if isValid {
+                if result.isValid {
                     plugin.setApiKey(trimmedKey)
                 }
                 isValidating = false
-                validationResult = isValid
+                validationResult = result
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -99,6 +99,8 @@ private struct ElevenLabsAPIErrorResponse: Decodable {
 @objc(ElevenLabsPlugin)
 final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.elevenlabs"
+    private static let missingUserReadPermissionMessage =
+        "The API key you used is missing the permission user_read to execute this operation."
     static let pluginName = "ElevenLabs"
     static let transcriptionModeKey = "transcriptionMode"
 
@@ -527,7 +529,7 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         // this plugin even though the optional user-profile validation endpoint returns HTTP 401.
         if statusCode == 401,
            detail?.status == "missing_permissions",
-           message?.localizedCaseInsensitiveContains("user_read") == true {
+           message?.caseInsensitiveCompare(Self.missingUserReadPermissionMessage) == .orderedSame {
             return .valid
         }
 

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
@@ -11,6 +11,65 @@ final class ElevenLabsPluginTests: XCTestCase {
         super.tearDown()
     }
 
+    func testAPIKeyValidationAcceptsSuccessfulUserResponse() {
+        XCTAssertEqual(
+            ElevenLabsPlugin.apiKeyValidationResult(statusCode: 200, data: Data()),
+            .valid
+        )
+    }
+
+    func testAPIKeyValidationAcceptsKeyWithoutUserReadPermission() {
+        let data = Data(#"""
+        {
+            "detail": {
+                "type": "authentication_error",
+                "code": "unauthorized",
+                "message": "The API key you used is missing the permission user_read to execute this operation.",
+                "status": "missing_permissions"
+            }
+        }
+        """#.utf8)
+
+        XCTAssertEqual(
+            ElevenLabsPlugin.apiKeyValidationResult(statusCode: 401, data: data),
+            .valid
+        )
+    }
+
+    func testAPIKeyValidationRejectsInvalidKeyWithProviderMessage() {
+        let data = Data(#"""
+        {
+            "detail": {
+                "type": "authentication_error",
+                "code": "invalid_api_key",
+                "message": "Invalid API key",
+                "status": "invalid_api_key"
+            }
+        }
+        """#.utf8)
+
+        XCTAssertEqual(
+            ElevenLabsPlugin.apiKeyValidationResult(statusCode: 401, data: data),
+            .invalid(message: "Invalid API key")
+        )
+    }
+
+    func testAPIKeyValidationRejectsUnrelatedMissingPermission() {
+        let data = Data(#"""
+        {
+            "detail": {
+                "message": "The API key is missing the permission speech_to_text.",
+                "status": "missing_permissions"
+            }
+        }
+        """#.utf8)
+
+        XCTAssertEqual(
+            ElevenLabsPlugin.apiKeyValidationResult(statusCode: 401, data: data),
+            .invalid(message: "The API key is missing the permission speech_to_text.")
+        )
+    }
+
     func testTranscriptionModeDefaultsToAutomaticForMissingOrUnknownValue() throws {
         let defaultHost = try PluginTestHostServices()
         let defaultPlugin = ElevenLabsPlugin()

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
@@ -70,6 +70,23 @@ final class ElevenLabsPluginTests: XCTestCase {
         )
     }
 
+    func testAPIKeyValidationRejectsMultipleMissingPermissions() {
+        let message = "The API key you used is missing the permissions user_read and speech_to_text."
+        let data = Data(#"""
+        {
+            "detail": {
+                "message": "\#(message)",
+                "status": "missing_permissions"
+            }
+        }
+        """#.utf8)
+
+        XCTAssertEqual(
+            ElevenLabsPlugin.apiKeyValidationResult(statusCode: 401, data: data),
+            .invalid(message: message)
+        )
+    }
+
     func testTranscriptionModeDefaultsToAutomaticForMissingOrUnknownValue() throws {
         let defaultHost = try PluginTestHostServices()
         let defaultPlugin = ElevenLabsPlugin()

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- accept valid ElevenLabs API keys that lack the unrelated `user_read` scope
- surface ElevenLabs validation and network errors instead of always showing “Invalid API Key”
- reject ambiguous missing-permission responses that also include `speech_to_text`
- bump the ElevenLabs plugin to `1.0.10`
- add regression coverage for scoped, invalid, and unusable keys

## Issue context

Issue #1103 reports that working ElevenLabs Speech-to-Text keys are rejected during setup. ElevenLabs returns HTTP 401 with `status: missing_permissions` when a restricted key lacks `user_read`, even though the key can still have the required `speech_to_text` permission. The plugin previously treated every non-200 response from `/v1/user` as an invalid key.

Closes #1103

## Test plan

- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json >/dev/null`
- `swift test --package-path TypeWhisperPluginSDK --filter ElevenLabsPluginTests`
- `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run ElevenLabsPlugin --enable-plugin com.typewhisper.elevenlabs "$(pwd)"`
- Smoke-tested transcription through the installed ElevenLabs dev plugin with `scribe_v2`
