### PR TITLE
Fix release tool verification runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
   verify-release-tools:
     needs: [prepare]
     if: needs.prepare.outputs.should_run == 'true'
-    runs-on: ubuntu-latest
+    runs-on: macos-15
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Context

The manually dispatched daily release failed in `verify-release-tools` because `scripts/check_release_signing.sh --self-test` requires macOS tools (`plutil` and `/usr/libexec/PlistBuddy`), while the job ran on Ubuntu.

This moves only that verification job to `macos-15`.

## Test plan

- `bash scripts/check_release_binary_instrumentation.sh --self-test`
- `bash scripts/check_release_signing.sh --self-test`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release verification environment to macOS 15 for improved tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->