### PR TITLE
Fix iCloud container expansion during release signing

### DIFF
--- a/scripts/archive_release.sh
+++ b/scripts/archive_release.sh
@@ -266,6 +266,12 @@ if [[ "$without_icloud" == false ]]; then
     -c "Set :com.apple.security.application-groups:0 $app_group" \
     "$expanded_helper_entitlements"
   /usr/libexec/PlistBuddy \
+    -c "Set :com.apple.developer.icloud-container-identifiers:0 $icloud_container" \
+    "$expanded_helper_entitlements"
+  /usr/libexec/PlistBuddy \
+    -c "Set :com.apple.developer.ubiquity-container-identifiers:0 $icloud_container" \
+    "$expanded_helper_entitlements"
+  /usr/libexec/PlistBuddy \
     -c "Add :com.apple.application-identifier string $team_id.$helper_bundle_id" \
     "$expanded_helper_entitlements"
   /usr/libexec/PlistBuddy \


### PR DESCRIPTION
## Context

The scheduled Build and Release run failed in Check Developer ID Signing after #1140 changed the helper iCloud entitlements to use the ICLOUD_CONTAINER_ID build setting:

https://github.com/TypeWhisper/typewhisper-mac/actions/runs/32447634932/job/96671509738

The release script re-signs the exported helper outside Xcode. It copied the parameterized entitlement template directly, so the manually signed helper retained unresolved container identifiers instead of the production iCloud container.

## Changes

- Resolve the production iCloud container before manually re-signing the exported helper.
- Apply the value to both the iCloud and ubiquity container entitlement arrays.

## Test plan

- `bash -n scripts/archive_release.sh`
- `bash scripts/check_release_signing.sh --self-test`
- `git diff --check`
- Reproduced the release entitlements expansion with PlistBuddy and verified both container arrays resolve to iCloud.com.typewhisper.sync with no remaining build-setting marker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iCloud helper signing by ensuring the correct iCloud containers are explicitly assigned during release preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->