### PR TITLE
Fix correction learning for Electron and Chromium targets

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -147,7 +147,12 @@ final class ServiceContainer: ObservableObject {
         speechFeedbackService = SpeechFeedbackService()
         errorLogService = ErrorLogService()
         licenseService = LicenseService()
-        premiumAccountService = PremiumAccountService()
+        premiumAccountService = AppConstants.isRunningTests
+            ? PremiumAccountService(
+                isSignedInOverride: false,
+                automaticallyRefresh: false
+            )
+            : PremiumAccountService()
         supporterDiscordService = SupporterDiscordService(licenseService: licenseService)
         cloudFolderSyncController = CloudFolderSyncController(
             premiumAccountService: premiumAccountService,

--- a/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
+++ b/TypeWhisper/Services/TargetAppCorrectionLearningService.swift
@@ -274,12 +274,19 @@ final class TargetAppCorrectionLearningService: ObservableObject {
 
     func trackInsertion(
         insertedText: String,
-        baseline: TextInsertionService.FocusedTextObservation
+        baseline: TextInsertionService.FocusedTextObservation?
     ) async -> TargetAppCorrectionLearningResult {
         let attemptID = UUID()
         activeAttemptID = attemptID
         let insertedText = insertedText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !insertedText.isEmpty else {
+            return completeAttempt(
+                id: attemptID,
+                outcome: .unsupportedTextObservation,
+                commitSignal: nil
+            )
+        }
+        guard let baseline else {
             return completeAttempt(
                 id: attemptID,
                 outcome: .unsupportedTextObservation,
@@ -407,7 +414,7 @@ final class TargetAppCorrectionLearningService: ObservableObject {
 
     func trackInsertionResult(
         insertedText: String,
-        baseline: TextInsertionService.FocusedTextObservation
+        baseline: TextInsertionService.FocusedTextObservation?
     ) async -> TargetAppCorrectionLearningResult {
         await trackInsertion(insertedText: insertedText, baseline: baseline)
     }

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -7,6 +7,152 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "TextInsertionService")
 
+@MainActor
+final class TargetAppAccessibilityObservationLease {
+    private var endAction: (() -> Void)?
+
+    init(endAction: @escaping () -> Void) {
+        self.endAction = endAction
+    }
+
+    func end() {
+        let action = endAction
+        endAction = nil
+        action?()
+    }
+}
+
+@MainActor
+final class ChromiumAccessibilityObservationController {
+    struct RunningApplicationTarget: Equatable {
+        let processIdentifier: pid_t
+        let bundleIdentifier: String
+        let bundleURL: URL
+    }
+
+    typealias ResolveApplication = (String) -> RunningApplicationTarget?
+    typealias IsElectronApplication = (URL) -> Bool
+    typealias ReadManualAccessibility = (pid_t) -> (error: AXError, enabled: Bool?)
+    typealias SetManualAccessibility = (pid_t, Bool) -> AXError
+    typealias ValidateApplication = (RunningApplicationTarget) -> Bool
+
+    private static let manualAccessibilityAttribute = "AXManualAccessibility" as CFString
+    private static let chromiumBrowserBundleIdentifiers = SupportedMeetingBrowser
+        .automaticURLBundleIdentifiers
+        .subtracting([SupportedMeetingBrowser.safari])
+
+    private let resolveApplication: ResolveApplication
+    private let isElectronApplicationAtURL: IsElectronApplication
+    private let readManualAccessibility: ReadManualAccessibility
+    private let setManualAccessibility: SetManualAccessibility
+    private let validateApplication: ValidateApplication
+
+    init(
+        resolveApplication: ResolveApplication? = nil,
+        isElectronApplication: IsElectronApplication? = nil,
+        readManualAccessibility: ReadManualAccessibility? = nil,
+        setManualAccessibility: SetManualAccessibility? = nil,
+        validateApplication: ValidateApplication? = nil
+    ) {
+        self.resolveApplication = resolveApplication ?? Self.resolveRunningApplication
+        self.isElectronApplicationAtURL = isElectronApplication ?? Self.containsElectronFramework
+        self.readManualAccessibility = readManualAccessibility ?? Self.readManualAccessibilityValue
+        self.setManualAccessibility = setManualAccessibility ?? Self.setManualAccessibilityValue
+        self.validateApplication = validateApplication ?? Self.isSameRunningApplication
+    }
+
+    func beginObservation(bundleIdentifier: String?) -> TargetAppAccessibilityObservationLease? {
+        guard let bundleIdentifier,
+              let target = resolveApplication(bundleIdentifier),
+              Self.chromiumBrowserBundleIdentifiers.contains(target.bundleIdentifier)
+                || isElectronApplicationAtURL(target.bundleURL) else {
+            return nil
+        }
+
+        let currentState = readManualAccessibility(target.processIdentifier)
+        guard currentState.error == .success,
+              currentState.enabled == false,
+              setManualAccessibility(target.processIdentifier, true) == .success else {
+            return nil
+        }
+
+        return TargetAppAccessibilityObservationLease {
+            guard self.validateApplication(target) else { return }
+            _ = self.setManualAccessibility(target.processIdentifier, false)
+        }
+    }
+
+    func isElectronApplication(bundleIdentifier: String) -> Bool {
+        guard let target = resolveApplication(bundleIdentifier) else { return false }
+        return isElectronApplicationAtURL(target.bundleURL)
+    }
+
+    private static func resolveRunningApplication(
+        bundleIdentifier: String
+    ) -> RunningApplicationTarget? {
+        let runningApplication = NSRunningApplication
+            .runningApplications(withBundleIdentifier: bundleIdentifier)
+            .first
+        let frontmostApplication = NSWorkspace.shared.frontmostApplication
+        let application = runningApplication
+            ?? (frontmostApplication?.bundleIdentifier == bundleIdentifier
+                ? frontmostApplication
+                : nil)
+        guard let application,
+              let resolvedBundleIdentifier = application.bundleIdentifier,
+              let bundleURL = application.bundleURL else {
+            return nil
+        }
+
+        return RunningApplicationTarget(
+            processIdentifier: application.processIdentifier,
+            bundleIdentifier: resolvedBundleIdentifier,
+            bundleURL: bundleURL
+        )
+    }
+
+    private static func containsElectronFramework(bundleURL: URL) -> Bool {
+        let electronFrameworkURL = bundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("Frameworks", isDirectory: true)
+            .appendingPathComponent("Electron Framework.framework", isDirectory: true)
+        return FileManager.default.fileExists(atPath: electronFrameworkURL.path)
+    }
+
+    private static func readManualAccessibilityValue(
+        processIdentifier: pid_t
+    ) -> (error: AXError, enabled: Bool?) {
+        let application = AXUIElementCreateApplication(processIdentifier)
+        var value: AnyObject?
+        let error = AXUIElementCopyAttributeValue(
+            application,
+            manualAccessibilityAttribute,
+            &value
+        )
+        return (error, (value as? NSNumber)?.boolValue)
+    }
+
+    private static func setManualAccessibilityValue(
+        processIdentifier: pid_t,
+        enabled: Bool
+    ) -> AXError {
+        AXUIElementSetAttributeValue(
+            AXUIElementCreateApplication(processIdentifier),
+            manualAccessibilityAttribute,
+            NSNumber(value: enabled)
+        )
+    }
+
+    private static func isSameRunningApplication(_ target: RunningApplicationTarget) -> Bool {
+        guard let application = NSRunningApplication(processIdentifier: target.processIdentifier),
+              !application.isTerminated else {
+            return false
+        }
+        return application.bundleIdentifier == target.bundleIdentifier
+            && application.bundleURL == target.bundleURL
+    }
+}
+
 private final class LiveFieldApplicationActivationObservation: @unchecked Sendable {
     private let notificationCenter: NotificationCenter
     private let token: NSObjectProtocol
@@ -48,6 +194,7 @@ final class TextInsertionService {
     private static let liveFieldMessagingTimeout: Float = 0.05
 
     private let browserURLResolver: BrowserURLResolver
+    private let chromiumAccessibilityObservationController: ChromiumAccessibilityObservationController
     private let syntheticPastePreferredBundleIdentifiers: Set<String> = [
         "com.apple.Terminal",
         "com.googlecode.iterm2",
@@ -80,6 +227,7 @@ final class TextInsertionService {
     var liveFieldTargetEligibilityOverride: ((AXUIElement) -> Bool)?
     var liveFieldApplicationEligibilityOverride: ((String) -> Bool)?
     var liveFieldElectronApplicationOverride: ((String) -> Bool)?
+    var chromiumAccessibilityObservationOverride: ((String?) -> TargetAppAccessibilityObservationLease?)?
     var setMessagingTimeoutOverride: ((AXUIElement, Float) -> Void)?
     var setSelectedRangeOverride: ((AXUIElement, NSRange) -> Bool)?
     var textSelectionOverride: (() -> TextSelection?)?
@@ -99,8 +247,13 @@ final class TextInsertionService {
     var copySelectionRetryDelay: Duration = .milliseconds(120)
     var copySelectionReadSettleDelay: Duration = .milliseconds(20)
 
-    init(browserURLResolver: BrowserURLResolver = BrowserURLResolver()) {
+    init(
+        browserURLResolver: BrowserURLResolver = BrowserURLResolver(),
+        chromiumAccessibilityObservationController: ChromiumAccessibilityObservationController =
+            ChromiumAccessibilityObservationController()
+    ) {
         self.browserURLResolver = browserURLResolver
+        self.chromiumAccessibilityObservationController = chromiumAccessibilityObservationController
     }
 
     enum InsertionResult: Equatable {
@@ -154,6 +307,17 @@ final class TextInsertionService {
         let app = NSWorkspace.shared.frontmostApplication
         let bundleId = app?.bundleIdentifier
         return (app?.localizedName, bundleId, nil)
+    }
+
+    func beginChromiumAccessibilityObservation(
+        bundleIdentifier: String?
+    ) -> TargetAppAccessibilityObservationLease? {
+        if let chromiumAccessibilityObservationOverride {
+            return chromiumAccessibilityObservationOverride(bundleIdentifier)
+        }
+        return chromiumAccessibilityObservationController.beginObservation(
+            bundleIdentifier: bundleIdentifier
+        )
     }
 
     func resolveBrowserURL(bundleId: String) async -> String? {
@@ -1295,23 +1459,9 @@ final class TextInsertionService {
             return liveFieldElectronApplicationOverride(bundleIdentifier)
         }
 
-        let runningApplication = NSRunningApplication
-            .runningApplications(withBundleIdentifier: bundleIdentifier)
-            .first
-        let frontmostApplication = NSWorkspace.shared.frontmostApplication
-        let application = runningApplication
-            ?? (frontmostApplication?.bundleIdentifier == bundleIdentifier
-                ? frontmostApplication
-                : nil)
-        guard let bundleURL = application?.bundleURL else {
-            return false
-        }
-
-        let electronFrameworkURL = bundleURL
-            .appendingPathComponent("Contents", isDirectory: true)
-            .appendingPathComponent("Frameworks", isDirectory: true)
-            .appendingPathComponent("Electron Framework.framework", isDirectory: true)
-        return FileManager.default.fileExists(atPath: electronFrameworkURL.path)
+        return chromiumAccessibilityObservationController.isElectronApplication(
+            bundleIdentifier: bundleIdentifier
+        )
     }
 
     private func observation(from state: FocusedTextState) -> FocusedTextObservation {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -2960,7 +2960,10 @@ final class DictationViewModel: ObservableObject {
         bundleIdentifier: String?
     ) {
         endTargetAppAccessibilityObservation()
-        guard shouldTrackTargetAppCorrectionLearning else { return }
+        guard shouldTrackTargetAppCorrectionLearning
+                || improveTypeWhisperCaptureEnabled else {
+            return
+        }
         targetAppAccessibilityObservationLease = textInsertionService
             .beginChromiumAccessibilityObservation(bundleIdentifier: bundleIdentifier)
     }

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -338,6 +338,7 @@ final class DictationViewModel: ObservableObject {
     private var recordingStartTask: Task<Void, Never>?
     private var stopFinalizationTask: Task<Void, Never>?
     private var targetAppCorrectionLearningTask: Task<Void, Never>?
+    private var targetAppAccessibilityObservationLease: TargetAppAccessibilityObservationLease?
     private var pendingLearnedCorrections: [LearnedDictionaryCorrection] = []
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
@@ -971,6 +972,7 @@ final class DictationViewModel: ObservableObject {
         }
         clearRecordingStartCueState()
         clearDeferredRecordingContext()
+        endTargetAppAccessibilityObservation()
         cancelLiveFieldTranscriptSession()
         restoreRecordingSideEffects()
         streamingHandler.stop()
@@ -1195,6 +1197,7 @@ final class DictationViewModel: ObservableObject {
             lastStreamingParams = nil
             transcriptionTask?.cancel()
             transcriptionTask = nil
+            endTargetAppAccessibilityObservation()
             audioRecordingService.discardActiveRecoveryRecording()
             showNotchFeedback(message: cancelledMessage, icon: "xmark.circle", duration: 1.5)
         default:
@@ -1421,6 +1424,9 @@ final class DictationViewModel: ObservableObject {
         } else {
             clearActiveRuleState()
         }
+        beginTargetAppAccessibilityObservationIfNeeded(
+            bundleIdentifier: activeApp.bundleId
+        )
         applyEffectiveMicrophoneBoostToAudioService()
         if selectedInputUsesBluetooth {
             // The asynchronous Bluetooth start only returns after the current
@@ -1634,9 +1640,13 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func finalizeStopDictation() async {
+        var didStartTranscriptionTask = false
         defer {
             if Task.isCancelled {
                 isStopInFlight = false
+            }
+            if !didStartTranscriptionTask {
+                endTargetAppAccessibilityObservation()
             }
             stopFinalizationTask = nil
         }
@@ -1783,7 +1793,16 @@ final class DictationViewModel: ObservableObject {
 
         guard !Task.isCancelled else { return }
         let usedLiveSessionResult = liveSessionResult != nil
+        let accessibilityObservationLease = targetAppAccessibilityObservationLease
         transcriptionTask = Task {
+            var didTransferAccessibilityObservationLease = false
+            defer {
+                if !didTransferAccessibilityObservationLease {
+                    finishTargetAppAccessibilityObservation(
+                        accessibilityObservationLease
+                    )
+                }
+            }
             do {
                 // Wait for browser URL resolution so URL-based profile overrides apply
                 await urlResolutionTask?.value
@@ -2037,10 +2056,11 @@ final class DictationViewModel: ObservableObject {
                             modelId: transcription.modelId
                         )
                         : nil
-                    startTargetAppCorrectionLearningIfNeeded(
+                    didTransferAccessibilityObservationLease = startTargetAppCorrectionLearningIfNeeded(
                         insertedText: insertedTextForCorrectionTracking,
                         baseline: targetAppCorrectionBaseline,
-                        contributionContext: contributionContext
+                        contributionContext: contributionContext,
+                        accessibilityObservationLease: accessibilityObservationLease
                     )
                 }
 
@@ -2148,6 +2168,7 @@ final class DictationViewModel: ObservableObject {
             }
             self.transcriptionTask = nil
         }
+        didStartTranscriptionTask = true
         stopFinalizationTask = nil
     }
 
@@ -2869,19 +2890,32 @@ final class DictationViewModel: ObservableObject {
     private func startTargetAppCorrectionLearningIfNeeded(
         insertedText: String,
         baseline: TextInsertionService.FocusedTextObservation?,
-        contributionContext: CorrectionContributionContext?
-    ) {
+        contributionContext: CorrectionContributionContext?,
+        accessibilityObservationLease: TargetAppAccessibilityObservationLease?
+    ) -> Bool {
         targetAppCorrectionLearningTask?.cancel()
         targetAppCorrectionLearningTask = nil
 
         let shouldLearn = shouldTrackTargetAppCorrectionLearning
-        guard (shouldLearn || contributionContext != nil),
-              let baseline else {
-            return
+        guard shouldLearn || contributionContext != nil else {
+            return false
         }
 
         targetAppCorrectionLearningTask = Task {
-            @MainActor [weak self, baseline, insertedText, contributionContext, shouldLearn] in
+            @MainActor [
+                weak self,
+                baseline,
+                insertedText,
+                contributionContext,
+                shouldLearn,
+                accessibilityObservationLease
+            ] in
+            defer {
+                accessibilityObservationLease?.end()
+                self?.clearTargetAppAccessibilityObservation(
+                    ifMatching: accessibilityObservationLease
+                )
+            }
             guard let self else { return }
             let result = await self.targetAppCorrectionLearningService.trackInsertion(
                 insertedText: insertedText,
@@ -2909,6 +2943,7 @@ final class DictationViewModel: ObservableObject {
             guard shouldLearn, !result.learnedCorrections.isEmpty else { return }
             self.showLearnedCorrectionsFeedback(result.learnedCorrections)
         }
+        return true
     }
 
     private var improveTypeWhisperCaptureEnabled: Bool {
@@ -2918,6 +2953,39 @@ final class DictationViewModel: ObservableObject {
     private func cancelTargetAppCorrectionLearning() {
         targetAppCorrectionLearningTask?.cancel()
         targetAppCorrectionLearningTask = nil
+        endTargetAppAccessibilityObservation()
+    }
+
+    private func beginTargetAppAccessibilityObservationIfNeeded(
+        bundleIdentifier: String?
+    ) {
+        endTargetAppAccessibilityObservation()
+        guard shouldTrackTargetAppCorrectionLearning else { return }
+        targetAppAccessibilityObservationLease = textInsertionService
+            .beginChromiumAccessibilityObservation(bundleIdentifier: bundleIdentifier)
+    }
+
+    private func endTargetAppAccessibilityObservation() {
+        let lease = targetAppAccessibilityObservationLease
+        targetAppAccessibilityObservationLease = nil
+        lease?.end()
+    }
+
+    private func finishTargetAppAccessibilityObservation(
+        _ lease: TargetAppAccessibilityObservationLease?
+    ) {
+        lease?.end()
+        clearTargetAppAccessibilityObservation(ifMatching: lease)
+    }
+
+    private func clearTargetAppAccessibilityObservation(
+        ifMatching lease: TargetAppAccessibilityObservationLease?
+    ) {
+        guard let lease,
+              targetAppAccessibilityObservationLease === lease else {
+            return
+        }
+        targetAppAccessibilityObservationLease = nil
     }
 
     private func clearPendingUndoActionFeedback() {

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -4,6 +4,165 @@ import XCTest
 
 @MainActor
 final class TargetAppCorrectionLearningServiceTests: XCTestCase {
+    func testElectronAccessibilityObservationRestoresStateItEnabled() throws {
+        let target = electronTarget()
+        var setValues: [Bool] = []
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in true },
+            readManualAccessibility: { _ in (.success, false) },
+            setManualAccessibility: { _, enabled in
+                setValues.append(enabled)
+                return .success
+            },
+            validateApplication: { _ in true }
+        )
+
+        let lease = try XCTUnwrap(
+            controller.beginObservation(bundleIdentifier: target.bundleIdentifier)
+        )
+        XCTAssertEqual(setValues, [true])
+
+        lease.end()
+        lease.end()
+
+        XCTAssertEqual(setValues, [true, false])
+    }
+
+    func testElectronAccessibilityObservationDoesNotOwnAlreadyEnabledState() {
+        let target = electronTarget()
+        var setValues: [Bool] = []
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in true },
+            readManualAccessibility: { _ in (.success, true) },
+            setManualAccessibility: { _, enabled in
+                setValues.append(enabled)
+                return .success
+            }
+        )
+
+        XCTAssertNil(controller.beginObservation(bundleIdentifier: target.bundleIdentifier))
+        XCTAssertTrue(setValues.isEmpty)
+    }
+
+    func testElectronAccessibilityObservationFallsBackWhenAttributeIsUnsupported() {
+        let target = electronTarget()
+        var setValues: [Bool] = []
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in true },
+            readManualAccessibility: { _ in (.attributeUnsupported, nil) },
+            setManualAccessibility: { _, enabled in
+                setValues.append(enabled)
+                return .success
+            }
+        )
+
+        XCTAssertNil(controller.beginObservation(bundleIdentifier: target.bundleIdentifier))
+        XCTAssertTrue(setValues.isEmpty)
+    }
+
+    func testChromiumBrowserAccessibilityObservationEnablesManualAccessibility() throws {
+        let target = ChromiumAccessibilityObservationController.RunningApplicationTarget(
+            processIdentifier: 43,
+            bundleIdentifier: SupportedMeetingBrowser.chrome,
+            bundleURL: URL(fileURLWithPath: "/Applications/Google Chrome.app")
+        )
+        var setValues: [Bool] = []
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in false },
+            readManualAccessibility: { _ in (.success, false) },
+            setManualAccessibility: { _, enabled in
+                setValues.append(enabled)
+                return .success
+            },
+            validateApplication: { _ in true }
+        )
+
+        let lease = try XCTUnwrap(
+            controller.beginObservation(bundleIdentifier: target.bundleIdentifier)
+        )
+        lease.end()
+
+        XCTAssertEqual(setValues, [true, false])
+    }
+
+    func testNativeApplicationDoesNotRequestManualAccessibility() {
+        let target = ChromiumAccessibilityObservationController.RunningApplicationTarget(
+            processIdentifier: 44,
+            bundleIdentifier: "com.apple.Notes",
+            bundleURL: URL(fileURLWithPath: "/System/Applications/Notes.app")
+        )
+        var readCount = 0
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in false },
+            readManualAccessibility: { _ in
+                readCount += 1
+                return (.success, false)
+            },
+            setManualAccessibility: { _, _ in .success }
+        )
+
+        XCTAssertNil(controller.beginObservation(bundleIdentifier: target.bundleIdentifier))
+        XCTAssertEqual(readCount, 0)
+    }
+
+    func testElectronAccessibilityObservationDoesNotRestoreReplacedProcess() throws {
+        let target = electronTarget()
+        var setValues: [Bool] = []
+        var isSameApplication = true
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { _ in target },
+            isElectronApplication: { _ in true },
+            readManualAccessibility: { _ in (.success, false) },
+            setManualAccessibility: { _, enabled in
+                setValues.append(enabled)
+                return .success
+            },
+            validateApplication: { _ in isSameApplication }
+        )
+
+        let lease = try XCTUnwrap(
+            controller.beginObservation(bundleIdentifier: target.bundleIdentifier)
+        )
+        isSameApplication = false
+        lease.end()
+
+        XCTAssertEqual(setValues, [true])
+    }
+
+    func testMissingBaselineCompletesUnsupportedAttemptWithoutLearning() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let service = TargetAppCorrectionLearningService(
+            textInsertionService: TextInsertionService(),
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            persistLatestAttempt: false
+        )
+
+        let result = await service.trackInsertion(insertedText: "Korrektur", baseline: nil)
+
+        XCTAssertEqual(result.snapshot.outcome, .unsupportedTextObservation)
+        XCTAssertEqual(result.snapshot.learnedCorrectionCount, 0)
+        XCTAssertEqual(service.latestAttempt, result.snapshot)
+        XCTAssertTrue(result.learnedCorrections.isEmpty)
+        XCTAssertEqual(dictionaryService.correctionsCount, 0)
+    }
+
+    private func electronTarget() -> ChromiumAccessibilityObservationController.RunningApplicationTarget {
+        ChromiumAccessibilityObservationController.RunningApplicationTarget(
+            processIdentifier: 42,
+            bundleIdentifier: "com.example.electron",
+            bundleURL: URL(fileURLWithPath: "/Applications/Electron Target.app")
+        )
+    }
+
     func testLearnsSingleConfidentReplacementAfterCommitSignal() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -6053,6 +6053,80 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testContributionOnlyDictationBeginsChromiumAccessibilityObservation() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let learningEnabledKey = UserDefaultsKeys.targetAppCorrectionLearningEnabled
+        let improveCaptureKey = UserDefaultsKeys.improveTypeWhisperCaptureEnabled
+        let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
+        let saveAudioKey = UserDefaultsKeys.saveAudioWithHistory
+        let originalLearningEnabled = UserDefaults.standard.object(forKey: learningEnabledKey)
+        let originalImproveCapture = UserDefaults.standard.object(forKey: improveCaptureKey)
+        let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
+        let originalSaveAudio = UserDefaults.standard.object(forKey: saveAudioKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            Self.restoreUserDefault(originalLearningEnabled, forKey: learningEnabledKey)
+            Self.restoreUserDefault(originalImproveCapture, forKey: improveCaptureKey)
+            Self.restoreUserDefault(originalPreserveClipboard, forKey: preserveClipboardKey)
+            Self.restoreUserDefault(originalSaveAudio, forKey: saveAudioKey)
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set(false, forKey: learningEnabledKey)
+        UserDefaults.standard.set(true, forKey: improveCaptureKey)
+        UserDefaults.standard.set(false, forKey: preserveClipboardKey)
+        UserDefaults.standard.set(false, forKey: saveAudioKey)
+
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.preserveClipboard = false
+        let pasteboard = NSPasteboard.withUniqueName()
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Electron Target", "com.example.electron", nil)
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.focusedTextElementOverride = { nil }
+        context.textInsertionService.pasteSimulatorOverride = {}
+        var accessibilityObservationBundleIdentifiers: [String?] = []
+        var accessibilityObservationEndCount = 0
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier in
+            accessibilityObservationBundleIdentifiers.append(bundleIdentifier)
+            return TargetAppAccessibilityObservationLease {
+                accessibilityObservationEndCount += 1
+            }
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed,
+               context.targetAppCorrectionLearningService.latestAttempt != nil,
+               accessibilityObservationEndCount == 1 {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(
+            context.targetAppCorrectionLearningService.latestAttempt?.outcome,
+            .unsupportedTextObservation
+        )
+        XCTAssertEqual(accessibilityObservationBundleIdentifiers, ["com.example.electron"])
+        XCTAssertEqual(accessibilityObservationEndCount, 1)
+    }
+
+    @MainActor
     func testDictationDirectInsertionUsesContextWhenAppAwareFormattingIsEnabled() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let historyEnabledKey = UserDefaultsKeys.historyEnabled

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5968,6 +5968,91 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testDictationWithoutReadableFocusedTextRecordsUnsupportedCorrectionLearningAttempt() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let licenseSuiteName = "TypeWhisperIntegrationTests.License.\(UUID().uuidString)"
+        let learningEnabledKey = UserDefaultsKeys.targetAppCorrectionLearningEnabled
+        let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
+        let saveAudioKey = UserDefaultsKeys.saveAudioWithHistory
+        let originalLearningEnabled = UserDefaults.standard.object(forKey: learningEnabledKey)
+        let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
+        let originalSaveAudio = UserDefaults.standard.object(forKey: saveAudioKey)
+        guard let licenseDefaults = UserDefaults(suiteName: licenseSuiteName) else {
+            return XCTFail("Could not create isolated license defaults")
+        }
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            licenseDefaults.removePersistentDomain(forName: licenseSuiteName)
+            Self.restoreUserDefault(originalLearningEnabled, forKey: learningEnabledKey)
+            Self.restoreUserDefault(originalPreserveClipboard, forKey: preserveClipboardKey)
+            Self.restoreUserDefault(originalSaveAudio, forKey: saveAudioKey)
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set(true, forKey: learningEnabledKey)
+        UserDefaults.standard.set(false, forKey: preserveClipboardKey)
+        UserDefaults.standard.set(false, forKey: saveAudioKey)
+        licenseDefaults.set(LicenseStatus.active.rawValue, forKey: UserDefaultsKeys.licenseStatus)
+        let licenseService = LicenseService(
+            defaults: licenseDefaults,
+            keychainServiceName: "TypeWhisperIntegrationTests.License.\(UUID().uuidString)"
+        )
+
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            licenseService: licenseService
+        )
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.preserveClipboard = false
+        let pasteboard = NSPasteboard.withUniqueName()
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Electron Target", "com.example.electron", nil)
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.focusedTextElementOverride = { nil }
+        context.textInsertionService.pasteSimulatorOverride = {}
+        var accessibilityObservationBundleIdentifiers: [String?] = []
+        var accessibilityObservationEndCount = 0
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier in
+            accessibilityObservationBundleIdentifiers.append(bundleIdentifier)
+            return TargetAppAccessibilityObservationLease {
+                accessibilityObservationEndCount += 1
+            }
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed,
+               context.targetAppCorrectionLearningService.latestAttempt != nil,
+               accessibilityObservationEndCount == 1 {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        XCTAssertEqual(
+            context.targetAppCorrectionLearningService.latestAttempt?.outcome,
+            .unsupportedTextObservation
+        )
+        XCTAssertEqual(context.targetAppCorrectionLearningService.latestAttempt?.learnedCorrectionCount, 0)
+        XCTAssertEqual(context.dictionaryService.correctionsCount, 0)
+        XCTAssertEqual(accessibilityObservationBundleIdentifiers, ["com.example.electron"])
+        XCTAssertEqual(accessibilityObservationEndCount, 1)
+    }
+
+    @MainActor
     func testDictationDirectInsertionUsesContextWhenAppAwareFormattingIsEnabled() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let historyEnabledKey = UserDefaultsKeys.historyEnabled
@@ -7894,6 +7979,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let recentTranscriptionStore: RecentTranscriptionStore
         let profileService: ProfileService
         let workflowService: WorkflowService
+        let dictionaryService: DictionaryService
+        let targetAppCorrectionLearningService: TargetAppCorrectionLearningService
         let ttsProvider: MockTTSProviderPlugin
         private let retainedObjects: [AnyObject]
 
@@ -7909,6 +7996,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             recentTranscriptionStore: RecentTranscriptionStore,
             profileService: ProfileService,
             workflowService: WorkflowService,
+            dictionaryService: DictionaryService,
+            targetAppCorrectionLearningService: TargetAppCorrectionLearningService,
             ttsProvider: MockTTSProviderPlugin,
             retainedObjects: [AnyObject]
         ) {
@@ -7923,6 +8012,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             self.recentTranscriptionStore = recentTranscriptionStore
             self.profileService = profileService
             self.workflowService = workflowService
+            self.dictionaryService = dictionaryService
+            self.targetAppCorrectionLearningService = targetAppCorrectionLearningService
             self.ttsProvider = ttsProvider
             self.retainedObjects = retainedObjects
         }
@@ -7939,7 +8030,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         audioDeviceSelectionEngineValidator: AudioInputSelectionEngineValidating = AVAudioInputSelectionEngineValidator(),
         audioDeviceDefaultInputController: AudioInputDeviceDefaultControlling = CoreAudioInputDeviceDefaultController(),
         audioRecordingBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizing = CoreAudioBluetoothInputRouteStabilizer(),
-        audioRecordingRecoveryAudioStore: DictationRecoveryAudioStore = DictationRecoveryAudioStore()
+        audioRecordingRecoveryAudioStore: DictationRecoveryAudioStore = DictationRecoveryAudioStore(),
+        licenseService: LicenseService? = nil
     ) -> DictationContext {
         EventBus.shared = EventBus()
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
@@ -7993,6 +8085,13 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
         let audioDuckingService = audioDuckingService ?? AudioDuckingService()
         let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let targetAppCorrectionLearningService = TargetAppCorrectionLearningService(
+            textInsertionService: textInsertionService,
+            textDiffService: TextDiffService(),
+            dictionaryService: dictionaryService,
+            defaults: UserDefaults(suiteName: "TypeWhisperIntegrationTests.CorrectionLearning.\(UUID().uuidString)")!,
+            persistLatestAttempt: false
+        )
         let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
         let soundService = soundService ?? SoundService()
         let audioDeviceService = AudioDeviceService(
@@ -8045,6 +8144,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             translationService: nil,
             audioDuckingService: audioDuckingService,
             dictionaryService: dictionaryService,
+            licenseService: licenseService,
+            targetAppCorrectionLearningService: targetAppCorrectionLearningService,
             snippetService: snippetService,
             soundService: soundService,
             audioDeviceService: audioDeviceService,
@@ -8075,6 +8176,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             recentTranscriptionStore: recentTranscriptionStore,
             profileService: profileService,
             workflowService: workflowService,
+            dictionaryService: dictionaryService,
+            targetAppCorrectionLearningService: targetAppCorrectionLearningService,
             ttsProvider: ttsProvider,
             retainedObjects: [
                 EventBus.shared,
@@ -8088,6 +8191,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 profileService,
                 audioDuckingService,
                 dictionaryService,
+                targetAppCorrectionLearningService,
                 snippetService,
                 soundService,
                 audioDeviceService,


### PR DESCRIPTION
## Context

Correction learning currently skips an attempt entirely when the target app does not expose a focused-text baseline. Electron and Chromium apps can therefore leave the latest activity stale and record no learning outcome at all.

This change makes every started attempt observable and adds bounded accessibility observation support for compatible Electron and Chromium targets.

## Changes

- Complete missing-baseline attempts as `unsupportedTextObservation` without mutating the correction dictionary.
- Temporarily enable `AXManualAccessibility` for Electron and known Chromium targets during the correction-observation lifecycle.
- Restore the setting only when TypeWhisper enabled it and the target process identity still matches.
- Fall back safely when the accessibility attribute is unavailable, and leave native apps untouched.
- Isolate the premium-account service in XCTest so tests never query the user's real account token.
- Add service, controller, and end-to-end regression coverage.

## Test plan

- `xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- `xcodebuild build -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Closes #1168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text insertion reliability in Chromium and Electron apps by managing accessibility observation during dictation.
  * Prevented correction learning when focused text cannot be read, avoiding unsupported or inaccurate results.
  * Ensured accessibility observation is safely released when dictation ends, is canceled, or fails.

* **Tests**
  * Added coverage for Chromium, Electron, and native applications, including accessibility state restoration and unsupported text scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->