### PR TITLE
Automate localized plugin settings screenshots

### DIFF
--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -149,18 +149,39 @@ enum AppConstants {
         return defaultAppSupportDirectory
     }
 
-    private static let screenshotAppSupportDirectory: URL = {
-        if let override = screenshotArgumentValue(after: "--screenshot-app-support"),
-           override.hasPrefix("/") {
-            return URL(fileURLWithPath: override, isDirectory: true)
-        }
+    private static let screenshotAppSupportDirectory: URL =
+        resolveScreenshotAppSupportDirectory(
+            override: screenshotArgumentValue(after: "--screenshot-app-support"),
+            temporaryDirectory: FileManager.default.temporaryDirectory,
+            processIdentifier: ProcessInfo.processInfo.processIdentifier
+        )
 
-        return FileManager.default.temporaryDirectory
+    static func resolveScreenshotAppSupportDirectory(
+        override: String?,
+        temporaryDirectory: URL,
+        processIdentifier: Int32
+    ) -> URL {
+        let fallback = temporaryDirectory
             .appendingPathComponent(
-                "TypeWhisper-Screenshots-\(ProcessInfo.processInfo.processIdentifier)",
+                "TypeWhisper-Screenshots-\(processIdentifier)",
                 isDirectory: true
             )
-    }()
+
+        guard let override, override.hasPrefix("/") else { return fallback }
+
+        let temporaryRoot = temporaryDirectory
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let candidate = URL(fileURLWithPath: override, isDirectory: true)
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let temporaryPrefix = temporaryRoot.path.hasSuffix("/")
+            ? temporaryRoot.path
+            : temporaryRoot.path + "/"
+
+        guard candidate.path.hasPrefix(temporaryPrefix) else { return fallback }
+        return candidate
+    }
 
     static let defaultAppSupportDirectory: URL = {
         let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!

--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -16,9 +16,30 @@ enum AppConstants {
         return screenshotArgumentValue(after: "--screenshot-state")
     }()
 
+    static let screenshotPluginId: String? = {
+        guard isScreenshotAutomation else { return nil }
+        return screenshotArgumentValue(after: "--screenshot-plugin-id")
+    }()
+
+    static let screenshotPluginWindowSize: CGSize? = {
+        guard isScreenshotAutomation,
+              let widthValue = screenshotArgumentValue(after: "--screenshot-window-width"),
+              let heightValue = screenshotArgumentValue(after: "--screenshot-window-height"),
+              let width = Double(widthValue), width > 0,
+              let height = Double(heightValue), height > 0 else { return nil }
+        return CGSize(width: width, height: height)
+    }()
+
     static let screenshotReadyFileURL: URL? = {
         guard isScreenshotAutomation,
               let path = screenshotArgumentValue(after: "--screenshot-ready-file"),
+              path.hasPrefix("/") else { return nil }
+        return URL(fileURLWithPath: path)
+    }()
+
+    static let screenshotScrollCommandFileURL: URL? = {
+        guard isScreenshotAutomation,
+              let path = screenshotArgumentValue(after: "--screenshot-scroll-command-file"),
               path.hasPrefix("/") else { return nil }
         return URL(fileURLWithPath: path)
     }()
@@ -129,7 +150,12 @@ enum AppConstants {
     }
 
     private static let screenshotAppSupportDirectory: URL = {
-        FileManager.default.temporaryDirectory
+        if let override = screenshotArgumentValue(after: "--screenshot-app-support"),
+           override.hasPrefix("/") {
+            return URL(fileURLWithPath: override, isDirectory: true)
+        }
+
+        return FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "TypeWhisper-Screenshots-\(ProcessInfo.processInfo.processIdentifier)",
                 isDirectory: true

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -639,6 +639,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var appActivationObserver: NSObjectProtocol?
     private var workspaceWakeObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
+    private var pluginScreenshotCaptureController: PluginSettingsScreenshotCaptureController?
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
     var updateChecker: UpdateChecker {
@@ -851,6 +852,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     private func openScreenshotWindow() {
+        if let pluginId = AppConstants.screenshotPluginId {
+            openScreenshotPluginWindow(pluginId: pluginId)
+            return
+        }
+
         guard let destination = screenshotPremiumDestination else {
             openSettingsWindow()
             prepareScreenshotSettingsWindow()
@@ -859,6 +865,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         PremiumSettingsWindowManager.shared.present(destination)
         prepareScreenshotPremiumWindow(destination)
+    }
+
+    private func openScreenshotPluginWindow(pluginId: String) {
+        guard let plugin = PluginManager.shared.loadedPlugins.first(where: { $0.id == pluginId }) else {
+            fputs("Screenshot plugin was not loaded: \(pluginId)\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        guard plugin.supportsSettingsWindow else {
+            fputs("Screenshot plugin has no settings window: \(pluginId)\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+
+        PluginSettingsWindowManager.shared.present(plugin)
+        prepareScreenshotPluginWindow(pluginId: pluginId)
     }
 
     private func prepareScreenshotSettingsWindow(remainingAttempts: Int = 8) {
@@ -905,7 +927,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         prepareScreenshotWindow(window, contentSize: contentSize)
     }
 
-    private func prepareScreenshotWindow(_ window: NSWindow, contentSize: NSSize? = nil) {
+    private func prepareScreenshotPluginWindow(
+        pluginId: String,
+        remainingAttempts: Int = 8
+    ) {
+        guard AppConstants.isScreenshotAutomation else { return }
+
+        guard let window = PluginSettingsWindowManager.shared.managedWindow(for: pluginId) else {
+            guard remainingAttempts > 0 else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                self.prepareScreenshotPluginWindow(
+                    pluginId: pluginId,
+                    remainingAttempts: remainingAttempts - 1
+                )
+            }
+            return
+        }
+
+        var contentSize = AppConstants.screenshotPluginWindowSize
+        if let requestedSize = contentSize,
+           let visibleFrame = window.screen?.visibleFrame ?? NSScreen.main?.visibleFrame {
+            let titlebarHeight = window.frame.height - window.contentLayoutRect.height
+            let maximumHeight = max(400, visibleFrame.height - titlebarHeight - 80)
+            contentSize = NSSize(width: requestedSize.width, height: min(requestedSize.height, maximumHeight))
+        }
+
+        guard let readyFileURL = AppConstants.screenshotReadyFileURL,
+              let commandFileURL = AppConstants.screenshotScrollCommandFileURL else {
+            prepareScreenshotWindow(window, contentSize: contentSize)
+            return
+        }
+
+        prepareScreenshotWindow(window, contentSize: contentSize, writesReadyMarker: false)
+        Task { @MainActor [weak self, weak window] in
+            try? await Task.sleep(for: .seconds(1))
+            guard let self, let window else { return }
+            let controller = PluginSettingsScreenshotCaptureController(
+                window: window,
+                readyFileURL: readyFileURL,
+                commandFileURL: commandFileURL
+            )
+            self.pluginScreenshotCaptureController = controller
+            controller.start()
+        }
+    }
+
+    private func prepareScreenshotWindow(
+        _ window: NSWindow,
+        contentSize: NSSize? = nil,
+        writesReadyMarker: Bool = true
+    ) {
         if let contentSize {
             window.setContentSize(contentSize)
         }
@@ -913,7 +984,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         window.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
 
-        guard let readyFileURL = AppConstants.screenshotReadyFileURL else { return }
+        guard writesReadyMarker,
+              let readyFileURL = AppConstants.screenshotReadyFileURL else { return }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             do {
                 try "\(window.windowNumber)\n".write(

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -56,6 +56,10 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
     // MARK: - Keychain
 
     func storeSecret(key: String, value: String) throws {
+        if AppConstants.isScreenshotAutomation {
+            return
+        }
+
         let scopedService = "\(pluginId).\(key)"
         if value.isEmpty {
             try KeychainService.delete(service: scopedService)
@@ -65,6 +69,14 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
     }
 
     func loadSecret(key: String) -> String? {
+        if AppConstants.isScreenshotAutomation {
+            return ScreenshotPluginFixture.secret(
+                selectedPluginId: AppConstants.screenshotPluginId,
+                pluginId: pluginId,
+                key: key
+            )
+        }
+
         let scopedService = "\(pluginId).\(key)"
         return KeychainService.load(service: scopedService)
     }
@@ -157,6 +169,31 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
             MainActor.assumeIsolated {
                 body()
             }
+        }
+    }
+}
+
+enum ScreenshotPluginFixture {
+    static func secret(selectedPluginId: String?, pluginId: String, key: String) -> String? {
+        guard selectedPluginId == pluginId else { return nil }
+
+        switch key {
+        case "api-key":
+            return "tw-screenshot-api-key"
+        case let value where value.hasPrefix("api-key."):
+            return "tw-screenshot-api-key"
+        case "hf-token":
+            return "hf_tw_screenshot_fixture"
+        case "authorization-key":
+            return "tw-screenshot-authorization-key"
+        case "cf-client-id":
+            return "tw-screenshot-client-id"
+        case "cf-client-secret":
+            return "tw-screenshot-client-secret"
+        case "service-account-json":
+            return #"{"type":"service_account","project_id":"typewhisper-screenshot","private_key_id":"screenshot","private_key":"-----BEGIN PRIVATE KEY-----\nSCREENSHOT FIXTURE\n-----END PRIVATE KEY-----\n","client_email":"screenshots@typewhisper-screenshot.iam.gserviceaccount.com"}"#
+        default:
+            return nil
         }
     }
 }

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -192,6 +192,11 @@ enum ScreenshotPluginFixture {
             return "tw-screenshot-client-secret"
         case "service-account-json":
             return #"{"type":"service_account","project_id":"typewhisper-screenshot","private_key_id":"screenshot","private_key":"-----BEGIN PRIVATE KEY-----\nSCREENSHOT FIXTURE\n-----END PRIVATE KEY-----\n","client_email":"screenshots@typewhisper-screenshot.iam.gserviceaccount.com"}"#
+        case "contributor-token":
+            return "tw-screenshot-contributor-token"
+        case "oauth-access-token", "oauth-refresh-token", "oauth-id-token":
+            // Keep the OpenAI screenshot in API-key mode instead of simulating a ChatGPT account.
+            return nil
         default:
             return nil
         }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -635,6 +635,11 @@ final class PluginManager: ObservableObject {
     }
 
     private func resolvedEnabledState(for manifest: PluginManifest, isBundledSource: Bool) -> Bool {
+        if AppConstants.isScreenshotAutomation,
+           AppConstants.screenshotPluginId == manifest.id {
+            return true
+        }
+
         let enabledKey = "plugin.\(manifest.id).enabled"
         if let stored = UserDefaults.standard.object(forKey: enabledKey) as? Bool {
             return stored

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -524,6 +524,21 @@ final class PluginManager: ObservableObject {
             throw error
         }
 
+        guard ScreenshotPluginSourcePolicy.allowsCandidate(
+            isScreenshotAutomation: AppConstants.isScreenshotAutomation,
+            selectedPluginId: AppConstants.screenshotPluginId,
+            manifestId: manifest.id,
+            isBundledSource: isBundledSource,
+            isIsolatedScreenshotSource: url.deletingLastPathComponent()
+                .resolvingSymlinksInPath()
+                .standardizedFileURL == pluginsDirectory
+                .resolvingSymlinksInPath()
+                .standardizedFileURL
+        ) else {
+            logger.info("Skipping external screenshot plugin candidate \(manifest.id, privacy: .public)")
+            return
+        }
+
         if !isManifestCompatible(manifest) {
             let architecture = RuntimeArchitecture.current
             let reason = PluginCompatibility.incompatibilityReason(
@@ -862,5 +877,18 @@ final class PluginManager: ObservableObject {
         }
 
         return versionComparison == .orderedDescending
+    }
+}
+
+enum ScreenshotPluginSourcePolicy {
+    static func allowsCandidate(
+        isScreenshotAutomation: Bool,
+        selectedPluginId: String?,
+        manifestId: String,
+        isBundledSource: Bool,
+        isIsolatedScreenshotSource: Bool
+    ) -> Bool {
+        guard isScreenshotAutomation, selectedPluginId == manifestId else { return true }
+        return isBundledSource || isIsolatedScreenshotSource
     }
 }

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -68,8 +68,9 @@ final class PluginSettingsScreenshotCaptureController {
             scrollView = candidate
             candidate.hasVerticalScroller = false
             contentHeight = documentHeight(of: candidate)
-            viewportHeight = candidate.contentView.documentVisibleRect.height
-            let viewportRect = candidate.convert(candidate.bounds, to: nil)
+            let clipView = candidate.contentView
+            viewportHeight = clipView.documentVisibleRect.height
+            let viewportRect = clipView.convert(clipView.bounds, to: nil)
             scrollViewportMinY = viewportRect.minY
             scrollViewportMaxY = viewportRect.maxY
             pageOffsets = PluginScreenshotPagination.pageOffsets(

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -2,12 +2,189 @@ import AppKit
 import SwiftUI
 import TypeWhisperPluginSDK
 
+struct PluginScreenshotPagination {
+    static let overlap: CGFloat = 48
+
+    static func pageOffsets(
+        contentHeight: CGFloat,
+        viewportHeight: CGFloat
+    ) -> [CGFloat] {
+        guard contentHeight > viewportHeight + 1, viewportHeight > overlap + 1 else {
+            return [0]
+        }
+
+        let maximumOffset = contentHeight - viewportHeight
+        let stride = viewportHeight - overlap
+        let additionalPageCount = Int(ceil(maximumOffset / stride))
+        return (0...additionalPageCount).map { pageIndex in
+            min(CGFloat(pageIndex) * stride, maximumOffset)
+        }
+    }
+}
+
+private struct PluginScreenshotScrollState: Codable {
+    let windowNumber: Int
+    let pageIndex: Int
+    let pageCount: Int
+    let contentHeight: Double
+    let viewportHeight: Double
+    let scrollOffset: Double
+    let backingScaleFactor: Double
+    let windowFrameHeight: Double
+    let titlebarHeight: Double
+    let scrollViewportMinY: Double
+    let scrollViewportMaxY: Double
+}
+
+@MainActor
+final class PluginSettingsScreenshotCaptureController {
+    private let window: NSWindow
+    private let readyFileURL: URL
+    private let commandFileURL: URL
+    private var scrollView: NSScrollView?
+    private var pageOffsets: [CGFloat] = [0]
+    private var contentHeight: CGFloat = 0
+    private var viewportHeight: CGFloat = 0
+    private var scrollViewportMinY: CGFloat = 0
+    private var scrollViewportMaxY: CGFloat = 0
+    private var lastCommand: String?
+    private var commandMonitor: Task<Void, Never>?
+
+    init(window: NSWindow, readyFileURL: URL, commandFileURL: URL) {
+        self.window = window
+        self.readyFileURL = readyFileURL
+        self.commandFileURL = commandFileURL
+    }
+
+    deinit {
+        commandMonitor?.cancel()
+    }
+
+    func start() {
+        window.contentView?.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        if let candidate = primaryScrollableView() {
+            scrollView = candidate
+            candidate.hasVerticalScroller = false
+            contentHeight = documentHeight(of: candidate)
+            viewportHeight = candidate.contentView.documentVisibleRect.height
+            let viewportRect = candidate.convert(candidate.bounds, to: nil)
+            scrollViewportMinY = viewportRect.minY
+            scrollViewportMaxY = viewportRect.maxY
+            pageOffsets = PluginScreenshotPagination.pageOffsets(
+                contentHeight: contentHeight,
+                viewportHeight: viewportHeight
+            )
+            scroll(toPage: 0)
+        } else {
+            contentHeight = window.contentLayoutRect.height
+            viewportHeight = contentHeight
+            scrollViewportMinY = 0
+            scrollViewportMaxY = viewportHeight
+        }
+
+        writeReadyState(pageIndex: 0)
+        guard pageOffsets.count > 1 else { return }
+
+        commandMonitor = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(100))
+                guard let self else { return }
+                self.processCommandIfNeeded()
+            }
+        }
+    }
+
+    private func processCommandIfNeeded() {
+        guard let value = try? String(contentsOf: commandFileURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !value.isEmpty,
+              value != lastCommand,
+              let pageIndex = Int(value),
+              pageOffsets.indices.contains(pageIndex) else { return }
+
+        lastCommand = value
+        scroll(toPage: pageIndex)
+
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(250))
+            self?.writeReadyState(pageIndex: pageIndex)
+        }
+    }
+
+    private func scroll(toPage pageIndex: Int) {
+        guard let scrollView, let documentView = scrollView.documentView else { return }
+        let offset = pageOffsets[pageIndex]
+        let maximumOffset = max(0, contentHeight - viewportHeight)
+        let targetY = documentView.isFlipped ? offset : maximumOffset - offset
+        scrollView.contentView.scroll(
+            to: NSPoint(x: scrollView.contentView.bounds.minX, y: targetY)
+        )
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+        window.displayIfNeeded()
+    }
+
+    private func writeReadyState(pageIndex: Int) {
+        let state = PluginScreenshotScrollState(
+            windowNumber: window.windowNumber,
+            pageIndex: pageIndex,
+            pageCount: pageOffsets.count,
+            contentHeight: contentHeight,
+            viewportHeight: viewportHeight,
+            scrollOffset: pageOffsets[pageIndex],
+            backingScaleFactor: window.backingScaleFactor,
+            windowFrameHeight: window.frame.height,
+            titlebarHeight: window.frame.height - window.contentLayoutRect.height,
+            scrollViewportMinY: scrollViewportMinY,
+            scrollViewportMaxY: scrollViewportMaxY
+        )
+
+        do {
+            let data = try JSONEncoder().encode(state)
+            try data.write(to: readyFileURL, options: .atomic)
+        } catch {
+            fputs("Could not write plugin screenshot state: \(error)\n", stderr)
+        }
+    }
+
+    private func primaryScrollableView() -> NSScrollView? {
+        guard let contentView = window.contentView else { return nil }
+        return scrollViews(in: contentView)
+            .filter { scrollView in
+                documentHeight(of: scrollView) > scrollView.contentView.documentVisibleRect.height + 1
+            }
+            .max { lhs, rhs in
+                let lhsOverflow = documentHeight(of: lhs) - lhs.contentView.documentVisibleRect.height
+                let rhsOverflow = documentHeight(of: rhs) - rhs.contentView.documentVisibleRect.height
+                if lhsOverflow == rhsOverflow {
+                    return lhs.contentView.bounds.width < rhs.contentView.bounds.width
+                }
+                return lhsOverflow < rhsOverflow
+            }
+    }
+
+    private func scrollViews(in view: NSView) -> [NSScrollView] {
+        let current = (view as? NSScrollView).map { [$0] } ?? []
+        return current + view.subviews.flatMap(scrollViews(in:))
+    }
+
+    private func documentHeight(of scrollView: NSScrollView) -> CGFloat {
+        guard let documentView = scrollView.documentView else { return 0 }
+        return max(documentView.bounds.height, documentView.frame.height)
+    }
+}
+
 @MainActor
 final class PluginSettingsWindowManager {
     static let shared = PluginSettingsWindowManager()
 
     private var windows: [String: NSWindow] = [:]
     private var delegates: [String: PluginSettingsWindowDelegate] = [:]
+
+    func managedWindow(for pluginId: String) -> NSWindow? {
+        windows[pluginId]
+    }
 
     func present(_ plugin: LoadedPlugin) {
         guard let settingsView = plugin.instance.settingsView else { return }

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -469,6 +469,7 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let keytermsPrompt = streamingKeytermsPromptJSON(from: prompt, modelId: modelId)
         guard let url = Self.makeStreamingURL(
             modelId: modelId,

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -408,7 +408,10 @@ private struct CloudflareASRSettingsView: View {
                 Text("Server URL", bundle: bundle)
                     .font(.headline)
 
-                TextField("e.g. https://asr.example.com", text: $baseURLInput)
+                TextField(
+                    String(localized: "e.g. https://asr.example.com", bundle: bundle),
+                    text: $baseURLInput
+                )
                     .textFieldStyle(.roundedBorder)
                     .font(.system(.body, design: .monospaced))
             }

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "API Key": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -19,6 +25,12 @@
     },
     "All credentials are stored securely in the macOS Keychain.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle Zugangsdaten werden sicher im macOS-Schlüsselbund gespeichert."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -35,6 +47,12 @@
     },
     "Cloudflare Tunnel Auth": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloudflare-Tunnel-Authentifizierung"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -51,6 +69,12 @@
     },
     "Connected": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbunden"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -67,6 +91,12 @@
     },
     "Connection Failed": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung fehlgeschlagen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -81,8 +111,36 @@
         }
       }
     },
+    "e.g. https://asr.example.com": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "z. B. https://asr.example.com"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: https://asr.example.com"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例如：https://asr.example.com"
+          }
+        }
+      }
+    },
     "Model": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -99,6 +157,12 @@
     },
     "Model name": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modellname"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -115,6 +179,12 @@
     },
     "No models found. Enter model name manually.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Modelle gefunden. Gib den Modellnamen manuell ein."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -131,6 +201,12 @@
     },
     "None": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keines"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -147,6 +223,12 @@
     },
     "Optional Bearer token for the upstream API behind the tunnel.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optionales Bearer-Token für die Upstream-API hinter dem Tunnel."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -163,6 +245,12 @@
     },
     "Refresh": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -179,6 +267,12 @@
     },
     "Save": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -195,6 +289,12 @@
     },
     "Server URL": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Server-URL"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -211,6 +311,12 @@
     },
     "Service token credentials for Cloudflare Access. Stored in macOS Keychain.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugangsdaten für das Service-Token von Cloudflare Access. Sie werden im macOS-Schlüsselbund gespeichert."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -227,6 +333,12 @@
     },
     "Test Connection": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verbindung testen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -243,6 +355,12 @@
     },
     "Testing...": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird getestet …"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -259,6 +377,12 @@
     },
     "Transcription Model": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -101,6 +101,7 @@ struct CohereLocalModelAssets: Sendable {
         bearerToken: String? = nil,
         progressHandler: @Sendable @escaping (Double) -> Void
     ) async throws {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         migrateLegacyRootIfNeeded()
         try FileManager.default.createDirectory(
             at: rootDirectory,

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
@@ -226,6 +226,7 @@ final class CrispAsrServer: @unchecked Sendable {
         process: Process,
         baseURL: String
     ) async throws {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         guard let healthURL = URL(string: "\(baseURL)/health") else {
             throw CohereLocalPluginError.invalidLocalServerURL
         }

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -40,6 +40,7 @@ private final class RawWebSocket: @unchecked Sendable {
 
     private let streamTask: URLSessionStreamTask
     private let hostName: String
+    private let usesTLS: Bool
     private let path: String
     private let extraHeaders: [(String, String)]
     private let logger = Logger(subsystem: "com.typewhisper.deepgram", category: "WebSocket")
@@ -48,18 +49,20 @@ private final class RawWebSocket: @unchecked Sendable {
 
     init(host: String, port: Int, usesTLS: Bool, path: String, headers: [(String, String)]) {
         self.hostName = host
+        self.usesTLS = usesTLS
         self.path = path
         self.extraHeaders = headers
 
         self.streamTask = URLSession.shared.streamTask(withHostName: host, port: port)
-        if usesTLS {
-            streamTask.startSecureConnection()
-        }
     }
 
     // MARK: - Connect + Upgrade
 
     func connect() async throws {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        if usesTLS {
+            streamTask.startSecureConnection()
+        }
         streamTask.resume()
         logger.info("Stream task started, performing WebSocket upgrade to \(self.hostName)")
         try await performUpgrade()

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -295,6 +295,7 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let url = try Self.realtimeURL(language: language, modelId: modelId)
 
         var request = URLRequest(url: url)

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -600,6 +600,9 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
         try Task.checkCancellation()
         let downloadedDirectory = usableModelDirectory(for: modelDef)
         let isAlreadyDownloaded = downloadedDirectory != nil
+        if !isAlreadyDownloaded {
+            try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        }
         let loadGeneration = beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
         startModelLoadTimeout(generation: loadGeneration, modelName: modelDef.displayName)
         do {

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -436,6 +436,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let liveSession = try await createLiveSession(
             language: language,
             languageHints: languageHints,

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "Cloud Speech-to-Text API is not enabled for this Google Cloud project. Enable speech.googleapis.com in Google Cloud, wait a few minutes, and retry.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Cloud Speech-to-Text API ist für dieses Google-Cloud-Projekt nicht aktiviert. Aktiviere speech.googleapis.com in Google Cloud, warte einige Minuten und versuche es erneut."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -19,6 +25,12 @@
     },
     "Credentials look valid and Speech-to-Text is reachable.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Zugangsdaten sind gültig und Speech-to-Text ist erreichbar."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -35,6 +47,12 @@
     },
     "Default Language": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardsprache"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -51,6 +69,12 @@
     },
     "Google Cloud billing is not enabled for this project. Enable billing for the project and retry.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Für dieses Projekt ist die Google-Cloud-Abrechnung nicht aktiviert. Aktiviere die Abrechnung für das Projekt und versuche es erneut."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -67,6 +91,12 @@
     },
     "Google Cloud rate-limited the request. Please wait a moment and retry.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Cloud hat die Anfrage gedrosselt. Warte kurz und versuche es erneut."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -83,6 +113,12 @@
     },
     "Google denied access to Speech-to-Text. Make sure the API is enabled and the service account has the Cloud Speech Client role.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google hat den Zugriff auf Speech-to-Text verweigert. Stelle sicher, dass die API aktiviert ist und das Dienstkonto die Rolle „Cloud Speech Client“ besitzt."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -99,6 +135,12 @@
     },
     "Google rejected the service-account credentials.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google hat die Dienstkonto-Zugangsdaten abgelehnt."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -115,6 +157,12 @@
     },
     "Google rejected the service-account credentials. Check that you pasted the full JSON key file for the correct project.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google hat die Dienstkonto-Zugangsdaten abgelehnt. Prüfe, ob du die vollständige JSON-Schlüsseldatei für das richtige Projekt eingefügt hast."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -131,6 +179,12 @@
     },
     "Google Speech-to-Text does not accept simple API keys. Paste a Google Cloud service-account JSON key here. Credentials are stored in the macOS Keychain.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Google Speech-to-Text akzeptiert keine einfachen API-Schlüssel. Füge hier den JSON-Schlüssel eines Google-Cloud-Dienstkontos ein. Die Zugangsdaten werden im macOS-Schlüsselbund gespeichert."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -147,6 +201,12 @@
     },
     "If TypeWhisper already passes a spoken language, that value wins. Otherwise this BCP-47 code is used for Google recognition requests.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wenn TypeWhisper bereits eine gesprochene Sprache übergibt, hat dieser Wert Vorrang. Andernfalls wird dieser BCP-47-Code für die Spracherkennungsanfragen an Google verwendet."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -163,6 +223,12 @@
     },
     "Model": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -179,6 +245,12 @@
     },
     "No Google recognition model is selected.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es ist kein Google-Spracherkennungsmodell ausgewählt."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -195,6 +267,12 @@
     },
     "No service-account JSON is configured yet.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Es ist noch kein Dienstkonto-JSON konfiguriert."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -211,6 +289,12 @@
     },
     "Remove": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -227,6 +311,12 @@
     },
     "Replace Credentials": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugangsdaten ersetzen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -243,6 +333,12 @@
     },
     "Save Credentials": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zugangsdaten speichern"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -259,6 +355,12 @@
     },
     "Service Account JSON": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dienstkonto-JSON"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -275,6 +377,12 @@
     },
     "Stored credentials are active. Paste a new JSON key above to replace them.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die gespeicherten Zugangsdaten sind aktiv. Füge oben einen neuen JSON-Schlüssel ein, um sie zu ersetzen."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -291,6 +399,12 @@
     },
     "Test Stored Credentials": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gespeicherte Zugangsdaten testen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -307,6 +421,12 @@
     },
     "The JSON could not be parsed. Paste the full Google service-account JSON file.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das JSON konnte nicht gelesen werden. Füge die vollständige JSON-Datei des Google-Dienstkontos ein."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -323,6 +443,12 @@
     },
     "The verification audio was rejected as too large.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Audiodatei zur Überprüfung wurde als zu groß abgelehnt."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -339,6 +465,12 @@
     },
     "Use `default` or `command_and_search` for the broadest language coverage. The newer `latest_*` models can be more restrictive depending on language support.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Verwende `default` oder `command_and_search`, um möglichst viele Sprachen abzudecken. Die neueren `latest_*`-Modelle können je nach Sprachunterstützung stärker eingeschränkt sein."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -355,6 +487,12 @@
     },
     "Validating...": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft …"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/MemPalaceMCPClient.swift
+++ b/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/MemPalaceMCPClient.swift
@@ -165,6 +165,7 @@ final class NonLoggingMemPalaceMCPHTTP: MemPalaceMCPHTTP, @unchecked Sendable {
     }
 
     func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         do {
             return try await session.data(for: request)
         } catch {

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAIRealtimeTranscription.swift
@@ -317,6 +317,7 @@ public final class PluginOpenAIRealtimeTranscriptionSession: LiveTranscriptionSe
         configuration: PluginOpenAIRealtimeTranscriptionConfiguration,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginOpenAIRealtimeTranscriptionSession {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let openWaiter = PluginOpenAIRealtimeWebSocketOpenWaiter()
         let delegate = PluginOpenAIRealtimeWebSocketDelegate(openWaiter: openWaiter)
         let urlSession = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -1213,6 +1213,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
         configuration: OpenAIRealtimeTranscriptionConfiguration,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> OpenAIRealtimeTranscriptionSession {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let request = try makeRequest(apiKey: apiKey)
         let openWaiter = OpenAIRealtimeWebSocketOpenWaiter()
         let delegate = OpenAIRealtimeWebSocketDelegate(openWaiter: openWaiter)

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
@@ -40,6 +40,7 @@ private final class RawWebSocket: @unchecked Sendable {
 
     private let streamTask: URLSessionStreamTask
     private let hostName: String
+    private let usesTLS: Bool
     private let path: String
     private let extraHeaders: [(String, String)]
     private let logger = Logger(subsystem: "com.typewhisper.reson8", category: "WebSocket")
@@ -48,18 +49,20 @@ private final class RawWebSocket: @unchecked Sendable {
 
     init(host: String, port: Int, usesTLS: Bool, path: String, headers: [(String, String)]) {
         self.hostName = host
+        self.usesTLS = usesTLS
         self.path = path
         self.extraHeaders = headers
 
         self.streamTask = URLSession.shared.streamTask(withHostName: host, port: port)
-        if usesTLS {
-            streamTask.startSecureConnection()
-        }
     }
 
     // MARK: - Connect + Upgrade
 
     func connect() async throws {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        if usesTLS {
+            streamTask.startSecureConnection()
+        }
         streamTask.resume()
         logger.info("Stream task started, performing WebSocket upgrade to \(self.hostName)")
         try await performUpgrade()

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -626,6 +626,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
         onProgress: @Sendable @escaping (String) -> Bool,
         webSocketURLOverride: URL? = nil
     ) async throws -> SonioxLiveTranscriptionSession {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         guard let url = webSocketURLOverride ?? URL(string: region.sttRealtimeWebSocketURL) else {
             throw PluginTranscriptionError.apiError("Invalid Soniox WebSocket URL")
         }

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -394,6 +394,7 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let urlString = "wss://\(wsHost)/v2"
 
         guard let url = URL(string: urlString) else {

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings
@@ -3,6 +3,12 @@
   "strings": {
     "Balanced": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ausgewogen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -19,6 +25,12 @@
     },
     "Delete cached model": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwischengespeichertes Modell löschen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -35,6 +47,12 @@
     },
     "Download & Load": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Herunterladen und laden"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -51,6 +69,12 @@
     },
     "Fast": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Schnell"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -67,6 +91,12 @@
     },
     "High": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoch"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -83,6 +113,12 @@
     },
     "Hugging Face Token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hugging-Face-Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -99,6 +135,12 @@
     },
     "I have read and accept the Supertonic 3 model license terms": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ich habe die Lizenzbedingungen für das Supertonic-3-Modell gelesen und akzeptiere sie"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -115,6 +157,12 @@
     },
     "Invalid Hugging Face token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiges Hugging-Face-Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -131,6 +179,12 @@
     },
     "Local text-to-speech powered by Supertonic 3 ONNX models. Model assets are downloaded only after you accept the model license.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lokale Text-zu-Sprache-Ausgabe mit den ONNX-Modellen von Supertonic 3. Die Modelldateien werden erst heruntergeladen, nachdem du die Modelllizenz akzeptiert hast."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -147,6 +201,12 @@
     },
     "Model": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modell"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -163,6 +223,12 @@
     },
     "Model License": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelllizenz"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -179,6 +245,12 @@
     },
     "Open Supertonic 3 OpenRAIL-M license": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OpenRAIL-M-Lizenz für Supertonic 3 öffnen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -195,6 +267,12 @@
     },
     "Optional. It can increase download rate limits for the model download.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optional. Das Token kann die Download-Limits für das Modell erhöhen."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -211,6 +289,12 @@
     },
     "Quality": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Qualität"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -227,6 +311,12 @@
     },
     "Ready": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereit"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -243,6 +333,12 @@
     },
     "Remove": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -259,6 +355,12 @@
     },
     "Save": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -275,6 +377,12 @@
     },
     "Speed": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Geschwindigkeit"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -291,6 +399,12 @@
     },
     "Supertonic (Experimental)": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Supertonic (experimentell)"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -307,6 +421,12 @@
     },
     "Supertonic 3 model assets are licensed under OpenRAIL-M and include use restrictions. Review the full license before downloading the model.": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Die Modelldateien von Supertonic 3 stehen unter der OpenRAIL-M-Lizenz und unterliegen Nutzungsbeschränkungen. Lies vor dem Download die vollständige Lizenz."
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -323,6 +443,12 @@
     },
     "Valid Hugging Face token": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültiges Hugging-Face-Token"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",
@@ -339,6 +465,12 @@
     },
     "Voice": {
       "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stimme"
+          }
+        },
         "ja": {
           "stringUnit": {
             "state": "translated",

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/SupertonicModelAssetManager.swift
@@ -185,7 +185,7 @@ struct SupertonicModelAssetManager: Sendable {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await PluginHTTPClient.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200..<300).contains(httpResponse.statusCode) else {
             throw SupertonicPluginError.invalidDownloadResponse
@@ -215,7 +215,7 @@ struct SupertonicModelAssetManager: Sendable {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await PluginHTTPClient.data(for: request)
         guard let httpResponse = response as? HTTPURLResponse,
               (200..<300).contains(httpResponse.statusCode) else {
             throw SupertonicPluginError.invalidDownloadResponse

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -893,6 +893,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         relativePath: String,
         destination: URL
     ) async throws {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         var url = URL(string: Self.modelEndpoint)!
         for component in Self.modelRepo.split(separator: "/") {
             url.append(path: String(component))

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -554,6 +554,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
                 downloadProgress = 0.05
 
                 var lastProgress = 0.0
+                try PluginHTTPClient.ensureNetworkAccessIsAllowed()
                 modelFolder = try await WhisperKit.download(
                     variant: modelDef.id,
                     downloadBase: downloadBase,

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
@@ -749,6 +749,7 @@ final class XAIPlugin: NSObject,
     }
 
     func speak(_ request: TTSSpeakRequest) async throws -> any TTSPlaybackSession {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         guard let apiKey = normalizedAPIKey else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -1016,6 +1017,7 @@ final class XAIPlugin: NSObject,
         language: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> XAILiveTranscriptionSession {
+        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
         let request = try Self.makeSTTStreamingRequest(apiKey: apiKey, language: language, interimResults: true)
         let task = URLSession.shared.webSocketTask(with: request)
         task.resume()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -99,8 +99,12 @@ public enum PluginHTTPClient {
         return try await session.data(for: request)
     }
 
-    private static func ensureNetworkAccessIsAllowed() throws {
-        guard networkAccessAllowed(arguments: ProcessInfo.processInfo.arguments) else {
+    public static func ensureNetworkAccessIsAllowed() throws {
+        try ensureNetworkAccessIsAllowed(arguments: ProcessInfo.processInfo.arguments)
+    }
+
+    @_spi(Testing) public static func ensureNetworkAccessIsAllowed(arguments: [String]) throws {
+        guard networkAccessAllowed(arguments: arguments) else {
             throw URLError(.notConnectedToInternet)
         }
     }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -74,13 +74,15 @@ public enum PluginHTTPClient {
     }
 
     public static func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        try await data(for: request, allowsRetry: true)
+        try ensureNetworkAccessIsAllowed()
+        return try await data(for: request, allowsRetry: true)
     }
 
     public static func data(
         for request: URLRequest,
         resourceTimeout: TimeInterval?
     ) async throws -> (Data, URLResponse) {
+        try ensureNetworkAccessIsAllowed()
         guard let resourceTimeout, resourceTimeout > longRunningResourceTimeout else {
             return try await data(for: request, allowsRetry: true)
         }
@@ -95,6 +97,20 @@ public enum PluginHTTPClient {
         let url = request.url?.absoluteString ?? "unknown"
         logger.info("\(method) \(url) (dedicated session, resourceTimeout=\(resourceTimeout))")
         return try await session.data(for: request)
+    }
+
+    private static func ensureNetworkAccessIsAllowed() throws {
+        guard networkAccessAllowed(arguments: ProcessInfo.processInfo.arguments) else {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+
+    static func networkAccessAllowed(arguments: [String]) -> Bool {
+        #if DEBUG
+        return !arguments.contains("--store-screenshots")
+        #else
+        return true
+        #endif
     }
 
     public static func resetSharedSession(reason: String? = nil) {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
@@ -72,6 +72,15 @@ final class PluginHTTPClientTests: XCTestCase {
         XCTAssertEqual(store.sessions.first?.requestedRequests.first?.timeoutInterval, 600)
     }
 
+    func testHTTPClientDisablesNetworkForScreenshotAutomation() {
+        XCTAssertFalse(
+            PluginHTTPClient.networkAccessAllowed(arguments: ["TypeWhisper", "--store-screenshots"])
+        )
+        XCTAssertTrue(
+            PluginHTTPClient.networkAccessAllowed(arguments: ["TypeWhisper", "--ui-testing"])
+        )
+    }
+
     private static func request(path: String) -> URLRequest {
         var request = URLRequest(url: URL(string: "https://example.test\(path)")!)
         request.httpMethod = "POST"

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PluginHTTPClientTests.swift
@@ -81,6 +81,22 @@ final class PluginHTTPClientTests: XCTestCase {
         )
     }
 
+    func testDirectClientNetworkGateFailsClosedForScreenshotAutomation() throws {
+        XCTAssertThrowsError(
+            try PluginHTTPClient.ensureNetworkAccessIsAllowed(
+                arguments: ["TypeWhisper", "--store-screenshots"]
+            )
+        ) { error in
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+
+        XCTAssertNoThrow(
+            try PluginHTTPClient.ensureNetworkAccessIsAllowed(
+                arguments: ["TypeWhisper", "--ui-testing"]
+            )
+        )
+    }
+
     private static func request(path: String) -> URLRequest {
         var request = URLRequest(url: URL(string: "https://example.test\(path)")!)
         request.httpMethod = "POST"

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -9386,6 +9386,99 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             JSONSerialization.jsonObject(with: Data(serviceAccount.utf8)) as? [String: Any]
         )
         XCTAssertEqual(decoded["project_id"] as? String, "typewhisper-screenshot")
+
+        XCTAssertEqual(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "com.typewhisper.improve",
+                pluginId: "com.typewhisper.improve",
+                key: "contributor-token"
+            ),
+            "tw-screenshot-contributor-token"
+        )
+
+        for oauthKey in ["oauth-access-token", "oauth-refresh-token", "oauth-id-token"] {
+            XCTAssertNil(
+                ScreenshotPluginFixture.secret(
+                    selectedPluginId: "com.typewhisper.openai",
+                    pluginId: "com.typewhisper.openai",
+                    key: oauthKey
+                ),
+                "Screenshot fixtures should keep OpenAI in API-key mode"
+            )
+        }
+    }
+
+    func testScreenshotAppSupportOverrideMustStayInsideTemporaryDirectory() {
+        let temporaryDirectory = URL(fileURLWithPath: "/tmp/typewhisper-screenshot-root", isDirectory: true)
+        let fallback = temporaryDirectory.appendingPathComponent(
+            "TypeWhisper-Screenshots-42",
+            isDirectory: true
+        )
+        let validOverride = temporaryDirectory.appendingPathComponent("capture", isDirectory: true)
+
+        XCTAssertEqual(
+            AppConstants.resolveScreenshotAppSupportDirectory(
+                override: validOverride.path,
+                temporaryDirectory: temporaryDirectory,
+                processIdentifier: 42
+            ).standardizedFileURL.path,
+            validOverride.resolvingSymlinksInPath().standardizedFileURL.path
+        )
+        XCTAssertEqual(
+            AppConstants.resolveScreenshotAppSupportDirectory(
+                override: "/tmp/typewhisper-screenshot-root-escape",
+                temporaryDirectory: temporaryDirectory,
+                processIdentifier: 42
+            ),
+            fallback
+        )
+        XCTAssertEqual(
+            AppConstants.resolveScreenshotAppSupportDirectory(
+                override: "/Users/shared/typewhisper-screenshots",
+                temporaryDirectory: temporaryDirectory,
+                processIdentifier: 42
+            ),
+            fallback
+        )
+    }
+
+    func testScreenshotPluginSourcePolicyRejectsSelectedExternalCandidate() {
+        XCTAssertFalse(
+            ScreenshotPluginSourcePolicy.allowsCandidate(
+                isScreenshotAutomation: true,
+                selectedPluginId: "com.typewhisper.groq",
+                manifestId: "com.typewhisper.groq",
+                isBundledSource: false,
+                isIsolatedScreenshotSource: false
+            )
+        )
+        XCTAssertTrue(
+            ScreenshotPluginSourcePolicy.allowsCandidate(
+                isScreenshotAutomation: true,
+                selectedPluginId: "com.typewhisper.groq",
+                manifestId: "com.typewhisper.groq",
+                isBundledSource: true,
+                isIsolatedScreenshotSource: false
+            )
+        )
+        XCTAssertTrue(
+            ScreenshotPluginSourcePolicy.allowsCandidate(
+                isScreenshotAutomation: true,
+                selectedPluginId: "com.typewhisper.groq",
+                manifestId: "com.typewhisper.groq",
+                isBundledSource: false,
+                isIsolatedScreenshotSource: true
+            )
+        )
+        XCTAssertTrue(
+            ScreenshotPluginSourcePolicy.allowsCandidate(
+                isScreenshotAutomation: false,
+                selectedPluginId: "com.typewhisper.groq",
+                manifestId: "com.typewhisper.groq",
+                isBundledSource: false,
+                isIsolatedScreenshotSource: false
+            )
+        )
     }
 
     func testPluginScreenshotPaginationUsesOnePageWhenContentFits() {

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -9332,6 +9332,79 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(observedLoadedModel, "legacy-loaded-model")
     }
 
+    func testScreenshotPluginFixtureScopesDummyCredentialsToSelectedPlugin() {
+        XCTAssertEqual(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "com.typewhisper.groq",
+                pluginId: "com.typewhisper.groq",
+                key: "api-key"
+            ),
+            "tw-screenshot-api-key"
+        )
+        XCTAssertNil(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "com.typewhisper.groq",
+                pluginId: "com.typewhisper.openai",
+                key: "api-key"
+            )
+        )
+        XCTAssertNil(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: nil,
+                pluginId: "com.typewhisper.groq",
+                key: "api-key"
+            )
+        )
+    }
+
+    func testScreenshotPluginFixtureProvidesSupportedCredentialShapes() throws {
+        XCTAssertEqual(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "plugin",
+                pluginId: "plugin",
+                key: "api-key.profile-id"
+            ),
+            "tw-screenshot-api-key"
+        )
+        XCTAssertEqual(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "plugin",
+                pluginId: "plugin",
+                key: "hf-token"
+            ),
+            "hf_tw_screenshot_fixture"
+        )
+
+        let serviceAccount = try XCTUnwrap(
+            ScreenshotPluginFixture.secret(
+                selectedPluginId: "plugin",
+                pluginId: "plugin",
+                key: "service-account-json"
+            )
+        )
+        let decoded = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(serviceAccount.utf8)) as? [String: Any]
+        )
+        XCTAssertEqual(decoded["project_id"] as? String, "typewhisper-screenshot")
+    }
+
+    func testPluginScreenshotPaginationUsesOnePageWhenContentFits() {
+        XCTAssertEqual(
+            PluginScreenshotPagination.pageOffsets(contentHeight: 440, viewportHeight: 440),
+            [0]
+        )
+    }
+
+    func testPluginScreenshotPaginationEndsAtMaximumScrollOffset() {
+        let offsets = PluginScreenshotPagination.pageOffsets(
+            contentHeight: 3_000,
+            viewportHeight: 800
+        )
+
+        XCTAssertEqual(offsets, [0, 752, 1_504, 2_200])
+        XCTAssertEqual(offsets.last, 3_000 - 800)
+    }
+
     @MainActor
     func testModelManagerAutoUnloadsAvailableLocalLLMWithoutPromptProcessing() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()

--- a/docs/screenshot-automation.md
+++ b/docs/screenshot-automation.md
@@ -74,3 +74,68 @@ bundle exec fastlane mac screenshots_check
 
 The menu-bar and hardware-notch images are specialty captures and remain
 separate from the Settings-window matrix.
+
+## Plugin screenshots for typewhisper.com
+
+The plugin lane covers the 42 current first-party bundles. It builds each
+selected bundle, stages only that bundle in a temporary Application Support
+directory, opens its native settings window, and captures English and German
+website assets:
+
+```sh
+bundle exec fastlane mac plugin_screenshots
+```
+
+Use comma-separated locale and add-on slug filters while iterating:
+
+```sh
+bundle exec fastlane mac plugin_screenshots \
+  languages:en-US plugins:groq,qwen3-asr
+```
+
+Raw PNGs are written to ignored paths such as
+`fastlane/screenshots/en-US/plugins/groq.png`. Pass `skip_build:true` only when
+the screenshot app and every selected plugin bundle were already built from
+the current checkout.
+
+Long settings views are captured page by page. The app scrolls its primary
+native scroll view with a small overlap, and Fastlane stitches the pages into
+one window image with a single title bar and continuous window shadow. Requested
+plugin window sizes are clamped to the current display before capture, so a tall
+window cannot be clipped at the screen edge. Multi-page capture requires
+ImageMagick's `magick` executable. If a plugin has a nested scrollable region,
+the surrounding controls are kept once while only that region is expanded in
+the stitched result.
+
+Credential-gated settings use deterministic dummy credentials scoped to the
+single selected plugin. Screenshot mode never reads or writes real keychain
+items, and requests made through `PluginHTTPClient` fail locally before reaching
+a provider. Local-model settings display their catalog without downloading a
+model. If a future settings screen requires remote-only response data, add a
+deterministic screenshot fixture for that response instead of using a real API
+key or live service.
+
+Publishing requires `cwebp`, `oxipng`, and ImageMagick's `identify`. After
+reviewing both locale images, copy and optimize the PNG/WebP assets in a local
+website checkout:
+
+```sh
+bundle exec fastlane mac plugin_screenshots_publish \
+  website_path:/absolute/path/to/typewhisper.com
+```
+
+The English image is written to both `public/screenshots/en/plugins/` and the
+legacy `public/screenshots/plugins/` fallback. The German image is written to
+`public/screenshots/de/plugins/`. Capture and publish can be combined:
+
+```sh
+bundle exec fastlane mac plugin_screenshots_release \
+  website_path:/absolute/path/to/typewhisper.com
+```
+
+`openai-chatgpt-login`, `mcp-client-activity`, and `mcp-client-servers` show
+secondary interaction states and remain specialty captures. The main
+`openai` and `mcp-client` settings windows are part of the automated matrix.
+The legacy website entries `gemma-local`, `sherpa-onnx`, and `whisper-cpp` do
+not have matching Xcode plugin targets in this repository and are not part of
+the lane.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,7 @@
 require "cgi"
 require "fileutils"
+require "json"
+require "rbconfig"
 require "shellwords"
 require "tmpdir"
 require "timeout"
@@ -16,6 +18,7 @@ SCREENSHOT_APP_PATH = File.join(
   "TypeWhisper.app"
 )
 SCREENSHOT_BUNDLE_ID = "com.typewhisper.mac.screenshots"
+SCREENSHOT_ARCHITECTURE = RbConfig::CONFIG.fetch("host_cpu")
 SCREENSHOT_LANGUAGES = %w[en-US de-DE ja-JP zh-Hans].freeze
 SCREENSHOT_LOCALES = {
   "en-US" => "en_US",
@@ -23,6 +26,51 @@ SCREENSHOT_LOCALES = {
   "ja-JP" => "ja_JP",
   "zh-Hans" => "zh_Hans",
 }.freeze
+PLUGIN_SCREENSHOT_LANGUAGES = %w[en-US de-DE].freeze
+PLUGIN_SCREENSHOTS = [
+  { slug: "apple-speech", target: "SpeechAnalyzerPlugin", id: "com.typewhisper.speechanalyzer" },
+  { slug: "assemblyai", target: "AssemblyAIPlugin", id: "com.typewhisper.assemblyai" },
+  { slug: "cartesia", target: "CartesiaPlugin", id: "com.typewhisper.cartesia" },
+  { slug: "cerebras", target: "CerebrasPlugin", id: "com.typewhisper.cerebras" },
+  { slug: "claude", target: "ClaudePlugin", id: "com.typewhisper.claude" },
+  { slug: "cloudflare-asr", target: "CloudflareASRPlugin", id: "com.typewhisper.cloudflare-asr" },
+  { slug: "cohere", target: "CoherePlugin", id: "com.typewhisper.cohere" },
+  { slug: "cohere-local", target: "CohereLocalPlugin", id: "com.typewhisper.cohere-transcribe" },
+  { slug: "deepgram", target: "DeepgramPlugin", id: "com.typewhisper.deepgram" },
+  { slug: "elevenlabs", target: "ElevenLabsPlugin", id: "com.typewhisper.elevenlabs" },
+  { slug: "file-memory", target: "FileMemoryPlugin", id: "com.typewhisper.memory.file" },
+  { slug: "filler-words", target: "FillerWordsPlugin", id: "com.typewhisper.filler-words" },
+  { slug: "fireworks", target: "FireworksPlugin", id: "com.typewhisper.fireworks" },
+  { slug: "gemini", target: "GeminiPlugin", id: "com.typewhisper.gemini" },
+  { slug: "gemma4", target: "Gemma4Plugin", id: "com.typewhisper.gemma4", size: [560, 661] },
+  { slug: "gladia", target: "GladiaPlugin", id: "com.typewhisper.gladia" },
+  { slug: "google-cloud-stt", target: "GoogleCloudSTTPlugin", id: "com.typewhisper.google-cloud-stt" },
+  { slug: "granite", target: "GranitePlugin", id: "com.typewhisper.granite" },
+  { slug: "groq", target: "GroqPlugin", id: "com.typewhisper.groq" },
+  { slug: "improve-typewhisper", target: "ContributorPlugin", id: "com.typewhisper.improve" },
+  { slug: "linear", target: "LinearPlugin", id: "com.typewhisper.linear" },
+  { slug: "live-transcript", target: "LiveTranscriptPlugin", id: "com.typewhisper.livetranscript" },
+  { slug: "mcp-client", target: "MCPClientPlugin", id: "com.typewhisper.mcp-client" },
+  { slug: "mistral", target: "MistralAIPlugin", id: "com.minerale.mistralai" },
+  { slug: "obsidian", target: "ObsidianPlugin", id: "com.typewhisper.obsidian" },
+  { slug: "openai", target: "OpenAIPlugin", id: "com.typewhisper.openai", size: [560, 627] },
+  { slug: "openai-compatible", target: "OpenAICompatiblePlugin", id: "com.typewhisper.openai-compatible" },
+  { slug: "openai-vector-memory", target: "OpenAIVectorMemoryPlugin", id: "com.typewhisper.memory.openai-vector" },
+  { slug: "openrouter", target: "OpenRouterPlugin", id: "com.typewhisper.openrouter" },
+  { slug: "parakeet", target: "ParakeetPlugin", id: "com.typewhisper.parakeet" },
+  { slug: "qwen3-asr", target: "Qwen3Plugin", id: "com.typewhisper.qwen3", size: [560, 954] },
+  { slug: "reson8", target: "Reson8Plugin", id: "com.typewhisper.reson8" },
+  { slug: "sber-salutespeech", target: "SaluteSpeechPlugin", id: "com.typewhisper.sber-salutespeech" },
+  { slug: "script-runner", target: "ScriptPlugin", id: "com.typewhisper.script" },
+  { slug: "smallest-pulse", target: "SmallestAIPlugin", id: "com.typewhisper.smallest-pulse", size: [534, 414] },
+  { slug: "soniox", target: "SonioxPlugin", id: "com.typewhisper.soniox" },
+  { slug: "speechmatics", target: "SpeechmaticsPlugin", id: "com.typewhisper.speechmatics" },
+  { slug: "supertonic", target: "SupertonicPlugin", id: "com.typewhisper.tts.supertonic", size: [560, 536] },
+  { slug: "voxtral", target: "VoxtralPlugin", id: "com.typewhisper.voxtral" },
+  { slug: "webhook", target: "WebhookPlugin", id: "com.typewhisper.webhook" },
+  { slug: "whisperkit", target: "WhisperKitPlugin", id: "com.typewhisper.whisperkit", size: [560, 557] },
+  { slug: "xai-grok", target: "XAIPlugin", id: "com.typewhisper.xai" },
+].freeze
 FREE_SCREENSHOT_NAMES = %w[
   home
   general
@@ -87,6 +135,38 @@ def selected_screenshot_languages(value)
   requested
 end
 
+def selected_plugin_screenshot_languages(value)
+  requested = case value
+              when Array then value
+              else value.to_s.split(",")
+              end
+  requested = requested.map(&:strip).reject(&:empty?)
+  requested = PLUGIN_SCREENSHOT_LANGUAGES if requested.empty?
+
+  unsupported = requested - PLUGIN_SCREENSHOT_LANGUAGES
+  unless unsupported.empty?
+    UI.user_error!(
+      "Unsupported plugin screenshot languages: #{unsupported.join(', ')}. " \
+      "Website add-on assets support #{PLUGIN_SCREENSHOT_LANGUAGES.join(', ')}."
+    )
+  end
+  requested
+end
+
+def selected_plugin_screenshots(value)
+  requested = case value
+              when Array then value
+              else value.to_s.split(",")
+              end
+  requested = requested.map(&:strip).reject(&:empty?)
+  return PLUGIN_SCREENSHOTS if requested.empty?
+
+  available = PLUGIN_SCREENSHOTS.to_h { |plugin| [plugin.fetch(:slug), plugin] }
+  unsupported = requested - available.keys
+  UI.user_error!("Unknown plugin screenshot slugs: #{unsupported.join(', ')}") unless unsupported.empty?
+  requested.map { |slug| available.fetch(slug) }
+end
+
 def verify_raw_screenshots!(languages)
   expected = languages.flat_map do |language|
     SCREENSHOT_NAMES_BY_VARIANT.flat_map do |variant, names|
@@ -104,6 +184,23 @@ def verify_raw_screenshots!(languages)
     File.size(path) <= 100_000 || File.binread(path, 8) != png_signature
   end
   UI.user_error!("Invalid generated screenshots:\n#{invalid.join("\n")}") unless invalid.empty?
+end
+
+def verify_raw_plugin_screenshots!(languages, plugins)
+  expected = languages.flat_map do |language|
+    plugins.map do |plugin|
+      File.join(SCREENSHOT_OUTPUT, language, "plugins", "#{plugin.fetch(:slug)}.png")
+    end
+  end
+
+  missing = expected.reject { |path| File.file?(path) }
+  UI.user_error!("Missing generated plugin screenshots:\n#{missing.join("\n")}") unless missing.empty?
+
+  png_signature = "\x89PNG\r\n\x1A\n".b
+  invalid = expected.select do |path|
+    File.size(path) <= 100_000 || File.binread(path, 8) != png_signature
+  end
+  UI.user_error!("Invalid generated plugin screenshots:\n#{invalid.join("\n")}") unless invalid.empty?
 end
 
 def build_screenshot_app!
@@ -135,6 +232,48 @@ def build_screenshot_app!
     log: false
   )
   sh("/usr/bin/codesign --verify --deep --strict #{Shellwords.escape(SCREENSHOT_APP_PATH)}", log: false)
+end
+
+def plugin_screenshot_bundle_path(plugin)
+  File.join(
+    SCREENSHOT_DERIVED_DATA,
+    "Build",
+    "Products",
+    "Debug",
+    "#{plugin.fetch(:target)}.bundle"
+  )
+end
+
+def build_plugin_screenshot_targets!(plugins)
+  targets = plugins.map { |plugin| plugin.fetch(:target) }.uniq
+  command = [
+    "xcodebuild",
+    "-project", File.join(REPOSITORY_ROOT, "TypeWhisper.xcodeproj"),
+  ]
+  targets.each do |target|
+    command.concat(["-target", target])
+  end
+  command.concat([
+    "-configuration", "Debug",
+    "SYMROOT=#{File.join(SCREENSHOT_DERIVED_DATA, 'Build', 'Products')}",
+    "OBJROOT=#{File.join(SCREENSHOT_DERIVED_DATA, 'Build', 'Intermediates.noindex')}",
+    "SDKROOT=macosx",
+    "CODE_SIGN_IDENTITY=-",
+    "CODE_SIGN_STYLE=Manual",
+    "CODE_SIGNING_REQUIRED=YES",
+    "CODE_SIGNING_ALLOWED=YES",
+    "COMPILER_INDEX_STORE_ENABLE=NO",
+    "ARCHS=#{SCREENSHOT_ARCHITECTURE}",
+    "ONLY_ACTIVE_ARCH=YES",
+    "build",
+  ])
+  sh(Shellwords.join(command))
+
+  missing = plugins.filter_map do |plugin|
+    path = plugin_screenshot_bundle_path(plugin)
+    path unless File.directory?(path)
+  end
+  UI.user_error!("Missing built plugin bundles:\n#{missing.join("\n")}") unless missing.empty?
 end
 
 def screenshot_app_language(language)
@@ -257,6 +396,244 @@ def capture_screenshot!(language, state, variant, destination)
   end
 end
 
+def stage_plugin_screenshot_bundle!(plugin, app_support_directory)
+  source = plugin_screenshot_bundle_path(plugin)
+  UI.user_error!("Missing built plugin bundle: #{source}") unless File.directory?(source)
+
+  plugins_directory = File.join(app_support_directory, "Plugins")
+  FileUtils.mkdir_p(plugins_directory)
+  destination = File.join(plugins_directory, File.basename(source))
+  FileUtils.rm_rf(destination)
+  FileUtils.cp_r(source, destination)
+end
+
+def plugin_screenshot_launch_arguments(
+  language,
+  plugin,
+  ready_file,
+  app_support_directory,
+  scroll_command_file
+)
+  arguments = screenshot_launch_arguments(language, "plugins", "free", ready_file) + [
+    "--screenshot-plugin-id", plugin.fetch(:id),
+    "--screenshot-app-support", app_support_directory,
+    "--screenshot-scroll-command-file", scroll_command_file,
+  ]
+  if plugin[:size]
+    arguments.concat([
+      "--screenshot-window-width", plugin.fetch(:size).fetch(0).to_s,
+      "--screenshot-window-height", plugin.fetch(:size).fetch(1).to_s,
+    ])
+  end
+  arguments
+end
+
+def wait_for_plugin_screenshot_page!(ready_file, expected_page, process_id, log_file)
+  deadline = Time.now + SCREENSHOT_WINDOW_TIMEOUT
+  loop do
+    if File.file?(ready_file)
+      begin
+        state = JSON.parse(File.read(ready_file))
+        return state if state.fetch("pageIndex") == expected_page
+      rescue JSON::ParserError, KeyError
+        # The app writes the state atomically, but tolerate a stale or incomplete read.
+      end
+    end
+
+    begin
+      Process.kill(0, process_id)
+    rescue Errno::ESRCH
+      UI.user_error!("Screenshot app exited before page #{expected_page} was ready.\n#{screenshot_log_tail(log_file)}")
+    end
+
+    if Time.now >= deadline
+      UI.user_error!("Timed out waiting for plugin screenshot page #{expected_page}.\n#{screenshot_log_tail(log_file)}")
+    end
+    sleep(0.1)
+  end
+end
+
+def request_plugin_screenshot_page!(command_file, page_index)
+  temporary = "#{command_file}.tmp"
+  File.write(temporary, "#{page_index}\n")
+  File.rename(temporary, command_file)
+end
+
+def capture_plugin_screenshot_page!(window_id, destination)
+  sh(
+    "/usr/sbin/screencapture -x -l #{window_id} #{Shellwords.escape(destination)}",
+    log: false
+  )
+  unless File.file?(destination) && File.size(destination) > 100_000
+    UI.user_error!("Plugin screenshot page did not produce a valid PNG: #{destination}")
+  end
+end
+
+def plugin_screenshot_opaque_bounds!(magick, path)
+  output = Actions.sh(
+    Shellwords.join([
+      magick,
+      "-quiet",
+      path,
+      "-channel", "A",
+      "-threshold", "99%",
+      "-format", "%@ %w %h",
+      "info:",
+    ]),
+    log: false
+  ).strip
+  match = output.match(/\A(\d+)x(\d+)\+(\d+)\+(\d+)\s+(\d+)\s+(\d+)\z/)
+  UI.user_error!("Could not determine screenshot window bounds for #{path}: #{output}") unless match
+  {
+    opaque_width: Integer(match[1], 10),
+    opaque_height: Integer(match[2], 10),
+    opaque_x: Integer(match[3], 10),
+    opaque_y: Integer(match[4], 10),
+    image_width: Integer(match[5], 10),
+    image_height: Integer(match[6], 10),
+  }
+end
+
+def stitch_plugin_screenshot_pages!(page_paths, states, destination)
+  if page_paths.one?
+    FileUtils.mv(page_paths.first, destination)
+    return
+  end
+
+  magick = required_executable!("magick")
+  piece_paths = []
+  previous_document_end = 0.0
+
+  page_paths.each_with_index do |page_path, index|
+    state = states.fetch(index)
+    bounds = plugin_screenshot_opaque_bounds!(magick, page_path)
+    scale = Float(state.fetch("backingScaleFactor"))
+    content_top = bounds.fetch(:opaque_y) + (Float(state.fetch("titlebarHeight")) * scale).round
+    content_bottom = bounds.fetch(:opaque_y) + (Float(state.fetch("windowFrameHeight")) * scale).round
+    scroll_view_top = content_bottom - (Float(state.fetch("scrollViewportMaxY")) * scale).round
+    scroll_view_bottom = content_bottom - (Float(state.fetch("scrollViewportMinY")) * scale).round
+    seam_inset = (16 * scale).round
+    unless content_top.positive? &&
+           content_top <= scroll_view_top &&
+           scroll_view_top < scroll_view_bottom &&
+           scroll_view_bottom <= content_bottom &&
+           content_bottom <= bounds.fetch(:image_height)
+      UI.user_error!("Plugin screenshot window was clipped on page #{index}: #{page_path}")
+    end
+
+    crop_top = if index.zero?
+                 0
+               else
+                 overlap = [previous_document_end - Float(state.fetch("scrollOffset")), 0].max
+                 scroll_view_top + (overlap * scale).round - seam_inset
+               end
+    crop_bottom = if index == page_paths.length - 1
+                    bounds.fetch(:image_height)
+                  else
+                    scroll_view_bottom - seam_inset
+                  end
+    crop_height = crop_bottom - crop_top
+    UI.user_error!("Invalid plugin screenshot crop on page #{index}: #{page_path}") unless crop_height.positive?
+
+    piece_path = File.join(File.dirname(page_path), "piece-#{index}.png")
+    sh(
+      Shellwords.join([
+        magick,
+        page_path,
+        "-crop", "#{bounds.fetch(:image_width)}x#{crop_height}+0+#{crop_top}",
+        "+repage",
+        piece_path,
+      ]),
+      log: false
+    )
+    piece_paths << piece_path
+    previous_document_end = [
+      previous_document_end,
+      Float(state.fetch("scrollOffset")) + Float(state.fetch("viewportHeight")),
+    ].max
+  end
+
+  sh(Shellwords.join([magick, *piece_paths, "-append", "+repage", destination]), log: false)
+end
+
+def capture_plugin_screenshot!(language, plugin, destination)
+  executable = File.join(SCREENSHOT_APP_PATH, "Contents", "MacOS", "TypeWhisper")
+  reset_screenshot_defaults!
+
+  Dir.mktmpdir("typewhisper-plugin-screenshot-run") do |run_directory|
+    ready_file = File.join(run_directory, "window-ready.txt")
+    scroll_command_file = File.join(run_directory, "scroll-command.txt")
+    log_file = File.join(run_directory, "application.log")
+    home_directory = File.join(run_directory, "home")
+    app_support_directory = File.join(run_directory, "app-support")
+    FileUtils.mkdir_p(home_directory)
+    stage_plugin_screenshot_bundle!(plugin, app_support_directory)
+
+    environment = {
+      "CFFIXED_USER_HOME" => home_directory,
+      "LLVM_PROFILE_FILE" => File.join(run_directory, "%p.profraw"),
+      "NSUnbufferedIO" => "YES",
+    }
+    arguments = plugin_screenshot_launch_arguments(
+      language,
+      plugin,
+      ready_file,
+      app_support_directory,
+      scroll_command_file
+    )
+    log = File.open(log_file, "w")
+    process_id = Process.spawn(
+      environment,
+      executable,
+      *arguments,
+      chdir: REPOSITORY_ROOT,
+      out: log,
+      err: log
+    )
+    log.close
+
+    begin
+      first_state = wait_for_plugin_screenshot_page!(ready_file, 0, process_id, log_file)
+      page_count = Integer(first_state.fetch("pageCount"))
+      states = [first_state]
+      page_paths = []
+
+      page_count.times do |page_index|
+        if page_index.positive?
+          request_plugin_screenshot_page!(scroll_command_file, page_index)
+          states << wait_for_plugin_screenshot_page!(ready_file, page_index, process_id, log_file)
+        end
+        page_path = File.join(run_directory, "page-#{page_index}.png")
+        capture_plugin_screenshot_page!(Integer(states.fetch(page_index).fetch("windowNumber")), page_path)
+        page_paths << page_path
+      end
+
+      stitch_plugin_screenshot_pages!(page_paths, states, destination)
+      unless File.file?(destination) && File.size(destination) > 100_000
+        UI.user_error!("Plugin screenshot capture did not produce a valid PNG: #{destination}")
+      end
+    ensure
+      stop_screenshot_app(process_id)
+      reset_screenshot_defaults!
+    end
+  end
+end
+
+def capture_plugin_screenshot_language!(language, plugins)
+  UI.header("Capturing #{language} plugin screenshots")
+  destination = File.join(SCREENSHOT_OUTPUT, language, "plugins")
+  FileUtils.mkdir_p(destination)
+
+  plugins.each do |plugin|
+    UI.message("#{language} / #{plugin.fetch(:slug)}")
+    capture_plugin_screenshot!(
+      language,
+      plugin,
+      File.join(destination, "#{plugin.fetch(:slug)}.png")
+    )
+  end
+end
+
 def capture_screenshot_language!(language)
   UI.header("Capturing #{language} screenshots")
   destination = File.join(SCREENSHOT_OUTPUT, language)
@@ -344,6 +721,75 @@ def publish_english_screenshots!
   end
 end
 
+def required_executable!(name)
+  directory = ENV.fetch("PATH", "").split(File::PATH_SEPARATOR).find do |directory|
+    candidate = File.join(directory, name)
+    File.file?(candidate) && File.executable?(candidate)
+  end
+  path = File.join(directory, name) if directory
+  UI.user_error!("Required executable is unavailable: #{name}") unless path
+  path
+end
+
+def validated_website_path(value)
+  UI.user_error!("Pass website_path:/absolute/path/to/typewhisper.com") if value.to_s.strip.empty?
+  path = File.expand_path(value.to_s)
+  required = [
+    File.join(path, "package.json"),
+    File.join(path, "public", "screenshots"),
+  ]
+  missing = required.reject { |candidate| File.exist?(candidate) }
+  UI.user_error!("Not a TypeWhisper website checkout: #{path}") unless missing.empty?
+  path
+end
+
+def publish_plugin_screenshots!(website_path, languages, plugins)
+  verify_raw_plugin_screenshots!(languages, plugins)
+  cwebp = required_executable!("cwebp")
+  oxipng = required_executable!("oxipng")
+  identify = required_executable!("identify")
+  locale_directories = {
+    "en-US" => "en",
+    "de-DE" => "de",
+  }
+  published_pngs = []
+
+  languages.each do |language|
+    locale = locale_directories.fetch(language)
+    plugins.each do |plugin|
+      slug = plugin.fetch(:slug)
+      source = File.join(SCREENSHOT_OUTPUT, language, "plugins", "#{slug}.png")
+      localized = File.join(website_path, "public", "screenshots", locale, "plugins", "#{slug}.png")
+      FileUtils.mkdir_p(File.dirname(localized))
+      FileUtils.cp(source, localized)
+      published_pngs << localized
+
+      next unless language == "en-US"
+
+      fallback = File.join(website_path, "public", "screenshots", "plugins", "#{slug}.png")
+      FileUtils.mkdir_p(File.dirname(fallback))
+      FileUtils.cp(source, fallback)
+      published_pngs << fallback
+    end
+  end
+
+  published_pngs.uniq.each do |png|
+    webp = png.sub(/\.png\z/, ".webp")
+    sh(Shellwords.join([cwebp, "-quiet", "-q", "85", png, "-o", webp]), log: false)
+  end
+  sh(
+    Shellwords.join([oxipng, "-o", "4", "--strip", "safe", *published_pngs.uniq]),
+    log: false
+  )
+
+  published_assets = published_pngs.uniq.flat_map { |png| [png, png.sub(/\.png\z/, ".webp")] }
+  sh(
+    Shellwords.join([identify, "-format", "%f %wx%h %b\\n", *published_assets]),
+    log: false
+  )
+  UI.success("Published #{published_assets.count} optimized website plugin screenshot assets")
+end
+
 default_platform(:mac)
 
 platform :mac do
@@ -371,5 +817,40 @@ platform :mac do
   desc "Validate the committed README screenshot gallery"
   lane :screenshots_check do
     update_readme_screenshot_block!(check: true)
+  end
+
+  desc "Capture localized add-on screenshots for first-party plugin settings windows"
+  lane :plugin_screenshots do |options|
+    languages = selected_plugin_screenshot_languages(options[:languages])
+    plugins = selected_plugin_screenshots(options[:plugins])
+    unless options[:skip_build].to_s.casecmp("true").zero?
+      build_screenshot_app!
+      build_plugin_screenshot_targets!(plugins)
+    end
+    UI.user_error!("Missing screenshot app: #{SCREENSHOT_APP_PATH}") unless File.directory?(SCREENSHOT_APP_PATH)
+    languages.each { |language| capture_plugin_screenshot_language!(language, plugins) }
+    verify_raw_plugin_screenshots!(languages, plugins)
+  end
+
+  desc "Optimize and publish generated plugin screenshots into a typewhisper.com checkout"
+  lane :plugin_screenshots_publish do |options|
+    languages = selected_plugin_screenshot_languages(options[:languages])
+    plugins = selected_plugin_screenshots(options[:plugins])
+    website_path = validated_website_path(options[:website_path])
+    publish_plugin_screenshots!(website_path, languages, plugins)
+  end
+
+  desc "Capture plugin screenshots and publish their PNG/WebP website assets"
+  lane :plugin_screenshots_release do |options|
+    plugin_screenshots(
+      languages: options[:languages],
+      plugins: options[:plugins],
+      skip_build: options[:skip_build]
+    )
+    plugin_screenshots_publish(
+      languages: options[:languages],
+      plugins: options[:plugins],
+      website_path: options[:website_path]
+    )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,7 +18,23 @@ SCREENSHOT_APP_PATH = File.join(
   "TypeWhisper.app"
 )
 SCREENSHOT_BUNDLE_ID = "com.typewhisper.mac.screenshots"
-SCREENSHOT_ARCHITECTURE = RbConfig::CONFIG.fetch("host_cpu")
+
+def screenshot_hardware_architecture
+  if RUBY_PLATFORM.include?("darwin")
+    arm64_capable = IO.popen(
+      ["/usr/sbin/sysctl", "-in", "hw.optional.arm64"],
+      err: File::NULL,
+      &:read
+    ).strip
+    return "arm64" if arm64_capable == "1"
+  end
+
+  IO.popen(["/usr/bin/uname", "-m"], &:read).strip
+rescue Errno::ENOENT
+  RbConfig::CONFIG.fetch("host_cpu")
+end
+
+SCREENSHOT_ARCHITECTURE = screenshot_hardware_architecture
 SCREENSHOT_LANGUAGES = %w[en-US de-DE ja-JP zh-Hans].freeze
 SCREENSHOT_LOCALES = {
   "en-US" => "en_US",
@@ -441,8 +457,11 @@ def wait_for_plugin_screenshot_page!(ready_file, expected_page, process_id, log_
     end
 
     begin
+      if Process.waitpid(process_id, Process::WNOHANG)
+        UI.user_error!("Screenshot app exited before page #{expected_page} was ready.\n#{screenshot_log_tail(log_file)}")
+      end
       Process.kill(0, process_id)
-    rescue Errno::ESRCH
+    rescue Errno::ECHILD, Errno::ESRCH
       UI.user_error!("Screenshot app exited before page #{expected_page} was ready.\n#{screenshot_log_tail(log_file)}")
     end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,30 @@ Capture every locale, publish English, and validate the README gallery
 
 Validate the committed README screenshot gallery
 
+### mac plugin_screenshots
+
+```sh
+[bundle exec] fastlane mac plugin_screenshots
+```
+
+Capture localized add-on screenshots for first-party plugin settings windows
+
+### mac plugin_screenshots_publish
+
+```sh
+[bundle exec] fastlane mac plugin_screenshots_publish
+```
+
+Optimize and publish generated plugin screenshots into a typewhisper.com checkout
+
+### mac plugin_screenshots_release
+
+```sh
+[bundle exec] fastlane mac plugin_screenshots_release
+```
+
+Capture plugin screenshots and publish their PNG/WebP website assets
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
## Context

The website add-on catalog needs consistent settings screenshots for every first-party macOS plugin. These screenshots were previously incomplete and difficult to refresh when settings windows changed or required credentials, local model state, or scrolling.

## Summary

- add deterministic Fastlane capture and publish lanes for all 42 first-party macOS plugin settings windows in English and German
- isolate screenshot fixtures from real keychain data, block every first-party plugin network entry point, and scope dummy credentials to the selected plugin
- paginate and stitch long settings windows while keeping a single title bar and the surrounding UI
- add missing German settings strings for Cloudflare ASR, Google Cloud STT, and Supertonic
- document the capture and website asset handoff workflow

## Test Plan

- [x] `scripts/pr-preflight.sh origin/main` (598 Plugin SDK tests)
- [x] `swift test --package-path TypeWhisperPluginSDK --filter PluginHTTPClientTests` (6 tests)
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -derivedDataPath build-plugin-screenshot-tests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testPluginScreenshotPaginationUsesOnePageWhenContentFits -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testPluginScreenshotPaginationEndsAtMaximumScrollOffset -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testScreenshotPluginFixtureScopesDummyCredentialsToSelectedPlugin -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testScreenshotPluginFixtureProvidesSupportedCredentialShapes -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testScreenshotAppSupportOverrideMustStayInsideTemporaryDirectory -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testScreenshotPluginSourcePolicyRejectsSelectedExternalCandidate CODE_SIGNING_ALLOWED=NO` (6 tests)
- [x] `bundle exec fastlane mac plugin_screenshots`
- [x] `bundle exec fastlane mac plugin_screenshots plugins:apple-speech,openai,improve-typewhisper,cohere-local languages:en-US,de-DE`
- [x] `ruby -c fastlane/Fastfile`
- [x] `jq empty TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Localizable.xcstrings`
- [x] Visually inspected English and German contact sheets plus representative long captures
- [x] Published and verified 252 PNG/WebP website assets in TypeWhisper/typewhisper.com@6a8254c4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated screenshot capture for plugin settings, including multi-page scrolling and image stitching.
  * Added screenshot publishing and release workflows for localized plugin images.
  * Added deterministic credential fixtures for safe, offline screenshot runs.
  * Added German translations across several plugin settings and messages.
  * Localized the Cloudflare ASR server URL placeholder.

* **Bug Fixes**
  * Added network-access checks before plugin connections, downloads, and model loading.
  * Improved screenshot reliability, window sizing, plugin validation, and credential isolation.

* **Documentation**
  * Added setup, usage, publishing, and workflow documentation for plugin screenshots.

* **Tests**
  * Added coverage for credential fixtures, pagination, plugin filtering, and offline network behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->