### PR TITLE
Clarify compatible ElevenLabs transcription options

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -937,6 +937,11 @@ private struct ElevenLabsSettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
+
+                        Text("Audio events and Clean transcript can be enabled together.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
 
                     VStack(alignment: .leading, spacing: 4) {

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings
@@ -287,6 +287,28 @@
         }
       }
     },
+    "Audio events and Clean transcript can be enabled together.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "„Audioereignisse“ und „Bereinigtes Transkript“ können gleichzeitig aktiviert werden."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「音声イベント」と「クリーンな文字起こし」は同時に有効にできます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“音频事件”和“清理转录”可以同时启用。"
+          }
+        }
+      }
+    },
     "Automatic": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Tests/ElevenLabsPluginTests.swift
@@ -411,6 +411,7 @@ final class ElevenLabsPluginTests: XCTestCase {
             "Removes filler words, false starts, and other speech disfluencies using ElevenLabs' native non-verbatim mode.",
             "Audio events",
             "Include non-speech events such as [laughter] or [background music]. Applies to REST transcription only.",
+            "Audio events and Clean transcript can be enabled together.",
             "Speaker count",
             "Choose Automatic or the maximum number of speakers (1–32). Applies to REST transcription only.",
             "Use TypeWhisper dictionary terms",


### PR DESCRIPTION
## Context

PR #1146 implemented the configurable ElevenLabs transcription options from #1006 and introduced ElevenLabsPlugin 1.0.11. The acceptance criteria also require the settings UI to explain that Audio events and Clean transcript can be enabled together. This follow-up completes that explanation before the 1.0.11 plugin release.

Closes #1006

## Summary

- add an explicit compatibility hint below the ElevenLabs Audio events option
- localize the hint in German, Japanese, and Simplified Chinese
- cover the new help text in the existing settings UI localization test
- retain the unreleased ElevenLabsPlugin version 1.0.11 introduced by #1146

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter ElevenLabsPluginTests`
- `git diff --check`
- `jq -e . TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/Localizable.xcstrings >/dev/null`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a settings note clarifying that Audio Events and Clean Transcript can be enabled simultaneously.
* **Localization**
  * Added German, Japanese, and Simplified Chinese translations for the new settings guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->