### PR TITLE
feat: add Adaptive Dictation community plugin

### DIFF
--- a/PluginRegistry/community-v1/com.raysun.typewhisper.adaptive-dictionary.json
+++ b/PluginRegistry/community-v1/com.raysun.typewhisper.adaptive-dictionary.json
@@ -1,0 +1,13 @@
+{
+  "id": "com.raysun.typewhisper.adaptive-dictionary",
+  "name": "Adaptive Dictation",
+  "author": "Ray Sun",
+  "description": "Clean dictation locally, learn vocabulary from committed edits, and use optional Gemma 4 semantic rewriting.",
+  "source": "community",
+  "category": "post-processor",
+  "categories": ["post-processor", "llm"],
+  "hosting": "local",
+  "requiresAPIKey": false,
+  "iconSystemName": "waveform.badge.checkmark",
+  "releases": []
+}


### PR DESCRIPTION
## Summary

Adds source-review metadata for Adaptive Dictation, an independent local post-processor for TypeWhisper.

- Source: https://github.com/rayshineeeee/typewhisper-adaptive-dictionary
- Public release: https://github.com/rayshineeeee/typewhisper-adaptive-dictionary/releases/tag/v1.1.1
- License: GPL-3.0-only
- Hosting: local
- API key: not required

## What the plugin does

Adaptive Dictation performs conservative filler, stutter, punctuation, self-correction, and list cleanup; routes between Casual and Clear writing profiles; learns vocabulary from committed edits; and optionally uses local Gemma 4 inference for ambiguous passages. It never answers dictated questions.

Inference, learned rules, and transcript history stay on the Mac. The only network path is an explicit user-requested model download from Hugging Face. Model weights are not bundled or redistributed.

## Source and release readiness

The public repository includes a one-ZIP manual installation path, 46 tests, a native plugin harness, deterministic and semantic runtime verification, pinned dependencies, GPL modification notices, bundled MIT and Apache-2.0 dependency licenses, and a SHA-256 release checksum.

`releases` is intentionally empty. Per the Community registry workflow, a TypeWhisper maintainer can review the source and later build, sign, host, and publish the marketplace artifact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Adaptive Dictation plugin to the community plugin registry.
  * Listed support for local dictation cleanup, vocabulary learning from edits, and optional semantic rewriting.
  * Identified the plugin as locally processed and requiring no API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->