### PR TITLE
Add timed OpenRouter STT segments for subtitle exports

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -188,6 +188,10 @@ final class OpenRouterPlugin: NSObject,
                 "format": uploadFile.format,
             ],
         ]
+        if Self.supportsVerboseTimestamps(modelId: modelId) {
+            body["response_format"] = "verbose_json"
+            body["timestamp_granularities"] = ["segment"]
+        }
         let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmedLanguage, !trimmedLanguage.isEmpty {
             body["language"] = trimmedLanguage
@@ -200,6 +204,11 @@ final class OpenRouterPlugin: NSObject,
         request.timeoutInterval = timeout
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
         return request
+    }
+
+    private static func supportsVerboseTimestamps(modelId: String) -> Bool {
+        let provider = modelId.split(separator: "/", maxSplits: 1).first?.lowercased()
+        return provider == "openai" || provider == "groq" || provider == "together"
     }
 
     static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
@@ -223,13 +232,28 @@ final class OpenRouterPlugin: NSObject,
     }
 
     static func parseTranscriptionResponse(_ data: Data) throws -> PluginTranscriptionResult {
+        struct Segment: Decodable {
+            let text: String
+            let start: Double
+            let end: Double
+        }
+
         struct Response: Decodable {
             let text: String
+            let language: String?
+            let segments: [Segment]?
         }
 
         do {
             let response = try JSONDecoder().decode(Response.self, from: data)
-            return PluginTranscriptionResult(text: response.text)
+            let segments = (response.segments ?? []).map {
+                PluginTranscriptionSegment(text: $0.text, start: $0.start, end: $0.end)
+            }
+            return PluginTranscriptionResult(
+                text: response.text,
+                detectedLanguage: response.language,
+                segments: segments
+            )
         } catch {
             if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                let text = json["text"] as? String {

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -276,6 +276,8 @@ final class OpenRouterPluginTests: XCTestCase {
         let body = try Self.jsonBody(from: request)
         XCTAssertEqual(body["model"] as? String, "openai/whisper-1")
         XCTAssertEqual(body["language"] as? String, "de")
+        XCTAssertEqual(body["response_format"] as? String, "verbose_json")
+        XCTAssertEqual(body["timestamp_granularities"] as? [String], ["segment"])
 
         let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
         XCTAssertEqual(inputAudio["format"] as? String, "m4a")
@@ -296,7 +298,21 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertNil(body["prompt"])
     }
 
-    func testTranscribeSendsJSONRequestAndParsesText() async throws {
+    func testTranscriptionRequestUsesPlainJSONForUnsupportedTimestampProvider() throws {
+        let request = try OpenRouterPlugin.makeTranscriptionRequest(
+            uploadFile: Self.m4aUpload(),
+            apiKey: "openrouter-key",
+            modelId: "deepgram/nova-3",
+            language: nil,
+            timeout: 120
+        )
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertNil(body["response_format"])
+        XCTAssertNil(body["timestamp_granularities"])
+    }
+
+    func testTranscribeRequestsAndParsesTimedSegments() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedModel": "openai/whisper-1"],
             secrets: ["api-key": "openrouter-key"]
@@ -308,7 +324,9 @@ final class OpenRouterPluginTests: XCTestCase {
         PluginHTTPClientTestHarness.configure { _ in
             store.makeSession(outcomes: [
                 .success(
-                    Data(#"{"text":"hello from openrouter","usage":{"cost":0.01}}"#.utf8),
+                    Data(
+                        #"{"text":"hello from openrouter","language":"en","segments":[{"id":0,"start":0.0,"end":1.25,"text":"hello from"},{"id":1,"start":1.25,"end":2.5,"text":"openrouter"}],"usage":{"cost":0.01}}"#.utf8
+                    ),
                     Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
                 ),
             ])
@@ -322,6 +340,14 @@ final class OpenRouterPluginTests: XCTestCase {
         )
 
         XCTAssertEqual(result.text, "hello from openrouter")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].text, "hello from")
+        XCTAssertEqual(result.segments[0].start, 0.0)
+        XCTAssertEqual(result.segments[0].end, 1.25)
+        XCTAssertEqual(result.segments[1].text, "openrouter")
+        XCTAssertEqual(result.segments[1].start, 1.25)
+        XCTAssertEqual(result.segments[1].end, 2.5)
 
         let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
         XCTAssertEqual(request.url?.path, "/api/v1/audio/transcriptions")
@@ -331,6 +357,8 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(body["model"] as? String, "openai/whisper-1")
         XCTAssertEqual(body["language"] as? String, "de")
         XCTAssertNil(body["prompt"])
+        XCTAssertEqual(body["response_format"] as? String, "verbose_json")
+        XCTAssertEqual(body["timestamp_granularities"] as? [String], ["segment"])
         let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
         XCTAssertEqual(inputAudio["format"] as? String, "m4a")
     }

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -312,6 +312,26 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertNil(body["timestamp_granularities"])
     }
 
+    func testTranscriptionRequestUsesVerboseJSONForCompatibleTimestampProviders() throws {
+        for modelId in [
+            "openai/whisper-1",
+            "groq/whisper-large-v3",
+            "together/whisper-large-v3",
+        ] {
+            let request = try OpenRouterPlugin.makeTranscriptionRequest(
+                uploadFile: Self.m4aUpload(),
+                apiKey: "openrouter-key",
+                modelId: modelId,
+                language: nil,
+                timeout: 120
+            )
+
+            let body = try Self.jsonBody(from: request)
+            XCTAssertEqual(body["response_format"] as? String, "verbose_json", modelId)
+            XCTAssertEqual(body["timestamp_granularities"] as? [String], ["segment"], modelId)
+        }
+    }
+
     func testTranscribeRequestsAndParsesTimedSegments() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedModel": "openai/whisper-1"],

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Context

A user reported that OpenRouter speech-to-text results export as one full-length SRT cue even when the upstream model can return timestamps. Local Parakeet output already exports as segmented subtitles.

The OpenRouter plugin requested the default plain JSON response and decoded only `text`, so no timing data reached `PluginTranscriptionResult.segments`.

## What changed

- Request `verbose_json` with segment timestamp granularity for OpenAI-compatible OpenRouter STT model routes.
- Decode returned language and segment timing data into `PluginTranscriptionResult` and `PluginTranscriptionSegment`.
- Keep the default plain JSON request for providers such as Deepgram that currently reject OpenRouter's verbose response format.
- Bump the OpenRouter plugin manifest to `1.1.5` for an independent plugin release.

## User impact

Supported OpenRouter STT models now preserve real segment boundaries for SRT and VTT export instead of falling back to one cue covering the complete recording. Deepgram through OpenRouter remains text-only until OpenRouter exposes structured timestamps for that provider.

## Test plan

```bash
swift test --package-path TypeWhisperPluginSDK --filter OpenRouterPluginTests
xcodebuild -project TypeWhisper.xcodeproj -target OpenRouterPlugin -configuration Release SYMROOT=/tmp/typewhisper-openrouter-pr CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.1.5 build
```

Expected: all focused OpenRouter tests pass, and the release plugin bundle builds successfully for arm64 and x86_64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcriptions from supported providers now include detected language and segment-level timestamps.
  * Improved handling for verbose transcription responses while preserving compatibility with text-only responses.

* **Bug Fixes**
  * Unsupported providers no longer receive timestamp-specific transcription options.
  * Transcription metadata is now parsed more reliably when available.

* **Chores**
  * Updated the OpenRouter plugin version to 1.1.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->