### PR TITLE
Align recorder transcription with file transcription

### DIFF
--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -1115,15 +1115,7 @@ final class AudioRecorderViewModel: ObservableObject {
             let result = if let liveSessionResult = request.liveSessionResult {
                 liveSessionResult
             } else {
-                try await modelManager.transcribe(
-                    audioSamples: buffer,
-                    languageSelection: request.languageSelection,
-                    task: effectiveTask,
-                    engineOverrideId: request.providerId,
-                    cloudModelOverride: request.modelOverrideId,
-                    prompt: request.prompt,
-                    dictionaryTermHints: request.dictionaryTermHints
-                )
+                try await transcribeFinalRecording(request, task: effectiveTask)
             }
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             if !text.isEmpty {
@@ -1162,15 +1154,7 @@ final class AudioRecorderViewModel: ObservableObject {
         let effectiveTask = resolvedTask(for: request)
 
         do {
-            let result = try await modelManager.transcribe(
-                audioSamples: request.buffer,
-                languageSelection: request.languageSelection,
-                task: effectiveTask,
-                engineOverrideId: request.providerId,
-                cloudModelOverride: request.modelOverrideId,
-                prompt: request.prompt,
-                dictionaryTermHints: request.dictionaryTermHints
-            )
+            let result = try await transcribeFinalRecording(request, task: effectiveTask)
             let text = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !text.isEmpty else {
                 let failure = makeTranscriptionFailure(
@@ -1198,6 +1182,23 @@ final class AudioRecorderViewModel: ObservableObject {
             }
             return .skipped
         }
+    }
+
+    private func transcribeFinalRecording(
+        _ request: FinalTranscriptionRequest,
+        task: TranscriptionTask
+    ) async throws -> TranscriptionResult {
+        try await modelManager.transcribe(
+            audioSamples: request.buffer,
+            languageSelection: request.languageSelection,
+            task: task,
+            engineOverrideId: request.providerId,
+            cloudModelOverride: request.modelOverrideId,
+            prompt: request.prompt,
+            dictionaryTermHints: request.dictionaryTermHints,
+            onProgress: { _ in true },
+            onSourceProgress: { _ in true }
+        )
     }
 
     private func resolvedTask(for request: FinalTranscriptionRequest) -> TranscriptionTask {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -524,6 +524,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(request.audioSampleCount, finalizedFileSamples.count)
         XCTAssertEqual(request.firstAudioSample, finalizedFileSamples.first)
         XCTAssertNotEqual(request.audioSampleCount, captureSamples.count)
+        XCTAssertTrue(request.usedFileTranscriptionPipeline)
         let recording = try XCTUnwrap(viewModel.recordings.first)
         XCTAssertEqual(recording.transcript, "complete meeting transcript")
         XCTAssertEqual(recording.calendarEvent, metadata)
@@ -901,6 +902,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(request.language, "de")
         XCTAssertTrue(request.translate)
         XCTAssertTrue(request.prompt?.contains("TypeWhisper") == true)
+        XCTAssertTrue(request.usedFileTranscriptionPipeline)
         XCTAssertTrue(plugin.selectedModelOverrides.contains("universal-3-5-pro"))
     }
 
@@ -1764,13 +1766,14 @@ private final class AudioRecorderRestorableTranscriptionPlugin: NSObject, Transc
     }
 }
 
-private final class AudioRecorderMockTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgressTranscriptionEnginePlugin, @unchecked Sendable {
     struct Request: Sendable {
         let language: String?
         let translate: Bool
         let prompt: String?
         let audioSampleCount: Int
         let firstAudioSample: Float?
+        let usedFileTranscriptionPipeline: Bool
     }
 
     enum TranscriptionBehavior {
@@ -1830,12 +1833,52 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, Transcriptio
         translate: Bool,
         prompt: String?
     ) async throws -> PluginTranscriptionResult {
+        try performTranscription(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            usedFileTranscriptionPipeline: false
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool,
+        onSourceProgress: @Sendable @escaping (PluginTranscriptionSourceProgress) -> Bool
+    ) async throws -> PluginTranscriptionResult {
+        let result = try performTranscription(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            usedFileTranscriptionPipeline: true
+        )
+        _ = onProgress(result.text)
+        _ = onSourceProgress(PluginTranscriptionSourceProgress(
+            processedDuration: audio.duration,
+            totalDuration: audio.duration
+        ))
+        return result
+    }
+
+    private func performTranscription(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        usedFileTranscriptionPipeline: Bool
+    ) throws -> PluginTranscriptionResult {
         lastRequest = Request(
             language: language,
             translate: translate,
             prompt: prompt,
             audioSampleCount: audio.samples.count,
-            firstAudioSample: audio.samples.first
+            firstAudioSample: audio.samples.first,
+            usedFileTranscriptionPipeline: usedFileTranscriptionPipeline
         )
         return switch behavior {
         case .success(let text):


### PR DESCRIPTION
## Summary

- route Recorder final transcription through the same source-progress-aware transcription pipeline used by File Transcription
- reuse that pipeline for Recorder retranscription so retries cannot diverge again
- extend recorder regression coverage to assert both finalized audio input and pipeline selection

## Issue context

Issue #1091 reports that automatic Microsoft Teams meeting recordings produce incomplete transcripts even though transcribing the saved recording through File Transcription is substantially more complete. The reporter confirmed the problem still occurs in the August 17 daily build, which already contains the earlier finalized-audio fix from #1109.

The remaining difference was the transcription entry point: Recorder finalization used the basic batch overload, while File Transcription used the source-progress-aware overload. Engines such as WhisperKit implement those as distinct paths. This change gives Recorder finalization and Recorder retries the same pipeline selection as File Transcription while preserving the existing live-session result path.

Closes #1091

## User impact

Automatic meeting transcripts and Recorder retries now use the same long-audio transcription path as manual File Transcription when a finalized batch transcription is required.

## Test plan

- [x] Recorder and meeting automation suites:
  ```shell
  xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/AudioRecorderViewModelTests -only-testing:TypeWhisperTests/CalendarMeetingAutomationControllerTests CODE_SIGNING_ALLOWED=NO
  ```
- [x] Diff validation:
  ```shell
  git diff --check origin/main...HEAD
  ```
- [ ] Manual 30-minute meeting retest with the reporter's model and recording setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved final transcription and retranscription reliability by routing both workflows through the file-based transcription process.
  * Ensured transcription progress continues correctly during processing.

* **Tests**
  * Added coverage confirming the correct transcription pipeline is used for calendar meetings and recorder retranscriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->