### PR TITLE
Fix command palette layout crash during translation

### DIFF
--- a/TypeWhisper/Views/SelectionPalettePanel.swift
+++ b/TypeWhisper/Views/SelectionPalettePanel.swift
@@ -398,6 +398,9 @@ final class SelectionPaletteController: SelectionPaletteControlling {
         )
 
         let hosting = NSHostingView(rootView: contentView)
+        // The panel owns its fixed content size. Prevent SwiftUI from feeding
+        // intrinsic and min/max sizes back into the window constraint cycle.
+        hosting.sizingOptions = []
         hosting.translatesAutoresizingMaskIntoConstraints = true
         hostingView = hosting
 

--- a/TypeWhisper/Views/TranslationHostWindow.swift
+++ b/TypeWhisper/Views/TranslationHostWindow.swift
@@ -35,9 +35,13 @@ final class TranslationHostWindow: NSWindow {
         level = .init(rawValue: Int(CGWindowLevelForKey(.minimumWindow)) - 1)
         collectionBehavior = [.canJoinAllSpaces, .stationary]
 
-        contentView = NSHostingView(
+        let hostingView = NSHostingView(
             rootView: TranslationHostView(translationService: translationService)
         )
+        // This window owns its fixed 1x1 size while SwiftUI recreates the
+        // translation task. Do not feed SwiftUI sizing back into AppKit.
+        hostingView.sizingOptions = []
+        contentView = hostingView
 
         orderFrontRegardless()
     }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import TypeWhisperPluginSDK
 import XCTest
 @testable import TypeWhisper
@@ -283,6 +284,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
 
         var capturedPrompt: String?
         var pasteCount = 0
+        let pasteExpectation = expectation(description: "Rich-text workflow pastes its result")
         let controller = PromptPaletteControllerSpy()
         let handler = PromptPaletteHandler(
             textInsertionService: textInsertionService,
@@ -306,6 +308,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
         )
         textInsertionService.pasteSimulatorOverride = {
             pasteCount += 1
+            pasteExpectation.fulfill()
         }
 
         handler.processWorkflowDirectly(
@@ -314,7 +317,7 @@ final class PromptPaletteHandlerTests: XCTestCase {
             soundFeedbackEnabled: false
         )
 
-        try await Task.sleep(for: .milliseconds(100))
+        await fulfillment(of: [pasteExpectation], timeout: 2.0)
 
         XCTAssertFalse(controller.isVisible)
         XCTAssertNil(insertedText)
@@ -761,6 +764,59 @@ private final class PromptPaletteActionPluginSpy: NSObject, ActionPlugin, @unche
         ActionResult(success: true, message: "Done")
     }
 }
+
+@MainActor
+final class SelectionPaletteControllerTests: XCTestCase {
+    func testHostedPaletteDoesNotPropagateSwiftUISizingIntoPanelConstraints() throws {
+        let controller = SelectionPaletteController()
+        controller.show(
+            configuration: SelectionPaletteConfiguration(
+                panelWidth: 420,
+                panelHeight: 360,
+                searchPrompt: "Search prompts",
+                emptyStateTitle: "No prompts"
+            ),
+            items: [
+                SelectionPaletteItem(id: UUID(), title: "Translate to English"),
+                SelectionPaletteItem(id: UUID(), title: "Summarize"),
+            ],
+            onSelect: { _ in }
+        )
+        defer { controller.hide() }
+
+        let panel = try XCTUnwrap(activePanel(in: controller))
+        let hostingView = try XCTUnwrap(panel.contentView as? any HostingSizingOptionsProviding)
+
+        XCTAssertEqual(hostingView.sizingOptions, [])
+    }
+
+    private func activePanel(in controller: SelectionPaletteController) -> NSPanel? {
+        Mirror(reflecting: controller)
+            .descendant("panel", "some") as? NSPanel
+    }
+}
+
+@MainActor
+private protocol HostingSizingOptionsProviding {
+    var sizingOptions: NSHostingSizingOptions { get }
+}
+
+extension NSHostingView: HostingSizingOptionsProviding {}
+
+#if canImport(Translation)
+@available(macOS 15, *)
+@MainActor
+final class TranslationHostWindowTests: XCTestCase {
+    func testHostedTranslationViewDoesNotPropagateSwiftUISizingIntoWindowConstraints() throws {
+        let window = TranslationHostWindow(translationService: TranslationService())
+        defer { window.orderOut(nil) }
+
+        let hostingView = try XCTUnwrap(window.contentView as? any HostingSizingOptionsProviding)
+
+        XCTAssertEqual(hostingView.sizingOptions, [])
+    }
+}
+#endif
 
 @MainActor
 final class SelectionPaletteInteractionModelTests: XCTestCase {


### PR DESCRIPTION
## Context

A user running TypeWhisper 1.6.0 (build 1111) on macOS 26.5.2 reported an intermittent crash after opening the command palette with the right Command key and selecting “Translate to English.” The crash report points to an AppKit constraint-update exception reached through `NSHostingView.updateWindowContentSizeExtremaIfNecessary`.

This is a crash-only follow-up to [the report on PR #1142](https://github.com/TypeWhisper/typewhisper-mac/pull/1142#issuecomment-5412969479). It is intentionally separate from the Recorder/WhisperKit transcript investigation in #1091 and does not close that issue.

## Changes

- Disable SwiftUI window sizing propagation for the fixed-size selection palette host.
- Apply the same protection to the fixed 1×1 Apple Translation host while its translation task is recreated.
- Add regression coverage for both hosting views.
- Replace a fixed delay in the related rich-text workflow test with a deterministic paste expectation.

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` (1,628 tests passed)
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/RecentTranscriptionPaletteHandlerTests -only-testing:TypeWhisperTests/PromptPaletteHandlerTests -only-testing:TypeWhisperTests/SelectionPaletteControllerTests -only-testing:TypeWhisperTests/TranslationHostWindowTests -only-testing:TypeWhisperTests/SelectionPaletteInteractionModelTests -only-testing:TypeWhisperTests/WorkflowServiceTests/testWorkflowTextProcessingServiceUsesAppleTranslatorWithNormalizedLanguages` (21 tests passed)
- `scripts/check_release_binary_instrumentation.sh --self-test`
- `scripts/check_release_signing.sh --self-test`
- `swift test --package-path TypeWhisperPluginSDK --filter 'MCPClientPluginTests.testStreamableHTTPContractSupportsNoAuthenticationAndBearerToken'`

`./scripts/pr-preflight.sh origin/main` currently stops at 40 missing zh-Hans localizations in `AuthenticatedCLIPlugin`; the same failure reproduces on a clean `origin/main` worktree and is unrelated to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved palette and translation window sizing to remain at their intended dimensions.
  * Prevented SwiftUI content sizing from affecting AppKit panel and window constraints.

* **Tests**
  * Added coverage to verify fixed sizing behavior.
  * Improved rich-text workflow tests by waiting for paste completion explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->