### PR TITLE
Bump Soniox plugin version to 1.2.7

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.soniox",
     "name": "Soniox",
-    "version": "1.2.6",
+    "version": "1.2.7",
     "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -148,6 +148,18 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])
     }
 
+    func testSonioxPlugin127RequiresCompatibleHost17() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent(
+            "TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json"
+        )
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.version, "1.2.7")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
+    }
+
     func testGroqPluginReleaseRequiresHost15() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)


### PR DESCRIPTION
## Summary

- bump the Soniox plugin manifest from the already released 1.2.6 to 1.2.7
- keep the new TypeWhisper 1.7.0 minimum host requirement introduced with the live progress-mode SDK contract
- add an explicit manifest contract test for the Soniox version, host requirement, and SDK compatibility line

## Test Plan

- [x] `jq empty TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json`
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/PluginManifestValidationTests -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` — 12 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Soniox plugin to version 1.2.7.
  * Added compatibility with hosts running version 1.7.0 or later.

* **Tests**
  * Added validation to confirm the plugin version and host compatibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->