### PR TITLE
Fix WidgetData.save blocking the main thread

### DIFF
--- a/TypeWhisper/Services/WidgetDataService.swift
+++ b/TypeWhisper/Services/WidgetDataService.swift
@@ -21,8 +21,13 @@ final class WidgetDataService {
 
     private func updateWidgetData(records: [TranscriptionRecord], now: Date) {
         let data = buildWidgetData(records: records, now: now)
-        data.save()
-        WidgetCenter.shared.reloadAllTimelines()
+        // Reload only once the file is on disk, otherwise the widget can reload
+        // against the previous payload now that the write is asynchronous.
+        data.save {
+            Task { @MainActor in
+                WidgetCenter.shared.reloadAllTimelines()
+            }
+        }
     }
 
     func buildWidgetData(records: [TranscriptionRecord], now: Date = Date()) -> WidgetData {

--- a/TypeWhisperWidgetShared/WidgetData.swift
+++ b/TypeWhisperWidgetShared/WidgetData.swift
@@ -49,7 +49,9 @@ struct WidgetData: Codable {
             let dir = url.deletingLastPathComponent()
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
             do {
-                try data.write(to: url)
+                // Atomic: the widget extension reads this file from another process,
+                // so it must never observe a partially written payload.
+                try data.write(to: url, options: .atomic)
             } catch {
                 return
             }

--- a/TypeWhisperWidgetShared/WidgetData.swift
+++ b/TypeWhisperWidgetShared/WidgetData.swift
@@ -24,6 +24,9 @@ struct WidgetData: Codable {
             .appendingPathComponent(fileName)
     }
 
+    // Serial so overlapping saves are written in submission order.
+    private static let saveQueue = DispatchQueue(label: "com.typewhisper.widgetdata.save", qos: .utility)
+
     static func load() -> WidgetData {
         guard let url = sharedFileURL,
               let data = try? Data(contentsOf: url) else {
@@ -32,16 +35,25 @@ struct WidgetData: Codable {
         return (try? JSONDecoder().decode(WidgetData.self, from: data)) ?? .empty
     }
 
-    func save() {
-        guard let url = WidgetData.sharedFileURL,
-              let data = try? JSONEncoder().encode(self) else { return }
-        // App Group container access (containerURL/open) can stall on a broken
-        // code signature or slow disk, so keep this off the caller's thread —
-        // it must never block the main thread that triggers widget refreshes.
-        DispatchQueue.global(qos: .utility).async {
+    /// Persists the widget payload to the App Group container off the caller's thread.
+    /// - Parameter onWritten: Called on the write queue after the file has been written.
+    ///   It is not called when encoding, resolving the container, or writing fails.
+    func save(onWritten: (@Sendable () -> Void)? = nil) {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        // App Group container access (containerURL and the write itself) can stall on a
+        // broken code signature or slow disk, so resolve the URL and write here rather
+        // than on the caller's thread — it must never block the main thread that
+        // triggers widget refreshes.
+        WidgetData.saveQueue.async {
+            guard let url = WidgetData.sharedFileURL else { return }
             let dir = url.deletingLastPathComponent()
             try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try? data.write(to: url)
+            do {
+                try data.write(to: url)
+            } catch {
+                return
+            }
+            onWritten?()
         }
     }
 }

--- a/TypeWhisperWidgetShared/WidgetData.swift
+++ b/TypeWhisperWidgetShared/WidgetData.swift
@@ -35,10 +35,14 @@ struct WidgetData: Codable {
     func save() {
         guard let url = WidgetData.sharedFileURL,
               let data = try? JSONEncoder().encode(self) else { return }
-        // Ensure the group container directory exists
-        let dir = url.deletingLastPathComponent()
-        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        try? data.write(to: url)
+        // App Group container access (containerURL/open) can stall on a broken
+        // code signature or slow disk, so keep this off the caller's thread —
+        // it must never block the main thread that triggers widget refreshes.
+        DispatchQueue.global(qos: .utility).async {
+            let dir = url.deletingLastPathComponent()
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try? data.write(to: url)
+        }
     }
 }
 


### PR DESCRIPTION
## Problem

`WidgetData.save()` writes to the App Group container synchronously on the caller's thread. It is invoked through Combine on every transcription, so when container access stalls — `containerURL()` or `open()` on a slow disk, or a container whose code signature does not match — the whole app freezes after a single dictation.

## Fix

Move both the container URL resolution and the write onto a private serial utility queue.

- The URL lookup happens inside the queue: `containerURL(forSecurityApplicationGroupIdentifier:)` is one of the calls that can stall, so resolving it before dispatching would have left the caller blocked.
- The queue is serial, so overlapping saves are written in submission order rather than racing on the global concurrent queue.
- `WidgetDataService` now reloads widget timelines from an optional completion, after the write succeeds, so the widget does not reload against the previous payload now that the write is asynchronous.

## Verification

The original synchronous-write freeze was reproduced and confirmed fixed in a local build used for daily dictation. The review follow-up (off-thread URL resolution, serial queue, reload-after-write) is compile-verified against current main and covered by CI; it has not yet been exercised in a long-running local session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Widget data is now written atomically, preventing widgets from reading incomplete updates.
  * Widget timelines reload only after data is successfully saved, ensuring refreshed content is available.
* **Performance Improvements**
  * Widget data saves run asynchronously, helping keep the app interface responsive during file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->