### PR TITLE
docs: prepare TypeWhisper 1.6.0 release notes

### DIFF
--- a/docs/release-notes/1.6.0.md
+++ b/docs/release-notes/1.6.0.md
@@ -1,0 +1,51 @@
+TypeWhisper `1.6.0` is the stable `1.6` macOS release. It brings a redesigned settings experience, privacy-friendly statistics and portable backups, faster and more resilient recording, calendar-aware meeting automation, expanded workflow integrations, and a broad reliability pass across dictation, Recorder, local models, and cloud providers.
+
+## Highlights
+
+- Unified the visual language across Settings, including dashboards, forms, collections, workspaces, and advanced tool pages.
+- Added a Statistics view for privacy-friendly aggregate usage insights.
+- Added Backup & Restore for portable workflows, dictionary entries, snippets, profiles, prompt actions, hotkeys, installed community plugins, transcription history text, update-channel selection, and supported preferences.
+- Improved recording startup performance in controlled hardware tests: median request-to-first-buffer time fell by 22.6% on the built-in MacBook microphone and 13.1% on a tested USB microphone, while opt-in AirPods recording readiness improved by about 45%.
+- Added optional calendar-aware meeting automation with notifications, countdown controls, meeting activity checks, automatic Recorder sessions, sortable filenames, versioned transcript metadata, and Obsidian-ready Markdown transcript sidecars for the associated event.
+- Added an MCP Client action add-on with stdio and Streamable HTTP support, expanded Obsidian with live sync and Markdown templates, and added bulk plugin updates with automatic restart.
+- Added Simplified Chinese localization across the app and bundled integrations; two AirPods keep-alive descriptions remain in English.
+
+## Dictation and Recorder
+
+- Added an ordered microphone priority list and improved recovery for AirPods, Bluetooth system-default input, clamshell changes, virtual inputs, and FaceTime built-in microphone capture.
+- Moved recording startup work off the main actor and prewarmed eligible inputs to reduce the delay before audio capture begins.
+- Improved Whisper Mode amplification with smoother gain changes, less amplification of low-level background noise, stable handling of brief pauses, and protection against clipping; standard recording mode remains unchanged.
+- Added optional live transcript updates to active text fields while preserving the final insertion path.
+- Fixed automatic meeting transcripts to use the finalized recording as their source of truth, with a captured-audio fallback when the saved file cannot be read.
+- Improved long-meeting transcription completeness by aligning final Recorder transcription and retries with File Transcription's source-progress-aware path.
+- Improved contextual insertion for Firefox, CJK text, trailing spaces, secure-input situations, auto-submit targets, and target-app correction learning.
+- Improved indicator placement, dismissal, fullscreen visibility, feedback interaction, countdown progress, and optional screen-capture visibility.
+- Added recovery-audio retention controls and improved direct Recorder retranscription when local models have unloaded.
+
+## Dictionary, Workflows, and Automation
+
+- Added dictionary search, safe reset actions, grouped correction variants, clearer learned-correction visibility, and a guided microphone correction trainer.
+- Applied dictionary corrections to file transcription and connected per-term CTC tuning to Parakeet.
+- Added ordered global LLM provider and model fallbacks while keeping explicit workflow providers strict.
+- Added explicit workflow dictation through the local API and a live-preview engine override so preview can stay local while final transcription uses the configured dictation engine.
+- Regrouped the menu bar for faster access and now shows the active transcription provider alongside the selected model.
+
+## Models and Integrations
+
+- Added Soniox live WebSocket transcription and the local Cohere Transcribe integration.
+- Added context-aware OpenAI transcription and dynamic ChatGPT model discovery.
+- Expanded OpenAI-Compatible profiles with optional API versions, deployment-scoped endpoints, realtime transcription, and Responses API support.
+- Updated the separately distributed OpenRouter plugin to preserve segment timestamps for SRT and VTT exports on supported speech-to-text routes; Deepgram through OpenRouter remains text-only.
+- Improved MLX model storage, lazy restore, stalled-download recovery, and lifecycle handling across Qwen3, Gemma 4, Granite, Voxtral, Parakeet, and WhisperKit.
+- Fixed Qwen3 long-audio cutoff and loop-fallback behavior, and improved WhisperKit restore after unloads and for workflow-specific model overrides.
+- Improved Soniox cleanup and quota reporting, Speechmatics US batch routing and language-pack handling, restricted ElevenLabs key validation, AssemblyAI file-transcription routing, Mistral language handling, and Deepgram custom-URL validation.
+
+## Platform and Distribution Notes
+
+- Fixed calendar permission requests and the calendar entitlement used by distributed builds.
+- Fixed the Settings sidebar scroll pocket on macOS 27 while preserving the existing layout on macOS 14 through 26.
+- Stable `1.6.0` builds use the default Sparkle channel and require macOS 14.0 or later; release candidates and daily builds remain on their dedicated preview channels.
+- The final stable tag publishes DMG and ZIP assets, updates the stable Sparkle appcast entry, triggers the website release update, and updates the Homebrew cask.
+- Automatic private iCloud sync remains disabled while the production container and Developer ID provisioning profile are unavailable. Cloud Folder Sync through a user-selected iCloud Drive, Dropbox, OneDrive, Syncthing, or custom folder remains available.
+
+Release validation is tracked in the [TypeWhisper 1.6.0 checklist](https://github.com/TypeWhisper/typewhisper-mac/issues/1115).


### PR DESCRIPTION
## Release context

TypeWhisper `1.6.0-rc2` was published from `afddd36d72b3d5438e5b7a82cb724a45327b92d4` on August 16, 2026. The planned stable go/no-go remains August 19 at 08:24:45 UTC, after 72 full hours from the RC2 publication timestamp and only if no new unaccepted release blocker appears.

This PR tracks #1115. Merging it prepares the curated stable notes; it does not close the validation checklist and does not authorize the separate merge, tag, or publication decisions.

## Summary

- add curated stable `1.6.0` release notes covering the full change from `v1.5.1` through the current candidate on `main`
- keep measured microphone-start improvements prominent while qualifying the hardware scope
- document Obsidian-ready meeting Markdown sidecars and the final Recorder/File Transcription pipeline alignment
- document deployment-scoped OpenAI Compatible support and OpenRouter subtitle timestamps as separately distributed plugin updates
- retain the known two untranslated AirPods descriptions and the no-iCloud distribution limitation
- link the version-specific release validation checklist

This remains a notes-only change relative to current `main`. The exact preparation head is `34289c4f74b662e75e7d17d5860ed94796301682` on base `0b772db570edca1c612665d04ba63a18826046bd`.

## Accepted post-RC2 delta

The release manager explicitly accepts the post-RC2 repository delta without resetting the original soak clock:

- #1112 and #1117 changed the separately distributed OpenAI Compatible plugin and published version `1.1.8`.
- #1120 added Obsidian-ready Markdown sidecars for calendar meeting recordings.
- #1121 aligned final Recorder transcription and retries with File Transcription's source-progress-aware path after #1091 was reproduced on the August 17 daily. Its automated validation passed; the planned 30-minute reporter retest remains outstanding and is explicitly non-blocking for this release decision.
- #1122 changed the separately distributed OpenRouter plugin and published version `1.1.5` with timed subtitle segments on supported routes.
- #1125 refreshed the available-plugin-update count immediately after uninstall; its production delta is one refresh call backed by focused regression tests.
- #1126 changed only recorder retranscription test synchronization and does not modify product code.
- The current-main daily `v1.6.0-daily.20260819` was published successfully from `0b772db570edca1c612665d04ba63a18826046bd`, including #1125 and #1126.

These accepted changes mean the current application candidate is no longer code-identical to RC2. The unchanged August 19 go/no-go is a deliberate release-manager risk decision recorded in #1115, not a claim that the post-RC2 application code received the full RC2 soak.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] `PATH=/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin ./scripts/pr-preflight.sh origin/main` completed all shell and Python checks, then stopped on the two pre-existing incomplete `zh-Hans` AirPods strings already disclosed in the notes
- [x] `bash scripts/check_release_binary_instrumentation.sh --self-test`
- [x] `bash scripts/check_release_signing.sh --self-test`
- [x] Exact-head Build DMG, app tests, Plugin SDK tests, and release builds passed on `34289c4f74b662e75e7d17d5860ed94796301682`: [push run](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/32226673861) and [pull-request run](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/32226678734). CodeQL, Code Quality, PR Guard, and CodeRabbit are successful, and GraphQL reports zero review threads.
- [x] RC2 exact-base release workflow, including app tests, Plugin SDK tests, release build, signing, notarization, packaging, and public appcast verification: https://github.com/TypeWhisper/typewhisper-mac/actions/runs/31935559261
