### PR TITLE
Fix Cohere Local loading on TypeWhisper 1.6

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -101,7 +101,7 @@ struct CohereLocalModelAssets: Sendable {
         bearerToken: String? = nil,
         progressHandler: @Sendable @escaping (Double) -> Void
     ) async throws {
-        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        try CohereLocalNetworkAccessPolicy.ensureAccessIsAllowed()
         migrateLegacyRootIfNeeded()
         try FileManager.default.createDirectory(
             at: rootDirectory,

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -3,6 +3,17 @@ import SwiftUI
 import TypeWhisperPluginSDK
 import os
 
+// Keep this policy plugin-local because the SDK network guard was added after TypeWhisper 1.6.0.
+enum CohereLocalNetworkAccessPolicy {
+    static func ensureAccessIsAllowed(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws {
+        guard !arguments.contains("--store-screenshots") else {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
 // MARK: - Plugin Entry Point
 
 @objc(CohereLocalPlugin)

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CrispAsrServer.swift
@@ -226,7 +226,7 @@ final class CrispAsrServer: @unchecked Sendable {
         process: Process,
         baseURL: String
     ) async throws {
-        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        try CohereLocalNetworkAccessPolicy.ensureAccessIsAllowed()
         guard let healthURL = URL(string: "\(baseURL)/health") else {
             throw CohereLocalPluginError.invalidLocalServerURL
         }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -133,6 +133,40 @@ final class CohereLocalPluginTests: XCTestCase {
         )
     }
 
+    func testStableHostCompatibilityAvoidsPost16NetworkGuardSDKSymbol() throws {
+        let pluginDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURLs = try FileManager.default.contentsOfDirectory(
+            at: pluginDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+
+        for sourceURL in sourceURLs {
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            XCTAssertFalse(
+                source.contains("PluginHTTPClient.ensureNetworkAccessIsAllowed"),
+                "\(sourceURL.lastPathComponent) must remain loadable by the declared TypeWhisper 1.6.0 host"
+            )
+        }
+    }
+
+    func testLocalNetworkPolicyAllowsNormalRuntime() {
+        XCTAssertNoThrow(
+            try CohereLocalNetworkAccessPolicy.ensureAccessIsAllowed(arguments: ["TypeWhisper"])
+        )
+    }
+
+    func testLocalNetworkPolicyBlocksScreenshotAutomation() {
+        XCTAssertThrowsError(
+            try CohereLocalNetworkAccessPolicy.ensureAccessIsAllowed(
+                arguments: ["TypeWhisper", "--store-screenshots"]
+            )
+        ) { error in
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+    }
+
     func testSelectingAnotherModelStopsServerThatIsStillStarting() async throws {
         let host = try PluginTestHostServices(shouldRestoreLoadedModelsPassively: false)
         let plugin = CohereLocalPlugin()

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.cohere-transcribe",
     "name": "Cohere Transcribe (Local)",
-    "version": "0.1.1",
-    "minHostVersion": "1.5.0",
+    "version": "1.0.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -121,6 +121,19 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 
+    func testCohereLocalPlugin10RequiresCompatibleHost16() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent(
+            "TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json"
+        )
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.version, "1.0.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
+        XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
+    }
+
     func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)


### PR DESCRIPTION
## Issue context

Cohere Transcribe (Local) 0.1.1 does not load in TypeWhisper 1.6.0. Because the runtime bundle fails before its metadata becomes available, the Settings button is missing and enabling the integration immediately reverts.

The released plugin referenced `PluginHTTPClient.ensureNetworkAccessIsAllowed()`, an SDK symbol that is not exported by the TypeWhisper 1.6.0 host framework.

## Changes

- keep the screenshot-automation network guard inside Cohere Local so the plugin remains ABI-compatible with TypeWhisper 1.6.0
- bump Cohere Transcribe (Local) to 1.0.0 and declare TypeWhisper 1.6.0 as the minimum host
- add regression coverage for the forbidden post-1.6 SDK reference and the plugin-local network policy
- validate the updated plugin manifest from the host test suite

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter CohereLocalPluginTests`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" -only-testing:TypeWhisperTests/PluginManifestValidationTests/testCohereLocalPlugin10RequiresCompatibleHost16 CODE_SIGNING_ALLOWED=NO -quiet`
- `jq empty TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json`
- build the CohereLocalPlugin Release bundle with `MARKETING_VERSION=1.0.0` and verify its undefined TypeWhisperPluginSDK symbols against the framework shipped in the TypeWhisper 1.6.0 release artifact

Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved network access handling for the Cohere Local Plugin.
  * Added clear rejection when running in screenshot-automation mode without network access.

* **Bug Fixes**
  * Improved reliability for local network connectivity and host compatibility checks.

* **Chores**
  * Updated the Cohere Local Plugin to version 1.0.0.
  * Raised the minimum supported host version to 1.6.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->