### PR TITLE
Add configurable ElevenLabs transcription options

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -72,6 +72,18 @@ enum ElevenLabsTranscriptionMode: String, CaseIterable, Sendable {
     case restOnly
 }
 
+enum ElevenLabsTranscriptionTransport: Equatable, Sendable {
+    case rest
+    case realtime
+}
+
+enum ElevenLabsSettingsAccessibility {
+    static let cleanTranscript = "ElevenLabsCleanTranscript"
+    static let audioEvents = "ElevenLabsAudioEvents"
+    static let speakerCount = "ElevenLabsSpeakerCount"
+    static let useDictionaryTerms = "ElevenLabsUseDictionaryTerms"
+}
+
 enum ElevenLabsAPIKeyValidationResult: Equatable, Sendable {
     case valid
     case invalid(message: String?)
@@ -97,17 +109,32 @@ private struct ElevenLabsAPIErrorResponse: Decodable {
 }
 
 @objc(ElevenLabsPlugin)
-final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, @unchecked Sendable {
+final class ElevenLabsPlugin: NSObject, DictionaryTermHintTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.elevenlabs"
     private static let missingUserReadPermissionMessage =
         "The API key you used is missing the permission user_read to execute this operation."
+    private static let invalidKeytermCharacters = CharacterSet(charactersIn: "<>{}[]\\")
     static let pluginName = "ElevenLabs"
     static let transcriptionModeKey = "transcriptionMode"
+    static let tagAudioEventsKey = "tagAudioEvents"
+    static let noVerbatimKey = "noVerbatim"
+    static let speakerCountKey = "numSpeakers"
+    static let useDictionaryTermsKey = "useDictionaryTerms"
+    static let automaticSpeakerCount = 0
+    static let defaultSpeakerCount = 1
+    static let maximumSpeakerCount = 32
+    static let maximumKeytermCount = 1_000
+    static let maximumKeytermCharacterCount = 49
+    static let maximumKeytermWordCount = 5
 
     fileprivate var host: HostServices?
     fileprivate var _apiKey: String?
     fileprivate var _selectedModelId: String?
     fileprivate var _transcriptionMode = ElevenLabsTranscriptionMode.automatic
+    fileprivate var _tagAudioEvents = false
+    fileprivate var _noVerbatim = true
+    fileprivate var _speakerCount = ElevenLabsPlugin.defaultSpeakerCount
+    fileprivate var _useDictionaryTerms = true
 
     private let logger = Logger(subsystem: "com.typewhisper.elevenlabs", category: "Plugin")
 
@@ -123,6 +150,12 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         _transcriptionMode = (host.userDefault(forKey: Self.transcriptionModeKey) as? String)
             .flatMap(ElevenLabsTranscriptionMode.init(rawValue:))
             ?? .automatic
+        _tagAudioEvents = host.userDefault(forKey: Self.tagAudioEventsKey) as? Bool ?? false
+        _noVerbatim = host.userDefault(forKey: Self.noVerbatimKey) as? Bool ?? true
+        _speakerCount = Self.normalizedSpeakerCount(
+            host.userDefault(forKey: Self.speakerCountKey) as? Int ?? Self.defaultSpeakerCount
+        )
+        _useDictionaryTerms = host.userDefault(forKey: Self.useDictionaryTermsKey) as? Bool ?? true
     }
 
     func deactivate() {
@@ -151,6 +184,10 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
     }
 
     var transcriptionMode: ElevenLabsTranscriptionMode { _transcriptionMode }
+    var tagAudioEvents: Bool { _tagAudioEvents }
+    var noVerbatim: Bool { _noVerbatim }
+    var speakerCount: Int { _speakerCount }
+    var useDictionaryTerms: Bool { _useDictionaryTerms }
 
     func setTranscriptionMode(_ mode: ElevenLabsTranscriptionMode) {
         guard _transcriptionMode != mode else { return }
@@ -159,9 +196,44 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         host?.notifyCapabilitiesChanged()
     }
 
+    func setTagAudioEvents(_ enabled: Bool) {
+        guard _tagAudioEvents != enabled else { return }
+        _tagAudioEvents = enabled
+        host?.setUserDefault(enabled, forKey: Self.tagAudioEventsKey)
+    }
+
+    func setNoVerbatim(_ enabled: Bool) {
+        guard _noVerbatim != enabled else { return }
+        _noVerbatim = enabled
+        host?.setUserDefault(enabled, forKey: Self.noVerbatimKey)
+    }
+
+    func setSpeakerCount(_ speakerCount: Int) {
+        let normalized = Self.normalizedSpeakerCount(speakerCount)
+        guard _speakerCount != normalized else { return }
+        _speakerCount = normalized
+        host?.setUserDefault(normalized, forKey: Self.speakerCountKey)
+    }
+
+    func setUseDictionaryTerms(_ enabled: Bool) {
+        guard _useDictionaryTerms != enabled else { return }
+        _useDictionaryTerms = enabled
+        host?.setUserDefault(enabled, forKey: Self.useDictionaryTermsKey)
+        host?.notifyCapabilitiesChanged()
+    }
+
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { _transcriptionMode == .automatic }
-    var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsSupport: DictionaryTermsSupport {
+        _useDictionaryTerms ? .supported : .requiresPluginSetting
+    }
+    var dictionaryTermsBudget: DictionaryTermsBudget {
+        DictionaryTermsBudget(
+            maxTerms: Self.maximumKeytermCount,
+            maxCharsPerTerm: Self.maximumKeytermCharacterCount,
+            maxWordsPerTerm: Self.maximumKeytermWordCount
+        )
+    }
     var supportedLanguages: [String] { elevenLabsSupportedLanguages }
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
@@ -177,7 +249,30 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             language: language,
             modelId: modelId,
             apiKey: apiKey,
-            prompt: prompt
+            keyterms: activeKeyterms(prompt: prompt, dictionaryTermHints: [])
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        return try await transcribeREST(
+            audio: audio,
+            language: language,
+            modelId: modelId,
+            apiKey: apiKey,
+            keyterms: activeKeyterms(prompt: prompt, dictionaryTermHints: dictionaryTermHints)
         )
     }
 
@@ -188,6 +283,24 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         prompt: String?,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
+        try await transcribe(
+            audio: audio,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: [],
+            onProgress: onProgress
+        )
+    }
+
+    func transcribe(
+        audio: AudioData,
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> PluginTranscriptionResult {
         guard let apiKey = _apiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
@@ -195,35 +308,55 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             throw PluginTranscriptionError.noModelSelected
         }
 
-        if _transcriptionMode == .restOnly || !PluginDictionaryTerms.terms(fromPrompt: prompt).isEmpty {
+        let keyterms = activeKeyterms(prompt: prompt, dictionaryTermHints: dictionaryTermHints)
+        if transcriptionTransport(keyterms: keyterms) == .rest {
             let result = try await transcribeREST(
                 audio: audio,
                 language: language,
                 modelId: modelId,
                 apiKey: apiKey,
-                prompt: prompt
+                keyterms: keyterms
             )
             _ = onProgress(result.text)
             return result
         }
 
+        return try await Self.transcribeWithRESTFallback(
+            realtime: {
+                try await self.transcribeWebSocket(
+                    audio: audio,
+                    language: language,
+                    modelId: modelId,
+                    apiKey: apiKey,
+                    noVerbatim: self._noVerbatim,
+                    onProgress: onProgress
+                )
+            },
+            rest: {
+                try await self.transcribeREST(
+                    audio: audio,
+                    language: language,
+                    modelId: modelId,
+                    apiKey: apiKey,
+                    keyterms: keyterms
+                )
+            },
+            onRealtimeFailure: { error in
+                self.logger.warning("Realtime transcription failed, falling back to REST: \(error.localizedDescription)")
+            }
+        )
+    }
+
+    static func transcribeWithRESTFallback(
+        realtime: () async throws -> PluginTranscriptionResult,
+        rest: () async throws -> PluginTranscriptionResult,
+        onRealtimeFailure: (Error) -> Void = { _ in }
+    ) async throws -> PluginTranscriptionResult {
         do {
-            return try await transcribeWebSocket(
-                audio: audio,
-                language: language,
-                modelId: modelId,
-                apiKey: apiKey,
-                onProgress: onProgress
-            )
+            return try await realtime()
         } catch {
-            logger.warning("Realtime transcription failed, falling back to REST: \(error.localizedDescription)")
-            return try await transcribeREST(
-                audio: audio,
-                language: language,
-                modelId: modelId,
-                apiKey: apiKey,
-                prompt: prompt
-            )
+            onRealtimeFailure(error)
+            return try await rest()
         }
     }
 
@@ -232,7 +365,7 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         language: String?,
         modelId: String,
         apiKey: String,
-        prompt: String?
+        keyterms: [String]
     ) async throws -> PluginTranscriptionResult {
         guard let url = URL(string: "https://api.elevenlabs.io/v1/speech-to-text") else {
             throw PluginTranscriptionError.apiError("Invalid ElevenLabs REST URL")
@@ -258,8 +391,25 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             if let language, !language.isEmpty {
                 body.appendMultipartField(boundary: boundary, name: "language_code", value: language)
             }
+            body.appendMultipartField(
+                boundary: boundary,
+                name: "tag_audio_events",
+                value: Self.formattedBoolean(_tagAudioEvents)
+            )
+            body.appendMultipartField(
+                boundary: boundary,
+                name: "no_verbatim",
+                value: Self.formattedBoolean(_noVerbatim)
+            )
+            if _speakerCount != Self.automaticSpeakerCount {
+                body.appendMultipartField(
+                    boundary: boundary,
+                    name: "num_speakers",
+                    value: String(_speakerCount)
+                )
+            }
             if modelId == "scribe_v2" {
-                for term in PluginDictionaryTerms.terms(fromPrompt: prompt) {
+                for term in keyterms {
                     body.appendMultipartField(boundary: boundary, name: "keyterms", value: term)
                 }
             }
@@ -293,10 +443,11 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         language: String?,
         modelId: String,
         apiKey: String,
+        noVerbatim: Bool,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
         try PluginHTTPClient.ensureNetworkAccessIsAllowed()
-        let url = try Self.realtimeURL(language: language, modelId: modelId)
+        let url = try Self.realtimeURL(language: language, modelId: modelId, noVerbatim: noVerbatim)
 
         var request = URLRequest(url: url)
         request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
@@ -407,7 +558,55 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         return PluginTranscriptionResult(text: finalText, detectedLanguage: detectedLanguage)
     }
 
-    private static func realtimeURL(language: String?, modelId: String) throws -> URL {
+    static func transcriptionTransport(
+        mode: ElevenLabsTranscriptionMode,
+        keyterms: [String]
+    ) -> ElevenLabsTranscriptionTransport {
+        mode == .restOnly || !keyterms.isEmpty ? .rest : .realtime
+    }
+
+    func transcriptionTransport(
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) -> ElevenLabsTranscriptionTransport {
+        transcriptionTransport(
+            keyterms: activeKeyterms(prompt: prompt, dictionaryTermHints: dictionaryTermHints)
+        )
+    }
+
+    static func validKeyterms(from terms: [String]) -> [String] {
+        var valid: [String] = []
+        for term in PluginDictionaryTerms.normalizedTerms(from: terms) {
+            guard term.count <= maximumKeytermCharacterCount,
+                  term.split(whereSeparator: { $0.isWhitespace }).count <= maximumKeytermWordCount,
+                  term.rangeOfCharacter(from: invalidKeytermCharacters) == nil else {
+                continue
+            }
+
+            valid.append(term)
+            if valid.count == maximumKeytermCount {
+                break
+            }
+        }
+        return valid
+    }
+
+    private func activeKeyterms(
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint]
+    ) -> [String] {
+        guard _useDictionaryTerms else { return [] }
+        let terms = dictionaryTermHints.isEmpty
+            ? PluginDictionaryTerms.terms(fromPrompt: prompt)
+            : dictionaryTermHints.map(\.text)
+        return Self.validKeyterms(from: terms)
+    }
+
+    private func transcriptionTransport(keyterms: [String]) -> ElevenLabsTranscriptionTransport {
+        Self.transcriptionTransport(mode: _transcriptionMode, keyterms: keyterms)
+    }
+
+    static func realtimeURL(language: String?, modelId: String, noVerbatim: Bool) throws -> URL {
         guard var components = URLComponents(string: "wss://api.elevenlabs.io/v1/speech-to-text/realtime") else {
             throw PluginTranscriptionError.apiError("Invalid realtime URL")
         }
@@ -416,6 +615,7 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
             URLQueryItem(name: "model_id", value: realtimeModelId(for: modelId)),
             URLQueryItem(name: "audio_format", value: "pcm_16000"),
             URLQueryItem(name: "commit_strategy", value: "manual"),
+            URLQueryItem(name: "no_verbatim", value: formattedBoolean(noVerbatim)),
         ]
 
         if let language, !language.isEmpty {
@@ -429,6 +629,16 @@ final class ElevenLabsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTer
         }
 
         return url
+    }
+
+    static func normalizedSpeakerCount(_ speakerCount: Int) -> Int {
+        speakerCount == automaticSpeakerCount || (1...maximumSpeakerCount).contains(speakerCount)
+            ? speakerCount
+            : defaultSpeakerCount
+    }
+
+    private static func formattedBoolean(_ value: Bool) -> String {
+        value ? "true" : "false"
     }
 
     private static func realtimeModelId(for modelId: String) -> String {
@@ -574,6 +784,10 @@ private struct ElevenLabsSettingsView: View {
     @State private var showApiKey = false
     @State private var selectedModel = ""
     @State private var transcriptionMode = ElevenLabsTranscriptionMode.automatic
+    @State private var tagAudioEvents = false
+    @State private var noVerbatim = true
+    @State private var speakerCount = ElevenLabsPlugin.defaultSpeakerCount
+    @State private var useDictionaryTerms = true
     private let bundle = Bundle(for: ElevenLabsPlugin.self)
     private var trimmedInputKey: String {
         apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -690,6 +904,83 @@ private struct ElevenLabsSettingsView: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Transcription options", bundle: bundle)
+                        .font(.headline)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle(isOn: $noVerbatim) {
+                            Text("Clean transcript", bundle: bundle)
+                        }
+                        .accessibilityIdentifier(ElevenLabsSettingsAccessibility.cleanTranscript)
+                        .onChange(of: noVerbatim) {
+                            plugin.setNoVerbatim(noVerbatim)
+                        }
+
+                        Text("Removes filler words, false starts, and other speech disfluencies using ElevenLabs' native non-verbatim mode.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle(isOn: $tagAudioEvents) {
+                            Text("Audio events", bundle: bundle)
+                        }
+                        .accessibilityIdentifier(ElevenLabsSettingsAccessibility.audioEvents)
+                        .onChange(of: tagAudioEvents) {
+                            plugin.setTagAudioEvents(tagAudioEvents)
+                        }
+
+                        Text("Include non-speech events such as [laughter] or [background music]. Applies to REST transcription only.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Speaker count", bundle: bundle)
+                            .font(.subheadline)
+                            .fontWeight(.medium)
+
+                        Picker(
+                            String(localized: "Speaker count", bundle: bundle),
+                            selection: $speakerCount
+                        ) {
+                            Text("Automatic", bundle: bundle)
+                                .tag(ElevenLabsPlugin.automaticSpeakerCount)
+                            ForEach(1...ElevenLabsPlugin.maximumSpeakerCount, id: \.self) { count in
+                                Text(String(count)).tag(count)
+                            }
+                        }
+                        .labelsHidden()
+                        .accessibilityIdentifier(ElevenLabsSettingsAccessibility.speakerCount)
+                        .onChange(of: speakerCount) {
+                            plugin.setSpeakerCount(speakerCount)
+                        }
+
+                        Text("Choose Automatic or the maximum number of speakers (1–32). Applies to REST transcription only.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle(isOn: $useDictionaryTerms) {
+                            Text("Use TypeWhisper dictionary terms", bundle: bundle)
+                        }
+                        .accessibilityIdentifier(ElevenLabsSettingsAccessibility.useDictionaryTerms)
+                        .onChange(of: useDictionaryTerms) {
+                            plugin.setUseDictionaryTerms(useDictionaryTerms)
+                        }
+
+                        Text("Sends active TypeWhisper dictionary terms to ElevenLabs as recognition keyterms. ElevenLabs adds a 20% keyterm surcharge.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)
@@ -711,6 +1002,10 @@ private struct ElevenLabsSettingsView: View {
             }
             selectedModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
             transcriptionMode = plugin.transcriptionMode
+            tagAudioEvents = plugin.tagAudioEvents
+            noVerbatim = plugin.noVerbatim
+            speakerCount = plugin.speakerCount
+            useDictionaryTerms = plugin.useDictionaryTerms
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
@@ -264,6 +264,226 @@
           }
         }
       }
+    },
+    "Audio events": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audioereignisse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音声イベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "音频事件"
+          }
+        }
+      }
+    },
+    "Automatic": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Automatisch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自动"
+          }
+        }
+      }
+    },
+    "Choose Automatic or the maximum number of speakers (1–32). Applies to REST transcription only.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wählen Sie „Automatisch“ oder die maximale Anzahl der Sprecher (1–32). Gilt nur für die REST-Transkription."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動、または話者の最大人数（1～32）を選択します。REST文字起こしにのみ適用されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择“自动”或最大说话人数（1–32）。仅适用于 REST 转录。"
+          }
+        }
+      }
+    },
+    "Clean transcript": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bereinigtes Transkript"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クリーンな文字起こし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "清理转录"
+          }
+        }
+      }
+    },
+    "Include non-speech events such as [laughter] or [background music]. Applies to REST transcription only.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nichtsprachliche Ereignisse wie [Lachen] oder [Hintergrundmusik] einschließen. Gilt nur für die REST-Transkription."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "[笑い声]や[背景音楽]などの非音声イベントを含めます。REST文字起こしにのみ適用されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包括[笑声]或[背景音乐]等非语音事件。仅适用于 REST 转录。"
+          }
+        }
+      }
+    },
+    "Removes filler words, false starts, and other speech disfluencies using ElevenLabs' native non-verbatim mode.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernt Füllwörter, Fehlstarts und andere Sprechunflüssigkeiten mit dem nativen Nicht-Verbatim-Modus von ElevenLabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ElevenLabsのネイティブ非逐語モードを使用して、フィラーワード、言い直し、その他の発話の乱れを除去します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 ElevenLabs 原生非逐字模式移除填充词、错误开头和其他言语不流畅内容。"
+          }
+        }
+      }
+    },
+    "Sends active TypeWhisper dictionary terms to ElevenLabs as recognition keyterms. ElevenLabs adds a 20% keyterm surcharge.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sendet aktive TypeWhisper-Wörterbucheinträge als Erkennungsschlüsselbegriffe an ElevenLabs. ElevenLabs berechnet für Schlüsselbegriffe einen Aufschlag von 20 %."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なTypeWhisper辞書用語を認識キータームとしてElevenLabsに送信します。ElevenLabsではキータームに20%の追加料金がかかります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将启用的 TypeWhisper 词典术语作为识别关键词发送给 ElevenLabs。ElevenLabs 会对关键词提示加收 20% 的费用。"
+          }
+        }
+      }
+    },
+    "Speaker count": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sprecheranzahl"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "話者数"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "说话人数"
+          }
+        }
+      }
+    },
+    "Transcription options": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsoptionen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしオプション"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录选项"
+          }
+        }
+      }
+    },
+    "Use TypeWhisper dictionary terms": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TypeWhisper-Wörterbucheinträge verwenden"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "TypeWhisperの辞書用語を使用"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用 TypeWhisper 词典术语"
+          }
+        }
+      }
     }
   },
   "version": "1.0"

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
@@ -105,6 +105,66 @@ final class ElevenLabsPluginTests: XCTestCase {
         XCTAssertTrue(unknownPlugin.supportsStreaming)
     }
 
+    func testTranscriptionOptionsUseDictationDefaultsAndInvalidValuesFallbackSafely() throws {
+        let defaultHost = try PluginTestHostServices()
+        let defaultPlugin = ElevenLabsPlugin()
+        defaultPlugin.activate(host: defaultHost)
+
+        XCTAssertFalse(defaultPlugin.tagAudioEvents)
+        XCTAssertTrue(defaultPlugin.noVerbatim)
+        XCTAssertEqual(defaultPlugin.speakerCount, ElevenLabsPlugin.defaultSpeakerCount)
+        XCTAssertTrue(defaultPlugin.useDictionaryTerms)
+        XCTAssertEqual(defaultPlugin.dictionaryTermsSupport, .supported)
+        XCTAssertEqual(
+            defaultPlugin.dictionaryTermsBudget,
+            DictionaryTermsBudget(maxTerms: 1_000, maxCharsPerTerm: 49, maxWordsPerTerm: 5)
+        )
+
+        let invalidHost = try PluginTestHostServices(defaults: [
+            ElevenLabsPlugin.tagAudioEventsKey: "true",
+            ElevenLabsPlugin.noVerbatimKey: 1,
+            ElevenLabsPlugin.speakerCountKey: 33,
+            ElevenLabsPlugin.useDictionaryTermsKey: "false",
+        ])
+        let invalidPlugin = ElevenLabsPlugin()
+        invalidPlugin.activate(host: invalidHost)
+
+        XCTAssertFalse(invalidPlugin.tagAudioEvents)
+        XCTAssertTrue(invalidPlugin.noVerbatim)
+        XCTAssertEqual(invalidPlugin.speakerCount, ElevenLabsPlugin.defaultSpeakerCount)
+        XCTAssertTrue(invalidPlugin.useDictionaryTerms)
+    }
+
+    func testTranscriptionOptionsPersistAndRestoreExplicitAndAutomaticSpeakerCounts() throws {
+        let host = try PluginTestHostServices()
+        let plugin = ElevenLabsPlugin()
+        plugin.activate(host: host)
+
+        plugin.setTagAudioEvents(true)
+        plugin.setNoVerbatim(false)
+        plugin.setSpeakerCount(12)
+        plugin.setUseDictionaryTerms(false)
+
+        XCTAssertEqual(host.userDefault(forKey: ElevenLabsPlugin.tagAudioEventsKey) as? Bool, true)
+        XCTAssertEqual(host.userDefault(forKey: ElevenLabsPlugin.noVerbatimKey) as? Bool, false)
+        XCTAssertEqual(host.userDefault(forKey: ElevenLabsPlugin.speakerCountKey) as? Int, 12)
+        XCTAssertEqual(host.userDefault(forKey: ElevenLabsPlugin.useDictionaryTermsKey) as? Bool, false)
+        XCTAssertEqual(host.capabilitiesChangedCount, 1)
+
+        let reloaded = ElevenLabsPlugin()
+        reloaded.activate(host: host)
+        XCTAssertTrue(reloaded.tagAudioEvents)
+        XCTAssertFalse(reloaded.noVerbatim)
+        XCTAssertEqual(reloaded.speakerCount, 12)
+        XCTAssertFalse(reloaded.useDictionaryTerms)
+        XCTAssertEqual(reloaded.dictionaryTermsSupport, .requiresPluginSetting)
+
+        reloaded.setSpeakerCount(ElevenLabsPlugin.automaticSpeakerCount)
+        let automaticReload = ElevenLabsPlugin()
+        automaticReload.activate(host: host)
+        XCTAssertEqual(automaticReload.speakerCount, ElevenLabsPlugin.automaticSpeakerCount)
+    }
+
     func testTranscriptionModePersistsAndUpdatesStreamingCapability() throws {
         let host = try PluginTestHostServices()
         let plugin = ElevenLabsPlugin()
@@ -179,8 +239,259 @@ final class ElevenLabsPluginTests: XCTestCase {
         let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
         XCTAssertTrue(body.contains("name=\"model_id\"\r\n\r\nscribe_v2\r\n"))
         XCTAssertTrue(body.contains("name=\"language_code\"\r\n\r\nde\r\n"))
+        XCTAssertTrue(body.contains("name=\"tag_audio_events\"\r\n\r\nfalse\r\n"))
+        XCTAssertTrue(body.contains("name=\"no_verbatim\"\r\n\r\ntrue\r\n"))
+        XCTAssertTrue(body.contains("name=\"num_speakers\"\r\n\r\n1\r\n"))
         XCTAssertTrue(body.contains("name=\"keyterms\"\r\n\r\nTypeWhisper\r\n"))
         XCTAssertTrue(body.contains("name=\"keyterms\"\r\n\r\nScribe\r\n"))
+    }
+
+    func testRESTRequestEncodesCustomBooleanAndSpeakerOptions() async throws {
+        let request = try await captureRESTRequest { plugin in
+            plugin.setTagAudioEvents(true)
+            plugin.setNoVerbatim(false)
+            plugin.setSpeakerCount(12)
+        }
+
+        XCTAssertEqual(try Self.multipartValues(named: "model_id", in: request), ["scribe_v2"])
+        XCTAssertEqual(try Self.multipartValues(named: "language_code", in: request), ["en"])
+        XCTAssertEqual(try Self.multipartValues(named: "tag_audio_events", in: request), ["true"])
+        XCTAssertEqual(try Self.multipartValues(named: "no_verbatim", in: request), ["false"])
+        XCTAssertEqual(try Self.multipartValues(named: "num_speakers", in: request), ["12"])
+    }
+
+    func testRESTRequestOmitsAutomaticSpeakerCount() async throws {
+        let request = try await captureRESTRequest { plugin in
+            plugin.setSpeakerCount(ElevenLabsPlugin.automaticSpeakerCount)
+        }
+
+        XCTAssertTrue(try Self.multipartValues(named: "num_speakers", in: request).isEmpty)
+    }
+
+    func testRESTRequestFiltersAndNormalizesDictionaryKeyterms() async throws {
+        let validFortyNineCharacterTerm = String(repeating: "a", count: 49)
+        let invalidFiftyCharacterTerm = String(repeating: "b", count: 50)
+        let request = try await captureRESTRequest(dictionaryTermHints: [
+            PluginDictionaryTermHint(text: " TypeWhisper "),
+            PluginDictionaryTermHint(text: "typewhisper"),
+            PluginDictionaryTermHint(text: validFortyNineCharacterTerm),
+            PluginDictionaryTermHint(text: invalidFiftyCharacterTerm),
+            PluginDictionaryTermHint(text: "one two three four five"),
+            PluginDictionaryTermHint(text: "one two three four five six"),
+            PluginDictionaryTermHint(text: "bad<term"),
+            PluginDictionaryTermHint(text: "Second"),
+        ])
+
+        XCTAssertEqual(
+            try Self.multipartValues(named: "keyterms", in: request),
+            ["TypeWhisper", validFortyNineCharacterTerm, "one two three four five", "Second"]
+        )
+    }
+
+    func testRESTRequestLimitsDictionaryKeytermsToOneThousand() async throws {
+        let hints = (1...1_005).map { PluginDictionaryTermHint(text: "Term\($0)") }
+        let request = try await captureRESTRequest(dictionaryTermHints: hints)
+
+        let keyterms = try Self.multipartValues(named: "keyterms", in: request)
+        XCTAssertEqual(keyterms.count, 1_000)
+        XCTAssertEqual(keyterms.first, "Term1")
+        XCTAssertEqual(keyterms.last, "Term1000")
+        XCTAssertFalse(keyterms.contains("Term1001"))
+    }
+
+    func testRESTRequestExcludesDictionaryKeytermsWhenDisabled() async throws {
+        let request = try await captureRESTRequest(
+            prompt: "LegacyPromptTerm",
+            dictionaryTermHints: [PluginDictionaryTermHint(text: "TypeWhisper")]
+        ) { plugin in
+            plugin.setUseDictionaryTerms(false)
+        }
+
+        XCTAssertTrue(try Self.multipartValues(named: "keyterms", in: request).isEmpty)
+    }
+
+    func testRealtimeURLAppliesNoVerbatimWithoutRESTOnlyOptions() throws {
+        let cleanURL = try ElevenLabsPlugin.realtimeURL(
+            language: "zh",
+            modelId: "scribe_v2",
+            noVerbatim: true
+        )
+        let verbatimURL = try ElevenLabsPlugin.realtimeURL(
+            language: nil,
+            modelId: "scribe_v2",
+            noVerbatim: false
+        )
+
+        let cleanItems = Self.queryItems(in: cleanURL)
+        XCTAssertEqual(cleanURL.scheme, "wss")
+        XCTAssertEqual(cleanURL.host, "api.elevenlabs.io")
+        XCTAssertEqual(cleanItems["model_id"], "scribe_v2_realtime")
+        XCTAssertEqual(cleanItems["audio_format"], "pcm_16000")
+        XCTAssertEqual(cleanItems["commit_strategy"], "manual")
+        XCTAssertEqual(cleanItems["language_code"], "zh")
+        XCTAssertEqual(cleanItems["no_verbatim"], "true")
+        XCTAssertNil(cleanItems["tag_audio_events"])
+        XCTAssertNil(cleanItems["num_speakers"])
+        XCTAssertNil(cleanItems["keyterms"])
+
+        let verbatimItems = Self.queryItems(in: verbatimURL)
+        XCTAssertEqual(verbatimItems["no_verbatim"], "false")
+        XCTAssertNil(verbatimItems["language_code"])
+    }
+
+    func testRoutingPreservesModesAndUsesOnlyEnabledValidDictionaryKeyterms() throws {
+        let host = try PluginTestHostServices()
+        let plugin = ElevenLabsPlugin()
+        plugin.activate(host: host)
+        let validHints = [PluginDictionaryTermHint(text: "TypeWhisper")]
+        let invalidHints = [PluginDictionaryTermHint(text: "bad<term")]
+
+        XCTAssertEqual(
+            plugin.transcriptionTransport(prompt: nil, dictionaryTermHints: []),
+            .realtime
+        )
+        XCTAssertEqual(
+            plugin.transcriptionTransport(prompt: nil, dictionaryTermHints: validHints),
+            .rest
+        )
+        XCTAssertEqual(
+            plugin.transcriptionTransport(prompt: nil, dictionaryTermHints: invalidHints),
+            .realtime
+        )
+
+        plugin.setUseDictionaryTerms(false)
+        XCTAssertEqual(
+            plugin.transcriptionTransport(prompt: "LegacyPromptTerm", dictionaryTermHints: validHints),
+            .realtime
+        )
+
+        plugin.setTranscriptionMode(.restOnly)
+        XCTAssertEqual(
+            plugin.transcriptionTransport(prompt: nil, dictionaryTermHints: []),
+            .rest
+        )
+        XCTAssertFalse(plugin.supportsStreaming)
+    }
+
+    func testRealtimeFailurePreservesRESTFallbackBehavior() async throws {
+        let calls = StringRecorder()
+        let result = try await ElevenLabsPlugin.transcribeWithRESTFallback(
+            realtime: {
+                calls.append("realtime")
+                throw URLError(.cannotConnectToHost)
+            },
+            rest: {
+                calls.append("rest")
+                return PluginTranscriptionResult(text: "Fallback transcript", detectedLanguage: "en")
+            },
+            onRealtimeFailure: { _ in
+                calls.append("failure")
+            }
+        )
+
+        XCTAssertEqual(result.text, "Fallback transcript")
+        XCTAssertEqual(calls.values, ["realtime", "failure", "rest"])
+    }
+
+    func testSettingsUIExposesLocalizedOptionsAndStableAccessibilityIdentifiers() throws {
+        let source = try String(
+            contentsOf: Self.pluginRoot.appendingPathComponent("ElevenLabsPlugin.swift"),
+            encoding: .utf8
+        )
+        let catalogData = try Data(
+            contentsOf: Self.pluginRoot.appendingPathComponent("Localizable.xcstrings")
+        )
+        let catalog = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: catalogData) as? [String: Any]
+        )
+        let strings = try XCTUnwrap(catalog["strings"] as? [String: Any])
+        let requiredKeys = [
+            "Transcription options",
+            "Clean transcript",
+            "Removes filler words, false starts, and other speech disfluencies using ElevenLabs' native non-verbatim mode.",
+            "Audio events",
+            "Include non-speech events such as [laughter] or [background music]. Applies to REST transcription only.",
+            "Speaker count",
+            "Choose Automatic or the maximum number of speakers (1–32). Applies to REST transcription only.",
+            "Use TypeWhisper dictionary terms",
+            "Sends active TypeWhisper dictionary terms to ElevenLabs as recognition keyterms. ElevenLabs adds a 20% keyterm surcharge.",
+        ]
+
+        for key in requiredKeys {
+            let entry = try XCTUnwrap(strings[key] as? [String: Any], "Missing localization key: \(key)")
+            let localizations = try XCTUnwrap(entry["localizations"] as? [String: Any])
+            for language in ["de", "ja", "zh-Hans"] {
+                XCTAssertNotNil(localizations[language], "Missing \(language) localization for \(key)")
+            }
+            XCTAssertTrue(source.contains(key), "Settings UI should use \(key)")
+        }
+
+        XCTAssertTrue(source.contains(".accessibilityIdentifier(ElevenLabsSettingsAccessibility.cleanTranscript)"))
+        XCTAssertTrue(source.contains(".accessibilityIdentifier(ElevenLabsSettingsAccessibility.audioEvents)"))
+        XCTAssertTrue(source.contains(".accessibilityIdentifier(ElevenLabsSettingsAccessibility.speakerCount)"))
+        XCTAssertTrue(source.contains(".accessibilityIdentifier(ElevenLabsSettingsAccessibility.useDictionaryTerms)"))
+        XCTAssertEqual(ElevenLabsSettingsAccessibility.cleanTranscript, "ElevenLabsCleanTranscript")
+        XCTAssertEqual(ElevenLabsSettingsAccessibility.audioEvents, "ElevenLabsAudioEvents")
+        XCTAssertEqual(ElevenLabsSettingsAccessibility.speakerCount, "ElevenLabsSpeakerCount")
+        XCTAssertEqual(ElevenLabsSettingsAccessibility.useDictionaryTerms, "ElevenLabsUseDictionaryTerms")
+    }
+
+    private func captureRESTRequest(
+        prompt: String? = nil,
+        dictionaryTermHints: [PluginDictionaryTermHint] = [],
+        configure: (ElevenLabsPlugin) -> Void = { _ in }
+    ) async throws -> URLRequest {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "scribe_v2"],
+            secrets: ["api-key": "elevenlabs-key"]
+        )
+        let plugin = ElevenLabsPlugin()
+        plugin.activate(host: host)
+        configure(plugin)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"REST transcript","language_code":"en"}"#.utf8),
+                    Self.httpResponse(url: "https://api.elevenlabs.io/v1/speech-to-text", statusCode: 200)
+                )
+            ])
+        }
+
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        _ = try await plugin.transcribe(
+            audio: AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1),
+            language: "en",
+            translate: false,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints
+        )
+
+        return try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+    }
+
+    private static func multipartValues(named name: String, in request: URLRequest) throws -> [String] {
+        let body = String(decoding: try XCTUnwrap(request.httpBody), as: UTF8.self)
+        let marker = "name=\"\(name)\"\r\n\r\n"
+        return body.components(separatedBy: marker).dropFirst().compactMap { remainder in
+            remainder.components(separatedBy: "\r\n").first
+        }
+    }
+
+    private static func queryItems(in url: URL) -> [String: String] {
+        Dictionary(uniqueKeysWithValues: (URLComponents(
+            url: url,
+            resolvingAgainstBaseURL: false
+        )?.queryItems ?? []).compactMap { item in
+            item.value.map { (item.name, $0) }
+        })
+    }
+
+    private static var pluginRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
     }
 
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- add persisted, localized ElevenLabs settings for clean transcripts, audio-event tagging, speaker count, and TypeWhisper dictionary keyterms
- apply `no_verbatim` to REST and realtime transcription while keeping REST-only options out of the realtime handshake
- preserve Automatic, REST-only, realtime fallback, and dictionary-driven REST routing behavior
- normalize dictionary terms to ElevenLabs limits and add focused request, routing, persistence, UI, accessibility, and localization coverage

## Motivation

ElevenLabs Scribe v2 supports native non-verbatim transcription and controls for caption-oriented output, but the macOS plugin did not expose them. This made dictation more likely to include filler words, false starts, repetitions, and non-speech tags such as `[background music]`, even though ElevenLabs can handle these cases directly.

## User-facing behavior and defaults

- **Clean transcript:** on by default; removes speech disfluencies using ElevenLabs `no_verbatim`
- **Audio events:** off by default; controls REST `tag_audio_events`
- **Speaker count:** 1 by default; offers Automatic and 1–32, with Automatic omitting `num_speakers`
- **Use TypeWhisper dictionary terms:** on by default; sends active terms as ElevenLabs `keyterms` and explains the current 20% keyterm surcharge

Invalid stored speaker counts fall back to 1, and existing ElevenLabs settings are otherwise preserved.

## REST and realtime behavior

- REST multipart requests include the selected `no_verbatim` and `tag_audio_events` values, an explicit `num_speakers` when selected, and up to 1,000 valid keyterms limited to 50 characters and 5 words.
- Realtime requests apply only the supported `no_verbatim` option.
- Automatic mode continues to prefer realtime when compatible, REST-only remains REST-only, and realtime failures retain the existing REST fallback.
- When dictionary integration is enabled and at least one valid keyterm exists, transcription deterministically uses REST. Disabling dictionary integration prevents existing dictionary terms from forcing REST or being submitted.

No public plugin SDK API changes are required.

## Test Plan

- `swift test --package-path TypeWhisperPluginSDK --filter ElevenLabsPluginTests` — 19 tests passed
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 1,614 tests passed
- `git diff --check` — passed
- Built and installed a universal, locally signed Release app with ElevenLabs plugin 1.0.11; verified the host activated and loaded the plugin.
- Ran a low-volume live Scribe v2 comparison and confirmed clean versus verbatim transcript behavior.

`swift test --package-path TypeWhisperPluginSDK` reached 609 passing tests before stalling in the pre-existing `MCPMemoryStoragePluginTests.testDisconnectCancelsRunningWatchTasks` teardown; the focused ElevenLabs suite completes cleanly.

Closes #1006


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added REST and realtime transcription options, with automatic fallback if realtime transcription fails.
  * Added configurable audio-event tagging, transcript cleanup, speaker counts, and dictionary keyterm support.
  * Added settings persistence and controls in the plugin settings interface.
  * Added German, Japanese, and Simplified Chinese translations.

* **Bug Fixes**
  * Improved validation and filtering of dictionary keyterms before transmission.

* **Improvements**
  * Updated the plugin version to 1.0.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->