### PR TITLE
Fix recorder preview finalization race

### DIFF
--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -181,8 +181,13 @@ final class StreamingHandler: @unchecked Sendable {
         let finishStart = CFAbsoluteTimeGetCurrent()
         func elapsedMs() -> String { String(format: "%.0f", (CFAbsoluteTimeGetCurrent() - finishStart) * 1000) }
 
-        streamingTask?.cancel()
+        let previewTask = streamingTask
         streamingTask = nil
+        previewTask?.cancel()
+        if let previewTask {
+            await previewTask.value
+            logger.info("Finish timing: preview task stopped elapsedMs=\(elapsedMs(), privacy: .public)")
+        }
 
         guard let handle = claimLiveSessionHandleForFinish() else {
             clearStreamingState(notifyStreamingStopped: true)
@@ -319,8 +324,10 @@ final class StreamingHandler: @unchecked Sendable {
                             return true
                         }
                     )
+                    guard !Task.isCancelled else { return }
                     _ = processPreviewUpdate(result.text, audioGate: nil, persist: true)
                 } catch {
+                    guard !Task.isCancelled else { return }
                     logger.warning("Streaming preview error: \(error.localizedDescription)")
                 }
             }

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -94,6 +94,88 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
+    private actor BlockingPreviewFallbackRecorder {
+        private var activeTranscriptions = 0
+        private var maxConcurrentTranscriptions = 0
+        private var prompts: [String?] = []
+        private var firstCallReleased = false
+        private var firstCallReleaseContinuation: CheckedContinuation<Void, Never>?
+
+        func begin(prompt: String?) -> Int {
+            activeTranscriptions += 1
+            maxConcurrentTranscriptions = max(maxConcurrentTranscriptions, activeTranscriptions)
+            prompts.append(prompt)
+            return prompts.count
+        }
+
+        func waitForFirstCallRelease() async {
+            guard !firstCallReleased else { return }
+            await withCheckedContinuation { continuation in
+                firstCallReleaseContinuation = continuation
+            }
+        }
+
+        func releaseFirstCall() {
+            guard !firstCallReleased else { return }
+            firstCallReleased = true
+            firstCallReleaseContinuation?.resume()
+            firstCallReleaseContinuation = nil
+        }
+
+        func end() {
+            activeTranscriptions -= 1
+        }
+
+        func snapshot() -> (callCount: Int, maxConcurrentTranscriptions: Int, prompts: [String?]) {
+            (prompts.count, maxConcurrentTranscriptions, prompts)
+        }
+    }
+
+    private final class MockBlockingPreviewFallbackPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.blocking-preview-fallback" }
+        static var pluginName: String { "Mock Blocking Preview Fallback" }
+
+        var providerId: String { "mock-blocking-preview-fallback" }
+        var providerDisplayName: String { "Mock Blocking Preview Fallback" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { true }
+        var supportedLanguages: [String] { ["en"] }
+
+        private let recorder = BlockingPreviewFallbackRecorder()
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+        func selectModel(_ modelId: String) {}
+
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?
+        ) async throws -> PluginTranscriptionResult {
+            let callIndex = await recorder.begin(prompt: prompt)
+            if callIndex == 1 {
+                await recorder.waitForFirstCallRelease()
+            }
+            await recorder.end()
+            return PluginTranscriptionResult(
+                text: "result-\(prompt ?? "none")",
+                detectedLanguage: language
+            )
+        }
+
+        func releaseFirstCall() async {
+            await recorder.releaseFirstCall()
+        }
+
+        func snapshot() async -> (callCount: Int, maxConcurrentTranscriptions: Int, prompts: [String?]) {
+            await recorder.snapshot()
+        }
+    }
+
     private final class MockPreviewFallbackOptOutPlugin: NSObject, TranscriptionEnginePlugin, TranscriptPreviewFallbackPolicyProviding, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.preview-opt-out" }
         static var pluginName: String { "Mock Preview Opt Out" }
@@ -1000,6 +1082,93 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(snapshot.callCount, 1)
         XCTAssertEqual(snapshot.maxConcurrentTranscriptions, 1)
         XCTAssertEqual(snapshot.prompts, ["Final Terms"])
+    }
+
+    func testFinishWaitsForInFlightFallbackPreviewBeforeFinalTranscription() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let plugin = MockBlockingPreviewFallbackPlugin()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.blocking-preview-fallback",
+                    name: "Mock Blocking Preview Fallback",
+                    version: "1.0.0",
+                    principalClass: "MockBlockingPreviewFallbackPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider(plugin.providerId)
+
+        let handler = StreamingHandler(
+            modelManager: modelManager,
+            bufferProvider: {
+                XCTFail("full buffer provider should not be used for fallback previews")
+                return []
+            },
+            recentBufferProvider: { _ in Array(repeating: 0.5, count: 16_000) },
+            bufferDeltaProvider: { _ in ([], 0) },
+            bufferedDurationProvider: { 1.0 }
+        )
+
+        handler.start(
+            streamPrompt: "Preview Terms",
+            engineOverrideId: plugin.providerId,
+            selectedProviderId: plugin.providerId,
+            languageSelection: .exact("en"),
+            task: .transcribe,
+            cloudModelOverride: nil,
+            allowLiveTranscription: true,
+            stateCheck: { true }
+        )
+
+        var previewStarted = false
+        for _ in 0..<50 {
+            if await plugin.snapshot().callCount == 1 {
+                previewStarted = true
+                break
+            }
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        XCTAssertTrue(previewStarted)
+        guard previewStarted else {
+            handler.stop()
+            return
+        }
+
+        let finalTask = Task { @MainActor in
+            _ = await handler.finish()
+            return try await modelManager.transcribe(
+                audioSamples: Array(repeating: 0.5, count: 16_000),
+                languageSelection: .exact("en"),
+                task: .transcribe,
+                engineOverrideId: plugin.providerId,
+                cloudModelOverride: nil,
+                prompt: "Final Terms"
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+        let blockedSnapshot = await plugin.snapshot()
+        XCTAssertEqual(blockedSnapshot.callCount, 1)
+        XCTAssertEqual(blockedSnapshot.maxConcurrentTranscriptions, 1)
+
+        await plugin.releaseFirstCall()
+        let finalResult = try await finalTask.value
+        let finalSnapshot = await plugin.snapshot()
+
+        XCTAssertEqual(finalResult.text, "result-Final Terms")
+        XCTAssertEqual(finalSnapshot.callCount, 2)
+        XCTAssertEqual(finalSnapshot.maxConcurrentTranscriptions, 1)
+        XCTAssertEqual(finalSnapshot.prompts, ["Preview Terms", "Final Terms"])
     }
 
     func testLiveSessionConsumesOnlyIncrementalAudioDeltas() async throws {

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -167,6 +167,23 @@ final class StreamingHandlerTests: XCTestCase {
             )
         }
 
+        func transcribe(
+            audio: AudioData,
+            language: String?,
+            translate: Bool,
+            prompt: String?,
+            onProgress: @Sendable @escaping (String) -> Bool
+        ) async throws -> PluginTranscriptionResult {
+            let result = try await transcribe(
+                audio: audio,
+                language: language,
+                translate: translate,
+                prompt: prompt
+            )
+            _ = onProgress(result.text)
+            return result
+        }
+
         func releaseFirstCall() async {
             await recorder.releaseFirstCall()
         }
@@ -1118,6 +1135,7 @@ final class StreamingHandlerTests: XCTestCase {
             bufferDeltaProvider: { _ in ([], 0) },
             bufferedDurationProvider: { 1.0 }
         )
+        defer { handler.stop() }
 
         handler.start(
             streamPrompt: "Preview Terms",
@@ -1155,6 +1173,20 @@ final class StreamingHandlerTests: XCTestCase {
                 prompt: "Final Terms"
             )
         }
+        let finalCompleted = expectation(description: "final transcription completed")
+        var finalOutcome: Result<TranscriptionResult, Error>?
+        let finalWaitTask = Task { @MainActor in
+            do {
+                finalOutcome = .success(try await finalTask.value)
+            } catch {
+                finalOutcome = .failure(error)
+            }
+            finalCompleted.fulfill()
+        }
+        defer {
+            finalTask.cancel()
+            finalWaitTask.cancel()
+        }
 
         try await Task.sleep(for: .milliseconds(100))
         let blockedSnapshot = await plugin.snapshot()
@@ -1162,7 +1194,9 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(blockedSnapshot.maxConcurrentTranscriptions, 1)
 
         await plugin.releaseFirstCall()
-        let finalResult = try await finalTask.value
+        await fulfillment(of: [finalCompleted], timeout: 10)
+        guard let finalOutcome else { return }
+        let finalResult = try finalOutcome.get()
         let finalSnapshot = await plugin.snapshot()
 
         XCTAssertEqual(finalResult.text, "result-Final Terms")


### PR DESCRIPTION
## Summary

- wait for an in-flight Recorder preview task to stop before finalizing or starting the final transcription
- prevent cancelled fallback previews from publishing stale results
- add regression coverage proving preview and final WhisperKit-style batch calls do not overlap

## Issue context

In #1091, the saved meeting recording is complete and transcribes fully through File Transcription with WhisperKit Large V3, while the automatic Recorder transcription can fail or return only a short transcript. The Recorder-specific live-preview fallback could still be using the shared model when final transcription started.

Closes #1091

## Test plan

- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/StreamingHandlerTests/testFinishWaitsForInFlightFallbackPreviewBeforeFinalTranscription | xcbeautify`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/StreamingHandlerTests | xcbeautify`
- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests | xcbeautify`
- `scripts/pr-preflight.sh origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming session shutdown by waiting for in-progress preview transcription to complete before finalizing.
  * Prevented canceled preview operations from applying outdated results or reporting stale errors.
  * Ensured preview transcription requests are handled sequentially to avoid overlapping operations.

* **Tests**
  * Added coverage for shutdown timing, cancellation handling, and serialized preview transcription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->