### PR TITLE
Prepare OpenAIPlugin 1.3.2 release

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5565,7 +5565,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = OpenAIPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openai;
 				PRODUCT_NAME = OpenAIPlugin;
 				SKIP_INSTALL = YES;
@@ -5588,7 +5588,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = OpenAIPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.1;
+				MARKETING_VERSION = 1.3.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openai;
 				PRODUCT_NAME = OpenAIPlugin;
 				SKIP_INSTALL = YES;

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -2720,7 +2720,7 @@ final class OpenAIPlugin: NSObject,
     private static var chatGPTModelsClientVersion: String {
         let bundle = Bundle(for: OpenAIPlugin.self)
         return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "1.3.1"
+            ?? "1.3.2"
     }
 
     fileprivate var ttsInstructions: String { _ttsInstructions }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openai",
     "name": "OpenAI / ChatGPT",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
## Summary

- bump OpenAIPlugin from 1.3.1 to 1.3.2 after #1159
- keep the plugin manifest, Xcode target version, and ChatGPT model-client fallback version aligned
- prepare the official plugin release for the model-specific reasoning effort controls

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIPluginTests`
- `python3 -m json.tool TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json >/dev/null`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the OpenAI plugin to version 1.3.2.
  * Updated version information across the plugin for consistent release identification.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->