### PR TITLE
Add model-specific OpenAI reasoning effort controls

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Localizable.xcstrings
@@ -45,6 +45,28 @@
         }
       }
     },
+    "Advanced": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Erweitert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
+          }
+        }
+      }
+    },
     "ChatGPT Login": {
       "localizations": {
         "de": {
@@ -327,6 +349,50 @@
           "stringUnit": {
             "state": "translated",
             "value": "最小"
+          }
+        }
+      }
+    },
+    "Maximum": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Maximum"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最大"
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -14,14 +14,21 @@ private enum OpenAIAuthMode: String, Codable, CaseIterable, Hashable, Sendable {
     case chatGPT = "chatgpt"
 }
 
-private enum OpenAIReasoningEffort: String, Codable, CaseIterable, Hashable, Sendable {
+enum OpenAIReasoningEffort: String, Codable, CaseIterable, Hashable, Sendable {
+    case none
+    case minimal
     case low
     case medium
     case high
     case xhigh
+    case max
 
     var localizedKey: String {
         switch self {
+        case .none:
+            return "None"
+        case .minimal:
+            return "Minimal"
         case .low:
             return "Low"
         case .medium:
@@ -30,6 +37,8 @@ private enum OpenAIReasoningEffort: String, Codable, CaseIterable, Hashable, Sen
             return "High"
         case .xhigh:
             return "X High"
+        case .max:
+            return "Maximum"
         }
     }
 }
@@ -2359,7 +2368,7 @@ final class OpenAIPlugin: NSObject,
         temperatureDirective: PluginLLMTemperatureDirective
     ) async throws -> String {
         let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
-        let reasoningEffort = Self.supportsReasoningEffort(for: modelId) ? _reasoningEffort.rawValue : nil
+        let reasoningEffort = Self.effectiveReasoningEffort(_reasoningEffort, for: modelId)?.rawValue
 
         switch _authMode {
         case .apiKey:
@@ -2504,12 +2513,16 @@ final class OpenAIPlugin: NSObject,
     }
 
     fileprivate var chatGPTPlanType: String? { _oauthPlanType }
-    fileprivate func supportsReasoningEffort(for modelID: String) -> Bool {
-        Self.supportsReasoningEffort(for: modelID)
+    fileprivate func supportedReasoningEfforts(for modelID: String) -> [OpenAIReasoningEffort] {
+        Self.supportedReasoningEfforts(for: modelID)
+    }
+
+    fileprivate func effectiveReasoningEffort(for modelID: String) -> OpenAIReasoningEffort? {
+        Self.effectiveReasoningEffort(_reasoningEffort, for: modelID)
     }
 
     fileprivate func supportsCustomTemperature(for modelID: String) -> Bool {
-        let reasoningEffort = Self.supportsReasoningEffort(for: modelID) ? _reasoningEffort.rawValue : nil
+        let reasoningEffort = Self.effectiveReasoningEffort(_reasoningEffort, for: modelID)?.rawValue
         return Self.supportsCustomTemperature(for: modelID, reasoningEffort: reasoningEffort)
     }
 
@@ -2961,8 +2974,8 @@ final class OpenAIPlugin: NSObject,
         ]
 
         var mutableRequestBody = requestBody
-        if Self.supportsReasoningEffort(for: model) {
-            mutableRequestBody["reasoning"] = ["effort": _reasoningEffort.rawValue]
+        if let reasoningEffort = Self.effectiveReasoningEffort(_reasoningEffort, for: model) {
+            mutableRequestBody["reasoning"] = ["effort": reasoningEffort.rawValue]
         }
 
         var request = URLRequest(url: endpoint)
@@ -3129,12 +3142,96 @@ final class OpenAIPlugin: NSObject,
     }
 
     nonisolated static func supportsReasoningEffort(for modelID: String) -> Bool {
+        !supportedReasoningEfforts(for: modelID).isEmpty
+    }
+
+    nonisolated static func supportedReasoningEfforts(for modelID: String) -> [OpenAIReasoningEffort] {
+        // Keep this matrix aligned with the per-model values in
+        // https://developers.openai.com/api/docs/guides/reasoning.
         let lowered = modelID.lowercased()
-        return lowered.hasPrefix("gpt-5")
-            || lowered.hasPrefix("o1")
+        guard !lowered.contains("-chat") else { return [] }
+
+        if lowered.hasPrefix("gpt-5.6") {
+            return [.none, .low, .medium, .high, .xhigh, .max]
+        }
+
+        if lowered.hasPrefix("gpt-5.5-pro")
+            || lowered.hasPrefix("gpt-5.4-pro")
+            || lowered.hasPrefix("gpt-5.2-pro") {
+            return [.medium, .high, .xhigh]
+        }
+
+        if lowered.hasPrefix("gpt-5-pro") {
+            return [.high]
+        }
+
+        if lowered.hasPrefix("gpt-5.3-codex")
+            || lowered.hasPrefix("gpt-5.2-codex")
+            || lowered.hasPrefix("gpt-5.1-codex-max") {
+            return [.low, .medium, .high, .xhigh]
+        }
+
+        if lowered.contains("codex") {
+            return [.low, .medium, .high]
+        }
+
+        if lowered.hasPrefix("gpt-5.5")
+            || lowered.hasPrefix("gpt-5.4")
+            || lowered.hasPrefix("gpt-5.2") {
+            return [.none, .low, .medium, .high, .xhigh]
+        }
+
+        if lowered.hasPrefix("gpt-5.1") {
+            return [.none, .low, .medium, .high]
+        }
+
+        if lowered.hasPrefix("gpt-5") {
+            return [.minimal, .low, .medium, .high]
+        }
+
+        if lowered.hasPrefix("o1-mini")
+            || lowered.hasPrefix("o1-preview")
+            || lowered.hasPrefix("o1-pro")
+            || lowered.hasPrefix("o3-pro") {
+            return []
+        }
+
+        if lowered.hasPrefix("o1")
             || lowered.hasPrefix("o3")
-            || lowered.hasPrefix("o4")
-            || lowered.contains("codex")
+            || lowered.hasPrefix("o4") {
+            return [.low, .medium, .high]
+        }
+
+        return []
+    }
+
+    nonisolated static func defaultReasoningEffort(for modelID: String) -> OpenAIReasoningEffort? {
+        let lowered = modelID.lowercased()
+        let supported = supportedReasoningEfforts(for: modelID)
+        guard !supported.isEmpty else { return nil }
+
+        if lowered.hasPrefix("gpt-5.5-pro") || lowered.hasPrefix("gpt-5-pro") {
+            return .high
+        }
+
+        if (lowered.hasPrefix("gpt-5.4") && !lowered.hasPrefix("gpt-5.4-pro"))
+            || (lowered.hasPrefix("gpt-5.2") && !lowered.hasPrefix("gpt-5.2-pro") && !lowered.contains("codex"))
+            || (lowered.hasPrefix("gpt-5.1") && !lowered.contains("codex")) {
+            return OpenAIReasoningEffort.none
+        }
+
+        return supported.contains(.medium) ? .medium : supported[0]
+    }
+
+    nonisolated static func effectiveReasoningEffort(
+        _ preferred: OpenAIReasoningEffort,
+        for modelID: String
+    ) -> OpenAIReasoningEffort? {
+        let supported = supportedReasoningEfforts(for: modelID)
+        if supported.contains(preferred) {
+            return preferred
+        }
+        return defaultReasoningEffort(for: modelID)
     }
 
     nonisolated static func usesResponsesAPI(for modelID: String) -> Bool {
@@ -3249,6 +3346,7 @@ private struct OpenAISettingsView: View {
     @State private var selectedReasoningEffort: OpenAIReasoningEffort = .medium
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
+    @State private var isAdvancedExpanded = false
     @State private var fetchedLLMModels: [OpenAIFetchedModel] = []
     @State private var isRefreshingLLMModels = false
     @State private var llmRefreshMessage: String?
@@ -3271,6 +3369,7 @@ private struct OpenAISettingsView: View {
                 .onChange(of: authMode) {
                     plugin.setAuthMode(authMode)
                     selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+                    syncReasoningEffortWithSelectedModel()
                     llmRefreshMessage = nil
                     oauthErrorMessage = nil
                     oauthStatusMessage = nil
@@ -3376,7 +3475,7 @@ private struct OpenAISettingsView: View {
             ttsInstructions = plugin.ttsInstructions
             transcriptionContext = plugin.transcriptionContext
             liveTranscriptionDelay = plugin.liveTranscriptionDelay
-            selectedReasoningEffort = plugin.reasoningEffort
+            syncReasoningEffortWithSelectedModel()
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
@@ -3576,27 +3675,7 @@ private struct OpenAISettingsView: View {
             .labelsHidden()
             .onChange(of: selectedLLMModel) {
                 plugin.selectLLMModel(selectedLLMModel)
-            }
-
-            if plugin.supportsReasoningEffort(for: selectedLLMModel) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("Reasoning Effort", bundle: bundle)
-                        .font(.headline)
-
-                    Picker("Reasoning Effort", selection: $selectedReasoningEffort) {
-                        ForEach(OpenAIReasoningEffort.allCases, id: \.self) { effort in
-                            Text(LocalizedStringKey(effort.localizedKey), bundle: bundle).tag(effort)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .onChange(of: selectedReasoningEffort) {
-                        plugin.setReasoningEffort(selectedReasoningEffort)
-                    }
-
-                    Text("Controls how much thinking time the model spends before answering.", bundle: bundle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                syncReasoningEffortWithSelectedModel()
             }
 
             if authMode == .chatGPT {
@@ -3622,13 +3701,45 @@ private struct OpenAISettingsView: View {
                     .foregroundStyle(.secondary)
             }
 
-            if authMode == .apiKey {
+            if !supportedReasoningEfforts.isEmpty || authMode == .apiKey {
                 Divider()
+                DisclosureGroup(
+                    String(localized: "Advanced", bundle: bundle),
+                    isExpanded: $isAdvancedExpanded
+                ) {
+                    advancedLLMSettings
+                        .padding(.top, 8)
+                }
+            }
+        }
+    }
 
+    private var supportedReasoningEfforts: [OpenAIReasoningEffort] {
+        plugin.supportedReasoningEfforts(for: selectedLLMModel)
+    }
+
+    private var advancedLLMSettings: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !supportedReasoningEfforts.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Picker("Reasoning Effort", selection: $selectedReasoningEffort) {
+                        ForEach(supportedReasoningEfforts, id: \.self) { effort in
+                            Text(LocalizedStringKey(effort.localizedKey), bundle: bundle).tag(effort)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                    .onChange(of: selectedReasoningEffort) {
+                        plugin.setReasoningEffort(selectedReasoningEffort)
+                    }
+
+                    Text("Controls how much thinking time the model spends before answering.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            if authMode == .apiKey {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Temperature", bundle: bundle)
-                        .font(.headline)
-
                     Picker("Temperature Mode", selection: $llmTemperatureMode) {
                         Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
                         Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
@@ -3665,6 +3776,10 @@ private struct OpenAISettingsView: View {
         }
     }
 
+    private func syncReasoningEffortWithSelectedModel() {
+        selectedReasoningEffort = plugin.effectiveReasoningEffort(for: selectedLLMModel) ?? .medium
+    }
+
     private func saveApiKey() {
         let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else { return }
@@ -3683,6 +3798,7 @@ private struct OpenAISettingsView: View {
                     if !models.isEmpty {
                         fetchedLLMModels = models
                         selectedLLMModel = plugin.selectedLLMModelId ?? models.first?.id ?? selectedLLMModel
+                        syncReasoningEffortWithSelectedModel()
                     }
                 }
             } else {
@@ -3707,6 +3823,7 @@ private struct OpenAISettingsView: View {
                 if !models.isEmpty {
                     fetchedLLMModels = plugin._fetchedLLMModels
                     selectedLLMModel = plugin.selectedLLMModelId ?? models.first?.id ?? selectedLLMModel
+                    syncReasoningEffortWithSelectedModel()
                     if showStatus {
                         if authMode == .apiKey {
                             llmRefreshMessage = String(localized: "Fetched \(models.count) OpenAI API models.", bundle: bundle)
@@ -3733,7 +3850,7 @@ private struct OpenAISettingsView: View {
                     oauthBusy = false
                     oauthStatusMessage = String(localized: "ChatGPT login connected.", bundle: bundle)
                     selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
-                    selectedReasoningEffort = plugin.reasoningEffort
+                    syncReasoningEffortWithSelectedModel()
                     refreshLLMModels(showStatus: false)
                 }
             } catch {
@@ -3753,7 +3870,7 @@ private struct OpenAISettingsView: View {
             try plugin.importCodexLogin()
             oauthStatusMessage = String(localized: "Imported your existing Codex login.", bundle: bundle)
             selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
-            selectedReasoningEffort = plugin.reasoningEffort
+            syncReasoningEffortWithSelectedModel()
             refreshLLMModels(showStatus: false)
         } catch {
             oauthErrorMessage = error.localizedDescription

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -496,7 +496,8 @@ struct OpenAIResponsesClient: Sendable {
         systemPrompt: String,
         userText: String,
         model: String,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        temperature: Double?
     ) async throws -> String {
         guard let url = URL(string: "https://api.openai.com/v1/responses") else {
             throw OpenAIPluginError.invalidURL("https://api.openai.com/v1/responses")
@@ -512,7 +513,8 @@ struct OpenAIResponsesClient: Sendable {
                 model: model,
                 systemPrompt: systemPrompt,
                 userText: userText,
-                reasoningEffort: reasoningEffort
+                reasoningEffort: reasoningEffort,
+                temperature: temperature
             )
         )
 
@@ -537,7 +539,8 @@ struct OpenAIResponsesClient: Sendable {
         model: String,
         systemPrompt: String,
         userText: String,
-        reasoningEffort: String?
+        reasoningEffort: String?,
+        temperature: Double? = nil
     ) -> [String: Any] {
         let instructions = systemPrompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             ? "You are a helpful assistant."
@@ -562,6 +565,9 @@ struct OpenAIResponsesClient: Sendable {
 
         if let reasoningEffort, !reasoningEffort.isEmpty {
             body["reasoning"] = ["effort": reasoningEffort]
+        }
+        if let temperature {
+            body["temperature"] = temperature
         }
 
         return body
@@ -2380,7 +2386,12 @@ final class OpenAIPlugin: NSObject,
                     systemPrompt: systemPrompt,
                     userText: userText,
                     model: modelId,
-                    reasoningEffort: reasoningEffort
+                    reasoningEffort: reasoningEffort,
+                    temperature: resolvedTemperature(
+                        for: modelId,
+                        reasoningEffort: reasoningEffort,
+                        temperatureDirective: temperatureDirective
+                    )
                 )
             }
             return try await chatHelper.process(
@@ -3244,8 +3255,12 @@ final class OpenAIPlugin: NSObject,
 
     nonisolated static func chatCompletionTemperature(for modelID: String, reasoningEffort: String?) -> Double? {
         let lowered = modelID.lowercased()
-        if lowered.hasPrefix("gpt-5"), reasoningEffort?.isEmpty == false {
-            return nil
+        if lowered.hasPrefix("gpt-5") {
+            let supportsTemperatureAtNone = lowered.hasPrefix("gpt-5.1")
+                || lowered.hasPrefix("gpt-5.2")
+            return supportsTemperatureAtNone && reasoningEffort == OpenAIReasoningEffort.none.rawValue
+                ? 0.3
+                : nil
         }
         return 0.3
     }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -582,6 +582,86 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertFalse(OpenAIPlugin.usesResponsesAPI(for: "gpt-4o"))
     }
 
+    func testOpenAIReasoningEffortsMatchModelCapabilities() {
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5.6-sol"),
+            [.none, .low, .medium, .high, .xhigh, .max]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5.5"),
+            [.none, .low, .medium, .high, .xhigh]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5.4-pro-2026-03-05"),
+            [.medium, .high, .xhigh]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5.3-codex"),
+            [.low, .medium, .high, .xhigh]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5.1"),
+            [.none, .low, .medium, .high]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5"),
+            [.minimal, .low, .medium, .high]
+        )
+        XCTAssertEqual(
+            OpenAIPlugin.supportedReasoningEfforts(for: "o4-mini"),
+            [.low, .medium, .high]
+        )
+        XCTAssertEqual(OpenAIPlugin.supportedReasoningEfforts(for: "gpt-5-chat-latest"), [])
+        XCTAssertEqual(OpenAIPlugin.supportedReasoningEfforts(for: "gpt-4.1"), [])
+    }
+
+    func testOpenAIReasoningEffortFallsBackToModelDefault() {
+        XCTAssertEqual(OpenAIPlugin.effectiveReasoningEffort(.max, for: "gpt-5.6-luna"), .max)
+        XCTAssertEqual(OpenAIPlugin.effectiveReasoningEffort(.max, for: "gpt-5.5"), .medium)
+        XCTAssertEqual(
+            OpenAIPlugin.effectiveReasoningEffort(.max, for: "gpt-5.4"),
+            OpenAIReasoningEffort.none
+        )
+        XCTAssertEqual(OpenAIPlugin.effectiveReasoningEffort(.none, for: "gpt-5.4-pro"), .medium)
+        XCTAssertEqual(OpenAIPlugin.effectiveReasoningEffort(.low, for: "gpt-5-pro"), .high)
+        XCTAssertNil(OpenAIPlugin.effectiveReasoningEffort(.medium, for: "gpt-4.1"))
+    }
+
+    func testOpenAIProcessNormalizesPersistedReasoningEffortForSelectedModel() async throws {
+        let host = try PluginTestHostServices(
+            defaults: [
+                "selectedLLMModel": "gpt-5.5",
+                "reasoningEffort": "max",
+            ],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        #"{"output":[{"type":"message","content":[{"type":"output_text","text":"Done"}]}]}"#.utf8
+                    ),
+                    Self.httpResponse(url: "https://api.openai.com/v1/responses", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.process(systemPrompt: "Fix grammar", userText: "hello", model: nil)
+
+        XCTAssertEqual(result, "Done")
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let requestData = try XCTUnwrap(request.httpBody)
+        let requestBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requestData) as? [String: Any]
+        )
+        XCTAssertEqual(requestBody["model"] as? String, "gpt-5.5")
+        XCTAssertEqual((requestBody["reasoning"] as? [String: Any])?["effort"] as? String, "medium")
+    }
+
     func testOpenAIRealtimeRequestUsesRealtimeWhisperEndpointAndAuth() throws {
         let request = try OpenAIRealtimeTranscriptionSession.makeRequest(apiKey: "sk-test")
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -938,6 +938,30 @@ final class OpenAIPluginTests: XCTestCase {
         XCTAssertEqual(input.first?["role"] as? String, "user")
     }
 
+    func testOpenAIResponsesRequestPreservesCustomTemperatureForGPT51AtNone() async throws {
+        try await assertOpenAIResponsesRequestTemperature(
+            model: "gpt-5.1",
+            reasoningEffort: "none",
+            expectedTemperature: 0.7
+        )
+    }
+
+    func testOpenAIResponsesRequestPreservesCustomTemperatureForGPT52AtNone() async throws {
+        try await assertOpenAIResponsesRequestTemperature(
+            model: "gpt-5.2",
+            reasoningEffort: "none",
+            expectedTemperature: 0.7
+        )
+    }
+
+    func testOpenAIResponsesRequestOmitsCustomTemperatureForGPT52AboveNone() async throws {
+        try await assertOpenAIResponsesRequestTemperature(
+            model: "gpt-5.2",
+            reasoningEffort: "medium",
+            expectedTemperature: nil
+        )
+    }
+
     func testOpenAIResponsesParserExtractsOutputText() throws {
         let data = Data(
             """
@@ -1206,6 +1230,51 @@ final class OpenAIPluginTests: XCTestCase {
             httpVersion: nil,
             headerFields: nil
         )!
+    }
+
+    private func assertOpenAIResponsesRequestTemperature(
+        model: String,
+        reasoningEffort: String,
+        expectedTemperature: Double?
+    ) async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["reasoningEffort": reasoningEffort],
+            secrets: ["api-key": "sk-live"]
+        )
+        let plugin = OpenAIPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        #"{"output":[{"type":"message","content":[{"type":"output_text","text":"Done"}]}]}"#.utf8
+                    ),
+                    Self.httpResponse(url: "https://api.openai.com/v1/responses", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.process(
+            systemPrompt: "Fix grammar",
+            userText: "hello",
+            model: model,
+            temperatureDirective: .custom(0.7)
+        )
+
+        XCTAssertEqual(result, "Done")
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        let requestData = try XCTUnwrap(request.httpBody)
+        let requestBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requestData) as? [String: Any]
+        )
+        XCTAssertEqual(requestBody["model"] as? String, model)
+        XCTAssertEqual(
+            (requestBody["reasoning"] as? [String: Any])?["effort"] as? String,
+            reasoningEffort
+        )
+        XCTAssertEqual(requestBody["temperature"] as? Double, expectedTemperature)
     }
 }
 


### PR DESCRIPTION
## Summary

OpenAI models expose different subsets and defaults for `reasoning.effort`, but the existing settings used the same Low/Medium/High/X High picker for every GPT-5, o-series, and Codex model. That could leave a persisted effort selected that the current model does not support.

This PR:

- moves Reasoning Effort into the expandable Advanced section alongside temperature controls
- adds the officially documented `none`, `minimal`, and `max` values
- exposes only the effort levels supported by the selected OpenAI model family
- falls back to the model default before sending a request when a persisted value is unsupported
- keeps API-key and ChatGPT/Codex request paths consistent
- preserves custom temperature for GPT-5.1 and GPT-5.2 when the effective reasoning effort is `none`, while omitting it for higher efforts
- localizes the new Advanced, None, and Maximum labels in German, Japanese, and Simplified Chinese

The capability matrix follows the OpenAI reasoning guide and the individual model pages: https://developers.openai.com/api/docs/guides/reasoning

## Test Plan

- [x] `swift test --package-path TypeWhisperPluginSDK --filter OpenAIPluginTests` - 47 tests passed
- [x] `swift test --package-path TypeWhisperPluginSDK` - 647 tests passed, 2 live CLI tests skipped
- [x] `jq empty TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Localizable.xcstrings`
- [x] Verified every OpenAI catalog entry has non-empty `de`, `ja`, and `zh-Hans` values with `jq`
- [x] `git diff --check`
- [ ] Manual settings UI smoke test not run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model-specific reasoning effort options: None, Minimal, and Maximum.
  * Automatically selects a supported reasoning level when changing models or authentication.
  * Moved reasoning controls into an expandable Advanced settings section.
  * Added German, Japanese, and Simplified Chinese translations for new settings.
  * Added model-specific temperature controls for supported requests.

* **Bug Fixes**
  * Prevented unsupported or invalid reasoning settings and temperature values from being sent to the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->