### PR TITLE
Fix external microphone routing in clamshell mode

### DIFF
--- a/TypeWhisper/App/AppConstants.swift
+++ b/TypeWhisper/App/AppConstants.swift
@@ -145,6 +145,29 @@ enum AppConstants {
         #endif
     }()
 
+    static let premiumAccountKeychainService = resolvePremiumAccountKeychainService(
+        isScreenshotAutomation: isScreenshotAutomation,
+        isRunningTests: isRunningTests,
+        isDevelopment: isDevelopment
+    )
+
+    static func resolvePremiumAccountKeychainService(
+        isScreenshotAutomation: Bool,
+        isRunningTests: Bool,
+        isDevelopment: Bool
+    ) -> String {
+        if isScreenshotAutomation {
+            return "com.typewhisper.mac.screenshots.premium-account"
+        }
+        if isRunningTests {
+            return "com.typewhisper.mac.tests.premium-account"
+        }
+        if isDevelopment {
+            return "com.typewhisper.mac.dev.premium-account"
+        }
+        return "com.typewhisper.mac.premium-account"
+    }
+
     static let loggerSubsystem: String = Bundle.main.bundleIdentifier ?? "com.typewhisper.mac"
 
     static var appSupportDirectory: URL {

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -363,7 +363,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             selectedDeviceUID: selectedDeviceUID,
             defaultInputDeviceID: defaultInputDeviceID,
             listedDevicesByID: listedDevicesByID,
-            listedDevicesByUID: listedDevicesByUID
+            listedDevicesByUID: listedDevicesByUID,
+            hasMicrophonePermission: hasMicrophonePermission
         )
         let selectedInputDeviceID: UInt32?
         if let selectedDeviceID {
@@ -463,7 +464,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     func isInputDevicePriorityItemAvailable(_ item: AudioInputDevicePriorityItem) -> Bool {
         guard let device = inputDevices.first(where: { $0.uid == item.uid }) else { return false }
-        if transportType(for: device.deviceID) == kAudioDeviceTransportTypeBuiltIn, clamshellStateProvider.isLidClosed() {
+        if Self.isInternalMicrophoneUnavailableInClamshell(
+            deviceUID: device.uid,
+            transportType: transportType(for: device.deviceID),
+            lidClosed: clamshellStateProvider.isLidClosed()
+        ) {
             return false
         }
         return true
@@ -534,10 +539,14 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             return .systemDefault
         }
         let defaultInputTransport = transportType(for: defaultInputDeviceID)
+        let defaultInputDeviceUID = inputDevices.first(where: { $0.deviceID == defaultInputDeviceID })?.uid
+            ?? Self.deviceUID(for: defaultInputDeviceID)
 
-        if lidClosed,
-           let defaultInputTransport,
-           Self.isBuiltInTransportType(defaultInputTransport) {
+        if Self.isInternalMicrophoneUnavailableInClamshell(
+            deviceUID: defaultInputDeviceUID,
+            transportType: defaultInputTransport,
+            lidClosed: lidClosed
+        ) {
             for device in inputDevices {
                 guard let fallbackSelection = resolvedInputSelection(for: device, lidClosed: true),
                       fallbackSelection.deviceID != defaultInputDeviceID else {
@@ -575,9 +584,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         // physically disconnected by Apple Silicon / T2 hardware security,
         // but CoreAudio still reports it as available. Skip it so failover
         // proceeds to the next candidate. See #888 and #983.
-        if lidClosed,
-           let transport,
-           Self.isBuiltInTransportType(transport) {
+        if Self.isInternalMicrophoneUnavailableInClamshell(
+            deviceUID: device.uid,
+            transportType: transport,
+            lidClosed: lidClosed
+        ) {
             logger.info("Skipping built-in microphone \(device.name, privacy: .private) because lid is closed (clamshell mode)")
             return nil
         }
@@ -1178,7 +1189,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     static func isInputDeviceAvailable(_ deviceID: AudioDeviceID) -> Bool {
         guard inputChannelCount(for: deviceID) > 0 else { return false }
 
-        if transportType(for: deviceID) == kAudioDeviceTransportTypeBuiltIn, IOKitClamshellStateProvider().isLidClosed() {
+        if isInternalMicrophoneUnavailableInClamshell(
+            deviceUID: deviceUID(for: deviceID),
+            transportType: transportType(for: deviceID),
+            lidClosed: IOKitClamshellStateProvider().isLidClosed()
+        ) {
             return false
         }
 
@@ -1338,7 +1353,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         selectedDeviceUID: String?,
         defaultInputDeviceID: AudioDeviceID?,
         listedDevicesByID: [AudioDeviceID: AudioInputDevice],
-        listedDevicesByUID: [String: AudioInputDevice]
+        listedDevicesByUID: [String: AudioInputDevice],
+        hasMicrophonePermission: Bool
     ) -> [AudioInputDiagnosticsReport.Device] {
         var deviceIDs = Set(inputCapableAudioDeviceIDs())
         deviceIDs.formUnion(listedDevicesByID.keys)
@@ -1350,7 +1366,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 selectedDeviceUID: selectedDeviceUID,
                 defaultInputDeviceID: defaultInputDeviceID,
                 listedDevicesByID: listedDevicesByID,
-                listedDevicesByUID: listedDevicesByUID
+                listedDevicesByUID: listedDevicesByUID,
+                hasMicrophonePermission: hasMicrophonePermission
             )
         }
     }
@@ -1361,7 +1378,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         selectedDeviceUID: String?,
         defaultInputDeviceID: AudioDeviceID?,
         listedDevicesByID: [AudioDeviceID: AudioInputDevice],
-        listedDevicesByUID: [String: AudioInputDevice]
+        listedDevicesByUID: [String: AudioInputDevice],
+        hasMicrophonePermission: Bool
     ) -> AudioInputDiagnosticsReport.Device {
         let coreAudioUID = deviceUID(for: deviceID)
         var listedDevice = listedDevicesByID[deviceID]
@@ -1377,7 +1395,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let isAggregateOrVirtual = isAggregate || isVirtual
         let isSelectedByID = selectedDeviceID == deviceID
         let isSelectedByUID = selectedDeviceID == nil && listedDevice?.uid == selectedDeviceUID
-        let formatDiagnostic = inputOnlyCaptureFormatDiagnostic(for: deviceID)
+        let formatDiagnostic = hasMicrophonePermission
+            ? inputOnlyCaptureFormatDiagnostic(for: deviceID)
+            : (format: nil, error: "microphonePermissionNotGranted")
         let snapshot = AudioInputDeviceSnapshot(
             deviceID: deviceID,
             name: deviceName(for: deviceID) ?? listedDevice?.name,
@@ -1492,6 +1512,16 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
 
     static func isBuiltInTransportType(_ transportType: UInt32) -> Bool {
         transportType == kAudioDeviceTransportTypeBuiltIn
+    }
+
+    private static func isInternalMicrophoneUnavailableInClamshell(
+        deviceUID: String?,
+        transportType: UInt32?,
+        lidClosed: Bool
+    ) -> Bool {
+        lidClosed
+            && transportType == kAudioDeviceTransportTypeBuiltIn
+            && deviceUID == "BuiltInMicrophoneDevice"
     }
 
     fileprivate static func transportType(for deviceID: AudioDeviceID) -> UInt32? {

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -324,9 +324,7 @@ final class PremiumAccountService: ObservableObject {
         session: URLSession = .shared,
         requestExecutor: (@Sendable (URLRequest) async throws -> (Data, URLResponse))? = nil,
         appleWebAuthenticator: (any AppleWebAuthenticating)? = nil,
-        keychainService: String = AppConstants.isScreenshotAutomation
-            ? "com.typewhisper.mac.screenshots.premium-account"
-            : "com.typewhisper.mac.premium-account",
+        keychainService: String = AppConstants.premiumAccountKeychainService,
         entitlementPublicKeyBase64: String = PremiumAccountService.productionEntitlementPublicKeyBase64,
         isSignedInOverride: Bool? = nil,
         automaticallyRefresh: Bool = true,

--- a/TypeWhisperTests/AppFormatterServiceTests.swift
+++ b/TypeWhisperTests/AppFormatterServiceTests.swift
@@ -2,6 +2,41 @@ import XCTest
 @testable import TypeWhisper
 
 final class AppFormatterServiceTests: XCTestCase {
+    func testPremiumAccountKeychainServiceSeparatesRuntimeEnvironments() {
+        XCTAssertEqual(
+            AppConstants.resolvePremiumAccountKeychainService(
+                isScreenshotAutomation: false,
+                isRunningTests: false,
+                isDevelopment: false
+            ),
+            "com.typewhisper.mac.premium-account"
+        )
+        XCTAssertEqual(
+            AppConstants.resolvePremiumAccountKeychainService(
+                isScreenshotAutomation: false,
+                isRunningTests: false,
+                isDevelopment: true
+            ),
+            "com.typewhisper.mac.dev.premium-account"
+        )
+        XCTAssertEqual(
+            AppConstants.resolvePremiumAccountKeychainService(
+                isScreenshotAutomation: false,
+                isRunningTests: true,
+                isDevelopment: true
+            ),
+            "com.typewhisper.mac.tests.premium-account"
+        )
+        XCTAssertEqual(
+            AppConstants.resolvePremiumAccountKeychainService(
+                isScreenshotAutomation: true,
+                isRunningTests: true,
+                isDevelopment: true
+            ),
+            "com.typewhisper.mac.screenshots.premium-account"
+        )
+    }
+
     func testBundledReleaseChannelUsesInfoDictionaryValue() {
         let channel = AppConstants.bundledReleaseChannel(
             infoDictionary: ["TypeWhisperReleaseChannel": AppConstants.ReleaseChannel.releaseCandidate.rawValue]

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1243,7 +1243,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let builtInDeviceID = AudioDeviceID(703)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input")
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice")
             ],
             monitorDeviceChanges: false,
             probeCompatibilities: false,
@@ -1265,7 +1265,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let usbDeviceID = AudioDeviceID(705)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice"),
                 AudioInputDevice(deviceID: usbDeviceID, name: "Studio Display Microphone", uid: "display-input")
             ],
             monitorDeviceChanges: false,
@@ -1283,7 +1283,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         )
         service.audioDeviceIDResolverOverride = { uid in
             switch uid {
-            case "built-in-input": return builtInDeviceID
+            case "BuiltInMicrophoneDevice": return builtInDeviceID
             case "display-input": return usbDeviceID
             default: return nil
             }
@@ -1334,7 +1334,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             }
             let service = AudioDeviceService(
                 initialInputDevices: [
-                    AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-\(index)"),
+                    AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice"),
                     AudioInputDevice(deviceID: fallbackDeviceID, name: scenario.name, uid: "fallback-\(index)")
                 ],
                 monitorDeviceChanges: false,
@@ -1347,7 +1347,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             )
             service.audioDeviceIDResolverOverride = { uid in
                 switch uid {
-                case "built-in-\(index)": return builtInDeviceID
+                case "BuiltInMicrophoneDevice": return builtInDeviceID
                 case "fallback-\(index)": return fallbackDeviceID
                 default: return nil
                 }
@@ -1372,7 +1372,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let usbDeviceID = AudioDeviceID(732)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice"),
                 AudioInputDevice(deviceID: virtualDeviceID, name: "BlackHole 2ch", uid: "virtual-input"),
                 AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input")
             ],
@@ -1392,7 +1392,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         )
         service.audioDeviceIDResolverOverride = { uid in
             switch uid {
-            case "built-in-input": return builtInDeviceID
+            case "BuiltInMicrophoneDevice": return builtInDeviceID
             case "virtual-input": return virtualDeviceID
             case "usb-input": return usbDeviceID
             default: return nil
@@ -1433,12 +1433,125 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(selection, .systemDefault)
     }
 
+    func testClosedLidKeepsBuiltInHeadphoneInputPriorityItemAvailable() {
+        let headsetDeviceID = AudioDeviceID(735)
+        let headset = AudioInputDevice(
+            deviceID: headsetDeviceID,
+            name: "External Microphone",
+            uid: "BuiltInHeadphoneInputDevice"
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [headset],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [headsetDeviceID: kAudioDeviceTransportTypeBuiltIn]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true)
+        )
+        let priorityItem = AudioInputDevicePriorityItem(
+            uid: headset.uid,
+            name: headset.name
+        )
+
+        XCTAssertTrue(service.isInputDevicePriorityItemAvailable(priorityItem))
+    }
+
+    func testResolvedRecordingInputSelectionKeepsAnalogHeadsetPrimaryWhenLidIsClosed() throws {
+        let headsetDeviceID = AudioDeviceID(736)
+        let alternateDeviceID = AudioDeviceID(737)
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(
+                    uid: "BuiltInHeadphoneInputDevice",
+                    name: "External Microphone"
+                )
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(
+                    deviceID: headsetDeviceID,
+                    name: "External Microphone",
+                    uid: "BuiltInHeadphoneInputDevice"
+                ),
+                AudioInputDevice(
+                    deviceID: alternateDeviceID,
+                    name: "iPhone Microphone",
+                    uid: "continuity-input"
+                )
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    headsetDeviceID: kAudioDeviceTransportTypeBuiltIn,
+                    alternateDeviceID: kAudioDeviceTransportTypeVirtual
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: headsetDeviceID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "BuiltInHeadphoneInputDevice": return headsetDeviceID
+            case "continuity-input": return alternateDeviceID
+            default: return nil
+            }
+        }
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "BuiltInHeadphoneInputDevice")
+        XCTAssertEqual(selection.deviceID, headsetDeviceID)
+        XCTAssertEqual(selection.deviceName, "External Microphone")
+        XCTAssertTrue(selection.hasExplicitDeviceSelection)
+    }
+
+    func testResolvedRecordingInputSelectionKeepsAnalogHeadsetSystemDefaultWhenLidIsClosed() {
+        let headsetDeviceID = AudioDeviceID(738)
+        let alternateDeviceID = AudioDeviceID(739)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(
+                    deviceID: headsetDeviceID,
+                    name: "External Microphone",
+                    uid: "BuiltInHeadphoneInputDevice"
+                ),
+                AudioInputDevice(
+                    deviceID: alternateDeviceID,
+                    name: "iPhone Microphone",
+                    uid: "continuity-input"
+                )
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    headsetDeviceID: kAudioDeviceTransportTypeBuiltIn,
+                    alternateDeviceID: kAudioDeviceTransportTypeVirtual
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: headsetDeviceID
+            )
+        )
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection, .systemDefault)
+    }
+
     func testResolvedRecordingInputSelectionSkipsBuiltInMicWhenLidIsClosed() throws {
         let builtInDeviceID = AudioDeviceID(1)
         let usbDeviceID = AudioDeviceID(2)
         UserDefaults.standard.set(
             try JSONEncoder().encode([
-                AudioInputDevicePriorityItem(uid: "built-in", name: "MacBook Pro Microphone"),
+                AudioInputDevicePriorityItem(uid: "BuiltInMicrophoneDevice", name: "MacBook Pro Microphone"),
                 AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic")
             ]),
             forKey: UserDefaultsKeys.inputDevicePriorityList
@@ -1446,7 +1559,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let clamshellProvider = FakeClamshellStateProvider(lidClosed: true)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "built-in"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice"),
                 AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
             ],
             monitorDeviceChanges: false,
@@ -1461,7 +1574,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         )
         service.audioDeviceIDResolverOverride = { uid in
             switch uid {
-            case "built-in": return builtInDeviceID
+            case "BuiltInMicrophoneDevice": return builtInDeviceID
             case "usb-input": return usbDeviceID
             default: return nil
             }
@@ -1480,7 +1593,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let usbDeviceID = AudioDeviceID(2)
         UserDefaults.standard.set(
             try JSONEncoder().encode([
-                AudioInputDevicePriorityItem(uid: "built-in", name: "MacBook Pro Microphone"),
+                AudioInputDevicePriorityItem(uid: "BuiltInMicrophoneDevice", name: "MacBook Pro Microphone"),
                 AudioInputDevicePriorityItem(uid: "usb-input", name: "USB Mic")
             ]),
             forKey: UserDefaultsKeys.inputDevicePriorityList
@@ -1488,7 +1601,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let clamshellProvider = FakeClamshellStateProvider(lidClosed: false)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "built-in"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice"),
                 AudioInputDevice(deviceID: usbDeviceID, name: "USB Mic", uid: "usb-input")
             ],
             monitorDeviceChanges: false,
@@ -1503,7 +1616,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         )
         service.audioDeviceIDResolverOverride = { uid in
             switch uid {
-            case "built-in": return builtInDeviceID
+            case "BuiltInMicrophoneDevice": return builtInDeviceID
             case "usb-input": return usbDeviceID
             default: return nil
             }
@@ -1511,7 +1624,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
 
         let selection = service.resolvedRecordingInputSelection()
 
-        XCTAssertEqual(selection.deviceUID, "built-in")
+        XCTAssertEqual(selection.deviceUID, "BuiltInMicrophoneDevice")
         XCTAssertEqual(selection.deviceID, builtInDeviceID)
         XCTAssertEqual(selection.deviceName, "MacBook Pro Microphone")
         XCTAssertTrue(selection.hasExplicitDeviceSelection)
@@ -1521,14 +1634,14 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let builtInDeviceID = AudioDeviceID(1)
         UserDefaults.standard.set(
             try JSONEncoder().encode([
-                AudioInputDevicePriorityItem(uid: "built-in", name: "MacBook Pro Microphone")
+                AudioInputDevicePriorityItem(uid: "BuiltInMicrophoneDevice", name: "MacBook Pro Microphone")
             ]),
             forKey: UserDefaultsKeys.inputDevicePriorityList
         )
         let clamshellProvider = FakeClamshellStateProvider(lidClosed: true)
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "built-in")
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice")
             ],
             monitorDeviceChanges: false,
             probeCompatibilities: false,
@@ -1541,7 +1654,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
             )
         )
         service.audioDeviceIDResolverOverride = { uid in
-            uid == "built-in" ? builtInDeviceID : nil
+            uid == "BuiltInMicrophoneDevice" ? builtInDeviceID : nil
         }
 
         let selection = service.resolvedRecordingInputSelection()
@@ -1730,7 +1843,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let inputActivationGuard = FakeAudioInputDeviceActivator()
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input")
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice")
             ],
             monitorDeviceChanges: false,
             probeCompatibilities: false,
@@ -1762,7 +1875,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         let inputCaptureFactory = FakeAudioInputCaptureFactory()
         let service = AudioDeviceService(
             initialInputDevices: [
-                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "built-in-input"),
+                AudioInputDevice(deviceID: builtInDeviceID, name: "MacBook Microphone", uid: "BuiltInMicrophoneDevice"),
                 AudioInputDevice(deviceID: usbDeviceID, name: "Studio Display Microphone", uid: "display-input")
             ],
             monitorDeviceChanges: false,
@@ -1783,7 +1896,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         service.hasMicrophonePermissionOverride = true
         service.audioDeviceIDResolverOverride = { uid in
             switch uid {
-            case "built-in-input": builtInDeviceID
+            case "BuiltInMicrophoneDevice": builtInDeviceID
             case "display-input": usbDeviceID
             default: nil
             }
@@ -1908,6 +2021,7 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         }
 
         service.startPreview()
+        service.hasMicrophonePermissionOverride = false
         let report = service.diagnosticsReport()
         let selectedDevice = try XCTUnwrap(report.devices.first { $0.deviceID == UInt32(usbDeviceID) })
 
@@ -1920,6 +2034,8 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertTrue(selectedDevice.isSelected)
         XCTAssertTrue(selectedDevice.listedByTypeWhisper)
         XCTAssertEqual(selectedDevice.compatibility, "incompatible:engineStartFailed")
+        XCTAssertNil(selectedDevice.inputOnlyCaptureFormat)
+        XCTAssertEqual(selectedDevice.inputOnlyCaptureFormatError, "microphonePermissionNotGranted")
     }
 }
 


### PR DESCRIPTION
## Context

Issue #1163 reports that TypeWhisper marks a connected analog headset microphone as disconnected in clamshell mode and falls back to an iPhone microphone. The diagnostics identify that external input as `BuiltInHeadphoneInputDevice` with CoreAudio's `builtIn` transport, while the actual MacBook microphone uses `BuiltInMicrophoneDevice`.

The clamshell fallback previously classified every input with the `builtIn` transport as the physically unavailable internal microphone. Development validation also exposed two unrelated system prompts because development builds shared the production Premium Account keychain service and permission-free diagnostics opened a HAL input capture session.

## Changes

- identify the unavailable clamshell microphone by its stable internal microphone UID instead of transport type alone
- apply the identity check consistently to priority availability, explicit selection, System Default fallback, and static device availability
- keep analog headset inputs available and selected while the lid is closed
- isolate Premium Account keychain services for production, development, tests, and screenshot automation
- avoid probing capture formats in diagnostics until microphone permission has already been granted
- add regression coverage for analog headset priority and System Default routing, internal microphone failover, keychain service isolation, and permission-free diagnostics

Closes #1163

## Test plan

```bash
xcodebuild test -quiet -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests -only-testing:TypeWhisperTests/AppFormatterServiceTests
git diff --check origin/main...HEAD
```

Result: 53 tests passed, 0 failed, 0 skipped. A signed development build also completed successfully and launched with the development bundle identifier and expected App Group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone detection when a laptop lid is closed by distinguishing the internal microphone from other built-in audio inputs.
  * Kept compatible headphone inputs available for recording and device selection.
  * Improved diagnostics when microphone permission is denied with clearer status information.
  * Ensured premium account storage uses the correct environment-specific configuration.

* **Tests**
  * Added coverage for environment-specific account storage and closed-lid audio scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->