### PR TITLE
Bump model lifecycle plugins for release

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.cohere-transcribe",
     "name": "Cohere Transcribe (Local)",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.granite",
     "name": "Granite Speech",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.speechanalyzer",
     "name": "Apple Speech",
-    "version": "1.0.9",
+    "version": "1.0.15",
     "minHostVersion": "0.12.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "26.0",

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.voxtral",
     "name": "Voxtral",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -105,9 +105,9 @@ final class PluginManifestValidationTests: XCTestCase {
 
     func testMLXStoragePluginReleasesRequireHost16() throws {
         let manifestExpectations = [
-            ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.7"),
-            ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.13"),
-            ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.9"),
+            ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.8"),
+            ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.14"),
+            ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.10"),
             ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.4"),
         ]
 


### PR DESCRIPTION
## Context

PR #1154 fixed stale model lifecycle state and added model-specific restore behavior across seven local transcription plugins. Those plugin changes need new standalone plugin releases so existing installations receive the fix from the plugin registry.

This follow-up keeps the SDK core and compatibility contract unchanged. Every affected manifest remains on `sdkCompatibilityVersion: v1`.

SpeechAnalyzer requires version `1.0.15`: the public feeds already contain releases through `1.0.14`, while its source manifest had remained at `1.0.9`. The new release restores agreement between the release tag, Info.plist, and embedded manifest.

Related to #1153 and #1154.

## Version bumps

- Cohere Transcribe (Local): 0.1.0 → 0.1.1
- Granite Speech: 1.0.9 → 1.0.10
- Parakeet: 1.3.0 → 1.3.1
- Qwen3 ASR: 1.1.7 → 1.1.8
- Apple Speech: 1.0.9 → 1.0.15
- Voxtral: 1.0.13 → 1.0.14
- WhisperKit: 1.1.5 → 1.1.6

## Test plan

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginManifestValidationTests CODE_SIGNING_ALLOWED=NO
```

```bash
for scheme in CohereLocalPlugin GranitePlugin ParakeetPlugin Qwen3Plugin SpeechAnalyzerPlugin VoxtralPlugin WhisperKitPlugin; do
  xcodebuild build -project TypeWhisper.xcodeproj -scheme "$scheme" -configuration Release -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO || exit 1
done
```

Verified each local Release bundle has matching `CFBundleShortVersionString` and embedded manifest version, with SDK compatibility `v1`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated plugin versions for Cohere Local, Granite, Parakeet, Qwen3, Speech Analyzer, Voxtral, and WhisperKit.
  * Refreshed compatibility checks to recognize the latest MLX plugin versions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->