### PR TITLE
Add plugin UI contributions for TypeWhisper 1.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Optional exact release tag (for example v1.6.0-daily.20260719.1)
+        description: Optional exact release tag (for example v1.7.0-daily.20260825.1)
         required: false
         type: string
       without_icloud:

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5041,7 +5041,7 @@
 				ICLOUD_CONTAINER_ID = iCloud.com.typewhisper.sync.dev;
 				INFOPLIST_FILE = TypeWhisperICloudBridge/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.icloudbridge;
 				PRODUCT_NAME = TypeWhisperICloudBridge;
 				SKIP_INSTALL = YES;
@@ -5064,7 +5064,7 @@
 				ICLOUD_CONTAINER_ID = iCloud.com.typewhisper.sync;
 				INFOPLIST_FILE = TypeWhisperICloudBridge/Info.plist;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.typewhisper-mac;
 				PRODUCT_NAME = TypeWhisperICloudBridge;
 				PROVISIONING_PROFILE_SPECIFIER = "$(TYPEWHISPER_ICLOUD_HELPER_PROFILE_SPECIFIER)";
@@ -5270,7 +5270,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -5303,7 +5303,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac;
 				PRODUCT_NAME = TypeWhisper;
 				SWIFT_OBJC_BRIDGING_HEADER = TypeWhisper/TypeWhisper-Bridging-Header.h;
@@ -5321,7 +5321,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
@@ -5334,7 +5334,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_NAME = "typewhisper-cli";
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 6.0;
@@ -6008,7 +6008,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -6036,7 +6036,7 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MARKETING_VERSION = 1.6.0;
+				MARKETING_VERSION = 1.7.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -353,6 +353,7 @@ struct TypeWhisperApp<WindowConfiguration: ManagedAppWindowSceneConfiguration>: 
             CommandGroup(after: .appInfo) {
                 ManagedWindowOpenerRegistrar()
             }
+            PluginAppCommands(pluginManager: ServiceContainer.shared.pluginManager)
         }
 
         WindowConfiguration.settings(content: AnyView(settingsContent))

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1,6 +1,22 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "No Integration Commands" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Keine Integrationsbefehle"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有集成命令"
+          }
+        }
+      }
+    },
     "" : {
       "localizations" : {
         "de" : {
@@ -40318,6 +40334,8 @@
     "Save Changes?" : {"localizations":{"de":{"stringUnit":{"state":"translated","value":"Änderungen speichern?"}},"ja":{"stringUnit":{"state":"translated","value":"変更を保存しますか？"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"保存更改？"}}}},
     "Save or discard your changes before leaving this entry." : {"localizations":{"de":{"stringUnit":{"state":"translated","value":"Speichere oder verwirf deine Änderungen, bevor du diesen Eintrag verlässt."}},"ja":{"stringUnit":{"state":"translated","value":"この項目を離れる前に変更を保存または破棄してください。"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"离开此条目前，请保存或放弃更改。"}}}},
     "Smart Mailboxes" : {"localizations":{"de":{"stringUnit":{"state":"translated","value":"Intelligente Postfächer"}},"ja":{"stringUnit":{"state":"translated","value":"スマートメールボックス"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"智能邮箱"}}}},
+    "Enable the integration to open this page." : {"localizations":{"de":{"stringUnit":{"state":"translated","value":"Aktiviere die Integration, um diese Seite zu öffnen."}},"ja":{"stringUnit":{"state":"translated","value":"このページを開くにはインテグレーションを有効にしてください。"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"启用集成后即可打开此页面。"}}}},
+    "Integration Unavailable" : {"localizations":{"de":{"stringUnit":{"state":"translated","value":"Integration nicht verfügbar"}},"ja":{"stringUnit":{"state":"translated","value":"インテグレーションを利用できません"}},"zh-Hans":{"stringUnit":{"state":"translated","value":"集成不可用"}}}},
     "calendarMeeting.settings.howItWorks" : {
       "localizations" : {
         "de" : {

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -168,10 +168,13 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
         }
     }
 
-    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool {
+    func enqueueImportedMediaForTranscription(
+        _ media: PluginImportedMedia,
+        fromMediaImporterId mediaImporterId: String
+    ) async -> Bool {
         await MainActor.run { [pluginId] in
             guard let importer = PluginManager.shared?.mediaImportPlugins.first(where: {
-                type(of: $0).pluginId == pluginId
+                type(of: $0).pluginId == pluginId && $0.mediaImportId == mediaImporterId
             }) else {
                 return false
             }

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -150,6 +150,35 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
         }
     }
 
+    func openPluginSettings() {
+        DispatchQueue.main.async { [pluginId] in
+            guard let plugin = PluginManager.shared?.loadedPlugins.first(where: {
+                $0.id == pluginId && $0.isEnabled && $0.isRuntimeLoaded
+            }) else { return }
+            PluginSettingsWindowManager.shared.present(plugin)
+        }
+    }
+
+    func openSettingsSidebarItem(_ itemId: String) {
+        DispatchQueue.main.async { [pluginId] in
+            SettingsNavigationCoordinator.shared.navigate(
+                to: .plugin(pluginId: pluginId, itemId: itemId)
+            )
+            ManagedAppWindowOpener.shared.open(id: "settings")
+        }
+    }
+
+    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool {
+        await MainActor.run { [pluginId] in
+            guard let importer = PluginManager.shared?.mediaImportPlugins.first(where: {
+                type(of: $0).pluginId == pluginId
+            }) else {
+                return false
+            }
+            return FileTranscriptionViewModel.shared.enqueueImportedMedia(media, from: importer)
+        }
+    }
+
     // MARK: - Streaming Display
 
     func setStreamingDisplayActive(_ active: Bool) {

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftUI
 import TypeWhisperPluginSDK
 import os.log
 
@@ -234,6 +235,20 @@ enum PluginModelManagementError: LocalizedError {
 // MARK: - Plugin Manager
 
 @MainActor
+struct PluginUserInterfaceContribution {
+    let pluginId: String
+    let pluginName: String
+    let provider: any PluginUserInterfaceProviding
+    let appMenuCommands: [PluginCommandDescriptor]
+    let primaryMenuBarCommands: [PluginCommandDescriptor]
+    let settingsSidebarItems: [PluginSettingsSidebarItemDescriptor]
+
+    var allCommands: [PluginCommandDescriptor] {
+        appMenuCommands + primaryMenuBarCommands
+    }
+}
+
+@MainActor
 final class PluginManager: ObservableObject {
     nonisolated(unsafe) static var shared: PluginManager!
 
@@ -245,6 +260,41 @@ final class PluginManager: ObservableObject {
     private var ruleNamesProvider: @MainActor () -> [String] = { [] }
     private var workflowProvider: @MainActor () -> [PluginWorkflowInfo] = { [] }
     private var deletingModelPluginIds = Set<String>()
+
+    var userInterfaceContributions: [PluginUserInterfaceContribution] {
+        loadedPlugins.compactMap { plugin in
+            guard plugin.isEnabled,
+                  let provider = plugin.instance as? any PluginUserInterfaceProviding else {
+                return nil
+            }
+            return PluginUserInterfaceContribution(
+                pluginId: plugin.manifest.id,
+                pluginName: plugin.manifest.name,
+                provider: provider,
+                appMenuCommands: provider.appMenuCommands,
+                primaryMenuBarCommands: provider.primaryMenuBarCommands,
+                settingsSidebarItems: provider.settingsSidebarItems
+            )
+        }
+    }
+
+    func settingsSidebarView(pluginId: String, itemId: String) -> AnyView? {
+        guard let contribution = userInterfaceContributions.first(where: { $0.pluginId == pluginId }),
+              contribution.settingsSidebarItems.contains(where: { $0.id == itemId }) else {
+            return nil
+        }
+        return contribution.provider.settingsSidebarView(for: itemId)
+    }
+
+    @discardableResult
+    func performPluginCommand(pluginId: String, commandId: String) -> Bool {
+        guard let contribution = userInterfaceContributions.first(where: { $0.pluginId == pluginId }),
+              contribution.allCommands.contains(where: { $0.id == commandId && $0.isEnabled }) else {
+            return false
+        }
+        contribution.provider.performPluginCommand(commandId)
+        return true
+    }
 
     var postProcessors: [PostProcessorPlugin] {
         loadedPlugins
@@ -258,6 +308,21 @@ final class PluginManager: ObservableObject {
             .filter { $0.isEnabled }
             .compactMap { $0.instance as? FileJobAutomationPlugin }
             .sorted { $0.priority < $1.priority }
+    }
+
+    var mediaImportPlugins: [any MediaImportPlugin] {
+        loadedPlugins
+            .filter { $0.isEnabled }
+            .flatMap { plugin -> [any MediaImportPlugin] in
+                var importers: [any MediaImportPlugin] = []
+                if let importer = plugin.instance as? any MediaImportPlugin {
+                    importers.append(importer)
+                }
+                if let expanded = plugin.instance as? any AdditionalMediaImportPluginsProviding {
+                    importers.append(contentsOf: expanded.additionalMediaImportPlugins)
+                }
+                return importers
+            }
     }
 
     var llmProviders: [LLMProviderPlugin] {

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -574,8 +574,13 @@ final class FileTranscriptionViewModel: ObservableObject {
     }
 
     private static func validateImportedMedia(_ media: PluginImportedMedia) throws {
+        var isDirectory: ObjCBool = false
         guard media.localFileURL.isFileURL,
-              FileManager.default.fileExists(atPath: media.localFileURL.path),
+              FileManager.default.fileExists(
+                atPath: media.localFileURL.path,
+                isDirectory: &isDirectory
+              ),
+              !isDirectory.boolValue,
               AudioFileService.supportedExtensions.contains(
                 media.localFileURL.pathExtension.lowercased()
               ) else {

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -41,6 +41,9 @@ final class FileTranscriptionViewModel: ObservableObject {
     struct FileItem: Identifiable {
         let id = UUID()
         let url: URL
+        let displayName: String?
+        let importedMedia: PluginImportedMedia?
+        let mediaImporter: (any MediaImportPlugin)?
         var state: FileItemState = .pending
         var result: TranscriptionResult?
         var errorMessage: String?
@@ -51,7 +54,19 @@ final class FileTranscriptionViewModel: ObservableObject {
         var startedAt: Date?
         var finishedAt: Date?
 
-        var fileName: String { url.lastPathComponent }
+        init(
+            url: URL,
+            displayName: String? = nil,
+            importedMedia: PluginImportedMedia? = nil,
+            mediaImporter: (any MediaImportPlugin)? = nil
+        ) {
+            self.url = url
+            self.displayName = displayName
+            self.importedMedia = importedMedia
+            self.mediaImporter = mediaImporter
+        }
+
+        var fileName: String { displayName ?? url.lastPathComponent }
     }
 
     enum FileItemState: Equatable {
@@ -264,8 +279,28 @@ final class FileTranscriptionViewModel: ObservableObject {
         files.append(contentsOf: newFiles)
     }
 
+    @discardableResult
+    func enqueueImportedMedia(
+        _ importedMedia: PluginImportedMedia,
+        from importer: any MediaImportPlugin
+    ) -> Bool {
+        guard (try? Self.validateImportedMedia(importedMedia)) != nil,
+              !files.contains(where: { $0.url == importedMedia.localFileURL }) else {
+            return false
+        }
+
+        files.append(FileItem(
+            url: importedMedia.localFileURL,
+            displayName: importedMedia.displayName,
+            importedMedia: importedMedia,
+            mediaImporter: importer
+        ))
+        return true
+    }
+
     func removeFile(_ item: FileItem) {
         files.removeAll { $0.id == item.id }
+        removeImportedMedia(for: item)
         if files.isEmpty {
             batchState = .idle
         }
@@ -503,7 +538,11 @@ final class FileTranscriptionViewModel: ObservableObject {
 
     func reset() {
         cancelTranscription()
+        let importedItems = files.filter { $0.importedMedia != nil }
         files = []
+        for item in importedItems {
+            removeImportedMedia(for: item)
+        }
         batchState = .idle
         currentIndex = 0
         activeBatchTask = nil
@@ -524,6 +563,24 @@ final class FileTranscriptionViewModel: ObservableObject {
 
         guard let engine = resolvedEngine else { return false }
         return modelManager.canPrepareForTranscription(engine)
+    }
+
+    private func removeImportedMedia(for item: FileItem) {
+        guard let importedMedia = item.importedMedia,
+              let mediaImporter = item.mediaImporter else { return }
+        Task {
+            await mediaImporter.removeImportedMedia(importedMedia)
+        }
+    }
+
+    private static func validateImportedMedia(_ media: PluginImportedMedia) throws {
+        guard media.localFileURL.isFileURL,
+              FileManager.default.fileExists(atPath: media.localFileURL.path),
+              AudioFileService.supportedExtensions.contains(
+                media.localFileURL.pathExtension.lowercased()
+              ) else {
+            throw CocoaError(.fileReadUnsupportedScheme)
+        }
     }
 
     private func reconcileSelectionWithAvailablePlugins() {

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import Combine
+import TypeWhisperPluginSDK
 
 /// Lightweight state tracker for MenuBarView that only re-publishes
 /// on menu-relevant changes, avoiding high-frequency audioLevel updates.
@@ -257,9 +258,67 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
     }
 }
 
+private struct PluginCommandButton: View {
+    let pluginId: String
+    let command: PluginCommandDescriptor
+    @ObservedObject var pluginManager: PluginManager
+
+    var body: some View {
+        Button {
+            pluginManager.performPluginCommand(pluginId: pluginId, commandId: command.id)
+        } label: {
+            if let systemImageName = command.systemImageName {
+                Label {
+                    Text(verbatim: command.title)
+                } icon: {
+                    Image(systemName: systemImageName)
+                }
+            } else {
+                Text(verbatim: command.title)
+            }
+        }
+        .disabled(!command.isEnabled)
+    }
+}
+
+struct PluginAppCommands: Commands {
+    @ObservedObject var pluginManager: PluginManager
+
+    var body: some Commands {
+        CommandMenu(String(localized: "Integrations")) {
+            let contributions = pluginManager.userInterfaceContributions.filter {
+                !$0.appMenuCommands.isEmpty
+            }
+            if contributions.isEmpty {
+                Button(String(localized: "No Integration Commands")) {}
+                    .disabled(true)
+            } else {
+                ForEach(contributions, id: \.pluginId) { contribution in
+                    Menu {
+                        ForEach(contribution.appMenuCommands) { command in
+                            PluginCommandButton(
+                                pluginId: contribution.pluginId,
+                                command: command,
+                                pluginManager: pluginManager
+                            )
+                        }
+                    } label: {
+                        Text(verbatim: contribution.pluginName)
+                    }
+                }
+            }
+        }
+    }
+}
+
 struct MenuBarView: View {
     @Environment(\.openWindow) private var openWindow
     @StateObject private var status = MenuBarState()
+    @ObservedObject private var pluginManager: PluginManager
+
+    init(pluginManager: PluginManager = PluginManager.shared) {
+        self._pluginManager = ObservedObject(wrappedValue: pluginManager)
+    }
 
     var body: some View {
         Group {
@@ -279,6 +338,28 @@ struct MenuBarView: View {
                 Section(String(localized: section.titleResource)) {
                     ForEach(section.items(hasRecoverableRecording: status.hasRecoverableRecording), id: \.self) { item in
                         menuItem(for: item)
+                    }
+                }
+            }
+
+            let pluginContributions = pluginManager.userInterfaceContributions.filter {
+                !$0.primaryMenuBarCommands.isEmpty
+            }
+            if !pluginContributions.isEmpty {
+                Divider()
+                Section(String(localized: "Integrations")) {
+                    ForEach(pluginContributions, id: \.pluginId) { contribution in
+                        Menu {
+                            ForEach(contribution.primaryMenuBarCommands) { command in
+                                PluginCommandButton(
+                                    pluginId: contribution.pluginId,
+                                    command: command,
+                                    pluginManager: pluginManager
+                                )
+                            }
+                        } label: {
+                            Text(verbatim: contribution.pluginName)
+                        }
                     }
                 }
             }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -5,6 +5,7 @@ import TypeWhisperPluginSDK
 enum SettingsTab: Hashable {
     case home, general, dictation, hotkeys, recorder
     case dictationRecovery, fileTranscription, history, statistics, dictionary, snippets, workflows, profiles, prompts, premium, integrations, advanced, license, about
+    case plugin(pluginId: String, itemId: String)
 }
 
 private struct SettingsDestination: Identifiable, Hashable {
@@ -29,6 +30,7 @@ struct SettingsView: View {
     @ObservedObject private var homeViewModel = HomeViewModel.shared
     @ObservedObject private var promptActionsViewModel = PromptActionsViewModel.shared
     @ObservedObject private var settingsNavigation = SettingsNavigationCoordinator.shared
+    @ObservedObject private var pluginManager = PluginManager.shared
 
     init() {
         _selectedTab = State(initialValue: Self.initialScreenshotTab)
@@ -60,7 +62,7 @@ struct SettingsView: View {
     }
 
     private var destinations: [SettingsDestination] {
-        [
+        let builtInDestinations = [
             SettingsDestination(tab: .home, title: String(localized: "Home"), systemImage: "house", badge: nil),
             SettingsDestination(tab: .general, title: String(localized: "General"), systemImage: "gear", badge: nil),
             SettingsDestination(tab: .dictation, title: String(localized: "Dictation"), systemImage: "mic.fill", badge: nil),
@@ -109,6 +111,19 @@ struct SettingsView: View {
             SettingsDestination(tab: .license, title: String(localized: "License"), systemImage: "key", badge: nil),
             SettingsDestination(tab: .about, title: String(localized: "About"), systemImage: "info.circle", badge: nil)
         ].compactMap { $0 }
+
+        let pluginDestinations = pluginManager.userInterfaceContributions.flatMap { contribution in
+            contribution.settingsSidebarItems.map { item in
+                SettingsDestination(
+                    tab: .plugin(pluginId: contribution.pluginId, itemId: item.id),
+                    title: item.title,
+                    systemImage: item.systemImageName,
+                    badge: nil
+                )
+            }
+        }
+
+        return builtInDestinations + pluginDestinations
     }
 
     private var destinationSections: [SettingsDestinationSection] {
@@ -232,6 +247,16 @@ struct SettingsView: View {
             LicenseSettingsView()
         case .about:
             AboutSettingsView()
+        case .plugin(let pluginId, let itemId):
+            if let view = pluginManager.settingsSidebarView(pluginId: pluginId, itemId: itemId) {
+                view
+            } else {
+                ContentUnavailableView(
+                    String(localized: "Integration Unavailable"),
+                    systemImage: "puzzlepiece.extension",
+                    description: Text(String(localized: "Enable the integration to open this page."))
+                )
+            }
         }
     }
 }
@@ -494,7 +519,7 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         settingsDestination(destinations, .recorder)
     ])
 
-    var workspaceDestinations = [
+    let workspaceDestinations = [
         settingsDestination(destinations, .history),
         settingsDestination(destinations, .statistics),
         settingsDestination(destinations, .dictionary),
@@ -503,7 +528,12 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         settingsDestination(destinations, .premium)
     ]
 
-    workspaceDestinations.append(settingsDestination(destinations, .integrations))
+    let pluginDestinations = destinations.filter {
+        if case .plugin = $0.tab { return true }
+        return false
+    }
+
+    let integrationDestinations = [settingsDestination(destinations, .integrations)] + pluginDestinations
 
     return [
         SettingsDestinationSection(
@@ -517,6 +547,10 @@ private func settingsDestinationSections(_ destinations: [SettingsDestination]) 
         SettingsDestinationSection(
             id: "workspace",
             destinations: workspaceDestinations
+        ),
+        SettingsDestinationSection(
+            id: "integrations",
+            destinations: integrationDestinations
         ),
         SettingsDestinationSection(
             id: "system",

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -19,6 +19,8 @@ The first-party plugin sources that ship with this repository now live under
 | `TTSProviderPlugin` | Add text-to-speech providers for spoken feedback and readback | Yes (playback session) |
 | `TranscriptionEnginePlugin` | Custom transcription engines | Yes (transcription result) |
 | `ActionPlugin` | Route LLM output to custom actions (e.g. create Linear issues) | Yes (action result) |
+| `MediaImportPlugin` | Resolve a remote media link into a temporary local file | Yes (imported media) |
+| `PluginUserInterfaceProviding` | Add host-rendered menu commands and plugin-owned settings-sidebar pages | No |
 
 For transcription plugins, dictionary-term support remains optional. Engines that
 have documented input limits can additionally conform to `DictionaryTermsBudgetProviding`
@@ -75,7 +77,35 @@ Each plugin receives a `HostServices` object providing:
 - **Rules**: `availableRuleNames` - list of user-defined rule names
 - **Event Bus**: `eventBus` for subscribing to events
 - **Capabilities**: `notifyCapabilitiesChanged()` - notify the host when plugin state changes (e.g. model loaded/unloaded)
+- **Settings**: `openPluginSettings()` - ask TypeWhisper to open this plugin's host-managed settings window
+- **Settings sidebar**: `openSettingsSidebarItem(_:)` - open a sidebar page contributed by this plugin
+- **Imported media**: `enqueueImportedMediaForTranscription(_:)` - hand downloaded media to TypeWhisper's transcription queue
 - **Streaming display hint**: `setStreamingDisplayActive(_:)` - tell TypeWhisper that your plugin renders its own streaming UI
+
+### Menu and menu-bar contributions (TypeWhisper 1.7+)
+
+Plugins can optionally conform to `PluginUserInterfaceProviding` and return
+localized `PluginCommandDescriptor` values in one or more placements:
+
+- `appMenuCommands` appear in TypeWhisper's **Integrations** application menu,
+  grouped in a submenu named after the plugin.
+- `primaryMenuBarCommands` appear in the existing TypeWhisper menu-bar menu.
+- `settingsSidebarItems` appear in the **Integrations** group of TypeWhisper's
+  settings sidebar. The host requests their SwiftUI content through
+  `settingsSidebarView(for:)`.
+
+TypeWhisper owns the native menu objects, removes commands when the plugin is
+disabled, and routes declared command identifiers back through
+`performPluginCommand(_:)`. If a plugin changes its descriptors at runtime, it
+must call `HostServices.notifyCapabilitiesChanged()`. Plugins using this API
+should declare `"minHostVersion": "1.7.0"` in their manifest.
+
+Media-import plugins download or otherwise resolve a URL into a local media
+file. They can hand that file to the host with
+`enqueueImportedMediaForTranscription(_:)`, while the host retains
+responsibility for audio loading, transcription-engine selection, progress,
+subtitles, and batch processing. The host returns temporary imports to the
+plugin for cleanup when a queue item is removed.
 
 Bundled MLX plugins such as Qwen3, Granite, and Voxtral store their optional HuggingFace token via the same plugin-scoped keychain helpers.
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -32,6 +32,16 @@ public protocol HostServices: Sendable {
     // Notify host that plugin capabilities changed (e.g. model loaded/unloaded)
     func notifyCapabilitiesChanged()
 
+    // Present this plugin's host-managed settings window, when available.
+    func openPluginSettings()
+
+    // Open a settings-sidebar page contributed by this plugin.
+    func openSettingsSidebarItem(_ itemId: String)
+
+    // Add media produced by this plugin to TypeWhisper's transcription queue.
+    // Returns false when the plugin is inactive or the media is rejected.
+    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool
+
     // Streaming display: call with true when the plugin provides its own streaming text UI,
     // so the built-in indicator suppresses its streaming text display.
     func setStreamingDisplayActive(_ active: Bool)
@@ -47,6 +57,12 @@ public extension HostServices {
     }
 
     var availableWorkflows: [PluginWorkflowInfo] { [] }
+
+    func openPluginSettings() {}
+
+    func openSettingsSidebarItem(_ itemId: String) {}
+
+    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool { false }
 
     @available(*, deprecated, renamed: "availableRuleNames")
     var availableProfileNames: [String] { availableRuleNames }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -38,9 +38,13 @@ public protocol HostServices: Sendable {
     // Open a settings-sidebar page contributed by this plugin.
     func openSettingsSidebarItem(_ itemId: String)
 
-    // Add media produced by this plugin to TypeWhisper's transcription queue.
-    // Returns false when the plugin is inactive or the media is rejected.
-    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool
+    // Add media produced by one of this plugin's importers to TypeWhisper's
+    // transcription queue. Returns false when the plugin/importer is inactive
+    // or the media is rejected.
+    func enqueueImportedMediaForTranscription(
+        _ media: PluginImportedMedia,
+        fromMediaImporterId mediaImporterId: String
+    ) async -> Bool
 
     // Streaming display: call with true when the plugin provides its own streaming text UI,
     // so the built-in indicator suppresses its streaming text display.
@@ -62,7 +66,10 @@ public extension HostServices {
 
     func openSettingsSidebarItem(_ itemId: String) {}
 
-    func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool { false }
+    func enqueueImportedMediaForTranscription(
+        _ media: PluginImportedMedia,
+        fromMediaImporterId mediaImporterId: String
+    ) async -> Bool { false }
 
     @available(*, deprecated, renamed: "availableRuleNames")
     var availableProfileNames: [String] { availableRuleNames }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -30,6 +30,68 @@ public extension PluginSettingsWindowLayoutProviding {
     var minimumSettingsWindowSize: CGSize? { nil }
 }
 
+// MARK: - Plugin User Interface Contributions
+
+/// A host-rendered command contributed by a plugin.
+///
+/// Titles must already be localized by the plugin. Command identifiers are
+/// scoped to the plugin and are passed back to `performPluginCommand(_:)`.
+public struct PluginCommandDescriptor: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let systemImageName: String?
+    public let isEnabled: Bool
+
+    public init(
+        id: String,
+        title: String,
+        systemImageName: String? = nil,
+        isEnabled: Bool = true
+    ) {
+        self.id = id
+        self.title = title
+        self.systemImageName = systemImageName
+        self.isEnabled = isEnabled
+    }
+}
+
+/// A plugin-owned destination rendered in TypeWhisper's settings sidebar.
+///
+/// Titles must already be localized by the plugin. Identifiers are scoped to
+/// the plugin and are passed to `settingsSidebarView(for:)` when selected.
+public struct PluginSettingsSidebarItemDescriptor: Identifiable, Sendable, Equatable {
+    public let id: String
+    public let title: String
+    public let systemImageName: String
+
+    public init(id: String, title: String, systemImageName: String) {
+        self.id = id
+        self.title = title
+        self.systemImageName = systemImageName
+    }
+}
+
+/// Optional capability for contributing commands to TypeWhisper's application
+/// menu and primary menu-bar menu, plus plugin-owned settings-sidebar pages.
+///
+/// The host owns all native menu objects. Call
+/// `HostServices.notifyCapabilitiesChanged()` after changing a descriptor so
+/// the host refreshes the rendered menus and sidebar.
+public protocol PluginUserInterfaceProviding: TypeWhisperPlugin {
+    @MainActor var appMenuCommands: [PluginCommandDescriptor] { get }
+    @MainActor var primaryMenuBarCommands: [PluginCommandDescriptor] { get }
+    @MainActor var settingsSidebarItems: [PluginSettingsSidebarItemDescriptor] { get }
+    @MainActor func settingsSidebarView(for itemId: String) -> AnyView?
+    @MainActor func performPluginCommand(_ commandId: String)
+}
+
+public extension PluginUserInterfaceProviding {
+    @MainActor var appMenuCommands: [PluginCommandDescriptor] { [] }
+    @MainActor var primaryMenuBarCommands: [PluginCommandDescriptor] { [] }
+    @MainActor var settingsSidebarItems: [PluginSettingsSidebarItemDescriptor] { [] }
+    @MainActor func settingsSidebarView(for itemId: String) -> AnyView? { nil }
+}
+
 public protocol HostModelLifecyclePolicyAwarePlugin: TypeWhisperPlugin {}
 
 // MARK: - Shared Settings Activity
@@ -392,6 +454,75 @@ public protocol FileJobAutomationPlugin: TypeWhisperPlugin {
 
 public extension FileJobAutomationPlugin {
     var priority: Int { 400 }
+}
+
+// MARK: - Media Import Plugin
+
+/// Progress emitted while a plugin resolves a remote media source into a local file.
+public struct PluginMediaImportProgress: Sendable, Equatable {
+    public let fractionCompleted: Double?
+    public let status: String?
+
+    public init(fractionCompleted: Double? = nil, status: String? = nil) {
+        self.fractionCompleted = fractionCompleted
+        self.status = status
+    }
+}
+
+/// A local media file produced by a media-import plugin.
+///
+/// `cleanupToken` is opaque to the host. The host returns the complete value to
+/// `removeImportedMedia(_:)` when the queue item is removed or reset.
+public struct PluginImportedMedia: Sendable, Equatable {
+    public let localFileURL: URL
+    public let displayName: String?
+    public let cleanupToken: String?
+
+    public init(
+        localFileURL: URL,
+        displayName: String? = nil,
+        cleanupToken: String? = nil
+    ) {
+        self.localFileURL = localFileURL
+        self.displayName = displayName
+        self.cleanupToken = cleanupToken
+    }
+}
+
+public struct PluginMediaImportAvailability: Sendable, Equatable {
+    public let isAvailable: Bool
+    public let unavailableReason: String?
+
+    public init(isAvailable: Bool, unavailableReason: String? = nil) {
+        self.isAvailable = isAvailable
+        self.unavailableReason = unavailableReason
+    }
+
+    public static let available = PluginMediaImportAvailability(isAvailable: true)
+}
+
+/// Optional plugin capability for turning a remote URL into a local audio or
+/// video file that the host can feed through its regular file-transcription pipeline.
+public protocol MediaImportPlugin: TypeWhisperPlugin {
+    @MainActor var mediaImportId: String { get }
+    @MainActor var mediaImportDisplayName: String { get }
+    @MainActor var mediaImportAvailability: PluginMediaImportAvailability { get }
+    @MainActor func canImportMedia(from url: URL) -> Bool
+    @MainActor func importMedia(
+        from url: URL,
+        onProgress: @Sendable @escaping (PluginMediaImportProgress) -> Bool
+    ) async throws -> PluginImportedMedia
+    @MainActor func removeImportedMedia(_ media: PluginImportedMedia) async
+}
+
+public extension MediaImportPlugin {
+    @MainActor var mediaImportAvailability: PluginMediaImportAvailability { .available }
+    @MainActor func removeImportedMedia(_ media: PluginImportedMedia) async {}
+}
+
+/// Optional extension for bundles that expose more than one media importer.
+public protocol AdditionalMediaImportPluginsProviding: TypeWhisperPlugin {
+    @MainActor var additionalMediaImportPlugins: [any MediaImportPlugin] { get }
 }
 
 // MARK: - Transcription Engine Plugin

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
@@ -46,6 +46,8 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
         var defaults: [String: AnySendable]
         var secrets: [String: String]
         var capabilitiesChangedCount = 0
+        var openedSettingsSidebarItemIds: [String] = []
+        var enqueuedImportedMedia: [PluginImportedMedia] = []
         var streamingDisplayActiveValues: [Bool] = []
     }
 
@@ -132,6 +134,19 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
         }
     }
 
+    public func openSettingsSidebarItem(_ itemId: String) {
+        lock.withLock {
+            state.openedSettingsSidebarItemIds.append(itemId)
+        }
+    }
+
+    public func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool {
+        lock.withLock {
+            state.enqueuedImportedMedia.append(media)
+        }
+        return true
+    }
+
     public func setStreamingDisplayActive(_ active: Bool) {
         lock.withLock {
             state.streamingDisplayActiveValues.append(active)
@@ -140,6 +155,14 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
 
     public var capabilitiesChangedCount: Int {
         lock.withLock { state.capabilitiesChangedCount }
+    }
+
+    public var openedSettingsSidebarItemIds: [String] {
+        lock.withLock { state.openedSettingsSidebarItemIds }
+    }
+
+    public var enqueuedImportedMedia: [PluginImportedMedia] {
+        lock.withLock { state.enqueuedImportedMedia }
     }
 
     public var streamingDisplayActiveValues: [Bool] {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDKTesting/PluginTestSupport.swift
@@ -48,6 +48,7 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
         var capabilitiesChangedCount = 0
         var openedSettingsSidebarItemIds: [String] = []
         var enqueuedImportedMedia: [PluginImportedMedia] = []
+        var enqueuedMediaImporterIds: [String] = []
         var streamingDisplayActiveValues: [Bool] = []
     }
 
@@ -140,9 +141,13 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
         }
     }
 
-    public func enqueueImportedMediaForTranscription(_ media: PluginImportedMedia) async -> Bool {
+    public func enqueueImportedMediaForTranscription(
+        _ media: PluginImportedMedia,
+        fromMediaImporterId mediaImporterId: String
+    ) async -> Bool {
         lock.withLock {
             state.enqueuedImportedMedia.append(media)
+            state.enqueuedMediaImporterIds.append(mediaImporterId)
         }
         return true
     }
@@ -163,6 +168,10 @@ public final class PluginTestHostServices: HostServices, HostModelLifecyclePolic
 
     public var enqueuedImportedMedia: [PluginImportedMedia] {
         lock.withLock { state.enqueuedImportedMedia }
+    }
+
+    public var enqueuedMediaImporterIds: [String] {
+        lock.withLock { state.enqueuedMediaImporterIds }
     }
 
     public var streamingDisplayActiveValues: [Bool] {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import os
+import SwiftUI
 import XCTest
 @testable import TypeWhisperPluginSDK
 
@@ -170,6 +171,45 @@ private final class MockAuthRoleStatusPlugin: NSObject, TypeWhisperPlugin, Plugi
                 requiredCredentialLabel: "API key"
             )
             : .available
+    }
+}
+
+@objc(MockUserInterfacePlugin)
+private final class MockUserInterfacePlugin: NSObject, TypeWhisperPlugin, PluginUserInterfaceProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.user-interface"
+    static let pluginName = "Mock User Interface"
+
+    @MainActor private(set) var performedCommandIds: [String] = []
+
+    required override init() {}
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+
+    @MainActor var appMenuCommands: [PluginCommandDescriptor] {
+        [PluginCommandDescriptor(id: "open-player", title: "Open Player", systemImageName: "play.circle")]
+    }
+
+    @MainActor var primaryMenuBarCommands: [PluginCommandDescriptor] {
+        [PluginCommandDescriptor(id: "pause-player", title: "Pause", isEnabled: false)]
+    }
+
+    @MainActor var settingsSidebarItems: [PluginSettingsSidebarItemDescriptor] {
+        [
+            PluginSettingsSidebarItemDescriptor(
+                id: "player",
+                title: "Player",
+                systemImageName: "play.rectangle"
+            )
+        ]
+    }
+
+    @MainActor func settingsSidebarView(for itemId: String) -> AnyView? {
+        itemId == "player" ? AnyView(Text("Player")) : nil
+    }
+
+    @MainActor func performPluginCommand(_ commandId: String) {
+        performedCommandIds.append(commandId)
     }
 }
 
@@ -430,6 +470,29 @@ private final class MockTTSPlugin: NSObject, TTSProviderPlugin, @unchecked Senda
 }
 
 final class ProtocolContractTests: XCTestCase {
+    @MainActor
+    func testPluginUserInterfaceDescriptorsSupportMenusAndSettingsSidebarItems() {
+        let plugin = MockUserInterfacePlugin()
+
+        XCTAssertEqual(plugin.appMenuCommands, [
+            PluginCommandDescriptor(id: "open-player", title: "Open Player", systemImageName: "play.circle")
+        ])
+        XCTAssertEqual(plugin.primaryMenuBarCommands.first?.isEnabled, false)
+        XCTAssertEqual(plugin.settingsSidebarItems, [
+            PluginSettingsSidebarItemDescriptor(
+                id: "player",
+                title: "Player",
+                systemImageName: "play.rectangle"
+            )
+        ])
+        XCTAssertNotNil(plugin.settingsSidebarView(for: "player"))
+        XCTAssertNil(plugin.settingsSidebarView(for: "missing"))
+
+        plugin.performPluginCommand("open-player")
+
+        XCTAssertEqual(plugin.performedCommandIds, ["open-player"])
+    }
+
     func testLocalInferenceGateSerializesConcurrentOperations() async throws {
         let gate = PluginLocalInferenceGate()
         let state = GateConcurrencyState()

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -5,6 +5,93 @@ import XCTest
 
 @MainActor
 final class FileTranscriptionViewModelTests: XCTestCase {
+    func testImportedPluginMediaCanBeAddedToTranscriptionQueue() throws {
+        let previousPluginManager = PluginManager.shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = previousPluginManager
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let downloadedFile = makeTemporaryFile(named: "downloaded-web-link.m4a")
+        let plugin = FileTranscriptionMediaImportPlugin(downloadedFile: downloadedFile)
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: try makeDefaults()
+        )
+
+        let accepted = viewModel.enqueueImportedMedia(
+            PluginImportedMedia(
+                localFileURL: downloadedFile,
+                displayName: "Downloaded episode",
+                cleanupToken: "cleanup"
+            ),
+            from: plugin
+        )
+
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(viewModel.files.map(\.url), [downloadedFile])
+        XCTAssertEqual(viewModel.files.map(\.fileName), ["Downloaded episode"])
+    }
+
+    func testImportedPluginMediaRejectsUnsupportedFile() throws {
+        let previousPluginManager = PluginManager.shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = previousPluginManager
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let unsupportedFile = makeTemporaryFile(named: "downloaded-web-link.txt")
+        let plugin = FileTranscriptionMediaImportPlugin(downloadedFile: unsupportedFile)
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: try makeDefaults()
+        )
+
+        let accepted = viewModel.enqueueImportedMedia(
+            PluginImportedMedia(localFileURL: unsupportedFile),
+            from: plugin
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertTrue(viewModel.files.isEmpty)
+    }
+
+    func testImportedPluginMediaRejectsDuplicateQueueItem() throws {
+        let previousPluginManager = PluginManager.shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = previousPluginManager
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let downloadedFile = makeTemporaryFile(named: "downloaded-web-link.m4a")
+        let plugin = FileTranscriptionMediaImportPlugin(downloadedFile: downloadedFile)
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: try makeDefaults()
+        )
+
+        let imported = PluginImportedMedia(localFileURL: downloadedFile)
+        XCTAssertTrue(viewModel.enqueueImportedMedia(imported, from: plugin))
+        XCTAssertFalse(viewModel.enqueueImportedMedia(imported, from: plugin))
+
+        XCTAssertEqual(viewModel.files.count, 1)
+    }
+
     func testEngineSwitchPreservesFullLanguageSelectionAndPersistence() throws {
         let previousPluginManager = PluginManager.shared
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
@@ -785,6 +872,10 @@ final class FileTranscriptionViewModelTests: XCTestCase {
     func testRecoverySettingsTabRemainsAvailableWithoutRecoveryContent() {
         XCTAssertEqual(SettingsView.availableTab(.dictationRecovery), .dictationRecovery)
         XCTAssertEqual(SettingsView.availableTab(.fileTranscription), .fileTranscription)
+        XCTAssertEqual(
+            SettingsView.availableTab(.plugin(pluginId: "com.example.player", itemId: "player")),
+            .plugin(pluginId: "com.example.player", itemId: "player")
+        )
     }
 
     func testAutomaticRecoveryFallbackAllowsKnownRecoverableErrors() {
@@ -1016,6 +1107,47 @@ private actor AsyncGate {
 }
 
 private struct UnknownTranscriptionError: Error {}
+
+private final class FileTranscriptionMediaImportPlugin: NSObject, MediaImportPlugin, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.mock.media-import"
+    static let pluginName = "Media Import"
+
+    let mediaImportId = "mock-media-import"
+    let mediaImportDisplayName = "Mock Media Import"
+    private let downloadedFile: URL
+    private(set) var requestedURLs: [URL] = []
+    private(set) var removedMedia: [PluginImportedMedia] = []
+
+    required override convenience init() {
+        self.init(downloadedFile: URL(fileURLWithPath: "/tmp/mock-media-import.m4a"))
+    }
+
+    init(downloadedFile: URL) {
+        self.downloadedFile = downloadedFile
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
+    func canImportMedia(from url: URL) -> Bool { url.scheme == "https" }
+
+    func importMedia(
+        from url: URL,
+        onProgress: @Sendable @escaping (PluginMediaImportProgress) -> Bool
+    ) async throws -> PluginImportedMedia {
+        requestedURLs.append(url)
+        _ = onProgress(PluginMediaImportProgress(fractionCompleted: 0.5, status: "Downloading"))
+        return PluginImportedMedia(
+            localFileURL: downloadedFile,
+            displayName: "Downloaded episode",
+            cleanupToken: UUID().uuidString
+        )
+    }
+
+    func removeImportedMedia(_ media: PluginImportedMedia) async {
+        removedMedia.append(media)
+    }
+}
 
 private final class FileTranscriptionLanguageSelectionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {
     static let pluginId = "com.typewhisper.mock.file-transcription-language-selection"

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -66,6 +66,95 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.files.isEmpty)
     }
 
+    func testImportedPluginMediaRejectsDirectoryWithSupportedExtension() throws {
+        let directory = makeTemporaryDirectory()
+            .appendingPathComponent("downloaded-web-link.m4a", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let plugin = FileTranscriptionMediaImportPlugin(downloadedFile: directory)
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: try makeDefaults()
+        )
+
+        let accepted = viewModel.enqueueImportedMedia(
+            PluginImportedMedia(localFileURL: directory),
+            from: plugin
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertTrue(viewModel.files.isEmpty)
+    }
+
+    func testHostServicesRetainsOriginatingMediaImporterForCleanup() async throws {
+        let previousPluginManager = PluginManager.shared
+        let previousViewModel = FileTranscriptionViewModel._shared
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = previousPluginManager
+            FileTranscriptionViewModel._shared = previousViewModel
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        let downloadedFile = makeTemporaryFile(named: "downloaded-web-link.m4a")
+        let firstImporter = FileTranscriptionMediaImportPlugin(
+            mediaImportId: "first-importer",
+            downloadedFile: downloadedFile
+        )
+        let secondImporter = FileTranscriptionMediaImportPlugin(
+            mediaImportId: "second-importer",
+            downloadedFile: downloadedFile
+        )
+        let plugin = MultipleFileTranscriptionMediaImportPlugin(
+            importers: [firstImporter, secondImporter]
+        )
+        let pluginManager = PluginManager(appSupportDirectory: appSupportDirectory)
+        pluginManager.loadedPlugins = [
+            LoadedPlugin(
+                manifest: PluginManifest(
+                    id: MultipleFileTranscriptionMediaImportPlugin.pluginId,
+                    name: "Multiple Media Import",
+                    version: "1.0.0",
+                    principalClass: "MultipleFileTranscriptionMediaImportPlugin"
+                ),
+                instance: plugin,
+                bundle: Bundle.main,
+                sourceURL: appSupportDirectory,
+                isEnabled: true
+            )
+        ]
+        PluginManager.shared = pluginManager
+
+        let viewModel = FileTranscriptionViewModel(
+            modelManager: ModelManagerService(),
+            audioFileService: AudioFileService(),
+            dictionaryService: makeDictionaryService(),
+            defaults: try makeDefaults()
+        )
+        FileTranscriptionViewModel._shared = viewModel
+        let host = HostServicesImpl(
+            pluginId: MultipleFileTranscriptionMediaImportPlugin.pluginId,
+            eventBus: FileTranscriptionTestEventBus(),
+            ruleNamesProvider: { [] }
+        )
+
+        let media = PluginImportedMedia(localFileURL: downloadedFile, cleanupToken: "cleanup")
+        let accepted = await host.enqueueImportedMediaForTranscription(
+            media,
+            fromMediaImporterId: secondImporter.mediaImportId
+        )
+
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(viewModel.files.first?.mediaImporter?.mediaImportId, "second-importer")
+
+        viewModel.reset()
+        try await waitUntil {
+            secondImporter.removedMedia == [media]
+        }
+        XCTAssertTrue(firstImporter.removedMedia.isEmpty)
+    }
+
     func testImportedPluginMediaRejectsDuplicateQueueItem() throws {
         let previousPluginManager = PluginManager.shared
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
@@ -1108,21 +1197,37 @@ private actor AsyncGate {
 
 private struct UnknownTranscriptionError: Error {}
 
+private final class FileTranscriptionTestEventBus: EventBusProtocol, @unchecked Sendable {
+    func subscribe(handler: @escaping @Sendable (TypeWhisperEvent) async -> Void) -> UUID {
+        UUID()
+    }
+
+    func unsubscribe(id: UUID) {}
+}
+
 private final class FileTranscriptionMediaImportPlugin: NSObject, MediaImportPlugin, @unchecked Sendable {
-    static let pluginId = "com.typewhisper.mock.media-import"
+    static let pluginId = MultipleFileTranscriptionMediaImportPlugin.pluginId
     static let pluginName = "Media Import"
 
-    let mediaImportId = "mock-media-import"
+    let mediaImportId: String
     let mediaImportDisplayName = "Mock Media Import"
     private let downloadedFile: URL
     private(set) var requestedURLs: [URL] = []
     private(set) var removedMedia: [PluginImportedMedia] = []
 
     required override convenience init() {
-        self.init(downloadedFile: URL(fileURLWithPath: "/tmp/mock-media-import.m4a"))
+        self.init(
+            mediaImportId: "mock-media-import",
+            downloadedFile: URL(fileURLWithPath: "/tmp/mock-media-import.m4a")
+        )
     }
 
-    init(downloadedFile: URL) {
+    convenience init(downloadedFile: URL) {
+        self.init(mediaImportId: "mock-media-import", downloadedFile: downloadedFile)
+    }
+
+    init(mediaImportId: String, downloadedFile: URL) {
+        self.mediaImportId = mediaImportId
         self.downloadedFile = downloadedFile
         super.init()
     }
@@ -1147,6 +1252,30 @@ private final class FileTranscriptionMediaImportPlugin: NSObject, MediaImportPlu
     func removeImportedMedia(_ media: PluginImportedMedia) async {
         removedMedia.append(media)
     }
+}
+
+private final class MultipleFileTranscriptionMediaImportPlugin:
+    NSObject,
+    TypeWhisperPlugin,
+    AdditionalMediaImportPluginsProviding,
+    @unchecked Sendable
+{
+    static let pluginId = "com.typewhisper.mock.media-import"
+    static let pluginName = "Multiple Media Import"
+
+    let additionalMediaImportPlugins: [any MediaImportPlugin]
+
+    required override convenience init() {
+        self.init(importers: [])
+    }
+
+    init(importers: [any MediaImportPlugin]) {
+        self.additionalMediaImportPlugins = importers
+        super.init()
+    }
+
+    func activate(host: HostServices) {}
+    func deactivate() {}
 }
 
 private final class FileTranscriptionLanguageSelectionPlugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendable {

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1,4 +1,5 @@
 import Combine
+import SwiftUI
 import XCTest
 import TypeWhisperPluginSDK
 @testable import TypeWhisper
@@ -171,6 +172,104 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manager.readinessRevision, initialRevision + 1)
         wait(for: [notification], timeout: 1)
         withExtendedLifetime(cancellable) {}
+    }
+}
+
+@MainActor
+final class PluginUserInterfaceContributionTests: XCTestCase {
+    private final class MockPlugin: NSObject, TypeWhisperPlugin, PluginUserInterfaceProviding, @unchecked Sendable {
+        static let pluginId = "com.typewhisper.tests.user-interface"
+        static let pluginName = "User Interface Test"
+
+        private(set) var performedCommandIds: [String] = []
+
+        required override init() {}
+
+        func activate(host: HostServices) {}
+        func deactivate() {}
+
+        var appMenuCommands: [PluginCommandDescriptor] {
+            [PluginCommandDescriptor(id: "open", title: "Open Player", systemImageName: "play.circle")]
+        }
+
+        var primaryMenuBarCommands: [PluginCommandDescriptor] {
+            [PluginCommandDescriptor(id: "pause", title: "Pause Player")]
+        }
+
+        var settingsSidebarItems: [PluginSettingsSidebarItemDescriptor] {
+            [PluginSettingsSidebarItemDescriptor(id: "player", title: "Player", systemImageName: "play.rectangle")]
+        }
+
+        func settingsSidebarView(for itemId: String) -> AnyView? {
+            itemId == "player" ? AnyView(Text("Player")) : nil
+        }
+
+        func performPluginCommand(_ commandId: String) {
+            performedCommandIds.append(commandId)
+        }
+    }
+
+    func testManagerExposesUserInterfaceContributionsFromEnabledPluginsOnly() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginUserInterface")
+        defer { TestSupport.remove(appSupportDirectory) }
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let enabledPlugin = MockPlugin()
+        let disabledPlugin = MockPlugin()
+        manager.loadedPlugins = [
+            loadedPlugin(enabledPlugin, id: "com.typewhisper.tests.ui.enabled", enabled: true, source: appSupportDirectory),
+            loadedPlugin(disabledPlugin, id: "com.typewhisper.tests.ui.disabled", enabled: false, source: appSupportDirectory),
+        ]
+
+        XCTAssertEqual(manager.userInterfaceContributions.count, 1)
+        let contribution = try XCTUnwrap(manager.userInterfaceContributions.first)
+
+        XCTAssertEqual(contribution.pluginId, "com.typewhisper.tests.ui.enabled")
+        XCTAssertEqual(contribution.pluginName, "User Interface Test")
+        XCTAssertEqual(contribution.appMenuCommands.map(\.id), ["open"])
+        XCTAssertEqual(contribution.primaryMenuBarCommands.map(\.id), ["pause"])
+        XCTAssertEqual(contribution.settingsSidebarItems.map(\.id), ["player"])
+        XCTAssertNotNil(manager.settingsSidebarView(
+            pluginId: "com.typewhisper.tests.ui.enabled",
+            itemId: "player"
+        ))
+        XCTAssertNil(manager.settingsSidebarView(
+            pluginId: "com.typewhisper.tests.ui.disabled",
+            itemId: "player"
+        ))
+    }
+
+    func testManagerRoutesCommandsOnlyToEnabledContributingPlugin() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(prefix: "PluginUserInterfaceActions")
+        defer { TestSupport.remove(appSupportDirectory) }
+        let manager = PluginManager(appSupportDirectory: appSupportDirectory)
+        let plugin = MockPlugin()
+        manager.loadedPlugins = [
+            loadedPlugin(plugin, id: "com.typewhisper.tests.ui.actions", enabled: true, source: appSupportDirectory)
+        ]
+
+        XCTAssertTrue(manager.performPluginCommand(pluginId: "com.typewhisper.tests.ui.actions", commandId: "open"))
+        XCTAssertEqual(plugin.performedCommandIds, ["open"])
+        XCTAssertFalse(manager.performPluginCommand(pluginId: "missing", commandId: "open"))
+    }
+
+    private func loadedPlugin(
+        _ plugin: MockPlugin,
+        id: String,
+        enabled: Bool,
+        source: URL
+    ) -> LoadedPlugin {
+        LoadedPlugin(
+            manifest: PluginManifest(
+                id: id,
+                name: MockPlugin.pluginName,
+                version: "1.0.0",
+                principalClass: "MockPlugin"
+            ),
+            instance: plugin,
+            bundle: Bundle.main,
+            sourceURL: source,
+            isEnabled: enabled
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- add SDK descriptors for app-menu, primary menu-bar, and settings-sidebar contributions
- render enabled plugin contributions in TypeWhisper and route plugin-owned sidebar pages
- add a generic media-import handoff and prepare the 1.7 daily build version

## Context

TypeWhisper plugins need host-owned menu entries and plugin-owned settings-sidebar pages so integrations can expose first-class workflows without creating separate status items.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter ProtocolContractTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination "platform=macOS,arch=arm64" -only-testing:TypeWhisperTests/PluginUserInterfaceContributionTests -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests build-for-testing`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added plugin-provided commands to the app and menu bar.
  - Added plugin-specific settings pages and navigation.
  - Added support for importing external audio and video for transcription, including progress tracking and cleanup.
  - Plugins can now provide additional integrations and media importers.

- **Improvements**
  - Expanded German, Japanese, and Simplified Chinese translations for integration messages.
  - Updated the application version to 1.7.0.

- **Documentation**
  - Expanded plugin integration documentation for commands, settings, and media importing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->