### PR TITLE
Fix Soniox live transcript continuity

### DIFF
--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -111,10 +111,12 @@ final class StreamingHandler: @unchecked Sendable {
 
         let providerId = engineOverrideId ?? selectedProviderId
         guard let providerId,
-              PluginManager.shared.transcriptionEngine(for: providerId) != nil else {
+              let provider = PluginManager.shared.transcriptionEngine(for: providerId) else {
             logger.info("Live transcript preview skipped: provider unavailable")
             return
         }
+        let replacesLiveSessionPreview =
+            (provider as? LiveTranscriptionProgressModeProviding)?.liveTranscriptionProgressMode == .completeSnapshot
 
         resetStreamingState()
         sharedState.withLock { state in
@@ -141,7 +143,7 @@ final class StreamingHandler: @unchecked Sendable {
                         text,
                         audioGate: self.currentLivePreviewAudioGateSnapshot(),
                         persist: true,
-                        replacesPreviousPreview: self.liveSessionProgressReplacesPreviousPreview()
+                        replacesPreviousPreview: replacesLiveSessionPreview
                     )
                     return true
                 }
@@ -382,15 +384,6 @@ final class StreamingHandler: @unchecked Sendable {
 
     private func currentLivePreviewAudioGateSnapshot() -> LivePreviewAudioGateSnapshot {
         sharedState.withLock { $0.livePreviewAudioGate.snapshot }
-    }
-
-    private func liveSessionProgressReplacesPreviousPreview() -> Bool {
-        sharedState.withLock { state in
-            guard let session = state.liveSessionHandle?.session as? LiveTranscriptionProgressModeProviding else {
-                return false
-            }
-            return session.liveTranscriptionProgressMode == .completeSnapshot
-        }
     }
 
     @discardableResult

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -140,7 +140,8 @@ final class StreamingHandler: @unchecked Sendable {
                     _ = self.processPreviewUpdate(
                         text,
                         audioGate: self.currentLivePreviewAudioGateSnapshot(),
-                        persist: true
+                        persist: true,
+                        replacesPreviousPreview: true
                     )
                     return true
                 }
@@ -387,13 +388,16 @@ final class StreamingHandler: @unchecked Sendable {
     private func processPreviewUpdate(
         _ text: String,
         audioGate: LivePreviewAudioGateSnapshot?,
-        persist: Bool
+        persist: Bool,
+        replacesPreviousPreview: Bool = false
     ) -> Bool {
         let preview = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !preview.isEmpty else { return false }
 
         let confirmed = progressText.withLock { $0 }
-        let stable = Self.stabilizeText(confirmed: confirmed, new: preview)
+        let stable = replacesPreviousPreview
+            ? preview
+            : Self.stabilizeText(confirmed: confirmed, new: preview)
         if Self.shouldSuppressLivePreviewUpdate(confirmed: confirmed, stable: stable, audioGate: audioGate) {
             logger.debug("Live transcript preview update suppressed during sustained silence")
             return false

--- a/TypeWhisper/ViewModels/StreamingHandler.swift
+++ b/TypeWhisper/ViewModels/StreamingHandler.swift
@@ -141,7 +141,7 @@ final class StreamingHandler: @unchecked Sendable {
                         text,
                         audioGate: self.currentLivePreviewAudioGateSnapshot(),
                         persist: true,
-                        replacesPreviousPreview: true
+                        replacesPreviousPreview: self.liveSessionProgressReplacesPreviousPreview()
                     )
                     return true
                 }
@@ -382,6 +382,15 @@ final class StreamingHandler: @unchecked Sendable {
 
     private func currentLivePreviewAudioGateSnapshot() -> LivePreviewAudioGateSnapshot {
         sharedState.withLock { $0.livePreviewAudioGate.snapshot }
+    }
+
+    private func liveSessionProgressReplacesPreviousPreview() -> Bool {
+        sharedState.withLock { state in
+            guard let session = state.liveSessionHandle?.session as? LiveTranscriptionProgressModeProviding else {
+                return false
+            }
+            return session.liveTranscriptionProgressMode == .completeSnapshot
+        }
     }
 
     @discardableResult

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -359,9 +359,6 @@ actor SonioxTranscriptCollector {
     private var lastInterimLanguage: String?
     private var _detectedLanguage: String?
     private var _error: String?
-    private var _finishRequested = false
-    private var _finishAcknowledged = false
-    private var _streamFinished = false
 
     func addFinal(_ text: String, language: String? = nil) {
         if !text.isEmpty {
@@ -389,13 +386,6 @@ actor SonioxTranscriptCollector {
         _error = message
     }
 
-    func beginFinish() {
-        _finishRequested = true
-        _finishAcknowledged = false
-    }
-
-    var shouldStopReceiving: Bool { _finishAcknowledged || _streamFinished }
-
     var error: String? { _error }
 
     @discardableResult
@@ -413,7 +403,6 @@ actor SonioxTranscriptCollector {
         // them before clearing the interim state.
         if json["finished"] as? Bool == true {
             interim = ""
-            _streamFinished = true
         }
 
         guard let tokens = json["tokens"] as? [[String: Any]] else {
@@ -432,10 +421,6 @@ actor SonioxTranscriptCollector {
 
             if isSonioxTranscriptSentinel(tokenText) {
                 interim = ""
-                if tokenText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "<fin>",
-                   _finishRequested {
-                    _finishAcknowledged = true
-                }
                 continue
             }
 
@@ -607,7 +592,7 @@ actor SonioxTranscriptCollector {
 
 // MARK: - Live STT Session
 
-final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
+final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, LiveTranscriptionProgressModeProviding, @unchecked Sendable {
     private struct State {
         var finished = false
         var cancelled = false
@@ -621,6 +606,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
     private let collector: SonioxTranscriptCollector
     private let language: String?
     private let state = OSAllocatedUnfairLock(initialState: State())
+    let liveTranscriptionProgressMode: LiveTranscriptionProgressMode = .completeSnapshot
 
     private init(
         webSocketTask: URLSessionWebSocketTask,
@@ -655,7 +641,6 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
         let webSocketTask = URLSession.shared.webSocketTask(with: request)
         let collector = SonioxTranscriptCollector()
         let receiveTask = Task { [webSocketTask, collector, onProgress] in
-            var hasCompletedFinish = false
             do {
                 while !Task.isCancelled {
                     let message = try await webSocketTask.receive()
@@ -664,14 +649,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
                        !text.isEmpty {
                         _ = onProgress(text)
                     }
-                    if !hasCompletedFinish, await collector.shouldStopReceiving {
-                        hasCompletedFinish = true
-                        let current = await collector.finalResult()
-                        if !current.isEmpty {
-                            _ = onProgress(current)
-                        }
-                    }
-                    if Self.isFinishedResponse(data) || hasCompletedFinish {
+                    if Self.isFinishedResponse(data) {
                         break
                     }
                 }
@@ -747,7 +725,6 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
 
         if shouldFinish {
             let finishStart = CFAbsoluteTimeGetCurrent()
-            await collector.beginFinish()
             do {
                 try await webSocketTask.send(.string(#"{"type":"finalize"}"#))
                 try await webSocketTask.send(.data(Data()))
@@ -761,7 +738,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
                 await collector.setError(error.localizedDescription)
                 throw PluginTranscriptionError.networkError(error.localizedDescription)
             }
-            let finishedCleanly = await waitForReceiveTask(collector: collector)
+            let finishedCleanly = await waitForReceiveTask()
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - finishStart) * 1000
             if finishedCleanly {
                 Self.logger.info("Live finish: server confirmed finished in \(String(format: "%.0f", elapsedMs), privacy: .public)ms")
@@ -792,29 +769,16 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
         webSocketTask.cancel(with: .goingAway, reason: nil)
     }
 
-    /// Waits for the receive loop to observe `<fin>` for our explicit finalize
-    /// request or the server's terminal `finished` response.
+    /// Waits for the receive loop to observe the server's terminal `finished` response.
     /// Returns `false` on timeout. The task group cannot exit while the receive
     /// loop is still blocked in `receive()` — awaiting `receiveTask.value` does
     /// not react to cancellation — so on timeout the socket is torn down first
     /// to unblock the receive loop; otherwise this method would silently wait
     /// until the server closes the connection (~10s) despite the timeout.
-    private func waitForReceiveTask(collector: SonioxTranscriptCollector) async -> Bool {
+    private func waitForReceiveTask() async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
             group.addTask { [receiveTask] in
                 await receiveTask.value
-                return true
-            }
-            group.addTask { [collector] in
-                while !Task.isCancelled {
-                    if await collector.shouldStopReceiving {
-                        return true
-                    }
-                    if await collector.error != nil {
-                        return false
-                    }
-                    try? await Task.sleep(nanoseconds: 10_000_000)
-                }
                 return true
             }
             group.addTask {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -592,7 +592,7 @@ actor SonioxTranscriptCollector {
 
 // MARK: - Live STT Session
 
-final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, LiveTranscriptionProgressModeProviding, @unchecked Sendable {
+final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
     private struct State {
         var finished = false
         var cancelled = false
@@ -606,7 +606,6 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, LiveTransc
     private let collector: SonioxTranscriptCollector
     private let language: String?
     private let state = OSAllocatedUnfairLock(initialState: State())
-    let liveTranscriptionProgressMode: LiveTranscriptionProgressMode = .completeSnapshot
 
     private init(
         webSocketTask: URLSessionWebSocketTask,
@@ -821,6 +820,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, LiveTransc
 final class SonioxPlugin: NSObject,
     SourceProgressLanguageHintTranscriptionEnginePlugin,
     LiveLanguageHintTranscriptionCapablePlugin,
+    LiveTranscriptionProgressModeProviding,
     DictionaryTermsCapabilityProviding,
     DictionaryTermsBudgetProviding,
     TTSProviderPlugin,
@@ -915,6 +915,7 @@ final class SonioxPlugin: NSObject,
 
     var providerId: String { "soniox" }
     var providerDisplayName: String { "Soniox" }
+    var liveTranscriptionProgressMode: LiveTranscriptionProgressMode { .completeSnapshot }
 
     var isConfigured: Bool {
         guard let key = normalizedAPIKey else { return false }

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -353,17 +353,19 @@ actor SonioxTranscriptCollector {
         let usedInterimPreview: Bool
     }
 
-    private var finals: [String] = []
+    private var finalTranscript: String = ""
     private var interim: String = ""
     private var lastInterimPreview: String = ""
     private var lastInterimLanguage: String?
     private var _detectedLanguage: String?
     private var _error: String?
+    private var _finishRequested = false
+    private var _finishAcknowledged = false
+    private var _streamFinished = false
 
     func addFinal(_ text: String, language: String? = nil) {
-        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !trimmed.isEmpty {
-            finals.append(trimmed)
+        if !text.isEmpty {
+            finalTranscript.append(text)
         }
         interim = ""
         if let language, !language.isEmpty {
@@ -372,7 +374,7 @@ actor SonioxTranscriptCollector {
     }
 
     func setInterim(_ text: String, language: String? = nil) {
-        interim = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        interim = text
         let preview = currentText()
         if !preview.isEmpty {
             lastInterimPreview = preview
@@ -386,6 +388,13 @@ actor SonioxTranscriptCollector {
     func setError(_ message: String) {
         _error = message
     }
+
+    func beginFinish() {
+        _finishRequested = true
+        _finishAcknowledged = false
+    }
+
+    var shouldStopReceiving: Bool { _finishAcknowledged || _streamFinished }
 
     var error: String? { _error }
 
@@ -404,6 +413,7 @@ actor SonioxTranscriptCollector {
         // them before clearing the interim state.
         if json["finished"] as? Bool == true {
             interim = ""
+            _streamFinished = true
         }
 
         guard let tokens = json["tokens"] as? [[String: Any]] else {
@@ -416,8 +426,16 @@ actor SonioxTranscriptCollector {
 
         for token in tokens {
             guard let tokenText = token["text"] as? String,
-                  !tokenText.isEmpty,
-                  !isSonioxTranscriptSentinel(tokenText) else {
+                  !tokenText.isEmpty else {
+                continue
+            }
+
+            if isSonioxTranscriptSentinel(tokenText) {
+                interim = ""
+                if tokenText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "<fin>",
+                   _finishRequested {
+                    _finishAcknowledged = true
+                }
                 continue
             }
 
@@ -455,15 +473,15 @@ actor SonioxTranscriptCollector {
     }
 
     func currentText() -> String {
-        var parts = finals
+        var text = finalTranscript
         if !interim.isEmpty {
-            parts.append(interim)
+            text.append(interim)
         }
-        return parts.joined(separator: " ")
+        return text
     }
 
     func finalResult() -> String {
-        finals.joined(separator: " ")
+        finalTranscript
     }
 
     func detectedLanguage(fallback: String?) -> String? {
@@ -637,6 +655,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
         let webSocketTask = URLSession.shared.webSocketTask(with: request)
         let collector = SonioxTranscriptCollector()
         let receiveTask = Task { [webSocketTask, collector, onProgress] in
+            var hasCompletedFinish = false
             do {
                 while !Task.isCancelled {
                     let message = try await webSocketTask.receive()
@@ -645,7 +664,14 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
                        !text.isEmpty {
                         _ = onProgress(text)
                     }
-                    if Self.isFinishedResponse(data) {
+                    if !hasCompletedFinish, await collector.shouldStopReceiving {
+                        hasCompletedFinish = true
+                        let current = await collector.finalResult()
+                        if !current.isEmpty {
+                            _ = onProgress(current)
+                        }
+                    }
+                    if Self.isFinishedResponse(data) || hasCompletedFinish {
                         break
                     }
                 }
@@ -721,6 +747,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
 
         if shouldFinish {
             let finishStart = CFAbsoluteTimeGetCurrent()
+            await collector.beginFinish()
             do {
                 try await webSocketTask.send(.string(#"{"type":"finalize"}"#))
                 try await webSocketTask.send(.data(Data()))
@@ -734,7 +761,7 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
                 await collector.setError(error.localizedDescription)
                 throw PluginTranscriptionError.networkError(error.localizedDescription)
             }
-            let finishedCleanly = await waitForReceiveTask()
+            let finishedCleanly = await waitForReceiveTask(collector: collector)
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - finishStart) * 1000
             if finishedCleanly {
                 Self.logger.info("Live finish: server confirmed finished in \(String(format: "%.0f", elapsedMs), privacy: .public)ms")
@@ -765,16 +792,29 @@ final class SonioxLiveTranscriptionSession: LiveTranscriptionSession, @unchecked
         webSocketTask.cancel(with: .goingAway, reason: nil)
     }
 
-    /// Waits for the receive loop to observe the server's `finished` response.
+    /// Waits for the receive loop to observe `<fin>` for our explicit finalize
+    /// request or the server's terminal `finished` response.
     /// Returns `false` on timeout. The task group cannot exit while the receive
     /// loop is still blocked in `receive()` — awaiting `receiveTask.value` does
     /// not react to cancellation — so on timeout the socket is torn down first
     /// to unblock the receive loop; otherwise this method would silently wait
     /// until the server closes the connection (~10s) despite the timeout.
-    private func waitForReceiveTask() async -> Bool {
+    private func waitForReceiveTask(collector: SonioxTranscriptCollector) async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
             group.addTask { [receiveTask] in
                 await receiveTask.value
+                return true
+            }
+            group.addTask { [collector] in
+                while !Task.isCancelled {
+                    if await collector.shouldStopReceiving {
+                        return true
+                    }
+                    if await collector.error != nil {
+                        return false
+                    }
+                    try? await Task.sleep(nanoseconds: 10_000_000)
+                }
                 return true
             }
             group.addTask {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -1356,10 +1356,16 @@ final class SonioxPluginTests: XCTestCase {
         XCTAssertEqual(result.text, "speech-to-text, especially long")
     }
 
-    func testLiveSessionFinishReturnsPromptlyOnFinToken() async throws {
+    func testLiveSessionWaitsForFinishedAfterFinToCollectDelayedTranslation() async throws {
         let server = try LocalWebSocketServer { text, server in
             guard text.contains("finalize") else { return }
-            server.sendText(#"{"tokens":[{"text":"hello","is_final":true},{"text":" world","is_final":true},{"text":"<fin>","is_final":true}]}"#)
+            server.sendText(#"{"tokens":[{"text":"Hallo","is_final":true,"translation_status":"original","language":"de"},{"text":"<fin>","is_final":true}]}"#)
+            DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                server.sendText(#"{"tokens":[{"text":"Hello","is_final":true,"translation_status":"translation","source_language":"de"},{"text":" world","is_final":true,"translation_status":"translation","source_language":"de"}]}"#)
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                    server.sendText(#"{"tokens":[],"finished":true}"#)
+                }
+            }
         }
         defer { server.stop() }
         let port = try await server.start()
@@ -1368,19 +1374,17 @@ final class SonioxPluginTests: XCTestCase {
             apiKey: "test-key",
             region: .unitedStates,
             modelId: "stt-rt-v5",
-            languageSelection: PluginLanguageSelection(requestedLanguage: "en"),
-            translate: false,
+            languageSelection: PluginLanguageSelection(requestedLanguage: "de"),
+            translate: true,
             prompt: nil,
             onProgress: { _ in true },
             webSocketURLOverride: URL(string: "ws://127.0.0.1:\(port)")!
         )
 
-        let start = CFAbsoluteTimeGetCurrent()
         let result = try await session.finish()
-        let elapsed = CFAbsoluteTimeGetCurrent() - start
 
-        XCTAssertEqual(result.text, "hello world")
-        XCTAssertLessThan(elapsed, 0.5)
+        XCTAssertEqual(result.text, "Hello world")
+        XCTAssertEqual(result.detectedLanguage, "de")
     }
 
     func testLiveSessionContinuesReceivingAfterEndpointToken() async throws {

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/Tests/SonioxPluginTests.swift
@@ -1341,6 +1341,80 @@ final class SonioxPluginTests: XCTestCase {
         ))
     }
 
+    func testRealtimeCollectorPreservesTokenSubwordsAndPunctuationSpacing() async throws {
+        let collector = SonioxTranscriptCollector()
+
+        _ = try await collector.applyWebSocketResponse(Data(
+            #"{"tokens":[{"text":"speech","is_final":true},{"text":"-to-text","is_final":true},{"text":",","is_final":true},{"text":" ","is_final":true},{"text":"espe","is_final":true},{"text":"cially","is_final":true},{"text":" ","is_final":true}]}"#.utf8
+        ), translating: false)
+
+        _ = try await collector.applyWebSocketResponse(Data(
+            #"{"tokens":[{"text":"long","is_final":true},{"text":"<fin>","is_final":true}]}"#.utf8
+        ), translating: false)
+
+        let result = await collector.finalTranscriptionResult(fallbackLanguage: nil)
+        XCTAssertEqual(result.text, "speech-to-text, especially long")
+    }
+
+    func testLiveSessionFinishReturnsPromptlyOnFinToken() async throws {
+        let server = try LocalWebSocketServer { text, server in
+            guard text.contains("finalize") else { return }
+            server.sendText(#"{"tokens":[{"text":"hello","is_final":true},{"text":" world","is_final":true},{"text":"<fin>","is_final":true}]}"#)
+        }
+        defer { server.stop() }
+        let port = try await server.start()
+
+        let session = try await SonioxLiveTranscriptionSession.connect(
+            apiKey: "test-key",
+            region: .unitedStates,
+            modelId: "stt-rt-v5",
+            languageSelection: PluginLanguageSelection(requestedLanguage: "en"),
+            translate: false,
+            prompt: nil,
+            onProgress: { _ in true },
+            webSocketURLOverride: URL(string: "ws://127.0.0.1:\(port)")!
+        )
+
+        let start = CFAbsoluteTimeGetCurrent()
+        let result = try await session.finish()
+        let elapsed = CFAbsoluteTimeGetCurrent() - start
+
+        XCTAssertEqual(result.text, "hello world")
+        XCTAssertLessThan(elapsed, 0.5)
+    }
+
+    func testLiveSessionContinuesReceivingAfterEndpointToken() async throws {
+        let server = try LocalWebSocketServer { text, server in
+            if text.contains("\"api_key\"") {
+                server.sendText(#"{"tokens":[{"text":"First phrase","is_final":true},{"text":"<end>","is_final":true}]}"#)
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                    server.sendText(#"{"tokens":[{"text":" after pause","is_final":true}]}"#)
+                }
+            } else if text.contains("finalize") {
+                server.sendText(#"{"tokens":[{"text":"<fin>","is_final":true}]}"#)
+            }
+        }
+        defer { server.stop() }
+        let port = try await server.start()
+
+        let session = try await SonioxLiveTranscriptionSession.connect(
+            apiKey: "test-key",
+            region: .unitedStates,
+            modelId: "stt-rt-v5",
+            languageSelection: PluginLanguageSelection(requestedLanguage: "en"),
+            translate: false,
+            prompt: nil,
+            onProgress: { _ in true },
+            webSocketURLOverride: URL(string: "ws://127.0.0.1:\(port)")!
+        )
+
+        try await session.appendAudio(samples: Array(repeating: 0, count: 3_200))
+        try await Task.sleep(for: .milliseconds(150))
+        let result = try await session.finish()
+
+        XCTAssertEqual(result.text, "First phrase after pause")
+    }
+
     func testRealtimeCollectorBuildsStableFinalAndInterimText() async throws {
         let collector = SonioxTranscriptCollector()
 

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
     "version": "1.2.6",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -736,6 +736,17 @@ public protocol LiveTranscriptionSession: AnyObject, Sendable {
     func cancel() async
 }
 
+/// Describes whether live progress text covers all audio so far or only a recent window.
+public enum LiveTranscriptionProgressMode: Sendable, Equatable {
+    case rollingWindow
+    case completeSnapshot
+}
+
+/// Optional session capability for declaring how progress callbacks should be interpreted.
+public protocol LiveTranscriptionProgressModeProviding: LiveTranscriptionSession {
+    var liveTranscriptionProgressMode: LiveTranscriptionProgressMode { get }
+}
+
 public enum PluginDictionaryTerms {
     public static func normalizedTermHints(from hints: [PluginDictionaryTermHint]) -> [PluginDictionaryTermHint] {
         var seen = Set<String>()

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -742,8 +742,8 @@ public enum LiveTranscriptionProgressMode: Sendable, Equatable {
     case completeSnapshot
 }
 
-/// Optional session capability for declaring how progress callbacks should be interpreted.
-public protocol LiveTranscriptionProgressModeProviding: LiveTranscriptionSession {
+/// Optional provider capability for declaring how live progress callbacks should be interpreted.
+public protocol LiveTranscriptionProgressModeProviding: Sendable {
     var liveTranscriptionProgressMode: LiveTranscriptionProgressMode { get }
 }
 

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -89,18 +89,18 @@ final class PluginManifestValidationTests: XCTestCase {
     }
 
     func testSourceFootageProgressPluginsDeclareCapability() throws {
-        let manifestPaths = [
-            "TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json",
-            "TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json",
+        let manifestExpectations = [
+            ("TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json", "1.5.0"),
+            ("TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json", "1.5.0"),
+            ("TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json", "1.7.0"),
         ]
 
-        for relativePath in manifestPaths {
+        for (relativePath, expectedMinHostVersion) in manifestExpectations {
             let manifestURL = TestSupport.repoRoot.appendingPathComponent(relativePath)
             let data = try Data(contentsOf: manifestURL)
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
             XCTAssertTrue(manifest.supportsCapability(.sourceFootageProgress), relativePath)
-            XCTAssertEqual(manifest.minHostVersion, "1.5.0", relativePath)
+            XCTAssertEqual(manifest.minHostVersion, expectedMinHostVersion, relativePath)
         }
     }
 

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -1351,7 +1351,7 @@ final class StreamingHandlerTests: XCTestCase {
         XCTAssertEqual(recorded, [firstChunk.count, tailChunk.count])
     }
 
-    func testLiveSessionProgressAllowsProviderCorrections() async throws {
+    func testLiveSessionProgressReplacesProviderSnapshotsWithoutDuplication() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
@@ -1359,6 +1359,7 @@ final class StreamingHandlerTests: XCTestCase {
         await plugin.session.setProgressUpdates([
             "Ich bin an Koin.",
             "Ich bin an Koeln.",
+            "Вот так вот. Я взагалі не розумію, що відбувається далі.",
         ])
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
         PluginManager.shared.loadedPlugins = [
@@ -1383,6 +1384,7 @@ final class StreamingHandlerTests: XCTestCase {
         let chunks = [
             Array(repeating: Float(0.2), count: 4000),
             Array(repeating: Float(0.3), count: 4000),
+            Array(repeating: Float(0.4), count: 4000),
         ]
         let indexLock = NSLock()
         var index = 0
@@ -1422,7 +1424,7 @@ final class StreamingHandlerTests: XCTestCase {
             allowLiveTranscription: true,
             stateCheck: {
                 activeChecks += 1
-                return activeChecks <= 3
+                return activeChecks <= 4
             }
         )
 
@@ -1430,8 +1432,11 @@ final class StreamingHandlerTests: XCTestCase {
         handler.stop()
 
         let updates = updatesLock.withLock { $0 }
-        XCTAssertEqual(updates.last, "Ich bin an Koeln.")
-        XCTAssertFalse(updates.contains("Ich bin an Koin.eln."))
+        XCTAssertEqual(updates, [
+            "Ich bin an Koin.",
+            "Ich bin an Koeln.",
+            "Вот так вот. Я взагалі не розумію, що відбувається далі.",
+        ])
     }
 
     func testLiveSessionSuppressesAdditiveProgressDuringSustainedSilence() async throws {

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -307,8 +307,18 @@ final class StreamingHandlerTests: XCTestCase {
         var supportsTranslation: Bool { false }
         var supportsStreaming: Bool { true }
         var supportedLanguages: [String] { ["en"] }
-        let session = MockLiveSession()
+        let session: MockLiveSession
         private(set) var lastPrompt: String?
+
+        override init() {
+            session = MockLiveSession(progressMode: .rollingWindow)
+            super.init()
+        }
+
+        init(progressMode: LiveTranscriptionProgressMode) {
+            session = MockLiveSession(progressMode: progressMode)
+            super.init()
+        }
 
         func activate(host: HostServices) {}
         func deactivate() {}
@@ -401,10 +411,15 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
-    private actor MockLiveSession: LiveTranscriptionSession {
+    private actor MockLiveSession: LiveTranscriptionSession, LiveTranscriptionProgressModeProviding {
+        nonisolated let liveTranscriptionProgressMode: LiveTranscriptionProgressMode
         private var appendedChunkSizes: [Int] = []
         private var onProgress: (@Sendable (String) -> Bool)?
         private var progressUpdates: [String] = []
+
+        init(progressMode: LiveTranscriptionProgressMode = .rollingWindow) {
+            liveTranscriptionProgressMode = progressMode
+        }
 
         func setOnProgress(_ onProgress: @escaping @Sendable (String) -> Bool) {
             self.onProgress = onProgress
@@ -960,9 +975,10 @@ final class StreamingHandlerTests: XCTestCase {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
-        let plugin = MockLivePlugin()
+        let plugin = MockLivePlugin(progressMode: .rollingWindow)
         await plugin.session.setProgressUpdates([
-            "English and Russian meaningful preview text",
+            "Early words stay in the transcript",
+            "the transcript while later words arrive",
         ])
         await plugin.session.setFinishError(PluginTranscriptionError.networkError("timeout"))
         PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
@@ -986,7 +1002,7 @@ final class StreamingHandlerTests: XCTestCase {
         modelManager.selectProvider(plugin.providerId)
 
         let deltaLock = NSLock()
-        var sentDelta = false
+        var sentDeltaCount = 0
         let handler = StreamingHandler(
             modelManager: modelManager,
             bufferProvider: { [] },
@@ -994,9 +1010,9 @@ final class StreamingHandlerTests: XCTestCase {
             bufferDeltaProvider: { offset in
                 deltaLock.lock()
                 defer { deltaLock.unlock() }
-                guard !sentDelta else { return ([], offset) }
-                sentDelta = true
-                return (Array(repeating: 0.2, count: 4000), 4000)
+                guard sentDeltaCount < 2 else { return ([], offset) }
+                sentDeltaCount += 1
+                return (Array(repeating: 0.2, count: 4000), sentDeltaCount * 4000)
             },
             bufferedDurationProvider: { 0.25 }
         )
@@ -1015,7 +1031,7 @@ final class StreamingHandlerTests: XCTestCase {
         try await Task.sleep(for: .milliseconds(500))
         let result = await handler.finish()
 
-        XCTAssertEqual(result?.text, "English and Russian meaningful preview text")
+        XCTAssertEqual(result?.text, "Early words stay in the transcript while later words arrive")
         XCTAssertEqual(result?.engineUsed, plugin.providerId)
     }
 
@@ -1355,7 +1371,7 @@ final class StreamingHandlerTests: XCTestCase {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }
 
-        let plugin = MockLivePlugin()
+        let plugin = MockLivePlugin(progressMode: .completeSnapshot)
         await plugin.session.setProgressUpdates([
             "Ich bin an Koin.",
             "Ich bin an Koeln.",

--- a/TypeWhisperTests/StreamingHandlerTests.swift
+++ b/TypeWhisperTests/StreamingHandlerTests.swift
@@ -295,7 +295,7 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
-    private final class MockLivePlugin: NSObject, LiveTranscriptionCapablePlugin, @unchecked Sendable {
+    private final class MockLivePlugin: NSObject, LiveTranscriptionCapablePlugin, LiveTranscriptionProgressModeProviding, @unchecked Sendable {
         static var pluginId: String { "com.typewhisper.mock.live" }
         static var pluginName: String { "Mock Live" }
 
@@ -307,16 +307,17 @@ final class StreamingHandlerTests: XCTestCase {
         var supportsTranslation: Bool { false }
         var supportsStreaming: Bool { true }
         var supportedLanguages: [String] { ["en"] }
-        let session: MockLiveSession
+        let session = MockLiveSession()
+        let liveTranscriptionProgressMode: LiveTranscriptionProgressMode
         private(set) var lastPrompt: String?
 
         override init() {
-            session = MockLiveSession(progressMode: .rollingWindow)
+            liveTranscriptionProgressMode = .rollingWindow
             super.init()
         }
 
         init(progressMode: LiveTranscriptionProgressMode) {
-            session = MockLiveSession(progressMode: progressMode)
+            liveTranscriptionProgressMode = progressMode
             super.init()
         }
 
@@ -411,15 +412,10 @@ final class StreamingHandlerTests: XCTestCase {
         }
     }
 
-    private actor MockLiveSession: LiveTranscriptionSession, LiveTranscriptionProgressModeProviding {
-        nonisolated let liveTranscriptionProgressMode: LiveTranscriptionProgressMode
+    private actor MockLiveSession: LiveTranscriptionSession {
         private var appendedChunkSizes: [Int] = []
         private var onProgress: (@Sendable (String) -> Bool)?
         private var progressUpdates: [String] = []
-
-        init(progressMode: LiveTranscriptionProgressMode = .rollingWindow) {
-            liveTranscriptionProgressMode = progressMode
-        }
 
         func setOnProgress(_ onProgress: @escaping @Sendable (String) -> Bool) {
             self.onProgress = onProgress


### PR DESCRIPTION
## Summary

- preserve Soniox token text exactly so response boundaries do not introduce spaces inside words or before punctuation
- keep the realtime receive loop alive across `<end>` and `<fin>` markers, and terminate only on the server's terminal `finished` response while retaining the bounded finish timeout
- declare live-session progress semantics explicitly so Soniox complete snapshots replace provisional text while rolling-window providers retain overlap stabilization
- require TypeWhisper 1.7.0 for Soniox because the snapshot progress mode depends on the new host SDK contract
- cover delayed translation after `<fin>`, rolling-window fallback preservation, multilingual snapshot correction, endpoint continuity, token spacing, and the minimum host contract with regression tests

## Test Plan

- [ ] Ran `scripts/pr-preflight.sh`
  - reached localization validation, then stopped on 40 pre-existing missing `zh-Hans` strings in `AuthenticatedCLIPlugin/Localizable.xcstrings`, which this PR does not change
- [x] Built and ran locally
  - `bash scripts/build-dev-local.sh` succeeded for `12f1bc6`; the dev app is installed at `/Applications/TypeWhisper-Dev.app`
- [x] Tested the changed functionality manually
  - Soniox dictation continued after a 1–2 second pause with the locally installed Soniox 1.2.6 bundle
- [x] No regressions in the focused existing suites
  - `cd TypeWhisperPluginSDK && swift test --filter SonioxPluginTests` — 47 tests passed
  - `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/StreamingHandlerTests -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` — 32 tests passed
  - `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/PluginManifestValidationTests -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` — 11 tests passed on `c44f26e80`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for interpreting live transcription updates as rolling-window or complete-snapshot progress.
  * Soniox transcription now reliably captures delayed translation results before completion.

* **Bug Fixes**
  * Prevented duplicated or outdated transcript text.
  * Improved spacing, subword handling, multilingual updates, and stream completion behavior.
  * Continued processing correctly after intermediate stream-end signals.

* **Compatibility**
  * Soniox now requires TypeWhisper host version 1.7.0 or later.

* **Tests**
  * Added coverage for progress updates, completion signals, formatting, delayed results, and stream behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
