### PR TITLE
Refresh plugin update count after uninstall

### DIFF
--- a/TypeWhisper/Services/PluginRegistryService.swift
+++ b/TypeWhisper/Services/PluginRegistryService.swift
@@ -901,6 +901,7 @@ final class PluginRegistryService: ObservableObject {
             appSupportDirectory: AppConstants.appSupportDirectory,
             deleteData: deleteData
         )
+        updateAvailableUpdatesCount()
         logger.info("Uninstalled plugin: \(pluginId)")
 
         if let error = keychainError {

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -557,6 +557,78 @@ final class PluginRegistryServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testUninstallingPluginWithAvailableUpdateRefreshesCount() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginUpdateUninstall")
+        let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginUpdateUninstallCache")
+        defer {
+            TestSupport.remove(appSupportDirectory)
+            TestSupport.remove(cacheDirectory)
+        }
+
+        let previousPluginManager = PluginManager.shared
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared = pluginManager
+        defer { PluginManager.shared = previousPluginManager }
+
+        let pluginId = "com.typewhisper.update-uninstall"
+        let bundleURL = pluginManager.pluginsDirectory
+            .appendingPathComponent("UpdateUninstallPlugin.bundle", isDirectory: true)
+        try Self.makePluginBundle(
+            at: bundleURL,
+            pluginId: pluginId,
+            pluginName: "Update Uninstall Plugin",
+            version: "1.0.0"
+        )
+        let bundle = try XCTUnwrap(Bundle(url: bundleURL))
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: pluginId,
+                    name: "Update Uninstall Plugin",
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "RuntimeUpdatePlugin"
+                ),
+                instance: MockRuntimeUpdatePlugin(),
+                bundle: bundle,
+                sourceURL: bundleURL,
+                isEnabled: false
+            ),
+        ]
+
+        let service = PluginRegistryService(
+            registryBaseURL: URL(string: "https://example.com")!,
+            cacheDirectory: cacheDirectory,
+            deleteCredentials: { _ in },
+            fetchData: { _ in throw URLError(.badServerResponse) }
+        )
+        service.registry = [
+            Self.makeRegistryPlugin(
+                id: pluginId,
+                name: "Update Uninstall Plugin",
+                version: "1.1.0"
+            ),
+        ]
+        service.updateAvailableUpdatesCount()
+        XCTAssertEqual(service.availableUpdatesCount, 1)
+
+        try service.uninstallPlugin(pluginId, deleteData: true)
+
+        XCTAssertEqual(service.availableUpdatesCount, 0)
+        XCTAssertTrue(service.availableUpdatePlugins().isEmpty)
+        XCTAssertTrue(pluginManager.loadedPlugins.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: bundleURL.path))
+
+        var installerWasCalled = false
+        let result = await service.updateAllAvailablePlugins { _ in
+            installerWasCalled = true
+            return true
+        }
+        XCTAssertEqual(result, .empty)
+        XCTAssertFalse(installerWasCalled)
+    }
+
+    @MainActor
     func testBulkUpdateContinuesAfterFailureAndReportsProgress() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdate")
         let cacheDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginBulkUpdateCache")


### PR DESCRIPTION
## Summary

- refresh the available plugin update count immediately after uninstalling a plugin
- add a regression test for uninstalling a plugin with a pending Marketplace update
- verify that the bulk updater no longer receives a stale, empty update action

## Context

Uninstalling a plugin removed it from `PluginManager.loadedPlugins`, but the separately published `availableUpdatesCount` was not recomputed. The Integrations header therefore continued to show an update and kept **Update All and Restart** visible even though the bulk-update selection was already empty. Clicking the button then appeared to do nothing.

The uninstall path now refreshes the count after removing the plugin and its persisted data. This keeps the counter, header summary, sidebar badge, and bulk-update button in sync.

## User impact

When users uninstall a plugin that had an available update, the update count decreases immediately. If it was the final pending update, **Update All and Restart** disappears instead of remaining as a no-op button.

## Test plan

- `xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/PluginRegistryServiceTests`
- Confirm 31 tests pass with 0 failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed plugin uninstallation so available update counts and update listings refresh correctly after removal.
  - Prevented removed plugins from being included in subsequent bulk updates.

- **Tests**
  - Added coverage for uninstalling plugins with available updates, including cleanup of related plugin data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->