### PR TITLE
Fix incomplete WhisperKit recorder transcripts

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -134,6 +134,7 @@ enum UserDefaultsKeys {
     static let recorderLivePreviewEnabled = "recorderLivePreviewEnabled"
     static let recorderTranscriptionEngine = "recorderTranscriptionEngine"
     static let recorderTranscriptionModel = "recorderTranscriptionModel"
+    static let recorderTranscriptionLanguage = "recorderTranscriptionLanguage"
     static let recorderMicDuckingMode = "recorderMicDuckingMode"
     static let recorderTrackMode = "recorderTrackMode"
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -1207,6 +1207,8 @@ final class AudioRecorderViewModel: ObservableObject {
                 errorMessage = recorderTranscriptionFailureAPISummary(recordedFailure)
                 return .failed(recordedFailure)
             }
+        } catch is CancellationError {
+            return .skipped
         } catch {
             logger.error("Final transcription failed: \(error.localizedDescription)")
             // Fall back to streaming result
@@ -1242,6 +1244,8 @@ final class AudioRecorderViewModel: ObservableObject {
             }
 
             return saveTranscriptOutcome(text, for: request.outputURL, request: request)
+        } catch is CancellationError {
+            return .skipped
         } catch {
             recordRetranscriptionFailure(
                 phase: .finalTranscription,

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -7,6 +7,69 @@ import TypeWhisperPluginSDK
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "typewhisper-mac", category: "AudioRecorderViewModel")
 
+private final class RecorderTranscriptionSourceProgressCapture: @unchecked Sendable {
+    private let maximumProcessedDuration = OSAllocatedUnfairLock(initialState: TimeInterval.zero)
+
+    func record(_ progress: PluginTranscriptionSourceProgress) -> Bool {
+        guard progress.processedDuration.isFinite else { return true }
+        maximumProcessedDuration.withLock { current in
+            current = max(current, progress.processedDuration)
+        }
+        return true
+    }
+
+    var processedDuration: TimeInterval {
+        maximumProcessedDuration.withLock { $0 }
+    }
+}
+
+private func recorderAudioHasAudibleTail(
+    samples: [Float],
+    startingAt startTime: TimeInterval,
+    sampleRate: Double = AudioRecorderService.transcriptionSampleRate
+) -> Bool {
+    let frameSampleCount = max(1, Int(sampleRate * 0.1))
+    let analysisStride = 8
+    let requiredActiveFrames = 10
+    let speechRMSFloor = 0.004
+    let startIndex = min(
+        samples.count,
+        max(0, Int((startTime + 0.5) * sampleRate))
+    )
+    guard startIndex < samples.count else { return false }
+
+    var activeFrames = 0
+    var frameStart = startIndex
+    while frameStart < samples.count {
+        guard !Task.isCancelled else { return false }
+        let frameEnd = min(samples.count, frameStart + frameSampleCount)
+        var squaredSum = 0.0
+        var analyzedSamples = 0
+        var index = frameStart
+        while index < frameEnd {
+            let sample = Double(samples[index])
+            if sample.isFinite {
+                squaredSum += sample * sample
+                analyzedSamples += 1
+            }
+            index += analysisStride
+        }
+
+        if analyzedSamples > 0 {
+            let rms = sqrt(squaredSum / Double(analyzedSamples))
+            if rms >= speechRMSFloor {
+                activeFrames += 1
+                if activeFrames >= requiredActiveFrames {
+                    return true
+                }
+            }
+        }
+        frameStart = frameEnd
+    }
+
+    return false
+}
+
 @MainActor
 final class AudioRecorderViewModel: ObservableObject {
     typealias AudioSamplesLoader = @MainActor (URL) async throws -> [Float]
@@ -191,7 +254,14 @@ final class AudioRecorderViewModel: ObservableObject {
     @Published var selectedModel: String? {
         didSet { defaults.set(selectedModel, forKey: UserDefaultsKeys.recorderTranscriptionModel) }
     }
-    @Published var languageSelection: LanguageSelection = .auto
+    @Published var languageSelection: LanguageSelection = .auto {
+        didSet {
+            defaults.set(
+                languageSelection.storedValue(nilBehavior: .auto),
+                forKey: UserDefaultsKeys.recorderTranscriptionLanguage
+            )
+        }
+    }
     @Published var selectedTask: TranscriptionTask = .transcribe
     @Published var recordings: [RecordingItem] = []
     @Published var errorMessage: String?
@@ -339,6 +409,10 @@ final class AudioRecorderViewModel: ObservableObject {
         }
         self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionEngine)
         self.selectedModel = defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionModel)
+        self.languageSelection = LanguageSelection(
+            storedValue: defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionLanguage),
+            nilBehavior: .auto
+        )
 
         recorderService.micDuckingMode = micDuckingMode
         recorderService.trackMode = trackMode
@@ -1188,17 +1262,132 @@ final class AudioRecorderViewModel: ObservableObject {
         _ request: FinalTranscriptionRequest,
         task: TranscriptionTask
     ) async throws -> TranscriptionResult {
-        try await modelManager.transcribe(
+        let initialPass = try await transcribeFinalRecordingPass(
+            request,
+            task: task,
+            prompt: request.prompt,
+            dictionaryTermHints: request.dictionaryTermHints
+        )
+
+        guard await shouldRetryWhisperKitWithoutConditioning(
+            request: request,
+            pass: initialPass
+        ) else {
+            return initialPass.result
+        }
+
+        logger.warning(
+            "WhisperKit final transcription stopped with audible audio remaining; retrying without dictionary conditioning [processedDuration=\(initialPass.processedDuration, privacy: .public), audioDuration=\(initialPass.result.duration, privacy: .public)]"
+        )
+
+        do {
+            try Task.checkCancellation()
+            let retryPass = try await transcribeFinalRecordingPass(
+                request,
+                task: task,
+                prompt: nil,
+                dictionaryTermHints: []
+            )
+            return preferredFinalTranscriptionResult(
+                initial: initialPass,
+                retry: retryPass
+            )
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            logger.warning(
+                "WhisperKit final transcription retry without dictionary conditioning failed; keeping the initial result: \(error.localizedDescription, privacy: .public)"
+            )
+            return initialPass.result
+        }
+    }
+
+    private struct FinalTranscriptionPass {
+        let result: TranscriptionResult
+        let processedDuration: TimeInterval
+    }
+
+    private func transcribeFinalRecordingPass(
+        _ request: FinalTranscriptionRequest,
+        task: TranscriptionTask,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) async throws -> FinalTranscriptionPass {
+        let progressCapture = RecorderTranscriptionSourceProgressCapture()
+        let result = try await modelManager.transcribe(
             audioSamples: request.buffer,
             languageSelection: request.languageSelection,
             task: task,
             engineOverrideId: request.providerId,
             cloudModelOverride: request.modelOverrideId,
-            prompt: request.prompt,
-            dictionaryTermHints: request.dictionaryTermHints,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
             onProgress: { _ in true },
-            onSourceProgress: { _ in true }
+            onSourceProgress: progressCapture.record
         )
+        let segmentDuration = result.segments
+            .map(\.end)
+            .filter(\.isFinite)
+            .max() ?? 0
+        return FinalTranscriptionPass(
+            result: result,
+            processedDuration: max(progressCapture.processedDuration, segmentDuration)
+        )
+    }
+
+    private func shouldRetryWhisperKitWithoutConditioning(
+        request: FinalTranscriptionRequest,
+        pass: FinalTranscriptionPass
+    ) async -> Bool {
+        guard request.providerId == "whisper",
+              let prompt = request.prompt?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !prompt.isEmpty else {
+            return false
+        }
+
+        let text = pass.result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty {
+            return true
+        }
+
+        let audioDuration = Double(request.buffer.count) / AudioRecorderService.transcriptionSampleRate
+        guard audioDuration >= 60,
+              pass.processedDuration > 0,
+              audioDuration - pass.processedDuration >= 30 else {
+            return false
+        }
+
+        let samples = request.buffer
+        let processedDuration = pass.processedDuration
+        let analysisTask = Task.detached(priority: .utility) {
+            recorderAudioHasAudibleTail(
+                samples: samples,
+                startingAt: processedDuration
+            )
+        }
+        return await withTaskCancellationHandler {
+            await analysisTask.value
+        } onCancel: {
+            analysisTask.cancel()
+        }
+    }
+
+    private func preferredFinalTranscriptionResult(
+        initial: FinalTranscriptionPass,
+        retry: FinalTranscriptionPass
+    ) -> TranscriptionResult {
+        let initialText = initial.result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        let retryText = retry.result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !retryText.isEmpty else { return initial.result }
+        guard !initialText.isEmpty else { return retry.result }
+
+        if retry.processedDuration > initial.processedDuration + 5 {
+            return retry.result
+        }
+        if retryText.count > Int(Double(initialText.count) * 1.2) {
+            return retry.result
+        }
+        return initial.result
     }
 
     private func resolvedTask(for request: FinalTranscriptionRequest) -> TranscriptionTask {

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -32,9 +32,10 @@ private func recorderAudioHasAudibleTail(
     let analysisStride = 8
     let requiredActiveFrames = 10
     let speechRMSFloor = 0.004
+    let analysisStartOffset = startTime > 0 ? 0.5 : 0
     let startIndex = min(
         samples.count,
-        max(0, Int((startTime + 0.5) * sampleRate))
+        max(0, Int((startTime + analysisStartOffset) * sampleRate))
     )
     guard startIndex < samples.count else { return false }
 

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -1272,8 +1272,9 @@ final class AudioRecorderViewModel: ObservableObject {
             prompt: request.prompt,
             dictionaryTermHints: request.dictionaryTermHints
         )
+        try Task.checkCancellation()
 
-        guard await shouldRetryWhisperKitWithoutConditioning(
+        guard try await shouldRetryWhisperKitWithoutConditioning(
             request: request,
             pass: initialPass
         ) else {
@@ -1342,7 +1343,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private func shouldRetryWhisperKitWithoutConditioning(
         request: FinalTranscriptionRequest,
         pass: FinalTranscriptionPass
-    ) async -> Bool {
+    ) async throws -> Bool {
         guard request.providerId == "whisper",
               let prompt = request.prompt?.trimmingCharacters(in: .whitespacesAndNewlines),
               !prompt.isEmpty else {
@@ -1350,30 +1351,33 @@ final class AudioRecorderViewModel: ObservableObject {
         }
 
         let text = pass.result.text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if text.isEmpty {
-            return true
-        }
-
         let audioDuration = Double(request.buffer.count) / AudioRecorderService.transcriptionSampleRate
-        guard audioDuration >= 60,
-              pass.processedDuration > 0,
-              audioDuration - pass.processedDuration >= 30 else {
-            return false
+        let analysisStartTime: TimeInterval
+        if text.isEmpty {
+            analysisStartTime = 0
+        } else {
+            guard audioDuration >= 60,
+                  pass.processedDuration > 0,
+                  audioDuration - pass.processedDuration >= 30 else {
+                return false
+            }
+            analysisStartTime = pass.processedDuration
         }
 
         let samples = request.buffer
-        let processedDuration = pass.processedDuration
         let analysisTask = Task.detached(priority: .utility) {
             recorderAudioHasAudibleTail(
                 samples: samples,
-                startingAt: processedDuration
+                startingAt: analysisStartTime
             )
         }
-        return await withTaskCancellationHandler {
+        let hasAudibleAudio = await withTaskCancellationHandler {
             await analysisTask.value
         } onCancel: {
             analysisTask.cancel()
         }
+        try Task.checkCancellation()
+        return hasAudibleAudio
     }
 
     private func preferredFinalTranscriptionResult(

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -278,6 +278,25 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(defaults.bool(forKey: UserDefaultsKeys.recorderLivePreviewEnabled))
     }
 
+    func testRecorderLanguageSelectionPersistsSeparatelyFromFileTranscription() throws {
+        let defaults = try makeDefaults()
+        defaults.set("fr", forKey: UserDefaultsKeys.fileTranscriptionLanguage)
+
+        let viewModel = makeViewModel(defaults: defaults)
+        XCTAssertEqual(viewModel.languageSelection, .auto)
+
+        viewModel.languageSelection = .hints(["nl", "en"])
+
+        XCTAssertEqual(
+            defaults.string(forKey: UserDefaultsKeys.recorderTranscriptionLanguage),
+            "[\"nl\",\"en\"]"
+        )
+        XCTAssertEqual(defaults.string(forKey: UserDefaultsKeys.fileTranscriptionLanguage), "fr")
+
+        let restoredViewModel = makeViewModel(defaults: defaults)
+        XCTAssertEqual(restoredViewModel.languageSelection, .hints(["nl", "en"]))
+    }
+
     func testLivePreviewStartsOnlyWhenTranscriptAndPreviewAreEnabled() async throws {
         try preserveStandardDefaults()
         setupPluginManager()
@@ -780,6 +799,92 @@ final class AudioRecorderViewModelTests: XCTestCase {
         let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
         XCTAssertEqual(session.text, "unforced whisper-large-v3")
         XCTAssertEqual(plugin.selectedModelOverrides, [])
+    }
+
+    func testWhisperKitFinalTranscriptionRetriesWithoutDictionaryConditioningForAudibleTail() async throws {
+        try preserveStandardDefaults()
+        let plugin = setupWhisperPluginManager(
+            behavior: .conditionedShortFallbackComplete(
+                shortText: "short conditioned transcript",
+                completeText: "complete unconditioned transcript"
+            )
+        )
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("whisper")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let samples = Array(
+            repeating: Float(0.1),
+            count: Int(AudioRecorderService.transcriptionSampleRate * 90)
+        )
+        let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(
+                recordingsDirectory: recordingsDirectory,
+                samples: samples
+            ),
+            dictionaryService: dictionaryService,
+            audioSamplesLoader: { _ in samples }
+        )
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(
+            micEnabled: true,
+            systemAudioEnabled: false
+        )
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        XCTAssertEqual(session.text, "complete unconditioned transcript")
+        XCTAssertEqual(plugin.requests.count, 2)
+        XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
+        XCTAssertNil(plugin.requests[1].prompt)
+    }
+
+    func testWhisperKitFinalTranscriptionKeepsConditionedResultWhenRemainingTailIsSilent() async throws {
+        try preserveStandardDefaults()
+        let plugin = setupWhisperPluginManager(
+            behavior: .conditionedShortFallbackComplete(
+                shortText: "complete speech before silence",
+                completeText: "unexpected retry"
+            )
+        )
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("whisper")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let sampleRate = Int(AudioRecorderService.transcriptionSampleRate)
+        let samples = Array(repeating: Float(0.1), count: sampleRate * 18)
+            + Array(repeating: Float.zero, count: sampleRate * 72)
+        let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(
+                recordingsDirectory: recordingsDirectory,
+                samples: samples
+            ),
+            dictionaryService: dictionaryService,
+            audioSamplesLoader: { _ in samples }
+        )
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(
+            micEnabled: true,
+            systemAudioEnabled: false
+        )
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        XCTAssertEqual(session.text, "complete speech before silence")
+        XCTAssertEqual(plugin.requests.count, 1)
+        XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
     }
 
     func testFailureSidecarWriteErrorStillShowsRecorderFailure() async throws {
@@ -1685,6 +1790,46 @@ final class AudioRecorderViewModelTests: XCTestCase {
         return plugin
     }
 
+    private func setupWhisperPluginManager(
+        behavior: AudioRecorderMockTranscriptionPlugin.TranscriptionBehavior
+    ) -> AudioRecorderMockTranscriptionPlugin {
+        let previousPluginManager = PluginManager.shared
+        addTeardownBlock {
+            PluginManager.shared = previousPluginManager
+        }
+
+        let appSupportDirectory = makeTemporaryDirectory()
+        let plugin = AudioRecorderMockTranscriptionPlugin(
+            providerId: "whisper",
+            displayName: "WhisperKit",
+            models: [
+                PluginModelInfo(
+                    id: "openai_whisper-large-v3",
+                    displayName: "Whisper Large V3"
+                )
+            ],
+            selectedModelId: "openai_whisper-large-v3",
+            behavior: behavior
+        )
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: "com.typewhisper.mock.whisperkit",
+                    name: "WhisperKit",
+                    version: "1.0.0",
+                    principalClass: "AudioRecorderMockTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+        return plugin
+    }
+
     private func preserveStandardDefaults(additionalKeys: [String] = []) throws {
         let keys = Array(Set([
             UserDefaultsKeys.selectedEngine,
@@ -1813,6 +1958,7 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
         case success(String)
         case empty
         case failure(String)
+        case conditionedShortFallbackComplete(shortText: String, completeText: String)
     }
 
     static let pluginId = "com.typewhisper.mock.audio-recorder"
@@ -1826,6 +1972,7 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
     var supportsTranslation = true
     private let behavior: TranscriptionBehavior
     private(set) var lastRequest: Request?
+    private(set) var requests: [Request] = []
     private(set) var selectedModelOverrides: [String] = []
 
     required override init() {
@@ -1891,8 +2038,12 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
             usedFileTranscriptionPipeline: true
         )
         _ = onProgress(result.text)
+        let processedDuration = result.segments
+            .map(\.end)
+            .filter(\.isFinite)
+            .max() ?? audio.duration
         _ = onSourceProgress(PluginTranscriptionSourceProgress(
-            processedDuration: audio.duration,
+            processedDuration: processedDuration,
             totalDuration: audio.duration
         ))
         return result
@@ -1905,7 +2056,7 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
         prompt: String?,
         usedFileTranscriptionPipeline: Bool
     ) throws -> PluginTranscriptionResult {
-        lastRequest = Request(
+        let request = Request(
             language: language,
             translate: translate,
             prompt: prompt,
@@ -1913,6 +2064,8 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
             firstAudioSample: audio.samples.first,
             usedFileTranscriptionPipeline: usedFileTranscriptionPipeline
         )
+        lastRequest = request
+        requests.append(request)
         return switch behavior {
         case .success(let text):
             PluginTranscriptionResult(text: text)
@@ -1920,6 +2073,30 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
             PluginTranscriptionResult(text: "")
         case .failure(let message):
             throw PluginTranscriptionError.apiError(message)
+        case .conditionedShortFallbackComplete(let shortText, let completeText):
+            if let prompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                PluginTranscriptionResult(
+                    text: shortText,
+                    segments: [
+                        PluginTranscriptionSegment(
+                            text: shortText,
+                            start: 0,
+                            end: audio.duration * 0.2
+                        )
+                    ]
+                )
+            } else {
+                PluginTranscriptionResult(
+                    text: completeText,
+                    segments: [
+                        PluginTranscriptionSegment(
+                            text: completeText,
+                            start: 0,
+                            end: audio.duration
+                        )
+                    ]
+                )
+            }
         }
     }
 }

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -430,6 +430,32 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(summary.contains("HTTP 413"))
     }
 
+    func testCancelledFinalTranscriptionDoesNotPersistRecorderFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .cancellation)
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let viewModel = makeFinalTranscriptionViewModel(defaults: defaults, modelManager: modelManager)
+
+        let sessionID = try await viewModel.apiStartRecording(micEnabled: true, systemAudioEnabled: false)
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        let outputFile = try XCTUnwrap(session.outputFile)
+        XCTAssertNil(session.text)
+        XCTAssertNil(session.error)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: failureSidecarURL(for: URL(fileURLWithPath: outputFile)).path
+            )
+        )
+
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+        XCTAssertNil(viewModel.recordings.first?.transcriptionFailure)
+    }
+
     func testEmptyFinalTranscriptionPersistsRecorderFailure() async throws {
         try preserveStandardDefaults()
         setupPluginManager(groqBehavior: .empty)
@@ -801,7 +827,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(plugin.selectedModelOverrides, [])
     }
 
-    func testWhisperKitFinalTranscriptionRetriesWithoutDictionaryConditioningForAudibleTail() async throws {
+    func testWhisperKitFinalTranscriptionRetriesWithLivePreviewEnabledForAudibleTail() async throws {
         try preserveStandardDefaults()
         let plugin = setupWhisperPluginManager(
             behavior: .conditionedShortFallbackComplete(
@@ -819,6 +845,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
         )
         let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
         dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        var livePreviewStartCount = 0
         let viewModel = makeViewModel(
             defaults: defaults,
             modelManager: modelManager,
@@ -827,10 +854,11 @@ final class AudioRecorderViewModelTests: XCTestCase {
                 samples: samples
             ),
             dictionaryService: dictionaryService,
-            audioSamplesLoader: { _ in samples }
+            audioSamplesLoader: { _ in samples },
+            livePreviewStartObserver: { livePreviewStartCount += 1 }
         )
         viewModel.transcriptionEnabled = true
-        viewModel.livePreviewEnabled = false
+        viewModel.livePreviewEnabled = true
 
         let sessionID = try await viewModel.apiStartRecording(
             micEnabled: true,
@@ -840,6 +868,7 @@ final class AudioRecorderViewModelTests: XCTestCase {
 
         let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
         XCTAssertEqual(session.text, "complete unconditioned transcript")
+        XCTAssertEqual(livePreviewStartCount, 1)
         XCTAssertEqual(plugin.requests.count, 2)
         XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
         XCTAssertNil(plugin.requests[1].prompt)
@@ -1958,6 +1987,7 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
         case success(String)
         case empty
         case failure(String)
+        case cancellation
         case conditionedShortFallbackComplete(shortText: String, completeText: String)
     }
 
@@ -2073,6 +2103,8 @@ private final class AudioRecorderMockTranscriptionPlugin: NSObject, SourceProgre
             PluginTranscriptionResult(text: "")
         case .failure(let message):
             throw PluginTranscriptionError.apiError(message)
+        case .cancellation:
+            throw CancellationError()
         case .conditionedShortFallbackComplete(let shortText, let completeText):
             if let prompt, !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 PluginTranscriptionResult(

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -916,6 +916,44 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
     }
 
+    func testWhisperKitEmptyFinalTranscriptionDoesNotRetrySilentAudio() async throws {
+        try preserveStandardDefaults()
+        let plugin = setupWhisperPluginManager(behavior: .empty)
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("whisper")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let samples = Array(
+            repeating: Float.zero,
+            count: Int(AudioRecorderService.transcriptionSampleRate * 90)
+        )
+        let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(
+                recordingsDirectory: recordingsDirectory,
+                samples: samples
+            ),
+            dictionaryService: dictionaryService,
+            audioSamplesLoader: { _ in samples }
+        )
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(
+            micEnabled: true,
+            systemAudioEnabled: false
+        )
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .failed)
+        XCTAssertNil(session.text)
+        XCTAssertEqual(plugin.requests.count, 1)
+        XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
+    }
+
     func testFailureSidecarWriteErrorStillShowsRecorderFailure() async throws {
         try preserveStandardDefaults()
         setupPluginManager(groqBehavior: .failure("HTTP 500: provider unavailable"))
@@ -1134,6 +1172,35 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
         XCTAssertEqual(viewModel.recordings.first?.transcriptionFailure?.phase, .preparingFinalAudio)
         XCTAssertNil(viewModel.retranscribingRecordingURL)
+    }
+
+    func testCancelledRetranscriptionPreservesExistingTranscriptWithoutFailure() async throws {
+        try preserveStandardDefaults()
+        setupPluginManager(groqBehavior: .cancellation)
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("groq")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let audioURL = recordingsDirectory.appendingPathComponent("Meeting.wav")
+        let transcriptURL = audioURL.deletingPathExtension().appendingPathExtension("txt")
+        try Data("audio".utf8).write(to: audioURL)
+        try "keep me".write(to: transcriptURL, atomically: true, encoding: .utf8)
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(recordingsDirectory: recordingsDirectory),
+            audioSamplesLoader: { _ in [0.25, -0.25] }
+        )
+        viewModel.loadRecordings()
+        try await waitForRecordingsToLoad(viewModel, count: 1)
+
+        viewModel.transcribeRecording(try XCTUnwrap(viewModel.recordings.first))
+        try await waitForRetranscriptionToFinish(viewModel)
+
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "keep me")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: failureSidecarURL(for: audioURL).path))
+        XCTAssertNil(viewModel.retranscribingRecordingURL)
+        XCTAssertNil(viewModel.recordings.first?.transcriptionFailure)
     }
 
     func testRetranscriptionEngineFailurePreservesExistingTranscript() async throws {

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -954,6 +954,49 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
     }
 
+    func testWhisperKitEmptyFinalTranscriptionRetriesForAudibleRecordingStart() async throws {
+        try preserveStandardDefaults()
+        let plugin = setupWhisperPluginManager(
+            behavior: .conditionedShortFallbackComplete(
+                shortText: "",
+                completeText: "recovered transcript"
+            )
+        )
+        let defaults = try makeDefaults()
+        let modelManager = ModelManagerService()
+        modelManager.selectProvider("whisper")
+        let recordingsDirectory = makeTemporaryDirectory()
+        let sampleRate = Int(AudioRecorderService.transcriptionSampleRate)
+        let samples = Array(repeating: Float(0.1), count: sampleRate)
+            + Array(repeating: Float.zero, count: sampleRate * 89)
+        let dictionaryService = DictionaryService(appSupportDirectory: makeTemporaryDirectory())
+        dictionaryService.addEntry(type: .term, original: "TypeWhisper")
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            modelManager: modelManager,
+            recorderService: makeRecorderService(
+                recordingsDirectory: recordingsDirectory,
+                samples: samples
+            ),
+            dictionaryService: dictionaryService,
+            audioSamplesLoader: { _ in samples }
+        )
+        viewModel.transcriptionEnabled = true
+        viewModel.livePreviewEnabled = false
+
+        let sessionID = try await viewModel.apiStartRecording(
+            micEnabled: true,
+            systemAudioEnabled: false
+        )
+        _ = try viewModel.apiStopRecording()
+
+        let session = try await waitForRecorderSession(viewModel, id: sessionID, status: .completed)
+        XCTAssertEqual(session.text, "recovered transcript")
+        XCTAssertEqual(plugin.requests.count, 2)
+        XCTAssertTrue(plugin.requests[0].prompt?.contains("TypeWhisper") == true)
+        XCTAssertNil(plugin.requests[1].prompt)
+    }
+
     func testFailureSidecarWriteErrorStillShowsRecorderFailure() async throws {
         try preserveStandardDefaults()
         setupPluginManager(groqBehavior: .failure("HTTP 500: provider unavailable"))


### PR DESCRIPTION
## Context

Issue #1091 still reproduces with live preview disabled: Recorder can return an incomplete WhisperKit Large V3 transcript while File Transcription completes the same saved audio. The remaining Recorder-specific differences are its independently configured language and dictionary conditioning during final transcription.

This change persists the Recorder language independently from File Transcription and adds a narrowly scoped WhisperKit recovery pass. When a conditioned final result stops early while the remaining source audio contains an audible tail, Recorder retries once without dictionary conditioning and keeps the retry only when it materially improves source coverage or transcript length. Silent tails and fully silent empty results do not trigger a retry. Empty results still recover when audible speech exists at the beginning of the recording. Cancellation remains observable through tail analysis and does not create a failure sidecar. A failed retry preserves the initial result.

The recovery path is shared by automatic final transcription and Recorder retranscription. The automatic recording regression also runs with live preview enabled, confirming WhisperKit's fallback preview still reaches the tracked final recording pass.

Closes #1091

## Test plan

```sh
xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRecorderLanguageSelectionPersistsSeparatelyFromFileTranscription -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testWhisperKitFinalTranscriptionRetriesWithLivePreviewEnabledForAudibleTail -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testWhisperKitFinalTranscriptionKeepsConditionedResultWhenRemainingTailIsSilent -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testWhisperKitEmptyFinalTranscriptionDoesNotRetrySilentAudio -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testWhisperKitEmptyFinalTranscriptionRetriesForAudibleRecordingStart -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testCancelledFinalTranscriptionDoesNotPersistRecorderFailure -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testCancelledRetranscriptionPreservesExistingTranscriptWithoutFailure | xcbeautify

xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioRecorderViewModelTests | xcbeautify

scripts/pr-preflight.sh origin/main
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recorder transcription language selection is now remembered and restored automatically.
  * Transcription progress more accurately reflects recorded audio, including trailing speech.
* **Bug Fixes**
  * Improved final transcription results when speech is missed near the end of a recording.
  * Added a fallback for empty or incomplete transcription results.
  * Cancelling final transcription or retranscription no longer incorrectly reports a failure or removes existing transcripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->