### PR TITLE
Stabilize recorder retranscription test synchronization

### DIFF
--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -872,7 +872,13 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let recording = try XCTUnwrap(viewModel.recordings.first)
         viewModel.transcribeRecording(recording)
         XCTAssertFalse(viewModel.canToggleRecording)
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcript == "fresh retranscription"
+                    && $0.recordings.first?.transcriptionFailure == nil
+            }
+        )
 
         XCTAssertEqual(loadedURL?.standardizedFileURL, audioURL.standardizedFileURL)
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "fresh retranscription")
@@ -984,7 +990,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
         try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcriptionFailure?.phase == .preparingFinalAudio
+            }
+        )
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .preparingFinalAudio)
@@ -1012,7 +1023,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
         try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcriptionFailure?.phase == .finalTranscription
+            }
+        )
 
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .finalTranscription)
@@ -1038,7 +1054,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
         try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcriptionFailure?.phase == .emptyResult
+            }
+        )
 
         XCTAssertNil(viewModel.recordings.first?.transcript)
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .emptyResult)
@@ -1070,7 +1091,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
         try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcriptionFailure?.phase == .savingTranscript
+            }
+        )
 
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .savingTranscript)
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
@@ -1116,7 +1142,12 @@ final class AudioRecorderViewModelTests: XCTestCase {
         try await waitForRecordingsToLoad(viewModel, count: 1)
 
         viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
-        try await waitForRetranscriptionToFinish(viewModel)
+        try await waitForRetranscriptionToFinish(
+            viewModel,
+            recordingsSatisfy: {
+                $0.recordings.first?.transcriptionFailure?.phase == .savingTranscript
+            }
+        )
 
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .savingTranscript)
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
@@ -1435,16 +1466,18 @@ final class AudioRecorderViewModelTests: XCTestCase {
 
     private func waitForRetranscriptionToFinish(
         _ viewModel: AudioRecorderViewModel,
+        recordingsSatisfy: (AudioRecorderViewModel) -> Bool = { _ in true },
         file: StaticString = #filePath,
         line: UInt = #line
     ) async throws {
         for _ in 0..<100 {
-            if viewModel.retranscribingRecordingURL == nil {
+            // The operation flag is cleared before loadRecordings() publishes its asynchronous refresh.
+            if viewModel.retranscribingRecordingURL == nil, recordingsSatisfy(viewModel) {
                 return
             }
             try await Task.sleep(for: .milliseconds(20))
         }
-        XCTFail("Recorder retranscription did not finish", file: file, line: line)
+        XCTFail("Recorder retranscription or recording reload did not finish", file: file, line: line)
     }
 
     private func waitForRecordingsToLoad(


### PR DESCRIPTION
## Context

A full app test run on PR #1125 intermittently failed `testRetranscriptionMarkdownWriteFailureRestoresAllTranscriptFiles`: the expected `.savingTranscript` failure was still `nil`. A parallel full app test run for the same commit passed.

The test helper returned as soon as `retranscribingRecordingURL` became `nil`, but the view model clears that operation flag before the asynchronous `loadRecordings()` refresh publishes the updated recording state. The assertion could therefore read the stale pre-retranscription item.

This test-only PR is intentionally separate from #1125.

## Changes

- allow retranscription tests to wait for both operation completion and an expected published recording state
- use the state-aware wait in every retranscription test that asserts refreshed recording data
- leave production behavior unchanged

## Test plan

```bash
xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRetranscriptionUsesRecorderOverridesAndReplacesTranscriptAfterSuccess \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRetranscriptionAudioLoadFailurePreservesExistingTranscript \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRetranscriptionEngineFailurePreservesExistingTranscript \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testEmptyRetranscriptionPersistsFailureWithoutTranscript \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRetranscriptionSaveFailurePreservesExistingTranscriptAndRecordsFailure \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRetranscriptionMarkdownWriteFailureRestoresAllTranscriptFiles \
  -test-iterations 20 -run-tests-until-failure -test-repetition-relaunch-enabled NO
```

Result: 120/120 repetitions passed.

```bash
xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests
```

Result: 36/36 tests passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved retranscription test synchronization to wait for recording reloads to complete before verifying results.
  * Added clearer timeout reporting when asynchronous recording state updates do not finish in time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->