### PR TITLE
Fix OpenAI plugin installation on TypeWhisper 1.6

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -5565,7 +5565,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = OpenAIPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openai;
 				PRODUCT_NAME = OpenAIPlugin;
 				SKIP_INSTALL = YES;
@@ -5588,7 +5588,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = OpenAIPlugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.openai;
 				PRODUCT_NAME = OpenAIPlugin;
 				SKIP_INSTALL = YES;

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -7,6 +7,17 @@ import SwiftUI
 import TypeWhisperPluginSDK
 import os
 
+// Keep this policy plugin-local because the SDK network guard was added after TypeWhisper 1.6.0.
+enum OpenAINetworkAccessPolicy {
+    static func ensureAccessIsAllowed(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws {
+        guard !arguments.contains("--store-screenshots") else {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
 // MARK: - OAuth Helpers
 
 private enum OpenAIAuthMode: String, Codable, CaseIterable, Hashable, Sendable {
@@ -1228,7 +1239,7 @@ final class OpenAIRealtimeTranscriptionSession: LiveTranscriptionSession, @unche
         configuration: OpenAIRealtimeTranscriptionConfiguration,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> OpenAIRealtimeTranscriptionSession {
-        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        try OpenAINetworkAccessPolicy.ensureAccessIsAllowed()
         let request = try makeRequest(apiKey: apiKey)
         let openWaiter = OpenAIRealtimeWebSocketOpenWaiter()
         let delegate = OpenAIRealtimeWebSocketDelegate(openWaiter: openWaiter)
@@ -2720,7 +2731,7 @@ final class OpenAIPlugin: NSObject,
     private static var chatGPTModelsClientVersion: String {
         let bundle = Bundle(for: OpenAIPlugin.self)
         return bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-            ?? "1.3.2"
+            ?? "1.3.3"
     }
 
     fileprivate var ttsInstructions: String { _ttsInstructions }

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/Tests/OpenAIPluginTests.swift
@@ -10,6 +10,40 @@ final class OpenAIPluginTests: XCTestCase {
         super.tearDown()
     }
 
+    func testStableHostCompatibilityAvoidsPost16NetworkGuardSDKSymbol() throws {
+        let pluginDirectory = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sourceURLs = try FileManager.default.contentsOfDirectory(
+            at: pluginDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+
+        for sourceURL in sourceURLs {
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            XCTAssertFalse(
+                source.contains("PluginHTTPClient.ensureNetworkAccessIsAllowed"),
+                "\(sourceURL.lastPathComponent) must remain loadable by the declared TypeWhisper 1.6.0 host"
+            )
+        }
+    }
+
+    func testLocalNetworkPolicyAllowsNormalRuntime() {
+        XCTAssertNoThrow(
+            try OpenAINetworkAccessPolicy.ensureAccessIsAllowed(arguments: ["TypeWhisper"])
+        )
+    }
+
+    func testLocalNetworkPolicyBlocksScreenshotAutomation() {
+        XCTAssertThrowsError(
+            try OpenAINetworkAccessPolicy.ensureAccessIsAllowed(
+                arguments: ["TypeWhisper", "--store-screenshots"]
+            )
+        ) { error in
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+    }
+
     func testOpenAIPluginAdvertisesLiveSTTAndTTSProtocols() {
         let plugin: Any = OpenAIPlugin()
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.openai",
     "name": "OpenAI / ChatGPT",
-    "version": "1.3.2",
-    "minHostVersion": "1.5.0",
+    "version": "1.3.3",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -134,12 +134,14 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
     }
 
-    func testOpenAIPluginManifestDeclaresCloudHostingWithoutAPIKeyRequirement() throws {
+    func testOpenAIPlugin133RequiresCompatibleHost16AndDeclaresCloudHosting() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
-        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
+        XCTAssertEqual(manifest.version, "1.3.3")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
         XCTAssertEqual(manifest.hosting, .cloud)
         XCTAssertEqual(manifest.requiresAPIKey, false)
         XCTAssertEqual(manifest.resolvedHosting, .cloud)


### PR DESCRIPTION
## Context

OpenAI / ChatGPT 1.3.2 cannot be installed on TypeWhisper 1.6.0 (1091). The released plugin imports `PluginHTTPClient.ensureNetworkAccessIsAllowed()`, which was added after the 1.6.0 host SDK, so macOS rejects the bundle before TypeWhisper can load it.

The manifest also declared TypeWhisper 1.5.0 even though the plugin imports `PluginOpenAITranscriptionHelper.validateApiKey(_:apiVersion:)`, which first exists in the 1.6 host SDK.

## Changes

- keep the screenshot-automation network guard plugin-local so the bundle remains loadable by TypeWhisper 1.6
- add regression coverage for the forbidden post-1.6 SDK symbol and the local guard behavior
- release the fix as OpenAI / ChatGPT 1.3.3 with `minHostVersion` 1.6.0
- keep the bundle and manifest versions aligned

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter OpenAIPluginTests`
- `xcodebuild -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination platform=macOS CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/PluginManifestValidationTests/testOpenAIPlugin133RequiresCompatibleHost16AndDeclaresCloudHosting test`
- `xcodebuild -quiet -project TypeWhisper.xcodeproj -scheme OpenAIPlugin -configuration Release -destination generic/platform=macOS ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO build`
- compare the resulting universal plugin binary against the `TypeWhisperPluginSDK` framework from the published TypeWhisper 1.6.0 ZIP; both `x86_64` and `arm64` must report all SDK symbols present

## Release follow-up

After merge, publish the official OpenAI plugin release with `plugin-release.yml` for version 1.3.3 and independently verify the signed/notarized ZIP plus both registry feeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the OpenAI plugin to version 1.3.3.
  * Added compatibility with host version 1.6.0 and newer.

* **Bug Fixes**
  * Prevented screenshot-storage automation from accessing the network during OpenAI realtime transcription.
  * Preserved normal network access for supported runtime operations.

* **Tests**
  * Added validation for network access behavior and plugin/host compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->