### PR TITLE
Fix stale plugin model state synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,11 +378,41 @@ curl http://localhost:8978/v1/models
     {
       "id": "openai_whisper-large-v3_turbo",
       "engine": "whisper",
-      "ready": true
+      "name": "Large v3 Turbo",
+      "status": "ready",
+      "selected": true,
+      "downloaded": true,
+      "loaded": true
     }
   ]
 }
 ```
+
+### Manage Models
+
+Download (if needed), load, and select a model. The request returns after the model is ready or the load fails:
+
+```bash
+curl -X POST http://localhost:8978/v1/models/load \
+  -H "Content-Type: application/json" \
+  -d '{"engine":"whisper","model":"openai_whisper-large-v3_turbo"}'
+```
+
+Unload the active model while keeping its downloaded files:
+
+```bash
+curl -X POST http://localhost:8978/v1/models/unload \
+  -H "Content-Type: application/json" \
+  -d '{"engine":"whisper"}'
+```
+
+Delete downloaded model files:
+
+```bash
+curl -X DELETE "http://localhost:8978/v1/models?engine=whisper&model=openai_whisper-large-v3_turbo"
+```
+
+Deleting the final downloaded model for a plugin disables that plugin. If API authentication is enabled, include the same bearer token used by the other protected endpoints.
 
 ### History
 

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -41,6 +41,9 @@ final class APIHandlers: @unchecked Sendable {
         router.register("POST", "/v1/transcribe/local-file", handler: handleTranscribeLocalFile)
         router.register("GET", "/v1/status", handler: handleStatus)
         router.register("GET", "/v1/models", handler: handleModels)
+        router.register("POST", "/v1/models/load", handler: handleLoadModel)
+        router.register("POST", "/v1/models/unload", handler: handleUnloadModel)
+        router.register("DELETE", "/v1/models", handler: handleDeleteModel)
         router.register("GET", "/v1/history", handler: handleGetHistory)
         router.register("DELETE", "/v1/history", handler: handleDeleteHistory)
         router.register("GET", "/v1/rules", handler: handleGetRules)
@@ -666,7 +669,7 @@ final class APIHandlers: @unchecked Sendable {
             status: isReady ? "ready" : "no_model",
             engine: providerId,
             model: modelId,
-            api_version: "1.1",
+            api_version: "1.2",
             supports_workflow_dictation: true,
             supports_streaming: supportsStreaming,
             supports_translation: supportsTranslation
@@ -675,6 +678,17 @@ final class APIHandlers: @unchecked Sendable {
     }
 
     // MARK: - GET /v1/models
+
+    private struct ModelActionRequest: Decodable {
+        let engine: String
+        let model: String?
+    }
+
+    private struct ModelActionResponse: Encodable {
+        let engine: String
+        let model: String?
+        let status: String
+    }
 
     @MainActor
     private func handleModels(_ request: HTTPRequest) async -> HTTPResponse {
@@ -712,6 +726,96 @@ final class APIHandlers: @unchecked Sendable {
 
         struct ModelsResponse: Encodable { let models: [ModelEntry] }
         return .json(ModelsResponse(models: models))
+    }
+
+    // MARK: - POST /v1/models/load
+
+    @MainActor
+    private func handleLoadModel(_ request: HTTPRequest) async -> HTTPResponse {
+        let payload: ModelActionRequest
+        do {
+            payload = try JSONDecoder().decode(ModelActionRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Expected JSON with 'engine' and 'model'")
+        }
+
+        let engineId = payload.engine.trimmingCharacters(in: .whitespacesAndNewlines)
+        let modelId = payload.model?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !engineId.isEmpty, !modelId.isEmpty else {
+            return .error(status: 400, message: "Both 'engine' and 'model' are required")
+        }
+
+        do {
+            try await modelManager.loadModel(engineId, modelId: modelId)
+            return .json(ModelActionResponse(engine: engineId, model: modelId, status: "ready"))
+        } catch ModelLifecycleError.engineNotFound {
+            return .error(status: 404, message: "Engine '\(engineId)' was not found")
+        } catch ModelLifecycleError.modelNotFound {
+            return .error(status: 404, message: "Model '\(modelId)' was not found for engine '\(engineId)'")
+        } catch ModelLifecycleError.loadUnsupported {
+            return .error(status: 409, message: "Engine '\(engineId)' does not support explicit model loading")
+        } catch {
+            return .error(status: 409, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - POST /v1/models/unload
+
+    @MainActor
+    private func handleUnloadModel(_ request: HTTPRequest) async -> HTTPResponse {
+        let payload: ModelActionRequest
+        do {
+            payload = try JSONDecoder().decode(ModelActionRequest.self, from: request.body)
+        } catch {
+            return .error(status: 400, message: "Expected JSON with 'engine'")
+        }
+
+        let engineId = payload.engine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !engineId.isEmpty else {
+            return .error(status: 400, message: "'engine' is required")
+        }
+
+        do {
+            let modelId = try modelManager.unloadModel(engineId)
+            return .json(ModelActionResponse(engine: engineId, model: modelId, status: "unloaded"))
+        } catch ModelLifecycleError.engineNotFound {
+            return .error(status: 404, message: "Engine '\(engineId)' was not found")
+        } catch ModelLifecycleError.unloadUnsupported {
+            return .error(status: 409, message: "Engine '\(engineId)' does not support unloading")
+        } catch {
+            return .error(status: 409, message: error.localizedDescription)
+        }
+    }
+
+    // MARK: - DELETE /v1/models
+
+    @MainActor
+    private func handleDeleteModel(_ request: HTTPRequest) async -> HTTPResponse {
+        let engineId = request.queryParams["engine"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let modelId = request.queryParams["model"]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !engineId.isEmpty, !modelId.isEmpty else {
+            return .error(status: 400, message: "Both 'engine' and 'model' query parameters are required")
+        }
+
+        guard let loadedPlugin = PluginManager.shared.loadedPlugins.first(where: {
+            PluginManager.shared.transcriptionProviderIds(exposedBy: $0.instance).contains(engineId)
+        }) else {
+            return .error(status: 404, message: "Engine '\(engineId)' was not found")
+        }
+
+        do {
+            try await PluginManager.shared.deleteDownloadedModel(
+                pluginId: loadedPlugin.manifest.id,
+                modelId: modelId
+            )
+            return .json(ModelActionResponse(engine: engineId, model: modelId, status: "deleted"))
+        } catch PluginModelManagementError.modelNotFound {
+            return .error(status: 404, message: "Downloaded model '\(modelId)' was not found")
+        } catch PluginModelManagementError.unsupported {
+            return .error(status: 409, message: "Engine '\(engineId)' does not support deleting downloaded models")
+        } catch {
+            return .error(status: 409, message: error.localizedDescription)
+        }
     }
 
     // MARK: - GET /v1/history

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -28,6 +28,29 @@ enum TranscriptionEngineError: LocalizedError {
     }
 }
 
+enum ModelLifecycleError: LocalizedError {
+    case engineNotFound(String)
+    case modelNotFound(engineId: String, modelId: String)
+    case loadUnsupported(String)
+    case unloadUnsupported(String)
+    case unloadFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .engineNotFound(let engineId):
+            "Unknown engine '\(engineId)'."
+        case .modelNotFound(let engineId, let modelId):
+            "Model '\(modelId)' is not offered by engine '\(engineId)'."
+        case .loadUnsupported(let engineId):
+            "Engine '\(engineId)' does not support explicit model loading."
+        case .unloadUnsupported(let engineId):
+            "Engine '\(engineId)' does not support unloading its active model."
+        case .unloadFailed(let engineId):
+            "Engine '\(engineId)' did not unload its active model because it is currently in use."
+        }
+    }
+}
+
 extension TranscriptionEnginePlugin {
     var acceptsLanguageHints: Bool {
         self is LanguageHintTranscriptionEnginePlugin
@@ -264,6 +287,104 @@ final class ModelManagerService: ObservableObject {
     func selectModel(_ providerId: String, modelId: String) {
         selectProvider(providerId)
         PluginManager.shared.transcriptionEngine(for: providerId)?.selectModel(modelId)
+    }
+
+    func loadModel(_ providerId: String, modelId: String) async throws {
+        guard let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            throw ModelLifecycleError.engineNotFound(providerId)
+        }
+        let catalog = plugin.modelCatalog
+        guard catalog.isEmpty || catalog.contains(where: { $0.id == modelId }) else {
+            throw ModelLifecycleError.modelNotFound(engineId: providerId, modelId: modelId)
+        }
+
+        selectProvider(providerId)
+
+        if pluginConfiguredState(
+            plugin,
+            selectedModelId: modelId,
+            stopOnMismatchedSelection: true
+        ) == true {
+            PluginManager.shared.notifyPluginStateChanged()
+            return
+        }
+
+        let preferredRestoreSelector = NSSelectorFromString("triggerRestoreModelForModel:")
+        let genericRestoreSelector = NSSelectorFromString("triggerRestoreModel")
+        let object = plugin as? NSObject
+        var initiatedLoad = false
+        var requiresRequestedModelIdentity = false
+
+        if let object, object.responds(to: preferredRestoreSelector) {
+            _ = object.perform(preferredRestoreSelector, with: modelId as NSString)
+            initiatedLoad = true
+            requiresRequestedModelIdentity = true
+        } else {
+            plugin.selectModel(modelId)
+            await Task.yield()
+
+            if pluginConfiguredState(
+                plugin,
+                selectedModelId: plugin.selectedModelId == nil ? nil : modelId,
+                stopOnMismatchedSelection: true
+            ) == true {
+                PluginManager.shared.notifyPluginStateChanged()
+                return
+            }
+
+            if pluginSettingsActivity(plugin) != nil {
+                initiatedLoad = true
+            } else if let object, object.responds(to: genericRestoreSelector) {
+                _ = object.perform(genericRestoreSelector)
+                initiatedLoad = true
+            }
+        }
+
+        guard initiatedLoad else {
+            throw ModelLifecycleError.loadUnsupported(providerId)
+        }
+
+        let identityCheckModelId = requiresRequestedModelIdentity || plugin.selectedModelId != nil
+            ? modelId
+            : nil
+        switch await waitForPluginRestoreConfigured(
+            plugin,
+            selectedModelId: identityCheckModelId
+        ) {
+        case .configured:
+            PluginManager.shared.notifyPluginStateChanged()
+        case .failed(let message):
+            throw TranscriptionEngineError.modelLoadFailed(message)
+        case .timedOut(let activity):
+            if let activity {
+                throw TranscriptionEngineError.modelLoadFailed(
+                    Self.restoreTimeoutMessage(activity: activity)
+                )
+            }
+            throw ModelLifecycleError.loadUnsupported(providerId)
+        }
+    }
+
+    @discardableResult
+    func unloadModel(_ providerId: String) throws -> String? {
+        guard let plugin = PluginManager.shared.transcriptionEngine(for: providerId) else {
+            throw ModelLifecycleError.engineNotFound(providerId)
+        }
+        guard let object = plugin as? NSObject else {
+            throw ModelLifecycleError.unloadUnsupported(providerId)
+        }
+        let unloadSelector = NSSelectorFromString("triggerAutoUnload")
+        guard object.responds(to: unloadSelector) else {
+            throw ModelLifecycleError.unloadUnsupported(providerId)
+        }
+
+        let modelId = plugin.selectedModelId
+        _ = object.perform(unloadSelector)
+        guard !plugin.isConfigured else {
+            throw ModelLifecycleError.unloadFailed(providerId)
+        }
+        PluginManager.shared.notifyPluginStateChanged()
+        return modelId
     }
 
     func observePluginManager() {

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -298,13 +298,12 @@ final class ModelManagerService: ObservableObject {
             throw ModelLifecycleError.modelNotFound(engineId: providerId, modelId: modelId)
         }
 
-        selectProvider(providerId)
-
         if pluginConfiguredState(
             plugin,
             selectedModelId: modelId,
             stopOnMismatchedSelection: true
         ) == true {
+            selectProvider(providerId)
             PluginManager.shared.notifyPluginStateChanged()
             return
         }
@@ -328,6 +327,7 @@ final class ModelManagerService: ObservableObject {
                 selectedModelId: plugin.selectedModelId == nil ? nil : modelId,
                 stopOnMismatchedSelection: true
             ) == true {
+                selectProvider(providerId)
                 PluginManager.shared.notifyPluginStateChanged()
                 return
             }
@@ -352,6 +352,7 @@ final class ModelManagerService: ObservableObject {
             selectedModelId: identityCheckModelId
         ) {
         case .configured:
+            selectProvider(providerId)
             PluginManager.shared.notifyPluginStateChanged()
         case .failed(let message):
             throw TranscriptionEngineError.modelLoadFailed(message)
@@ -378,7 +379,8 @@ final class ModelManagerService: ObservableObject {
             throw ModelLifecycleError.unloadUnsupported(providerId)
         }
 
-        let modelId = plugin.selectedModelId
+        let modelId = plugin.modelCatalog.first(where: { $0.loaded == true })?.id
+            ?? plugin.selectedModelId
         _ = object.perform(unloadSelector)
         guard !plugin.isConfigured else {
             throw ModelLifecycleError.unloadFailed(providerId)

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -472,9 +472,11 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             return
         }
         if let modelId = modelId.map(String.init) {
-            state.withLock { $0.selectedModelId = modelId }
+            selectModel(modelId)
         }
-        triggerRestoreModel()
+        Task { [weak self] in
+            await self?.loadModel(allowDownloads: true)
+        }
     }
 
     private func beginModelLoad() -> (

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -256,6 +256,19 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        guard let modelId = modelId.map(String.init),
+              let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+            return
+        }
+        if loadedModelId != nil, loadedModelId != modelId {
+            unloadModel(clearPersistence: true)
+        }
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+        Task { try? await loadModel(modelDef) }
+    }
 
     func unloadModel(clearPersistence: Bool = true) {
         model = nil

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -746,6 +746,21 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        guard let modelId = modelId.map(String.init),
+              let version = ParakeetVersion.from(modelId: modelId) else {
+            return
+        }
+        if loadedModelId != nil, loadedModelId != modelId {
+            unloadModel(clearPersistence: false)
+        }
+        _selectedModelId = modelId
+        selectedVersion = version
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+        host?.setUserDefault(version.rawValue, forKey: "selectedVersion")
+        Task { await loadModel() }
+    }
 
     func unloadModel(clearPersistence: Bool = true) {
         clearVocabularyBoostingState(resetModelState: true)
@@ -776,7 +791,7 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
         await loadModel()
     }
 
-    private func isModelDownloaded(version: ParakeetVersion) -> Bool {
+    fileprivate func isModelDownloaded(version: ParakeetVersion) -> Bool {
         let cacheDir = AsrModels.defaultCacheDirectory(for: version.asrModelVersion)
         return AsrModels.modelsExist(at: cacheDir, version: version.asrModelVersion)
     }
@@ -956,7 +971,7 @@ private struct ParakeetSettingsView: View {
     @State private var selectedVersion: ParakeetVersion = .v3
     @State private var modelState: ParakeetModelState = .notLoaded
     @State private var downloadProgress: Double = 0
-    @State private var isPolling = false
+    @State private var selectedModelDownloaded = false
     @State private var hfTokenInput = ""
     @State private var showHfToken = false
     @State private var isValidatingToken = false
@@ -1089,15 +1104,16 @@ private struct ParakeetSettingsView: View {
 
                     switch modelState {
                     case .notLoaded:
-                        Button(String(localized: "Download & Load", bundle: bundle)) {
+                        Button(
+                            selectedModelDownloaded
+                                ? String(localized: "Load", bundle: bundle)
+                                : String(localized: "Download & Load", bundle: bundle)
+                        ) {
                             modelState = .downloading
                             downloadProgress = 0.05
-                            isPolling = true
                             Task {
                                 await plugin.loadModel()
-                                isPolling = false
-                                modelState = plugin.modelState
-                                downloadProgress = plugin.downloadProgress
+                                syncViewStateFromPlugin()
                             }
                         }
                         .buttonStyle(.borderedProminent)
@@ -1138,12 +1154,9 @@ private struct ParakeetSettingsView: View {
                             }
                             Button(String(localized: "Retry", bundle: bundle)) {
                                 modelState = .downloading
-                                isPolling = true
                                 Task {
                                     await plugin.loadModel()
-                                    isPolling = false
-                                    modelState = plugin.modelState
-                                    downloadProgress = plugin.downloadProgress
+                                    syncViewStateFromPlugin()
                                 }
                             }
                             .buttonStyle(.bordered)
@@ -1178,46 +1191,29 @@ private struct ParakeetSettingsView: View {
             }
         }
         .onAppear {
-            selectedVersion = plugin.selectedVersion
-            modelState = plugin.modelState
-            downloadProgress = plugin.downloadProgress
-            boostingEnabled = plugin.vocabularyBoostingEnabled
-            ctcModelState = plugin.ctcModelState
-            boostingTermCount = plugin.lastBoostingTermCount
+            syncViewStateFromPlugin()
             if let token = plugin._hfToken, !token.isEmpty {
                 hfTokenInput = token
             }
-            if case .downloading = plugin.modelState { isPolling = true }
         }
         .onChange(of: selectedVersion) { _, newVersion in
             guard newVersion != plugin.selectedVersion else { return }
             plugin.selectedVersion = newVersion
             plugin.host?.setUserDefault(newVersion.rawValue, forKey: "selectedVersion")
+            selectedModelDownloaded = plugin.isModelDownloaded(version: newVersion)
             if plugin.loadedModelId != nil {
                 // Reload with new version
                 modelState = .downloading
                 downloadProgress = 0.05
-                isPolling = true
                 Task {
                     plugin.unloadModel(clearPersistence: false)
                     await plugin.loadModel()
-                    isPolling = false
-                    modelState = plugin.modelState
-                    downloadProgress = plugin.downloadProgress
+                    syncViewStateFromPlugin()
                 }
             }
         }
         .onReceive(pollTimer) { _ in
-            guard isPolling else { return }
-            downloadProgress = plugin.downloadProgress
-            let pluginState = plugin.modelState
-            if pluginState != .notLoaded {
-                modelState = pluginState
-            }
-            ctcModelState = plugin.ctcModelState
-            boostingTermCount = plugin.lastBoostingTermCount
-            if case .ready = pluginState { isPolling = false }
-            else if case .error = pluginState { isPolling = false }
+            syncViewStateFromPlugin()
         }
         .onChange(of: hfTokenInput) { _, newValue in
             let trimmedValue = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1257,11 +1253,9 @@ private struct ParakeetSettingsView: View {
                             .font(.caption)
                             .foregroundStyle(.secondary)
                         Button(String(localized: "Download Now", bundle: bundle)) {
-                            isPolling = true
                             Task {
                                 await plugin.downloadCtcModel()
-                                ctcModelState = plugin.ctcModelState
-                                isPolling = false
+                                syncViewStateFromPlugin()
                             }
                         }
                         .buttonStyle(.bordered)
@@ -1297,11 +1291,9 @@ private struct ParakeetSettingsView: View {
                             .foregroundStyle(.secondary)
                             .lineLimit(1)
                         Button(String(localized: "Retry", bundle: bundle)) {
-                            isPolling = true
                             Task {
                                 await plugin.downloadCtcModel()
-                                ctcModelState = plugin.ctcModelState
-                                isPolling = false
+                                syncViewStateFromPlugin()
                             }
                         }
                         .buttonStyle(.bordered)
@@ -1310,6 +1302,16 @@ private struct ParakeetSettingsView: View {
                 }
             }
         }
+    }
+
+    private func syncViewStateFromPlugin() {
+        selectedVersion = plugin.selectedVersion
+        modelState = plugin.modelState
+        downloadProgress = plugin.downloadProgress
+        selectedModelDownloaded = plugin.isModelDownloaded(version: plugin.selectedVersion)
+        boostingEnabled = plugin.vocabularyBoostingEnabled
+        ctcModelState = plugin.ctcModelState
+        boostingTermCount = plugin.lastBoostingTermCount
     }
 
     private func validateAndSaveHuggingFaceToken() {

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -299,8 +299,16 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: false) } }
     @objc(triggerRestoreModelForModel:) func triggerRestoreModel(forModel modelId: NSString?) {
-        let preferredModelId = modelId.map(String.init)
-        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: preferredModelId) }
+        guard let preferredModelId = modelId.map(String.init),
+              Self.availableModels.contains(where: { $0.id == preferredModelId }) else {
+            return
+        }
+        if loadedModelId != nil, loadedModelId != preferredModelId {
+            unloadModel(clearPersistence: true)
+        }
+        _selectedModelId = preferredModelId
+        host?.setUserDefault(preferredModelId, forKey: "selectedModel")
+        Task { await restoreLoadedModel(allowDownloads: true, preferredModelId: preferredModelId) }
     }
 
     func unloadModel(clearPersistence: Bool = true) {

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -305,6 +305,24 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        guard let modelId = modelId.map(String.init) else { return }
+        if loadedModelId != nil, loadedModelId != modelId {
+            unloadModel(clearPersistence: false)
+        }
+        Task {
+            if cachedModels.isEmpty {
+                await populateModels()
+            }
+            guard let modelDef = cachedModels.first(where: { $0.id == modelId }) else {
+                modelState = .error("Unknown Apple Speech model '\(modelId)'.")
+                host?.notifyCapabilitiesChanged()
+                return
+            }
+            await loadModel(modelDef)
+        }
+    }
     @objc(triggerRestoreModelForLanguage:)
     func triggerRestoreModel(forLanguage languageCode: NSString?) {
         let requestedLanguage = languageCode as String?

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -9,7 +9,7 @@ import MLXAudioSTT
 // MARK: - Plugin Entry Point
 
 @objc(VoxtralPlugin)
-final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginDownloadedModelManaging, @unchecked Sendable {
+final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
     static let pluginId = "com.typewhisper.voxtral"
     static let pluginName = "Voxtral"
 
@@ -263,6 +263,19 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     @objc func triggerAutoUnload() { unloadModel(clearPersistence: false) }
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
+    @objc(triggerRestoreModelForModel:)
+    func triggerRestoreModel(forModel modelId: NSString?) {
+        guard let modelId = modelId.map(String.init),
+              let modelDef = Self.availableModels.first(where: { $0.id == modelId }) else {
+            return
+        }
+        if loadedModelId != nil, loadedModelId != modelId {
+            unloadModel(clearPersistence: true)
+        }
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedModel")
+        Task { try? await loadModel(modelDef) }
+    }
 
     func unloadModel(clearPersistence: Bool = true) {
         model = nil
@@ -357,6 +370,17 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     }
 
     // MARK: - Settings View
+
+    var currentSettingsActivity: PluginSettingsActivity? {
+        switch modelState {
+        case .notLoaded, .ready:
+            return nil
+        case .loading:
+            return PluginSettingsActivity(message: "Preparing model")
+        case .error(let message):
+            return PluginSettingsActivity(message: message, isError: true)
+        }
+    }
 
     var settingsView: AnyView? {
         AnyView(VoxtralSettingsView(plugin: self))

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -651,8 +651,16 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     @objc func triggerRestoreModel() { Task { await restoreLoadedModel(allowDownloads: true) } }
     @objc(triggerRestoreModelForModel:)
     func triggerRestoreModel(forModel modelId: NSString?) {
-        let preferredModelId = modelId.map(String.init)
-        Task { await restoreLoadedModel(allowDownloads: false, preferredModelId: preferredModelId) }
+        guard let preferredModelId = modelId.map(String.init),
+              Self.availableModels.contains(where: { $0.id == preferredModelId }) else {
+            return
+        }
+        if loadedModelId != nil, loadedModelId != preferredModelId {
+            unloadModel(clearPersistence: true)
+        }
+        _selectedModelId = preferredModelId
+        host?.setUserDefault(preferredModelId, forKey: "selectedModel")
+        Task { await restoreLoadedModel(allowDownloads: true, preferredModelId: preferredModelId) }
     }
 
     func unloadModel(clearPersistence: Bool = true) {
@@ -1123,6 +1131,7 @@ struct WhisperKitSettingsPollState: Equatable {
     var modelState: WhisperModelState
     var downloadProgress: Double
     var activeModelId: String?
+    var downloadedModelIds: Set<String>
     var isPolling: Bool
 
     var isBusy: Bool {
@@ -1137,20 +1146,23 @@ struct WhisperKitSettingsPollState: Equatable {
     func applyingPolledPluginState(
         _ pluginState: WhisperModelState,
         downloadProgress: Double,
-        selectedModelId: String?
+        selectedModelId: String?,
+        downloadedModelIds: Set<String>
     ) -> WhisperKitSettingsPollState {
         var updated = self
         updated.modelState = pluginState
         updated.downloadProgress = downloadProgress
+        updated.downloadedModelIds = downloadedModelIds
 
         switch pluginState {
-        case .ready:
-            updated.activeModelId = selectedModelId ?? updated.activeModelId
+        case .ready(let loadedModelId):
+            updated.activeModelId = selectedModelId ?? loadedModelId
             updated.isPolling = false
         case .downloading, .loading:
+            updated.activeModelId = selectedModelId ?? updated.activeModelId
             updated.isPolling = true
         case .notLoaded, .error:
-            updated.activeModelId = selectedModelId ?? updated.activeModelId
+            updated.activeModelId = selectedModelId
             updated.isPolling = false
         }
 
@@ -1166,6 +1178,7 @@ private struct WhisperKitSettingsView: View {
     @State private var modelState: WhisperModelState = .notLoaded
     @State private var downloadProgress: Double = 0
     @State private var activeModelId: String?
+    @State private var downloadedModelIds: Set<String> = []
     @State private var isPolling = false
     @State private var hfTokenInput = ""
     @State private var showHfToken = false
@@ -1313,8 +1326,10 @@ private struct WhisperKitSettingsView: View {
                 modelState: normalizedPluginModelState,
                 downloadProgress: plugin.downloadProgress,
                 activeModelId: plugin._selectedModelId,
+                downloadedModelIds: Set(plugin.downloadedModels.map(\.id)),
                 isPolling: false
             ).isBusy
+            downloadedModelIds = Set(plugin.downloadedModels.map(\.id))
 
             if plugin.whisperKit == nil,
                plugin.loadedModelId == nil,
@@ -1336,16 +1351,19 @@ private struct WhisperKitSettingsView: View {
                 modelState: modelState,
                 downloadProgress: downloadProgress,
                 activeModelId: activeModelId,
+                downloadedModelIds: downloadedModelIds,
                 isPolling: isPolling
             ).applyingPolledPluginState(
                 normalizedPluginModelState,
                 downloadProgress: plugin.downloadProgress,
-                selectedModelId: plugin._selectedModelId
+                selectedModelId: plugin._selectedModelId,
+                downloadedModelIds: Set(plugin.downloadedModels.map(\.id))
             )
 
             modelState = updatedState.modelState
             downloadProgress = updatedState.downloadProgress
             activeModelId = updatedState.activeModelId
+            downloadedModelIds = updatedState.downloadedModelIds
             isPolling = updatedState.isPolling
         }
         .onChange(of: hfTokenInput) { _, newValue in
@@ -1386,11 +1404,12 @@ private struct WhisperKitSettingsView: View {
 
     @ViewBuilder
     private func modelStatusView(_ modelDef: WhisperModelDef) -> some View {
-        let isDownloaded = plugin.isModelDownloaded(modelDef)
+        let isDownloaded = downloadedModelIds.contains(modelDef.id)
         let viewState = WhisperKitSettingsPollState(
             modelState: modelState,
             downloadProgress: downloadProgress,
             activeModelId: activeModelId,
+            downloadedModelIds: downloadedModelIds,
             isPolling: isPolling
         )
 
@@ -1471,15 +1490,15 @@ private struct WhisperKitSettingsView: View {
         modelState = normalizedPluginModelState
         downloadProgress = plugin.downloadProgress
         activeModelId = plugin._selectedModelId
+        downloadedModelIds = Set(plugin.downloadedModels.map(\.id))
         isPolling = false
     }
 
     private func removeDownloadedModel(_ modelDef: WhisperModelDef) {
-        if case .ready(let loadedId) = modelState, loadedId == modelDef.id {
-            plugin.unloadModel()
+        Task {
+            try? await plugin.deleteDownloadedModel(modelDef.id)
+            syncViewStateFromPlugin()
         }
-        try? plugin.deleteModelFiles(modelDef)
-        syncViewStateFromPlugin()
     }
 
     private func phaseText(_ phase: String) -> String {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1667,18 +1667,40 @@ private final class TestEventBus: EventBusProtocol, @unchecked Sendable {
 }
 
 final class WhisperKitSettingsStateTests: XCTestCase {
+    func testApplyingExternalDeletionClearsStaleActiveModel() {
+        let initial = WhisperKitSettingsPollState(
+            modelState: .notLoaded,
+            downloadProgress: 0,
+            activeModelId: "openai_whisper-large-v3_turbo",
+            downloadedModelIds: ["openai_whisper-large-v3_turbo"],
+            isPolling: false
+        )
+
+        let updated = initial.applyingPolledPluginState(
+            .notLoaded,
+            downloadProgress: 0,
+            selectedModelId: nil,
+            downloadedModelIds: []
+        )
+
+        XCTAssertNil(updated.activeModelId)
+        XCTAssertTrue(updated.downloadedModelIds.isEmpty)
+    }
+
     func testApplyingNotLoadedStateClearsStaleLoadingAndStopsPolling() {
         let initial = WhisperKitSettingsPollState(
             modelState: .loading(phase: "loading"),
             downloadProgress: 0.9,
             activeModelId: "openai_whisper-large-v3_turbo",
+            downloadedModelIds: ["openai_whisper-large-v3_turbo"],
             isPolling: true
         )
 
         let updated = initial.applyingPolledPluginState(
             .notLoaded,
             downloadProgress: 0,
-            selectedModelId: "openai_whisper-large-v3_turbo"
+            selectedModelId: "openai_whisper-large-v3_turbo",
+            downloadedModelIds: ["openai_whisper-large-v3_turbo"]
         )
 
         XCTAssertEqual(updated.modelState, .notLoaded)
@@ -1692,6 +1714,7 @@ final class WhisperKitSettingsStateTests: XCTestCase {
             modelState: .loading(phase: "prewarming"),
             downloadProgress: 0.9,
             activeModelId: "openai_whisper-large-v3_turbo",
+            downloadedModelIds: ["openai_whisper-large-v3_turbo"],
             isPolling: true
         )
 

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -1337,7 +1337,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         var configured = false
         var currentModelId: String?
+        var reportedLoadedModelId: String?
         var downloadedModelIds: Set<String> = ["tiny"]
+        var allowsRestore = true
         var allowsUnload = true
         var restoreInvocationCount = 0
 
@@ -1360,7 +1362,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                     id: modelId,
                     displayName: modelId.capitalized,
                     downloaded: downloadedModelIds.contains(modelId),
-                    loaded: configured && currentModelId == modelId
+                    loaded: configured && (reportedLoadedModelId ?? currentModelId) == modelId
                 )
             }
         }
@@ -1380,6 +1382,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 return
             }
             restoreInvocationCount += 1
+            guard allowsRestore else { return }
             currentModelId = modelId
             downloadedModelIds.insert(modelId)
             configured = true
@@ -11054,6 +11057,61 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testModelsLoadEndpointPreservesProviderSelectionWhenRestoreFails() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let originalProvider = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedEngine)
+        defer { Self.restoreUserDefault(originalProvider, forKey: UserDefaultsKeys.selectedEngine) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        context.modelManager.selectProvider("original-provider")
+        context.modelManager.setPluginRestoreWaitConfigurationForTesting(
+            initialAttempts: 0,
+            busyAttempts: 0,
+            pollInterval: .zero
+        )
+
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        plugin.allowsRestore = false
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/load",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock","model":"large"}"#.utf8)
+            )
+        )
+
+        XCTAssertEqual(response.status, 409)
+        XCTAssertEqual(context.modelManager.selectedProviderId, "original-provider")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine),
+            "original-provider"
+        )
+        XCTAssertFalse(plugin.isConfigured)
+    }
+
+    @MainActor
     func testModelsUnloadEndpointReflectsExternalUnloadImmediately() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
@@ -11142,6 +11200,51 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(response.status, 409)
         XCTAssertTrue(plugin.isConfigured)
         XCTAssertEqual(plugin.selectedModelId, "tiny")
+    }
+
+    @MainActor
+    func testModelsUnloadEndpointReturnsActuallyLoadedModel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        plugin.currentModelId = "large"
+        plugin.reportedLoadedModelId = "tiny"
+        plugin.configured = true
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/unload",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock"}"#.utf8)
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(json["model"] as? String, "tiny")
+        XCTAssertFalse(plugin.isConfigured)
     }
 
     @MainActor

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -1330,6 +1330,82 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
     }
 
+    @objc(APIRouterModelLifecycleTranscriptionPlugin)
+    private final class ModelLifecycleTranscriptionPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, PluginDownloadedModelManaging, @unchecked Sendable {
+        static var pluginId: String { "com.typewhisper.mock.model-lifecycle" }
+        static var pluginName: String { "Model Lifecycle Mock" }
+
+        var configured = false
+        var currentModelId: String?
+        var downloadedModelIds: Set<String> = ["tiny"]
+        var allowsUnload = true
+        var restoreInvocationCount = 0
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+
+        func deactivate() {
+            configured = false
+            currentModelId = nil
+        }
+
+        var providerId: String { "model-lifecycle-mock" }
+        var providerDisplayName: String { "Model Lifecycle Mock" }
+        var isConfigured: Bool { configured }
+        var transcriptionModels: [PluginModelInfo] { availableModels }
+        var availableModels: [PluginModelInfo] {
+            ["tiny", "large"].map { modelId in
+                PluginModelInfo(
+                    id: modelId,
+                    displayName: modelId.capitalized,
+                    downloaded: downloadedModelIds.contains(modelId),
+                    loaded: configured && currentModelId == modelId
+                )
+            }
+        }
+        var downloadedModels: [PluginModelInfo] {
+            availableModels.filter { $0.downloaded == true }
+        }
+        var selectedModelId: String? { currentModelId }
+
+        func selectModel(_ modelId: String) {
+            currentModelId = modelId
+        }
+
+        @objc(triggerRestoreModelForModel:)
+        func triggerRestoreModel(forModel modelId: NSString?) {
+            guard let modelId = modelId.map(String.init),
+                  availableModels.contains(where: { $0.id == modelId }) else {
+                return
+            }
+            restoreInvocationCount += 1
+            currentModelId = modelId
+            downloadedModelIds.insert(modelId)
+            configured = true
+        }
+
+        @objc func triggerAutoUnload() {
+            if allowsUnload {
+                configured = false
+            }
+        }
+
+        func deleteDownloadedModel(_ modelId: String) async throws {
+            downloadedModelIds.remove(modelId)
+            if currentModelId == modelId {
+                configured = false
+                currentModelId = nil
+            }
+        }
+
+        var supportsTranslation: Bool { false }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "transcribed", detectedLanguage: language)
+        }
+    }
+
     @objc(APIRouterMockTTSPlugin)
     private final class MockTTSProviderPlugin: NSObject, TTSProviderPlugin, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.tts" }
@@ -1828,7 +1904,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         )
 
         XCTAssertEqual(status["status"] as? String, "no_model")
-        XCTAssertEqual(status["api_version"] as? String, "1.1")
+        XCTAssertEqual(status["api_version"] as? String, "1.2")
         XCTAssertEqual(status["supports_workflow_dictation"] as? Bool, true)
         XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
@@ -10884,6 +10960,232 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(legacyIds, ["tiny"])
         XCTAssertEqual(catalogIds.sorted(), ["large", "tiny"])
         XCTAssertEqual(expandedIds, ["inception-whisper"])
+    }
+
+    @MainActor
+    func testModelsLoadEndpointDownloadsLoadsAndSelectsRequestedModel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/load",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock","model":"large"}"#.utf8)
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(json["engine"] as? String, plugin.providerId)
+        XCTAssertEqual(json["model"] as? String, "large")
+        XCTAssertEqual(json["status"] as? String, "ready")
+        XCTAssertEqual(context.modelManager.selectedProviderId, plugin.providerId)
+        XCTAssertEqual(plugin.selectedModelId, "large")
+        XCTAssertTrue(plugin.isConfigured)
+        XCTAssertTrue(plugin.downloadedModelIds.contains("large"))
+    }
+
+    @MainActor
+    func testModelsLoadEndpointDoesNotReloadAlreadyReadyModel() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        plugin.currentModelId = "tiny"
+        plugin.configured = true
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/load",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock","model":"tiny"}"#.utf8)
+            )
+        )
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(plugin.restoreInvocationCount, 0)
+        XCTAssertEqual(plugin.selectedModelId, "tiny")
+        XCTAssertTrue(plugin.isConfigured)
+    }
+
+    @MainActor
+    func testModelsUnloadEndpointReflectsExternalUnloadImmediately() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        plugin.currentModelId = "tiny"
+        plugin.configured = true
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/unload",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock"}"#.utf8)
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(json["engine"] as? String, plugin.providerId)
+        XCTAssertEqual(json["model"] as? String, "tiny")
+        XCTAssertEqual(json["status"] as? String, "unloaded")
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertTrue(plugin.downloadedModelIds.contains("tiny"))
+    }
+
+    @MainActor
+    func testModelsUnloadEndpointRejectsModelThatRemainsInUse() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        plugin.currentModelId = "tiny"
+        plugin.configured = true
+        plugin.allowsUnload = false
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "POST",
+                path: "/v1/models/unload",
+                queryParams: [:],
+                headers: ["content-type": "application/json"],
+                body: Data(#"{"engine":"model-lifecycle-mock"}"#.utf8)
+            )
+        )
+
+        XCTAssertEqual(response.status, 409)
+        XCTAssertTrue(plugin.isConfigured)
+        XCTAssertEqual(plugin.selectedModelId, "tiny")
+    }
+
+    @MainActor
+    func testModelsDeleteEndpointRemovesDownloadedModelThroughPluginManager() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let context = Self.makeAPIContext(
+            appSupportDirectory: appSupportDirectory,
+            withMockTranscriptionPlugin: false
+        )
+        let plugin = ModelLifecycleTranscriptionPlugin()
+        PluginManager.shared.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: ModelLifecycleTranscriptionPlugin.pluginId,
+                    name: ModelLifecycleTranscriptionPlugin.pluginName,
+                    version: "1.0.0",
+                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                    principalClass: "APIRouterModelLifecycleTranscriptionPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+
+        let response = await context.router.route(
+            HTTPRequest(
+                method: "DELETE",
+                path: "/v1/models",
+                queryParams: ["engine": plugin.providerId, "model": "tiny"],
+                headers: [:],
+                body: Data()
+            )
+        )
+        let json = try Self.jsonObject(response)
+
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(json["engine"] as? String, plugin.providerId)
+        XCTAssertEqual(json["model"] as? String, "tiny")
+        XCTAssertEqual(json["status"] as? String, "deleted")
+        XCTAssertFalse(plugin.downloadedModelIds.contains("tiny"))
     }
 
     @MainActor


### PR DESCRIPTION
## Issue context

Plugin settings could keep stale local snapshots after model lifecycle changes. This caused Whisper deletions to remain visible until the settings window was reopened, Parakeet CTC downloads to keep spinning after completion, and already-downloaded models to be presented as needing another download.

Closes #1153

## What changed

- continuously reconcile Whisper and Parakeet settings state with the plugin state while the settings view is open
- clear stale Whisper selections after an external model deletion and route settings deletion through the plugin manager
- add authenticated API 1.2 endpoints to load, unload, and delete models
- add model-specific restore hooks for local transcription engines used by the lifecycle API
- document the model lifecycle API and add regression/integration coverage

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/WhisperKitSettingsStateTests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsLoadEndpointDownloadsLoadsAndSelectsRequestedModel -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsLoadEndpointDoesNotReloadAlreadyReadyModel -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsLoadEndpointPreservesProviderSelectionWhenRestoreFails -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsUnloadEndpointReflectsExternalUnloadImmediately -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsUnloadEndpointRejectsModelThatRemainsInUse -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsUnloadEndpointReturnsActuallyLoadedModel -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testModelsDeleteEndpointRemovesDownloadedModelThroughPluginManager CODE_SIGNING_ALLOWED=NO
```

```bash
swift test --package-path TypeWhisperPluginSDK
```

```bash
for scheme in CohereLocalPlugin GranitePlugin ParakeetPlugin Qwen3Plugin SpeechAnalyzerPlugin VoxtralPlugin WhisperKitPlugin; do
  xcodebuild build -project TypeWhisper.xcodeproj -scheme "$scheme" -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO || exit 1
done
```

Live Dev-app verification:

- baseline API 1.1 returned HTTP 404 for `POST /v1/models/load`
- fixed API 1.2 loaded Whisper Tiny and reported `downloaded: true` / `loaded: true`
- `DELETE /v1/models?engine=whisper&model=openai_whisper-tiny` returned HTTP 200
- after re-enabling the plugin, the catalog immediately reported `downloaded: false` / `loaded: false`
- the original ElevenLabs `scribe_v2` selection was restored after the smoke test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model lifecycle APIs for loading, unloading, selecting, and deleting downloaded models.
  * Model status responses now report name, status, selection, download, and loaded states.
  * Model settings distinguish between “Load” and “Download & Load” actions.
  * Added safer model switching, clearer loading progress, and improved error reporting across supported providers.
  * Model deletion now refreshes settings and clears stale model state.

* **Documentation**
  * Updated API examples with model lifecycle and authentication guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->