### PR TITLE
Add Obsidian-ready Markdown meeting sidecars

### DIFF
--- a/TypeWhisper/Models/CalendarMeetingAutomationModels.swift
+++ b/TypeWhisper/Models/CalendarMeetingAutomationModels.swift
@@ -134,6 +134,118 @@ struct RecordingTranscriptDocument: Codable, Equatable, Sendable {
     }
 }
 
+enum RecordingTranscriptMarkdownRenderer {
+    static func render(
+        _ document: RecordingTranscriptDocument,
+        timeZone: TimeZone = .current
+    ) -> String {
+        let calendarEvent = document.calendarEvent
+        let dateFormatter = makeDateFormatter(timeZone: timeZone, format: "yyyy-MM-dd")
+        let dateTimeFormatter = makeDateFormatter(
+            timeZone: timeZone,
+            format: "yyyy-MM-dd'T'HH:mm:ss"
+        )
+        let type = yamlQuoted("meeting-transcript")
+        let location = yamlQuoted(calendarEvent.location ?? "")
+        let organizer = yamlQuoted(calendarEvent.organizer.map(participantDescription) ?? "")
+
+        var frontmatter = [
+            "---",
+            "type: \(type)",
+            "schemaVersion: \(document.schemaVersion)",
+            "title: \(yamlQuoted(calendarEvent.title))",
+            "date: \(dateFormatter.string(from: calendarEvent.startDate))",
+            "startDate: \(dateTimeFormatter.string(from: calendarEvent.startDate))",
+            "endDate: \(dateTimeFormatter.string(from: calendarEvent.endDate))",
+            "timeZone: \(yamlQuoted(timeZone.identifier))",
+            "location: \(location)",
+            "organizer: \(organizer)",
+        ]
+
+        if calendarEvent.attendees.isEmpty {
+            frontmatter.append("attendees: []")
+        } else {
+            frontmatter.append("attendees:")
+            frontmatter.append(contentsOf: calendarEvent.attendees.map {
+                "  - \(yamlQuoted(participantDescription($0)))"
+            })
+        }
+
+        frontmatter.append("eventIdentifier: \(yamlQuoted(calendarEvent.eventIdentifier))")
+        frontmatter.append("---")
+
+        let heading = calendarEvent.title
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+        let renderedHeading = heading.isEmpty ? "Meeting Transcript" : heading
+        var markdown = frontmatter.joined(separator: "\n")
+        markdown += "\n\n# \(renderedHeading)\n"
+
+        if let text = document.text, !text.isEmpty {
+            markdown += "\n\(text)"
+            if !text.hasSuffix("\n") {
+                markdown += "\n"
+            }
+        }
+
+        return markdown
+    }
+
+    private static func makeDateFormatter(timeZone: TimeZone, format: String) -> DateFormatter {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = timeZone
+        formatter.dateFormat = format
+        return formatter
+    }
+
+    private static func participantDescription(_ participant: CalendarMeetingParticipant) -> String {
+        let identity: String
+        switch (participant.name, participant.emailAddress) {
+        case let (name?, emailAddress?):
+            identity = "\(name) <\(emailAddress)>"
+        case let (name?, nil):
+            identity = name
+        case let (nil, emailAddress?):
+            identity = emailAddress
+        case (nil, nil):
+            identity = "Unnamed participant"
+        }
+
+        var details = [participant.status.rawValue]
+        if participant.isCurrentUser {
+            details.append("current-user")
+        }
+        return "\(identity) (\(details.joined(separator: ", ")))"
+    }
+
+    private static func yamlQuoted(_ value: String) -> String {
+        var quoted = "\""
+        for scalar in value.unicodeScalars {
+            switch scalar.value {
+            case 0x22:
+                quoted += "\\\""
+            case 0x5C:
+                quoted += "\\\\"
+            case 0x0A:
+                quoted += "\\n"
+            case 0x0D:
+                quoted += "\\r"
+            case 0x09:
+                quoted += "\\t"
+            case 0x00...0x1F, 0x7F, 0x85, 0x2028, 0x2029:
+                quoted += String(format: "\\u%04X", scalar.value)
+            default:
+                quoted.append(contentsOf: String(scalar))
+            }
+        }
+        quoted += "\""
+        return quoted
+    }
+}
+
 struct CalendarMeetingOccurrence: Identifiable, Equatable, Sendable {
     let eventIdentifier: String
     let occurrenceStart: Date

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -826,6 +826,7 @@ final class AudioRecorderViewModel: ObservableObject {
 
         do {
             try removeRecordingFileIfPresent(at: transcriptURL(for: item.url))
+            try removeRecordingFileIfPresent(at: transcriptMarkdownURL(for: item.url))
             try removeRecordingFileIfPresent(at: transcriptDocumentURL(for: item.url))
             try removeRecordingFileIfPresent(at: transcriptionFailureURL(for: item.url))
             try removeRecordingFileIfPresent(at: item.url)
@@ -1223,6 +1224,10 @@ final class AudioRecorderViewModel: ObservableObject {
         audioURL.deletingPathExtension().appendingPathExtension("transcript.json")
     }
 
+    private func transcriptMarkdownURL(for audioURL: URL) -> URL {
+        audioURL.deletingPathExtension().appendingPathExtension("transcript.md")
+    }
+
     private func saveTranscriptDocument(
         text: String?,
         calendarEvent: CalendarMeetingTranscriptMetadata,
@@ -1237,6 +1242,12 @@ final class AudioRecorderViewModel: ObservableObject {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(document)
         try data.write(to: transcriptDocumentURL(for: audioURL), options: .atomic)
+        let markdown = RecordingTranscriptMarkdownRenderer.render(document)
+        try markdown.write(
+            to: transcriptMarkdownURL(for: audioURL),
+            atomically: true,
+            encoding: .utf8
+        )
     }
 
     private func loadTranscript(for audioURL: URL) -> String? {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -824,12 +824,30 @@ final class AudioRecorderViewModel: ObservableObject {
     func deleteRecording(_ item: RecordingItem) {
         guard !isRetranscribing(item) else { return }
 
+        let sidecarURLs = [
+            transcriptURL(for: item.url),
+            transcriptMarkdownURL(for: item.url),
+            transcriptDocumentURL(for: item.url),
+            transcriptionFailureURL(for: item.url)
+        ]
+
         do {
-            try removeRecordingFileIfPresent(at: transcriptURL(for: item.url))
-            try removeRecordingFileIfPresent(at: transcriptMarkdownURL(for: item.url))
-            try removeRecordingFileIfPresent(at: transcriptDocumentURL(for: item.url))
-            try removeRecordingFileIfPresent(at: transcriptionFailureURL(for: item.url))
-            try removeRecordingFileIfPresent(at: item.url)
+            let sidecarSnapshots = try sidecarURLs.map(makeRecordingFileSnapshot(at:))
+            do {
+                for url in sidecarURLs {
+                    try removeRecordingFileIfPresent(at: url)
+                }
+                try removeRecordingFileIfPresent(at: item.url)
+            } catch {
+                do {
+                    try restoreRecordingFileSnapshots(sidecarSnapshots)
+                } catch {
+                    logger.error(
+                        "Failed to restore recording sidecars after deletion failed: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+                throw error
+            }
             transientTranscriptionFailures.removeValue(
                 forKey: transcriptionFailureKey(for: item.url)
             )
@@ -844,6 +862,28 @@ final class AudioRecorderViewModel: ObservableObject {
             try FileManager.default.removeItem(at: url)
         } catch let error as CocoaError where error.code == .fileNoSuchFile {
             return
+        }
+    }
+
+    private struct RecordingFileSnapshot {
+        let url: URL
+        let data: Data?
+    }
+
+    private func makeRecordingFileSnapshot(at url: URL) throws -> RecordingFileSnapshot {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return RecordingFileSnapshot(url: url, data: nil)
+        }
+        return RecordingFileSnapshot(url: url, data: try Data(contentsOf: url))
+    }
+
+    private func restoreRecordingFileSnapshots(_ snapshots: [RecordingFileSnapshot]) throws {
+        for snapshot in snapshots {
+            guard let data = snapshot.data,
+                  !FileManager.default.fileExists(atPath: snapshot.url.path) else {
+                continue
+            }
+            try data.write(to: snapshot.url, options: .atomic)
         }
     }
 
@@ -1209,13 +1249,17 @@ final class AudioRecorderViewModel: ObservableObject {
         calendarEvent: CalendarMeetingTranscriptMetadata?
     ) throws {
         let txtURL = transcriptURL(for: audioURL)
-        try text.write(to: txtURL, atomically: true, encoding: .utf8)
         if let calendarEvent {
-            try saveTranscriptDocument(
+            let documentWrites = try transcriptDocumentWrites(
                 text: text,
                 calendarEvent: calendarEvent,
                 for: audioURL
             )
+            try writeRecordingFilesTransactionally([
+                RecordingFileWrite(url: txtURL, data: Data(text.utf8))
+            ] + documentWrites)
+        } else {
+            try text.write(to: txtURL, atomically: true, encoding: .utf8)
         }
         clearTranscriptionFailure(for: audioURL)
     }
@@ -1233,6 +1277,32 @@ final class AudioRecorderViewModel: ObservableObject {
         calendarEvent: CalendarMeetingTranscriptMetadata,
         for audioURL: URL
     ) throws {
+        try writeRecordingFilesTransactionally(
+            try transcriptDocumentWrites(
+                text: text,
+                calendarEvent: calendarEvent,
+                for: audioURL
+            )
+        )
+    }
+
+    private struct RecordingFileWrite {
+        let url: URL
+        let data: Data
+    }
+
+    private struct RecordingFileCommit {
+        let write: RecordingFileWrite
+        let stagedURL: URL
+        let backupURL: URL?
+        var installedNewFile: Bool
+    }
+
+    private func transcriptDocumentWrites(
+        text: String?,
+        calendarEvent: CalendarMeetingTranscriptMetadata,
+        for audioURL: URL
+    ) throws -> [RecordingFileWrite] {
         let document = RecordingTranscriptDocument(
             text: text,
             calendarEvent: calendarEvent
@@ -1241,12 +1311,78 @@ final class AudioRecorderViewModel: ObservableObject {
         encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(document)
-        try data.write(to: transcriptDocumentURL(for: audioURL), options: .atomic)
         let markdown = RecordingTranscriptMarkdownRenderer.render(document)
-        try markdown.write(
-            to: transcriptMarkdownURL(for: audioURL),
-            atomically: true,
-            encoding: .utf8
+        return [
+            RecordingFileWrite(url: transcriptDocumentURL(for: audioURL), data: data),
+            RecordingFileWrite(url: transcriptMarkdownURL(for: audioURL), data: Data(markdown.utf8))
+        ]
+    }
+
+    private func writeRecordingFilesTransactionally(_ writes: [RecordingFileWrite]) throws {
+        let fileManager = FileManager.default
+        var stagedWrites: [(write: RecordingFileWrite, stagedURL: URL)] = []
+        var commits: [RecordingFileCommit] = []
+
+        do {
+            for write in writes {
+                let stagedURL = temporarySiblingURL(for: write.url, suffix: "staged")
+                try write.data.write(to: stagedURL, options: .atomic)
+                stagedWrites.append((write, stagedURL))
+            }
+
+            for stagedWrite in stagedWrites {
+                let backupURL: URL?
+                if fileManager.fileExists(atPath: stagedWrite.write.url.path) {
+                    let url = temporarySiblingURL(for: stagedWrite.write.url, suffix: "backup")
+                    try fileManager.moveItem(at: stagedWrite.write.url, to: url)
+                    backupURL = url
+                } else {
+                    backupURL = nil
+                }
+
+                commits.append(RecordingFileCommit(
+                    write: stagedWrite.write,
+                    stagedURL: stagedWrite.stagedURL,
+                    backupURL: backupURL,
+                    installedNewFile: false
+                ))
+                try fileManager.moveItem(at: stagedWrite.stagedURL, to: stagedWrite.write.url)
+                commits[commits.count - 1].installedNewFile = true
+            }
+        } catch {
+            for commit in commits.reversed() {
+                if commit.installedNewFile,
+                   fileManager.fileExists(atPath: commit.write.url.path) {
+                    try? fileManager.removeItem(at: commit.write.url)
+                }
+                if let backupURL = commit.backupURL,
+                   fileManager.fileExists(atPath: backupURL.path) {
+                    try? fileManager.moveItem(at: backupURL, to: commit.write.url)
+                }
+            }
+            for stagedWrite in stagedWrites where fileManager.fileExists(atPath: stagedWrite.stagedURL.path) {
+                try? fileManager.removeItem(at: stagedWrite.stagedURL)
+            }
+            throw error
+        }
+
+        for commit in commits {
+            if let backupURL = commit.backupURL,
+               fileManager.fileExists(atPath: backupURL.path) {
+                do {
+                    try fileManager.removeItem(at: backupURL)
+                } catch {
+                    logger.error(
+                        "Failed to remove transcript backup: \(error.localizedDescription, privacy: .public)"
+                    )
+                }
+            }
+        }
+    }
+
+    private func temporarySiblingURL(for url: URL, suffix: String) -> URL {
+        url.deletingLastPathComponent().appendingPathComponent(
+            ".\(url.lastPathComponent).\(UUID().uuidString).\(suffix)"
         )
     }
 

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -540,6 +540,14 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertEqual(document.text, "complete meeting transcript")
         XCTAssertEqual(document.calendarEvent, metadata)
+
+        let markdownURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.md")
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.hasPrefix("---\n"))
+        XCTAssertTrue(markdown.contains("title: \"RC2 Meeting\""))
+        XCTAssertTrue(markdown.contains("# RC2 Meeting\n\ncomplete meeting transcript"))
     }
 
     func testCalendarMetadataPersistsWhenFinalTranscriptionFails() async throws {
@@ -571,6 +579,9 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let documentURL = handle.outputURL
             .deletingPathExtension()
             .appendingPathExtension("transcript.json")
+        let markdownURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.md")
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let document = try decoder.decode(
@@ -580,6 +591,9 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertNil(document.text)
         XCTAssertEqual(document.calendarEvent, metadata)
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("title: \"Failed meeting\""))
+        XCTAssertTrue(markdown.hasSuffix("# Failed meeting\n"))
     }
 
     func testManualStopDuringCalendarStartupPersistsMetadata() async throws {
@@ -658,6 +672,9 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let documentURL = handle.outputURL
             .deletingPathExtension()
             .appendingPathExtension("transcript.json")
+        let markdownURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.md")
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         let document = try decoder.decode(
@@ -667,10 +684,14 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertNil(document.text)
         XCTAssertEqual(document.calendarEvent, metadata)
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("title: \"Planning\""))
+        XCTAssertTrue(markdown.hasSuffix("# Planning\n"))
 
         viewModel.deleteRecording(recording)
         XCTAssertFalse(FileManager.default.fileExists(atPath: handle.outputURL.path))
         XCTAssertFalse(FileManager.default.fileExists(atPath: documentURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: markdownURL.path))
     }
 
     func testDeleteRecordingRetainsAudioWhenCalendarMetadataCannotBeDeleted() async throws {
@@ -864,6 +885,9 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(document.schemaVersion, 1)
         XCTAssertEqual(document.text, "fresh retranscription")
         XCTAssertEqual(document.calendarEvent, metadata)
+        let markdownURL = audioURL.deletingPathExtension().appendingPathExtension("transcript.md")
+        let markdown = try String(contentsOf: markdownURL, encoding: .utf8)
+        XCTAssertTrue(markdown.contains("# Meeting\n\nfresh retranscription"))
 
         let plugin = try XCTUnwrap(
             PluginManager.shared.transcriptionEngine(for: "assemblyai") as? AudioRecorderMockTranscriptionPlugin

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -716,6 +716,10 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let documentURL = handle.outputURL
             .deletingPathExtension()
             .appendingPathExtension("transcript.json")
+        let markdownURL = handle.outputURL
+            .deletingPathExtension()
+            .appendingPathExtension("transcript.md")
+        let markdownBeforeDeletion = try Data(contentsOf: markdownURL)
         try FileManager.default.setAttributes(
             [.immutable: true],
             ofItemAtPath: documentURL.path
@@ -731,6 +735,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
 
         XCTAssertTrue(FileManager.default.fileExists(atPath: handle.outputURL.path))
         XCTAssertTrue(FileManager.default.fileExists(atPath: documentURL.path))
+        XCTAssertEqual(try Data(contentsOf: markdownURL), markdownBeforeDeletion)
         XCTAssertEqual(viewModel.recordings.map(\.id), [recording.id])
         XCTAssertNotNil(viewModel.errorMessage)
     }
@@ -1067,6 +1072,54 @@ final class AudioRecorderViewModelTests: XCTestCase {
 
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .savingTranscript)
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: failureURL.path))
+    }
+
+    func testRetranscriptionMarkdownWriteFailureRestoresAllTranscriptFiles() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .success("replacement"))
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        let documentURL = audioURL.deletingPathExtension().appendingPathExtension("transcript.json")
+        let markdownURL = audioURL.deletingPathExtension().appendingPathExtension("transcript.md")
+        let failureURL = failureSidecarURL(for: audioURL)
+        let metadata = makeCalendarMeetingTranscriptMetadata(title: "Meeting")
+        let originalDocument = RecordingTranscriptDocument(
+            text: "keep me",
+            calendarEvent: metadata
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let originalDocumentData = try encoder.encode(originalDocument)
+        let originalMarkdown = RecordingTranscriptMarkdownRenderer.render(originalDocument)
+        try Data("audio".utf8).write(to: audioURL)
+        try "keep me".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        try originalDocumentData.write(to: documentURL, options: .atomic)
+        try originalMarkdown.write(to: markdownURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: markdownURL.path)
+        defer {
+            try? FileManager.default.setAttributes([.immutable: false], ofItemAtPath: markdownURL.path)
+        }
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .savingTranscript)
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertEqual(try Data(contentsOf: documentURL), originalDocumentData)
+        XCTAssertEqual(try String(contentsOf: markdownURL, encoding: .utf8), originalMarkdown)
         XCTAssertTrue(FileManager.default.fileExists(atPath: failureURL.path))
     }
 

--- a/TypeWhisperTests/MeetingLinkParserTests.swift
+++ b/TypeWhisperTests/MeetingLinkParserTests.swift
@@ -118,6 +118,49 @@ final class MeetingLinkParserTests: XCTestCase {
     }
 }
 
+final class RecordingTranscriptMarkdownRendererTests: XCTestCase {
+    func testRendersFlatObsidianPropertiesAndTranscriptBody() throws {
+        let metadata = makeCalendarMeetingTranscriptMetadata(
+            title: "Planning: \"Q3\"\nReview",
+            location: "Room A\\B\nFloor 2"
+        )
+        let document = RecordingTranscriptDocument(
+            text: "First line\n\n- Action item",
+            calendarEvent: metadata
+        )
+        let timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
+
+        let markdown = RecordingTranscriptMarkdownRenderer.render(
+            document,
+            timeZone: timeZone
+        )
+
+        XCTAssertEqual(markdown, #"""
+        ---
+        type: "meeting-transcript"
+        schemaVersion: 1
+        title: "Planning: \"Q3\"\nReview"
+        date: 2033-05-18
+        startDate: 2033-05-18T03:33:20
+        endDate: 2033-05-18T04:33:20
+        timeZone: "GMT"
+        location: "Room A\\B\nFloor 2"
+        organizer: "Ada Organizer <ada@example.com> (accepted)"
+        attendees:
+          - "Marco Attendee <marco@example.com> (accepted, current-user)"
+        eventIdentifier: "event-1"
+        ---
+
+        # Planning: "Q3" Review
+
+        First line
+
+        - Action item
+
+        """#)
+    }
+}
+
 func makeCalendarMeetingTestOccurrence(
     eventID: String = "event-1",
     start: Date = Date(timeIntervalSince1970: 2_000_000_000),


### PR DESCRIPTION
## Context

Issue #1082 introduced local JSON sidecars for calendar meeting recordings. In a [follow-up comment](https://github.com/TypeWhisper/typewhisper-mac/issues/1082#issuecomment-5314613276), the reporter requested a Markdown variant that works well with Obsidian.

Closes #1082

## Summary

- create a `.transcript.md` file alongside each calendar recording's existing `.transcript.json` sidecar
- use flat, YAML-safe Obsidian frontmatter for the event title, date, start/end time, time zone, location, organizer, attendees, and event identifier
- include the transcript as Markdown content when transcription succeeds, and update the file after retranscription
- keep metadata-only Markdown files useful when transcription is disabled or fails
- remove the Markdown sidecar when the recording is deleted

## User impact

Calendar meeting recordings can be consumed directly as Obsidian notes without converting the JSON metadata. Existing `.txt` transcripts and `.transcript.json` sidecars remain supported.

## Test plan

- [x] 37 focused recorder and renderer tests:
  ```sh
  set -o pipefail
  xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/RecordingTranscriptMarkdownRendererTests -only-testing:TypeWhisperTests/AudioRecorderViewModelTests | xcbeautify
  ```
- [x] Re-ran the renderer test after the final escaping hardening:
  ```sh
  set -o pipefail
  xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/RecordingTranscriptMarkdownRendererTests | xcbeautify
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Calendar meeting transcripts are now saved as Markdown files alongside existing transcript formats.
  * Markdown files include meeting metadata, attendees, organizer details, localized dates, and transcript content.
  * Metadata is safely formatted for Markdown and YAML compatibility.

* **Bug Fixes**
  * Markdown transcript files are removed when associated recordings are deleted.
  * Retranscription updates the corresponding Markdown file with the latest content.
  * Failed saves or deletions now preserve existing transcript files and metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->