### PR TITLE
Bump OpenAI Compatible plugin to 1.1.8

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openai-compatible",
     "name": "OpenAI Compatible",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump the OpenAI Compatible plugin manifest from 1.1.7 to 1.1.8
- prepare the deployment-scoped batch transcription support from #1112 for an official plugin release
- satisfy the release workflow's exact manifest-version validation

## Impact

After this lands, the official plugin release workflow can publish `plugin-openai-compatible-v1.1.8` from `main`. Compatibility metadata remains unchanged at TypeWhisper 1.5.0, SDK v1, and macOS 14.0.

## Test plan

- `jq -e '.version == "1.1.8"' TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json`
- `swift test --package-path TypeWhisperPluginSDK --filter OpenAICompatiblePluginTests`

Release dispatch after merge:

`gh workflow run plugin-release.yml --repo TypeWhisper/typewhisper-mac --ref main -f plugin_name=openai-compatible -f plugin_version=1.1.8 -f distribution_source=official`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the OpenAI Compatible plugin to version 1.1.8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->