### PR TITLE
Add headless settings import and export to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,14 +426,19 @@ curl -X DELETE http://localhost:8978/v1/dictionary/corrections \
 
 ### Settings Backup
 
-The settings endpoints use the same JSON backup schema and merge/skip behavior as Settings > Advanced > Backup & Restore. Import applies every category present in the backup.
+The settings endpoints use the same JSON backup schema and merge/skip behavior as Settings > Advanced > Backup & Restore. Import applies every category present in the backup. While the API server is running, scripts can read its current bearer token from the owner-only discovery file:
 
 ```bash
+TYPEWHISPER_API_TOKEN="$(jq -r '.token' "$HOME/Library/Application Support/TypeWhisper/api-discovery.json")"
+
 # Export the current settings backup
-curl http://localhost:8978/v1/settings/export > typewhisper-settings.json
+curl http://localhost:8978/v1/settings/export \
+  -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
+  > typewhisper-settings.json
 
 # Import all categories from a settings backup
 curl -X POST http://localhost:8978/v1/settings/import \
+  -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
   -H "Content-Type: application/json" \
   --data-binary @typewhisper-settings.json
 ```

--- a/README.md
+++ b/README.md
@@ -432,12 +432,13 @@ The settings endpoints use the same JSON backup schema and merge/skip behavior a
 TYPEWHISPER_API_TOKEN="$(jq -r '.token' "$HOME/Library/Application Support/TypeWhisper/api-discovery.json")"
 
 # Export the current settings backup
-curl http://localhost:8978/v1/settings/export \
+curl --fail --silent --show-error http://localhost:8978/v1/settings/export \
   -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
-  > typewhisper-settings.json
+  --output typewhisper-settings.json.tmp && \
+  mv typewhisper-settings.json.tmp typewhisper-settings.json
 
 # Import all categories from a settings backup
-curl -X POST http://localhost:8978/v1/settings/import \
+curl --fail --silent --show-error -X POST http://localhost:8978/v1/settings/import \
   -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
   -H "Content-Type: application/json" \
   --data-binary @typewhisper-settings.json

--- a/README.md
+++ b/README.md
@@ -432,10 +432,14 @@ The settings endpoints use the same JSON backup schema and merge/skip behavior a
 TYPEWHISPER_API_TOKEN="$(jq -r '.token' "$HOME/Library/Application Support/TypeWhisper/api-discovery.json")"
 
 # Export the current settings backup
-curl --fail --silent --show-error http://localhost:8978/v1/settings/export \
-  -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
-  --output typewhisper-settings.json.tmp && \
-  mv typewhisper-settings.json.tmp typewhisper-settings.json
+(
+  settings_backup_tmp="$(mktemp ./typewhisper-settings.json.tmp.XXXXXX)" || exit
+  trap 'rm -f "$settings_backup_tmp"' EXIT
+  curl --fail --silent --show-error http://localhost:8978/v1/settings/export \
+    -H "Authorization: Bearer $TYPEWHISPER_API_TOKEN" \
+    --output "$settings_backup_tmp" && \
+    mv "$settings_backup_tmp" typewhisper-settings.json
+)
 
 # Import all categories from a settings backup
 curl --fail --silent --show-error -X POST http://localhost:8978/v1/settings/import \

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The localized macOS screenshot workflow is documented in [docs/screenshot-automa
   [plugin catalog](TypeWhisperPluginSDK/Plugins/README.md)
 - **Local model download controls** - Bundled Qwen3, Granite, Voxtral, and Supertonic plugins support an optional HuggingFace token for higher rate limits and clearer download errors. Supertonic requires explicit OpenRAIL-M model-license acceptance before model assets download.
 - **HTTP API** - Local REST API for integration with external tools and scripts
-- **CLI tool** - Shell-friendly transcription via the command line
+- **CLI tool** - Shell-friendly transcription and settings backup via the command line
 - **Discord claim service** - Optional external service for Polar supporter and GitHub Sponsors Discord role claims
 
 ### General
@@ -424,6 +424,20 @@ curl -X DELETE http://localhost:8978/v1/dictionary/corrections \
   -d '{"original":"teh"}'
 ```
 
+### Settings Backup
+
+The settings endpoints use the same JSON backup schema and merge/skip behavior as Settings > Advanced > Backup & Restore. Import applies every category present in the backup.
+
+```bash
+# Export the current settings backup
+curl http://localhost:8978/v1/settings/export > typewhisper-settings.json
+
+# Import all categories from a settings backup
+curl -X POST http://localhost:8978/v1/settings/import \
+  -H "Content-Type: application/json" \
+  --data-binary @typewhisper-settings.json
+```
+
 ### Workflows
 
 ```bash
@@ -535,6 +549,8 @@ Install via Settings > Advanced > CLI Tool > Install. This places the `typewhisp
 typewhisper status              # Show server status
 typewhisper models              # List available models
 typewhisper transcribe file.wav # Transcribe an audio file
+typewhisper export settings.json # Export all supported settings
+typewhisper import settings.json # Import all categories in a backup
 ```
 
 ### Options
@@ -563,6 +579,12 @@ cat audio.wav | typewhisper transcribe -
 
 # Use in a script
 typewhisper transcribe meeting.m4a --json | jq -r '.text'
+
+# Keep a portable backup in a dotfiles repository
+typewhisper export ~/.config/typewhisper/settings.json
+
+# Restore it and receive a machine-readable import summary
+typewhisper import ~/.config/typewhisper/settings.json --json
 ```
 
 The CLI requires the API server to be running (Settings > Advanced) and follows the documented command and flag surface for the current stable release.
@@ -609,7 +631,7 @@ See [TypeWhisperPluginSDK/Plugins/README.md](TypeWhisperPluginSDK/Plugins/README
 
 ```
 TypeWhisper/
-├── typewhisper-cli/           # Command-line tool (status, models, transcribe)
+├── typewhisper-cli/           # Command-line tool (transcription and settings backup)
 ├── PluginRegistry/            # Source registry entries for community plugin feeds
 ├── Plugins/                # Redirect docs and legacy entrypoint for moved first-party plugin sources
 ├── TypeWhisperPluginSDK/   # Plugin SDK (Swift package)

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -238,6 +238,23 @@ final class ServiceContainer: ObservableObject {
         // HTTP API
         let apiAuthenticator = LocalAPIAuthenticator()
         let router = APIRouter(apiTokenProvider: apiAuthenticator.tokenForEnforcedRequests)
+        let settingsBackupService = SettingsBackupAutomationService(
+            workflowService: workflowService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            profileService: profileService,
+            promptActionService: promptActionService,
+            pluginManager: pluginManager,
+            pluginRegistryService: pluginRegistryService,
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService,
+            liveFieldTranscriptEnabledDidChange: { [dictationViewModel] enabled in
+                dictationViewModel.liveFieldTranscriptEnabled = enabled
+            },
+            recoveryRetentionPolicyDidChange: { [audioRecordingService] policy in
+                _ = audioRecordingService.updateRecoveryRetentionPolicy(policy)
+            }
+        )
         let handlers = APIHandlers(
             modelManager: modelManagerService,
             audioFileService: audioFileService,
@@ -246,7 +263,8 @@ final class ServiceContainer: ObservableObject {
             workflowService: workflowService,
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel,
-            audioRecorderViewModel: audioRecorderViewModel
+            audioRecorderViewModel: audioRecorderViewModel,
+            settingsBackupService: settingsBackupService
         )
         handlers.register(on: router)
         httpServer = HTTPServer(router: router)

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -12,6 +12,7 @@ final class APIHandlers: @unchecked Sendable {
     private let dictionaryService: DictionaryService
     private let dictationViewModel: DictationViewModel
     private let audioRecorderViewModel: AudioRecorderViewModel
+    private let settingsBackupService: SettingsBackupAutomationService
 
     init(
         modelManager: ModelManagerService,
@@ -21,7 +22,8 @@ final class APIHandlers: @unchecked Sendable {
         workflowService: WorkflowService,
         dictionaryService: DictionaryService,
         dictationViewModel: DictationViewModel,
-        audioRecorderViewModel: AudioRecorderViewModel
+        audioRecorderViewModel: AudioRecorderViewModel,
+        settingsBackupService: SettingsBackupAutomationService
     ) {
         self.modelManager = modelManager
         self.audioFileService = audioFileService
@@ -31,6 +33,7 @@ final class APIHandlers: @unchecked Sendable {
         self.dictionaryService = dictionaryService
         self.dictationViewModel = dictationViewModel
         self.audioRecorderViewModel = audioRecorderViewModel
+        self.settingsBackupService = settingsBackupService
     }
 
     func register(on router: APIRouter) {
@@ -58,6 +61,36 @@ final class APIHandlers: @unchecked Sendable {
         router.register("GET", "/v1/dictionary/corrections", handler: handleGetDictionaryCorrections)
         router.register("PUT", "/v1/dictionary/corrections", handler: handlePutDictionaryCorrections)
         router.register("DELETE", "/v1/dictionary/corrections", handler: handleDeleteDictionaryCorrections)
+        router.register("GET", "/v1/settings/export", handler: handleExportSettings)
+        router.register("POST", "/v1/settings/import", handler: handleImportSettings)
+    }
+
+    // MARK: - /v1/settings
+
+    private func handleExportSettings(_ request: HTTPRequest) async -> HTTPResponse {
+        do {
+            let data = try await settingsBackupService.exportData()
+            return HTTPResponse(status: 200, contentType: "application/json", body: data)
+        } catch {
+            apiLogger.error("Settings export failed: \(error.localizedDescription, privacy: .public)")
+            return .error(status: 500, message: "Could not export TypeWhisper settings")
+        }
+    }
+
+    private func handleImportSettings(_ request: HTTPRequest) async -> HTTPResponse {
+        guard !request.body.isEmpty else {
+            return .error(status: 400, message: "Request body must contain a TypeWhisper settings backup")
+        }
+
+        do {
+            let result = try await settingsBackupService.importData(request.body)
+            return .json(result)
+        } catch SettingsBackupExporter.ImportError.invalidFile {
+            return .error(status: 400, message: "Request body is not a valid TypeWhisper settings backup")
+        } catch {
+            apiLogger.error("Settings import failed: \(error.localizedDescription, privacy: .public)")
+            return .error(status: 500, message: "Could not import TypeWhisper settings")
+        }
     }
 
     // MARK: - POST /v1/transcribe

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -261,7 +261,7 @@ enum SettingsBackupExporter {
         let preferences: PreferencesDTO
     }
 
-    struct ImportResult {
+    struct ImportResult: Encodable, Sendable {
         var workflowsImported = 0
         var dictionaryImported = 0
         var dictionarySkipped = 0
@@ -899,5 +899,85 @@ enum SettingsBackupExporter {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         return "typewhisper-backup-\(formatter.string(from: Date())).json"
+    }
+}
+
+/// Main-actor bridge used by headless automation surfaces. It keeps the HTTP
+/// layer independent from the individual settings stores while guaranteeing
+/// that exports and imports use the same schema and side effects as the UI.
+@MainActor
+final class SettingsBackupAutomationService {
+    private let workflowService: WorkflowService
+    private let dictionaryService: DictionaryService
+    private let snippetService: SnippetService
+    private let profileService: ProfileService
+    private let promptActionService: PromptActionService
+    private let pluginManager: PluginManager
+    private let pluginRegistryService: PluginRegistryService
+    private let historyService: HistoryService
+    private let usageStatisticsService: UsageStatisticsService
+    private let userDefaults: UserDefaults
+    private let liveFieldTranscriptEnabledDidChange: ((Bool) -> Void)?
+    private let recoveryRetentionPolicyDidChange: ((DictationRecoveryRetentionPolicy) -> Void)?
+
+    init(
+        workflowService: WorkflowService,
+        dictionaryService: DictionaryService,
+        snippetService: SnippetService,
+        profileService: ProfileService,
+        promptActionService: PromptActionService,
+        pluginManager: PluginManager,
+        pluginRegistryService: PluginRegistryService,
+        historyService: HistoryService,
+        usageStatisticsService: UsageStatisticsService,
+        userDefaults: UserDefaults = .standard,
+        liveFieldTranscriptEnabledDidChange: ((Bool) -> Void)? = nil,
+        recoveryRetentionPolicyDidChange: ((DictationRecoveryRetentionPolicy) -> Void)? = nil
+    ) {
+        self.workflowService = workflowService
+        self.dictionaryService = dictionaryService
+        self.snippetService = snippetService
+        self.profileService = profileService
+        self.promptActionService = promptActionService
+        self.pluginManager = pluginManager
+        self.pluginRegistryService = pluginRegistryService
+        self.historyService = historyService
+        self.usageStatisticsService = usageStatisticsService
+        self.userDefaults = userDefaults
+        self.liveFieldTranscriptEnabledDidChange = liveFieldTranscriptEnabledDidChange
+        self.recoveryRetentionPolicyDidChange = recoveryRetentionPolicyDidChange
+    }
+
+    func exportData() throws -> Data {
+        let backup = SettingsBackupExporter.buildBackup(
+            workflowService: workflowService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            profileService: profileService,
+            promptActionService: promptActionService,
+            pluginManager: pluginManager,
+            historyService: historyService,
+            userDefaults: userDefaults
+        )
+        return try SettingsBackupExporter.encodedJSON(backup)
+    }
+
+    func importData(_ data: Data) async throws -> SettingsBackupExporter.ImportResult {
+        let backup = try SettingsBackupExporter.parse(data)
+        return await SettingsBackupExporter.importBackup(
+            backup,
+            workflowService: workflowService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            profileService: profileService,
+            promptActionService: promptActionService,
+            pluginManager: pluginManager,
+            pluginRegistryService: pluginRegistryService,
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService,
+            userDefaults: userDefaults,
+            liveFieldTranscriptEnabledDidChange: liveFieldTranscriptEnabledDidChange,
+            recoveryRetentionPolicyDidChange: recoveryRetentionPolicyDidChange
+        )
     }
 }

--- a/TypeWhisperTests/CLISupportTests.swift
+++ b/TypeWhisperTests/CLISupportTests.swift
@@ -26,6 +26,17 @@ final class CLISupportTests: XCTestCase {
         XCTAssertEqual(OutputFormatter.formatStatus(statusJSON, json: false), "Ready - parakeet (tiny)")
         XCTAssertTrue(OutputFormatter.formatModels(modelsJSON, json: false).contains("tiny"))
         XCTAssertTrue(OutputFormatter.formatModels(modelsJSON, json: false).contains("*"))
+        XCTAssertEqual(
+            OutputFormatter.formatSettingsExport(path: "/tmp/settings.json", bytes: 123, json: false),
+            "Exported settings to /tmp/settings.json"
+        )
+
+        let importJSON = Data(#"{"workflowsImported":2,"dictionaryImported":1,"dictionarySkipped":3,"snippetsImported":0,"snippetsSkipped":0,"promptActionsImported":0,"profilesImported":0,"hotkeysApplied":1,"hotkeysSkipped":0,"pluginsInstalled":0,"pluginsSkipped":0,"pluginsRegistryFetchFailed":false,"historyImported":0,"historySkippedByRetention":0,"updateChannelApplied":false,"preferencesApplied":4}"#.utf8)
+        let importSummary = OutputFormatter.formatSettingsImport(importJSON, json: false)
+        XCTAssertTrue(importSummary.contains("Workflows: 2 imported"))
+        XCTAssertTrue(importSummary.contains("Dictionary: 1 imported, 3 skipped"))
+        XCTAssertTrue(importSummary.contains("Preferences: 4 applied"))
+        XCTAssertTrue(OutputFormatter.formatSettingsImport(importJSON, json: true).contains("\"workflowsImported\" : 2"))
     }
 
     func testPortDiscoveryUsesConfiguredPortFileAndFallback() throws {
@@ -160,6 +171,53 @@ final class CLISupportTests: XCTestCase {
 
         let request = try XCTUnwrap(recorder.recordedRequest)
         XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer cli-token")
+    }
+
+    func testCLIClientExportsSettingsFromAuthenticatedEndpoint() async throws {
+        let recorder = RequestRecorder()
+        let exportedBackup = Data(#"{"schemaVersion":1}"#.utf8)
+        let client = CLIClient(
+            port: 9876,
+            apiToken: "cli-token",
+            transport: { request in
+                recorder.record(request)
+                return (exportedBackup, Self.httpResponse(url: request.url!, statusCode: 200))
+            }
+        )
+
+        let result = try await client.exportSettings()
+
+        XCTAssertEqual(result, exportedBackup)
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/settings/export")
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(request.timeoutInterval, 300)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer cli-token")
+    }
+
+    func testCLIClientImportsSettingsBackupAsJSON() async throws {
+        let recorder = RequestRecorder()
+        let backup = Data(#"{"schemaVersion":1,"workflows":[]}"#.utf8)
+        let responseBody = Data(#"{"workflowsImported":0}"#.utf8)
+        let client = CLIClient(
+            port: 9876,
+            apiToken: "cli-token",
+            transport: { request in
+                recorder.record(request)
+                return (responseBody, Self.httpResponse(url: request.url!, statusCode: 200))
+            }
+        )
+
+        let result = try await client.importSettings(backup)
+
+        XCTAssertEqual(result, responseBody)
+        let request = try XCTUnwrap(recorder.recordedRequest)
+        XCTAssertEqual(request.url?.path, "/v1/settings/import")
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.timeoutInterval, 300)
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer cli-token")
+        XCTAssertEqual(request.httpBody, backup)
     }
 
     func testCLIClientTranscribeStdinKeepsMultipartUploadPath() async throws {

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -1787,6 +1787,67 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual((toggledRules["rules"] as? [[String: Any]])?.first?["is_enabled"] as? Bool, false)
     }
 
+    func testSettingsBackupEndpointsExportImportAndRejectInvalidFiles() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        var context: APIContext?
+        defer {
+            context = nil
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        context = await MainActor.run { () -> APIContext in
+            let context = Self.makeAPIContext(appSupportDirectory: appSupportDirectory)
+            _ = context.workflowService.addWorkflow(
+                name: "CLI Backup Workflow",
+                template: .cleanedText,
+                trigger: .manual()
+            )
+            return context
+        }
+        let apiContext = try XCTUnwrap(context)
+        let router = apiContext.router
+
+        let exportResponse = await router.route(
+            HTTPRequest(method: "GET", path: "/v1/settings/export", queryParams: [:], headers: [:], body: Data())
+        )
+        XCTAssertEqual(exportResponse.status, 200)
+        XCTAssertEqual(exportResponse.contentType, "application/json")
+        let exported = try Self.jsonObject(exportResponse)
+        XCTAssertEqual(exported["schemaVersion"] as? Int, 1)
+        XCTAssertEqual((exported["workflows"] as? [[String: Any]])?.first?["name"] as? String, "CLI Backup Workflow")
+
+        let importResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/settings/import",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: exportResponse.body
+            )
+        )
+        XCTAssertEqual(importResponse.status, 200)
+        let importResult = try Self.jsonObject(importResponse)
+        XCTAssertEqual(importResult["workflowsImported"] as? Int, 1)
+        let workflowCount = await MainActor.run { apiContext.workflowService.workflows.count }
+        XCTAssertEqual(workflowCount, 2)
+
+        let invalidResponse = await router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/settings/import",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"not":"a backup"}"#.utf8)
+            )
+        )
+        XCTAssertEqual(invalidResponse.status, 400)
+        let invalidBody = try Self.jsonObject(invalidResponse)
+        XCTAssertEqual(
+            (invalidBody["error"] as? [String: Any])?["message"] as? String,
+            "Request body is not a valid TypeWhisper settings backup"
+        )
+    }
+
     func testDictionaryTermsEndpointsReplaceMergeAndDeleteSingleTerm() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
@@ -7514,6 +7575,23 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             audioDeviceService: audioDeviceService
         )
 
+        let pluginRegistryService = PluginRegistryService(
+            cacheDirectory: appSupportDirectory.appendingPathComponent("MarketplaceCache", isDirectory: true),
+            fetchData: { _ in throw URLError(.notConnectedToInternet) }
+        )
+        let usageStatisticsService = UsageStatisticsService(appSupportDirectory: appSupportDirectory)
+        let settingsBackupService = SettingsBackupAutomationService(
+            workflowService: workflowService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            profileService: profileService,
+            promptActionService: promptActionService,
+            pluginManager: PluginManager.shared,
+            pluginRegistryService: pluginRegistryService,
+            historyService: historyService,
+            usageStatisticsService: usageStatisticsService
+        )
+
         let router = APIRouter()
         let handlers = APIHandlers(
             modelManager: modelManager,
@@ -7523,7 +7601,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             workflowService: workflowService,
             dictionaryService: dictionaryService,
             dictationViewModel: dictationViewModel,
-            audioRecorderViewModel: audioRecorderViewModel
+            audioRecorderViewModel: audioRecorderViewModel,
+            settingsBackupService: settingsBackupService
         )
         handlers.register(on: router)
 
@@ -7566,6 +7645,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 settingsViewModel,
                 dictationViewModel,
                 audioRecorderViewModel,
+                pluginRegistryService,
+                usageStatisticsService,
+                settingsBackupService,
                 router,
                 handlers
             ]

--- a/typewhisper-cli/CLIClient.swift
+++ b/typewhisper-cli/CLIClient.swift
@@ -85,6 +85,20 @@ struct CLIClient {
         try await get("/v1/models")
     }
 
+    func exportSettings() async throws -> Data {
+        try await get("/v1/settings/export", timeout: 300)
+    }
+
+    func importSettings(_ data: Data) async throws -> Data {
+        let url = URL(string: "\(baseURL)/v1/settings/import")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = data
+        request.timeoutInterval = 300
+        return try await performRequest(request)
+    }
+
     func transcribe(
         fileURL: URL?,
         language: String?,
@@ -219,10 +233,10 @@ struct CLIClient {
         return try await performRequest(request)
     }
 
-    private func get(_ path: String) async throws -> Data {
+    private func get(_ path: String, timeout: TimeInterval = 10) async throws -> Data {
         let url = URL(string: "\(baseURL)\(path)")!
         var request = URLRequest(url: url)
-        request.timeoutInterval = 10
+        request.timeoutInterval = timeout
         return try await performRequest(request)
     }
 

--- a/typewhisper-cli/OutputFormatter.swift
+++ b/typewhisper-cli/OutputFormatter.swift
@@ -81,6 +81,51 @@ enum OutputFormatter {
         return lines.joined(separator: "\n")
     }
 
+    static func formatSettingsExport(path: String, bytes: Int, json: Bool) -> String {
+        guard json else {
+            return "Exported settings to \(path)"
+        }
+
+        struct ExportResult: Encodable {
+            let file: String
+            let bytes: Int
+        }
+        let data = (try? JSONEncoder().encode(ExportResult(file: path, bytes: bytes))) ?? Data()
+        return prettyJSON(data)
+    }
+
+    static func formatSettingsImport(_ data: Data, json: Bool) -> String {
+        if json {
+            return prettyJSON(data)
+        }
+        guard let result = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return prettyJSON(data)
+        }
+
+        func integer(_ key: String) -> Int {
+            result[key] as? Int ?? 0
+        }
+
+        var lines = [
+            "Workflows: \(integer("workflowsImported")) imported",
+            "Dictionary: \(integer("dictionaryImported")) imported, \(integer("dictionarySkipped")) skipped",
+            "Snippets: \(integer("snippetsImported")) imported, \(integer("snippetsSkipped")) skipped",
+            "Prompt Actions: \(integer("promptActionsImported")) imported",
+            "Profiles: \(integer("profilesImported")) imported",
+            "Hotkeys: \(integer("hotkeysApplied")) applied, \(integer("hotkeysSkipped")) skipped",
+            "Plugins: \(integer("pluginsInstalled")) installed, \(integer("pluginsSkipped")) skipped",
+            "History: \(integer("historyImported")) imported, \(integer("historySkippedByRetention")) skipped by retention",
+            "Preferences: \(integer("preferencesApplied")) applied",
+        ]
+        if result["updateChannelApplied"] as? Bool == true {
+            lines.append("Update channel applied")
+        }
+        if result["pluginsRegistryFetchFailed"] as? Bool == true {
+            lines.append("Warning: The plugin marketplace could not be reached; some plugins may have been skipped.")
+        }
+        return lines.joined(separator: "\n")
+    }
+
     private static func prettyJSON(_ data: Data) -> String {
         if let obj = try? JSONSerialization.jsonObject(with: data),
            let pretty = try? JSONSerialization.data(withJSONObject: obj, options: [.prettyPrinted, .sortedKeys]),

--- a/typewhisper-cli/main.swift
+++ b/typewhisper-cli/main.swift
@@ -126,6 +126,29 @@ do {
         let data = try await client.models()
         print(OutputFormatter.formatModels(data, json: jsonOutput))
 
+    case "export":
+        guard positionalArgs.count == 1 else {
+            printError("Error: export requires exactly one output file.")
+            exit(1)
+        }
+        let fileURL = settingsFileURL(for: positionalArgs[0])
+        let data = try await client.exportSettings()
+        try data.write(to: fileURL, options: .atomic)
+        print(OutputFormatter.formatSettingsExport(path: fileURL.path, bytes: data.count, json: jsonOutput))
+
+    case "import":
+        guard positionalArgs.count == 1 else {
+            printError("Error: import requires exactly one input file.")
+            exit(1)
+        }
+        let fileURL = settingsFileURL(for: positionalArgs[0])
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            throw CLIError.fileNotFound(fileURL.path)
+        }
+        let backupData = try Data(contentsOf: fileURL)
+        let result = try await client.importSettings(backupData)
+        print(OutputFormatter.formatSettingsImport(result, json: jsonOutput))
+
     case "transcribe":
         let fileURL: URL?
         if let path = positionalArgs.first, path != "-" {
@@ -163,6 +186,16 @@ func printError(_ message: String) {
     FileHandle.standardError.write(Data((message + "\n").utf8))
 }
 
+func settingsFileURL(for path: String) -> URL {
+    let expandedPath = NSString(string: path).expandingTildeInPath
+    if expandedPath.hasPrefix("/") {
+        return URL(fileURLWithPath: expandedPath).standardizedFileURL
+    }
+    return URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+        .appendingPathComponent(expandedPath)
+        .standardizedFileURL
+}
+
 func printUsage() {
     let usage = """
         Usage: typewhisper <command> [options]
@@ -171,6 +204,8 @@ func printUsage() {
           transcribe <file>    Transcribe an audio file (or - for stdin)
           status               Show server status
           models               List available models
+          export <file>        Export a settings backup as JSON
+          import <file>        Import all settings from a JSON backup
 
         Global options:
           --port <N>           Server port (default: auto-detect)
@@ -192,6 +227,8 @@ func printUsage() {
 
         Examples:
           typewhisper status
+          typewhisper export typewhisper-settings.json
+          typewhisper import typewhisper-settings.json
           typewhisper transcribe recording.wav
           typewhisper transcribe recording.wav --language de --json
           typewhisper transcribe recording.wav --language-hint de --language-hint en


### PR DESCRIPTION
## Context

Issue #1144 asks for a headless way to move TypeWhisper settings between machines and use the existing Backup & Restore data in scripts and dotfiles workflows.

## Changes

- add `typewhisper export <file>` and `typewhisper import <file>` with `--json` output support
- expose authenticated `GET /v1/settings/export` and `POST /v1/settings/import` endpoints
- reuse the existing Settings Backup JSON schema, importer, merge/skip behavior, and live preference side effects
- document CLI, API, and dotfiles usage
- add CLI request/formatting coverage and an API export/import round-trip integration test

This implements the requested CLI automation path. It does not add automatic `$XDG_CONFIG_HOME/typewhisper/config.toml` loading.

Closes #1144

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/SettingsBackupExporterTests -only-testing:TypeWhisperTests/CLISupportTests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testSettingsBackupEndpointsExportImportAndRejectInvalidFiles`
- [x] 44 tests passed with 0 failures
- [x] `git diff --check`

## Validation note

`scripts/pr-preflight.sh origin/main` completed its shell, Python, localization, release-instrumentation, release-signing, and cold Plugin SDK build stages. The subsequent Plugin SDK test run was stopped after an existing HTTP fixture cleanup hung in `MCPClientPluginTests.stopHTTPFixture` while waiting for its child process to exit. The focused settings/CLI suites above completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated HTTP API support for exporting and importing settings backups.
  - Added CLI commands to export settings to a file and import them from a file.
  - Added human-readable and JSON output with import summaries and warnings.
  - Added support for relative and home-directory file paths.
  - Exports are written safely, with clear validation and error reporting.
- **Documentation**
  - Updated CLI usage, examples, and architecture documentation.
- **Tests**
  - Added coverage for CLI operations, API authentication, successful imports, and invalid backup handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->