### PR TITLE
Fall back to raw transcription when LLM post-processing fails

### DIFF
--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -7,6 +7,12 @@ private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhis
 struct PostProcessingResult {
     let text: String
     let appliedSteps: [String]
+    let fallback: PostProcessingFallback?
+}
+
+struct PostProcessingFallback: Equatable, Sendable {
+    let failedStep: String
+    let reason: String
 }
 
 @MainActor
@@ -38,7 +44,8 @@ final class PostProcessingPipeline {
         llmHandler: ((String) async throws -> String)? = nil,
         outputFormat: String? = nil,
         llmStepName: String? = nil,
-        normalizeNumbers: Bool? = nil
+        normalizeNumbers: Bool? = nil,
+        llmFailureFallbackText: String? = nil
     ) async throws -> PostProcessingResult {
         // Collect plugin processors with their priorities
         let plugins = PluginManager.shared.postProcessors
@@ -147,13 +154,28 @@ final class PostProcessingPipeline {
                 }
             } catch {
                 logger.error("Post-processing step '\(name)' failed after \(ContinuousClock.now - stepStart): \(error.localizedDescription)")
-                // Only re-throw for LLM step
                 if step.id == -1 {
+                    if error is CancellationError || Task.isCancelled {
+                        throw CancellationError()
+                    }
+
+                    if let llmFailureFallbackText {
+                        logger.warning("Using raw transcription fallback after post-processing step '\(name)' failed")
+                        return PostProcessingResult(
+                            text: llmFailureFallbackText,
+                            appliedSteps: [],
+                            fallback: PostProcessingFallback(
+                                failedStep: name,
+                                reason: error.localizedDescription
+                            )
+                        )
+                    }
+
                     throw error
                 }
             }
         }
 
-        return PostProcessingResult(text: result, appliedSteps: appliedSteps)
+        return PostProcessingResult(text: result, appliedSteps: appliedSteps, fallback: nil)
     }
 }

--- a/TypeWhisper/Services/PostProcessingPipeline.swift
+++ b/TypeWhisper/Services/PostProcessingPipeline.swift
@@ -4,6 +4,13 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "PostProcessingPipeline")
 
+private func isPostProcessingCancellation(_ error: Error) -> Bool {
+    if error is CancellationError { return true }
+    if let urlError = error as? URLError, urlError.code == .cancelled { return true }
+    let nsError = error as NSError
+    return nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled
+}
+
 struct PostProcessingResult {
     let text: String
     let appliedSteps: [String]
@@ -155,7 +162,7 @@ final class PostProcessingPipeline {
             } catch {
                 logger.error("Post-processing step '\(name)' failed after \(ContinuousClock.now - stepStart): \(error.localizedDescription)")
                 if step.id == -1 {
-                    if error is CancellationError || Task.isCancelled {
+                    if Task.isCancelled || isPostProcessingCancellation(error) {
                         throw CancellationError()
                     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1903,9 +1903,20 @@ final class DictationViewModel: ObservableObject {
                     text: text, context: ppContext, dictationContext: dictationContext, llmHandler: llmHandler,
                     outputFormat: resolvedOutputFormat,
                     llmStepName: llmStepName,
-                    normalizeNumbers: self.effectiveNumberNormalizationOverride
+                    normalizeNumbers: self.effectiveNumberNormalizationOverride,
+                    llmFailureFallbackText: actionPluginId == nil ? text : nil
                 )
                 text = ppResult.text
+                let postProcessingFallback = ppResult.fallback
+                if let postProcessingFallback {
+                    errorLogService.addEntry(
+                        message: localizedAppText(
+                            "\(postProcessingFallback.failedStep) post-processing failed. Raw transcription fallback selected. \(postProcessingFallback.reason)",
+                            de: "\(postProcessingFallback.failedStep)-Nachbearbeitung fehlgeschlagen. Rohtext-Fallback ausgewählt. \(postProcessingFallback.reason)"
+                        ),
+                        category: "prompt"
+                    )
+                }
                 let shouldAutoEnterAfterInsertion = actionPluginId == nil
                     && (autoEnterMode == .always
                         || (autoEnterResolution.shouldPressEnter
@@ -1926,6 +1937,9 @@ final class DictationViewModel: ObservableObject {
                 var targetAppCorrectionBaseline: TextInsertionService.FocusedTextObservation?
                 let modelDisplayName = transcription.modelDisplayName
                 var pipelineSteps = ppResult.appliedSteps
+                if postProcessingFallback != nil {
+                    pipelineSteps.append(localizedAppText("Raw transcription fallback", de: "Rohtext-Fallback"))
+                }
                 if transcription.usedRecoveryFallback {
                     pipelineSteps.append(localizedAppText("Recovery fallback", de: "Recovery-Fallback"))
                 }
@@ -2095,6 +2109,18 @@ final class DictationViewModel: ObservableObject {
                 speechFeedbackService.speakAutomaticTranscription(text: text, language: detectedLang)
                 lastTranscribedText = text
                 lastTranscriptionLanguage = detectedLang
+
+                if postProcessingFallback != nil {
+                    showNotchFeedback(
+                        message: localizedAppText(
+                            "AI post-processing failed — raw transcription inserted",
+                            de: "KI-Nachbearbeitung fehlgeschlagen – Rohtext eingefügt",
+                            ja: "AI後処理に失敗しました — 未処理の文字起こしを挿入しました"
+                        ),
+                        icon: "exclamationmark.triangle.fill",
+                        duration: 4.0
+                    )
+                }
 
                 state = .inserting
                 if actionFeedbackMessage != nil {

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -445,18 +445,19 @@ final class SpeechPunctuationServiceTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
 
         let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
-        let rawText = "ciao aperta parentesi mondo chiusa parentesi"
+        let rawText = "twenty three"
 
         let result = try await pipeline.process(
             text: rawText,
-            context: PostProcessingContext(language: "it"),
+            context: PostProcessingContext(language: "en"),
             dictationContext: DictationRuntimeContext(
-                engineId: "parakeet",
-                modelId: "parakeet-v3",
-                configuredLanguage: "it",
+                engineId: "mock",
+                modelId: "tiny",
+                configuredLanguage: "en",
                 detectedLanguage: nil
             ),
-            llmHandler: { _ in
+            llmHandler: { intermediateText in
+                XCTAssertEqual(intermediateText, "23")
                 throw NSError(
                     domain: "PostProcessingPipelineTests",
                     code: 1,
@@ -464,6 +465,7 @@ final class SpeechPunctuationServiceTests: XCTestCase {
                 )
             },
             llmStepName: "Workflow",
+            normalizeNumbers: true,
             llmFailureFallbackText: rawText
         )
 
@@ -495,6 +497,29 @@ final class SpeechPunctuationServiceTests: XCTestCase {
             XCTFail("Expected cancellation to propagate")
         } catch is CancellationError {
             // Expected: cancellation must not continue into text insertion.
+        }
+    }
+
+    @MainActor
+    func testPipelineDoesNotTreatCancelledURLErrorAsRawFallback() async throws {
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
+
+        do {
+            _ = try await pipeline.process(
+                text: "Keep this text",
+                context: PostProcessingContext(language: "en"),
+                llmHandler: { _ in throw URLError(.cancelled) },
+                llmStepName: "Workflow",
+                llmFailureFallbackText: "Keep this text"
+            )
+            XCTFail("Expected URL cancellation to propagate")
+        } catch is CancellationError {
+            // Expected: provider cancellation must not continue into text insertion.
         }
     }
 

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -438,6 +438,67 @@ final class SpeechPunctuationServiceTests: XCTestCase {
     }
 
     @MainActor
+    func testPipelineReturnsRawFallbackWhenLLMProcessingFails() async throws {
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
+        let rawText = "ciao aperta parentesi mondo chiusa parentesi"
+
+        let result = try await pipeline.process(
+            text: rawText,
+            context: PostProcessingContext(language: "it"),
+            dictationContext: DictationRuntimeContext(
+                engineId: "parakeet",
+                modelId: "parakeet-v3",
+                configuredLanguage: "it",
+                detectedLanguage: nil
+            ),
+            llmHandler: { _ in
+                throw NSError(
+                    domain: "PostProcessingPipelineTests",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "Provider unavailable"]
+                )
+            },
+            llmStepName: "Workflow",
+            llmFailureFallbackText: rawText
+        )
+
+        XCTAssertEqual(result.text, rawText)
+        XCTAssertEqual(result.appliedSteps, [])
+        XCTAssertEqual(
+            result.fallback,
+            PostProcessingFallback(failedStep: "Workflow", reason: "Provider unavailable")
+        )
+    }
+
+    @MainActor
+    func testPipelineDoesNotTreatCancellationAsRawFallback() async throws {
+        let appSupportDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: appSupportDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: appSupportDirectory) }
+
+        let pipeline = makePipeline(appSupportDirectory: appSupportDirectory)
+
+        do {
+            _ = try await pipeline.process(
+                text: "Keep this text",
+                context: PostProcessingContext(language: "en"),
+                llmHandler: { _ in throw CancellationError() },
+                llmStepName: "Workflow",
+                llmFailureFallbackText: "Keep this text"
+            )
+            XCTFail("Expected cancellation to propagate")
+        } catch is CancellationError {
+            // Expected: cancellation must not continue into text insertion.
+        }
+    }
+
+    @MainActor
     private func makePipeline(appSupportDirectory: URL) -> PostProcessingPipeline {
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         let profileStore = DictationPunctuationProfileStore(defaults: UserDefaults(suiteName: #function)!, storageKey: #function)


### PR DESCRIPTION
## Summary

- preserve the pre-pipeline dictation text when LLM or workflow post-processing fails
- continue normal insertion, history, completion events, and statistics with the raw fallback
- show a brief fallback notice and record the detailed failure in the error log and transcription history
- keep cancellation and action-plugin workflow failures as real failures
- cover raw fallback and cancellation behavior with regression tests

## Issue Context

A successful speech-to-text result was previously discarded when every configured LLM fallback failed during workflow or translation post-processing. This change makes text-insertion dictations fail safe by returning the captured pre-pipeline transcription instead of aborting the entire dictation completion flow.

Closes #1137

## Test Plan

- [x] Ran `scripts/pr-preflight.sh origin/main` (599 Plugin SDK tests passed)
- [x] Ran `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/SpeechPunctuationServiceTests CODE_SIGNING_ALLOWED=NO` (21 tests passed)
- [x] Ran `xcodebuild build -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- [x] Verified LLM failures return the original pre-pipeline text and record fallback metadata
- [x] Verified CancellationError and URLError.cancelled still propagate instead of inserting text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Raw transcriptions are now preserved and inserted when language-model post-processing fails.
  * Users receive a notification when unprocessed transcription text is inserted.
  * Cancellation correctly stops processing without inserting fallback text.
  * Failure details are recorded for improved visibility into post-processing issues.
  * Number normalization occurs before language-model processing.

* **Tests**
  * Added coverage for fallback behavior, cancellation handling, and number normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->