### PR TITLE
Fix daily release notes and MCP catalog refresh race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,15 +461,6 @@ jobs:
           else
             echo "No existing release. Generating notes from commits..."
 
-            if [ "$RELEASE_CHANNEL" = "stable" ]; then
-              # Stable notes should compare against the previous stable release,
-              # not against an RC or daily tag that may point at the same commit.
-              PREV_TAG=$(git tag --sort=-v:refname | grep '^v[0-9][0-9.]*$' | grep -v "^${TAG}$" | head -1)
-            else
-              # Pre-release notes can compare against the latest app tag of any prerelease type.
-              PREV_TAG=$(git tag --sort=-v:refname | grep '^v[0-9]' | grep -v "^${TAG}$" | head -1)
-            fi
-
             RANGE_END="$TAG"
             RELEASE_TARGET=""
             if ! git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -477,10 +468,29 @@ jobs:
               RELEASE_TARGET="$RANGE_END"
             fi
 
+            # Version sorting does not reflect release order for tags such as
+            # daily builds and RCs. Find the nearest prior app release on the
+            # branch instead, so notes contain only changes since that release.
+            DESCRIBE_ARGS=(
+              --tags
+              --abbrev=0
+              --first-parent
+              --match 'v[0-9]*'
+              --exclude "$TAG"
+            )
+            if [ "$RELEASE_CHANNEL" = "stable" ]; then
+              # Stable notes should compare against the previous stable release,
+              # not against an RC or daily tag that may point at the same commit.
+              DESCRIBE_ARGS+=(--exclude 'v*-*')
+            fi
+            PREV_TAG=$(git describe "${DESCRIBE_ARGS[@]}" "$RANGE_END" 2>/dev/null || true)
+
             if [ -n "$PREV_TAG" ]; then
               RANGE="${PREV_TAG}..${RANGE_END}"
+              echo "Generating release notes for $RANGE"
             else
               RANGE="$RANGE_END"
+              echo "No previous release tag found; generating notes through $RANGE_END"
             fi
 
             RELEASE_NOTES_FILE="docs/release-notes/${RAW_VERSION}.md"

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
@@ -83,6 +83,7 @@ actor MCPServerSession {
     private var errorPipe: Pipe?
     private var cachedTools: [MCPToolDescriptor] = []
     private var catalogIsStale = true
+    private var catalogGeneration = 0
     private var callIsActive = false
     private var callWaiters: [CheckedContinuation<Void, Never>] = []
     private let standardError = MCPStandardErrorBuffer()
@@ -102,7 +103,7 @@ actor MCPServerSession {
         let hadUsableConnection = hasUsableConnection
         try await ensureConnected()
         if forceRefresh, hadUsableConnection {
-            catalogIsStale = true
+            markCatalogStale()
         }
         if catalogIsStale {
             try await refreshToolsWithTimeout()
@@ -208,7 +209,7 @@ actor MCPServerSession {
         outputPipe = nil
         errorPipe = nil
         cachedTools = []
-        catalogIsStale = true
+        markCatalogStale()
     }
 
     private func ensureConnected() async throws {
@@ -361,6 +362,7 @@ actor MCPServerSession {
             throw MCPClientError.invalidConfiguration(MCPClientLocalization.string("The MCP client is not connected."))
         }
 
+        let refreshGeneration = catalogGeneration
         var allTools: [Tool] = []
         var cursor: String?
         repeat {
@@ -370,7 +372,8 @@ actor MCPServerSession {
         } while cursor != nil
 
         cachedTools = try allTools.map(MCPToolDescriptor.init)
-        catalogIsStale = false
+        // Preserve an invalidation delivered while listTools() suspended this actor.
+        catalogIsStale = catalogGeneration != refreshGeneration
     }
 
     private func refreshToolsWithTimeout() async throws {
@@ -408,6 +411,7 @@ actor MCPServerSession {
     }
 
     private func markCatalogStale() {
+        catalogGeneration &+= 1
         catalogIsStale = true
     }
 
@@ -427,7 +431,7 @@ actor MCPServerSession {
     private func processDidTerminate(processIdentifier: Int32) async {
         guard process?.processIdentifier == processIdentifier else { return }
         isConnected = false
-        catalogIsStale = true
+        markCatalogStale()
         if let client {
             await client.disconnect()
         } else if let transport {


### PR DESCRIPTION
## Context

Daily release notes were generated from a version-sorted app tag. RC tags sort ahead of daily tags, so releases such as `v1.7.0-daily.20260826` compared against `v1.6.0-rc2` instead of the immediately preceding daily release. This caused changes from many previous versions to be repeated.

The PR also fixes a race exposed by the resulting CI run: a `notifications/tools/list_changed` event received while MCP tool discovery was suspended could be overwritten when the in-flight refresh completed, leaving the old catalog cached.

## Changes

- select the nearest prior app release from the first-parent Git history
- exclude prerelease tags when generating stable release notes
- log the exact commit range used for generated notes
- preserve MCP catalog invalidations that arrive during an in-flight refresh using an actor-isolated generation counter

## Test plan

- `actionlint -shellcheck= .github/workflows/release.yml`
- `git diff --check`
- `swift test --package-path TypeWhisperPluginSDK --filter MCPClientPluginTests.testToolListChangedNotificationRefreshesCatalog`
- Run the notification refresh test 25 times with `swift test --package-path TypeWhisperPluginSDK --skip-build --filter MCPClientPluginTests.testToolListChangedNotificationRefreshesCatalog`
- `swift test --package-path TypeWhisperPluginSDK --skip-build --filter MCPClientPluginTests`
- `swift test --package-path TypeWhisperPluginSDK`
- Verify `v1.7.0-daily.20260826` resolves to `v1.6.0-daily.20260825`
- Verify consecutive daily tags resolve to the immediately preceding daily tag
- Verify stable `v1.6.0` resolves to stable `v1.5.0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release change detection by selecting the nearest preceding app-release tag from the main release history.
  * Stable releases now exclude prerelease tags when determining included changes.
  * Daily and release-candidate builds can correctly reference applicable prior release tags.
  * Improved tool catalog refresh reliability when resources close or processes terminate during updates.
* **Improvements**
  * Release logs now show the boundaries used to calculate included changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->