### PR TITLE
Add Gemini 3.5 Transcribe support

### DIFF
--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -68,6 +68,8 @@ enum UserDefaultsKeys {
     // MARK: - Home / Setup
     static let setupWizardCompleted = "setupWizardCompleted"
     static let setupWizardCurrentStep = "setupWizardCurrentStep"
+    /// Dev-tool launch mode that defers startup reads of privacy-protected app data.
+    static let devPrivacyQuietMode = "devPrivacyQuietMode"
 
     // MARK: - Dictionary
     static let activatedTermPacks = "activatedTermPacks" // Legacy - kept for migration cleanup

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -328,6 +328,7 @@ final class AudioRecorderViewModel: ObservableObject {
     private var transientTranscriptionFailures: [String: RecordingTranscriptionFailure] = [:]
     private var recordingsLoadTask: Task<Void, Never>?
     private var recordingsLoadGeneration = 0
+    private var hasRequestedInitialRecordingsLoad = false
     private var isInitialized = false
 
     init(
@@ -419,7 +420,9 @@ final class AudioRecorderViewModel: ObservableObject {
         recorderService.trackMode = trackMode
 
         setupBindings()
-        loadRecordings()
+        if !defaults.bool(forKey: UserDefaultsKeys.devPrivacyQuietMode) {
+            loadRecordingsIfNeeded()
+        }
 
         streamingHandler.onPartialTextUpdate = { [weak self] text in
             guard let self else { return }
@@ -1034,7 +1037,13 @@ final class AudioRecorderViewModel: ObservableObject {
         NSPasteboard.general.setString(text, forType: .string)
     }
 
+    func loadRecordingsIfNeeded() {
+        guard !hasRequestedInitialRecordingsLoad else { return }
+        loadRecordings()
+    }
+
     func loadRecordings() {
+        hasRequestedInitialRecordingsLoad = true
         let dir = recorderService.recordingsDirectory
         let transientFailures = transientTranscriptionFailures
         let loader = recordingsLoader

--- a/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
+++ b/TypeWhisper/ViewModels/AudioRecorderViewModel.swift
@@ -1039,11 +1039,12 @@ final class AudioRecorderViewModel: ObservableObject {
 
     func loadRecordingsIfNeeded() {
         guard !hasRequestedInitialRecordingsLoad else { return }
+        hasRequestedInitialRecordingsLoad = true
         loadRecordings()
     }
 
     func loadRecordings() {
-        hasRequestedInitialRecordingsLoad = true
+        guard hasRequestedInitialRecordingsLoad else { return }
         let dir = recorderService.recordingsDirectory
         let transientFailures = transientTranscriptionFailures
         let loader = recordingsLoader

--- a/TypeWhisper/Views/AudioRecorderView.swift
+++ b/TypeWhisper/Views/AudioRecorderView.swift
@@ -319,6 +319,9 @@ struct AudioRecorderView: View {
             .padding(.bottom, SettingsLayoutMetrics.pagePadding)
         }
         .frame(minWidth: 500, minHeight: 400)
+        .onAppear {
+            viewModel.loadRecordingsIfNeeded()
+        }
     }
 
     private var isLiveTranscriptPluginActive: Bool {

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 import SwiftUI
 import TypeWhisperPluginSDK
 
@@ -27,6 +28,8 @@ final class GeminiPlugin: NSObject,
     private static let transcriptionRequestTimeout: TimeInterval = 60
     private static let dedicatedTranscriptionRequestTimeout: TimeInterval = 900
     private static let modelCatalogRefreshInterval: TimeInterval = 24 * 60 * 60
+    private static let maxModelCatalogPages = 100
+    fileprivate static let dictionaryTermsMaxCount = 1_000
     private static let modelIdPrefix = "models/"
     private static let excludedCompatibleModelTokens = [
         "embedding",
@@ -41,14 +44,50 @@ final class GeminiPlugin: NSObject,
         "translate",
     ]
 
-    fileprivate var host: HostServices?
-    fileprivate var _apiKey: String?
-    fileprivate var _selectedLLMModelId: String?
-    fileprivate var _selectedTranscriptionModelId: String?
-    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
-    fileprivate var _llmTemperatureValue: Double = 0.3
-    fileprivate var _fetchedLLMModels: [GeminiFetchedModel] = []
-    fileprivate var _fetchedTranscriptionModels: [GeminiFetchedTranscriptionModel] = []
+    private struct State {
+        var host: HostServices?
+        var apiKey: String?
+        var selectedLLMModelId: String?
+        var selectedTranscriptionModelId: String?
+        var llmTemperatureModeRaw = PluginLLMTemperatureMode.providerDefault.rawValue
+        var llmTemperatureValue = 0.3
+        var fetchedLLMModels: [GeminiFetchedModel] = []
+        var fetchedTranscriptionModels: [GeminiFetchedTranscriptionModel] = []
+    }
+
+    private let state = OSAllocatedUnfairLock(initialState: State())
+    fileprivate var host: HostServices? {
+        get { state.withLock { $0.host } }
+        set { state.withLock { $0.host = newValue } }
+    }
+    fileprivate var _apiKey: String? {
+        get { state.withLock { $0.apiKey } }
+        set { state.withLock { $0.apiKey = newValue } }
+    }
+    fileprivate var _selectedLLMModelId: String? {
+        get { state.withLock { $0.selectedLLMModelId } }
+        set { state.withLock { $0.selectedLLMModelId = newValue } }
+    }
+    fileprivate var _selectedTranscriptionModelId: String? {
+        get { state.withLock { $0.selectedTranscriptionModelId } }
+        set { state.withLock { $0.selectedTranscriptionModelId = newValue } }
+    }
+    fileprivate var _llmTemperatureModeRaw: String {
+        get { state.withLock { $0.llmTemperatureModeRaw } }
+        set { state.withLock { $0.llmTemperatureModeRaw = newValue } }
+    }
+    fileprivate var _llmTemperatureValue: Double {
+        get { state.withLock { $0.llmTemperatureValue } }
+        set { state.withLock { $0.llmTemperatureValue = newValue } }
+    }
+    fileprivate var _fetchedLLMModels: [GeminiFetchedModel] {
+        get { state.withLock { $0.fetchedLLMModels } }
+        set { state.withLock { $0.fetchedLLMModels = newValue } }
+    }
+    fileprivate var _fetchedTranscriptionModels: [GeminiFetchedTranscriptionModel] {
+        get { state.withLock { $0.fetchedTranscriptionModels } }
+        set { state.withLock { $0.fetchedTranscriptionModels = newValue } }
+    }
     private var modelCatalogRefreshTask: Task<Void, Never>?
 
     private let chatHelper = PluginOpenAIChatHelper(
@@ -257,7 +296,9 @@ final class GeminiPlugin: NSObject,
         liveTranscriptionModelId(for: selectedModelId) != nil
     }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
-    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: 1_000) }
+    var dictionaryTermsBudget: DictionaryTermsBudget {
+        DictionaryTermsBudget(maxTerms: Self.dictionaryTermsMaxCount)
+    }
 
     var supportedLanguages: [String] {
         [
@@ -571,7 +612,7 @@ final class GeminiPlugin: NSObject,
 
         let dictionaryTerms = PluginDictionaryTerms.clippedTerms(
             from: PluginDictionaryTerms.terms(fromPrompt: prompt),
-            budget: DictionaryTermsBudget(maxTerms: 1_000)
+            budget: DictionaryTermsBudget(maxTerms: Self.dictionaryTermsMaxCount)
         )
         if !dictionaryTerms.isEmpty {
             transcriptionConfig["custom_vocabulary"] = dictionaryTerms
@@ -780,9 +821,19 @@ final class GeminiPlugin: NSObject,
     nonisolated private static func fetchModelCatalog(apiKey: String) async -> GeminiModelCatalog {
         var apiModels: [GeminiAPIModel] = []
         var nextPageToken: String?
+        var requestedPageTokens = Set<String>()
+        var pageCount = 0
 
         do {
             repeat {
+                try Task.checkCancellation()
+                guard pageCount < Self.maxModelCatalogPages else { return .empty }
+                if let nextPageToken,
+                   !requestedPageTokens.insert(nextPageToken).inserted {
+                    return .empty
+                }
+                pageCount += 1
+
                 guard let request = Self.makeModelsRequest(
                     apiKey: apiKey,
                     pageSize: 1_000,
@@ -951,7 +1002,7 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
         "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
     private static let pcmChunkSampleCount = 1_600
     private static let setupTimeout: Duration = .seconds(10)
-    private static let finishTimeout: Duration = .seconds(2)
+    private static let finishTimeout: Duration = .seconds(10)
 
     private let urlSession: URLSession
     private let webSocketTask: URLSessionWebSocketTask
@@ -960,6 +1011,7 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
     private var collector = GeminiLiveTranscriptCollector()
     private var setupComplete = false
     private var finalRevision = 0
+    private var turnCompleteRevision = 0
     private var latestError: String?
     private var finished = false
     private var cancelled = false
@@ -1062,10 +1114,12 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
         finished = true
 
         let revisionBeforeFinish = finalRevision
+        let turnCompleteRevisionBeforeFinish = turnCompleteRevision
         do {
             try await webSocketTask.send(.string(Self.audioStreamEndMessage))
         } catch {
             if collector.resultText.isEmpty {
+                closeSocket(code: .abnormalClosure)
                 throw PluginTranscriptionError.networkError(error.localizedDescription)
             }
         }
@@ -1073,12 +1127,19 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: Self.finishTimeout)
         while finalRevision == revisionBeforeFinish,
+              turnCompleteRevision == turnCompleteRevisionBeforeFinish,
               latestError == nil,
               clock.now < deadline {
             try? await Task.sleep(for: .milliseconds(25))
         }
 
         closeSocket(code: .normalClosure)
+        if finalRevision == revisionBeforeFinish,
+           collector.hasUncommittedInterimText {
+            throw PluginTranscriptionError.networkError(
+                "Timed out while finalizing Gemini Live transcription."
+            )
+        }
         return try finalResult()
     }
 
@@ -1146,6 +1207,9 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
         if finalText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
             finalRevision += 1
         }
+        if serverContent.turnComplete == true {
+            turnCompleteRevision += 1
+        }
         if let preview, !preview.isEmpty {
             _ = onProgress(preview)
         }
@@ -1179,7 +1243,9 @@ actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
             transcriptionConfig["languageCodes"] = languageCodes
         }
         if !customVocabulary.isEmpty {
-            transcriptionConfig["customVocabulary"] = Array(customVocabulary.prefix(1_000))
+            transcriptionConfig["customVocabulary"] = Array(
+                customVocabulary.prefix(GeminiPlugin.dictionaryTermsMaxCount)
+            )
         }
 
         let body: [String: Any] = [
@@ -1241,6 +1307,10 @@ struct GeminiLiveTranscriptCollector: Sendable {
         Self.combined(committed: committedText, interim: interimText)
     }
 
+    var hasUncommittedInterimText: Bool {
+        !interimText.isEmpty
+    }
+
     mutating func apply(interimText newInterim: String?, finalText newFinal: String?) -> String? {
         if let final = Self.normalized(newFinal), !final.isEmpty {
             if committedText.isEmpty || final.hasPrefix(committedText) {
@@ -1291,6 +1361,7 @@ private struct GeminiLiveResponse: Decodable, Sendable {
     struct ServerContent: Decodable, Sendable {
         let interimInputTranscription: Transcription?
         let inputTranscription: Transcription?
+        let turnComplete: Bool?
     }
 
     struct Transcription: Decodable, Sendable {
@@ -1535,8 +1606,20 @@ private struct GeminiSettingsView: View {
                 Divider()
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Transcription Model", bundle: bundle)
-                        .font(.headline)
+                    HStack {
+                        Text("Transcription Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
 
                     Picker("Transcription Model", selection: $selectedTranscriptionModel) {
                         ForEach(plugin.transcriptionModels, id: \.id) { model in

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -10,18 +10,23 @@ final class GeminiPlugin: NSObject,
     LLMTemperatureControllableProvider,
     LLMModelSelectable,
     TranscriptionEnginePlugin,
+    LiveLanguageHintDictionaryTermHintTranscriptionCapablePlugin,
     DictionaryTermsCapabilityProviding,
+    DictionaryTermsBudgetProviding,
     @unchecked Sendable
 {
     static let pluginId = "com.typewhisper.gemini"
     static let pluginName = "Gemini"
     private static let cachedLLMModelsKey = "fetchedLLMModels.v2"
+    private static let cachedTranscriptionModelsKey = "fetchedTranscriptionModels.v1"
+    private static let modelCatalogRefreshDateKey = "modelCatalogRefreshDate.v1"
     private static let legacyCachedLLMModelsKey = "fetchedLLMModels"
     private static let selectedLLMModelKey = "selectedLLMModel"
     private static let selectedTranscriptionModelKey = "selectedModel"
-    private static let compatibleModelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/openai/models"
-    private static let generateContentAPIBase = "https://generativelanguage.googleapis.com/v1beta/models"
+    private static let modelsEndpoint = "https://generativelanguage.googleapis.com/v1beta/models"
     private static let transcriptionRequestTimeout: TimeInterval = 60
+    private static let dedicatedTranscriptionRequestTimeout: TimeInterval = 900
+    private static let modelCatalogRefreshInterval: TimeInterval = 24 * 60 * 60
     private static let modelIdPrefix = "models/"
     private static let excludedCompatibleModelTokens = [
         "embedding",
@@ -32,6 +37,8 @@ final class GeminiPlugin: NSObject,
         "robotics",
         "computer-use",
         "deep-research",
+        "transcribe",
+        "translate",
     ]
 
     fileprivate var host: HostServices?
@@ -41,6 +48,8 @@ final class GeminiPlugin: NSObject,
     fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
     fileprivate var _llmTemperatureValue: Double = 0.3
     fileprivate var _fetchedLLMModels: [GeminiFetchedModel] = []
+    fileprivate var _fetchedTranscriptionModels: [GeminiFetchedTranscriptionModel] = []
+    private var modelCatalogRefreshTask: Task<Void, Never>?
 
     private let chatHelper = PluginOpenAIChatHelper(
         baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
@@ -52,11 +61,21 @@ final class GeminiPlugin: NSObject,
     }
 
     func activate(host: HostServices) {
+        modelCatalogRefreshTask?.cancel()
         self.host = host
         _apiKey = host.loadSecret(key: "api-key")
         if let data = host.userDefault(forKey: Self.cachedLLMModelsKey) as? Data,
            let models = try? JSONDecoder().decode([GeminiFetchedModel].self, from: data) {
             _fetchedLLMModels = models
+        }
+        if let data = host.userDefault(forKey: Self.cachedTranscriptionModelsKey) as? Data,
+           let models = try? JSONDecoder().decode([GeminiFetchedTranscriptionModel].self, from: data) {
+            let compatibleModels = Self.compatibleTranscriptionModels(from: models)
+            _fetchedTranscriptionModels = compatibleModels
+            if compatibleModels.count != models.count,
+               let compatibleData = try? JSONEncoder().encode(compatibleModels) {
+                host.setUserDefault(compatibleData, forKey: Self.cachedTranscriptionModelsKey)
+            }
         }
         host.setUserDefault(nil, forKey: Self.legacyCachedLLMModelsKey)
         _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
@@ -65,13 +84,16 @@ final class GeminiPlugin: NSObject,
             ?? 0.3
         _selectedTranscriptionModelId = Self.resolvedTranscriptionModelId(
             host.userDefault(forKey: Self.selectedTranscriptionModelKey) as? String,
+            availableModels: resolvedTranscriptionModels,
             host: host
         )
         normalizeSelectedModel()
-        refreshCompatibleModelsIfNeeded()
+        refreshModelCatalogIfNeeded()
     }
 
     func deactivate() {
+        modelCatalogRefreshTask?.cancel()
+        modelCatalogRefreshTask = nil
         host = nil
     }
 
@@ -172,33 +194,70 @@ final class GeminiPlugin: NSObject,
 
     var isConfigured: Bool { isAvailable }
 
-    private static let defaultTranscriptionModels: [PluginModelInfo] = [
-        PluginModelInfo(id: "gemini-flash-lite-latest", displayName: "Gemini Flash-Lite Latest"),
-        PluginModelInfo(id: "gemini-flash-latest", displayName: "Gemini Flash Latest"),
-        PluginModelInfo(id: "gemini-3.1-flash-lite", displayName: "Gemini 3.1 Flash-Lite"),
-        PluginModelInfo(id: "gemini-3.5-flash", displayName: "Gemini 3.5 Flash"),
-        PluginModelInfo(id: "gemini-2.5-flash-lite", displayName: "Gemini 2.5 Flash-Lite"),
-        PluginModelInfo(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
+    fileprivate static let fallbackTranscriptionModels: [GeminiFetchedTranscriptionModel] = [
+        GeminiFetchedTranscriptionModel(
+            id: "gemini-3.5-transcribe",
+            displayName: "Gemini 3.5 Transcribe",
+            liveModelId: "gemini-3.5-transcribe-live"
+        ),
     ]
 
     private static var defaultTranscriptionModelId: String {
-        defaultTranscriptionModels[0].id
+        fallbackTranscriptionModels[0].id
     }
 
-    var transcriptionModels: [PluginModelInfo] { Self.defaultTranscriptionModels }
+    fileprivate var resolvedTranscriptionModels: [GeminiFetchedTranscriptionModel] {
+        let fallbackById = Dictionary(
+            uniqueKeysWithValues: Self.fallbackTranscriptionModels.map { ($0.id, $0) }
+        )
+        let fetchedModels = Self.compatibleTranscriptionModels(from: _fetchedTranscriptionModels).map { model in
+            guard model.liveModelId == nil,
+                  let fallbackLiveModelId = fallbackById[model.id]?.liveModelId else {
+                return model
+            }
+            return GeminiFetchedTranscriptionModel(
+                id: model.id,
+                displayName: model.displayName,
+                liveModelId: fallbackLiveModelId
+            )
+        }
+        var seenIds = Set<String>()
+        return (fetchedModels + Self.fallbackTranscriptionModels)
+            .filter { seenIds.insert($0.id).inserted }
+            .sorted { lhs, rhs in
+                if lhs.id == Self.defaultTranscriptionModelId { return true }
+                if rhs.id == Self.defaultTranscriptionModelId { return false }
+                return lhs.id < rhs.id
+            }
+    }
+
+    var transcriptionModels: [PluginModelInfo] {
+        resolvedTranscriptionModels.map {
+            PluginModelInfo(id: $0.id, displayName: $0.displayName ?? $0.id)
+        }
+    }
 
     var selectedModelId: String? {
         _selectedTranscriptionModelId ?? Self.defaultTranscriptionModelId
     }
 
     func selectModel(_ modelId: String) {
-        _selectedTranscriptionModelId = modelId
-        host?.setUserDefault(modelId, forKey: Self.selectedTranscriptionModelKey)
+        let trimmedModelId = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        let supportedIds = Set(resolvedTranscriptionModels.map(\.id))
+        let resolvedModelId = supportedIds.contains(trimmedModelId)
+            ? trimmedModelId
+            : Self.defaultTranscriptionModelId
+        _selectedTranscriptionModelId = resolvedModelId
+        host?.setUserDefault(resolvedModelId, forKey: Self.selectedTranscriptionModelKey)
+        host?.notifyCapabilitiesChanged()
     }
 
     var supportsTranslation: Bool { false }
-    var supportsStreaming: Bool { false }
+    var supportsStreaming: Bool {
+        liveTranscriptionModelId(for: selectedModelId) != nil
+    }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
+    var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: 1_000) }
 
     var supportedLanguages: [String] {
         [
@@ -221,40 +280,18 @@ final class GeminiPlugin: NSObject,
             throw PluginTranscriptionError.notConfigured
         }
         guard let modelId = selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !modelId.isEmpty else {
+              Self.isDedicatedTranscriptionModelId(modelId),
+              resolvedTranscriptionModels.contains(where: { $0.id == modelId }) else {
             throw PluginTranscriptionError.noModelSelected
         }
 
-        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
-            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
-        var request = try Self.makeTranscriptionRequest(
-            uploadFile: preferredUpload,
+        return try await transcribeDedicated(
+            audio: audio,
             apiKey: apiKey,
             modelId: modelId,
             language: language,
-            prompt: prompt,
-            timeout: Self.transcriptionRequestTimeout
+            prompt: prompt
         )
-        var (data, response) = try await PluginHTTPClient.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-           preferredUpload.format != "wav",
-           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
-            statusCode: httpResponse.statusCode,
-            responseData: data
-           ) {
-            request = try Self.makeTranscriptionRequest(
-                uploadFile: PluginAudioUploadEncoder.wavUpload(from: audio),
-                apiKey: apiKey,
-                modelId: modelId,
-                language: language,
-                prompt: prompt,
-                timeout: Self.transcriptionRequestTimeout
-            )
-            (data, response) = try await PluginHTTPClient.data(for: request)
-        }
-        try Self.validateTranscriptionResponse(data: data, response: response)
-        let text = try Self.parseTranscriptionResponse(data)
-        return PluginTranscriptionResult(text: text, detectedLanguage: language)
     }
 
     func transcribe(
@@ -274,33 +311,239 @@ final class GeminiPlugin: NSObject,
         return result
     }
 
-    static func makeTranscriptionRequest(
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: PluginDictionaryTerms.termHints(fromPrompt: prompt),
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: languageSelection,
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: PluginDictionaryTerms.termHints(fromPrompt: prompt),
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        try await createLiveTranscriptionSession(
+            languageSelection: PluginLanguageSelection(requestedLanguage: language),
+            translate: translate,
+            prompt: prompt,
+            dictionaryTermHints: dictionaryTermHints,
+            onProgress: onProgress
+        )
+    }
+
+    func createLiveTranscriptionSession(
+        languageSelection: PluginLanguageSelection,
+        translate: Bool,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Gemini speech transcription does not support translation yet.")
+        }
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let liveModelId = liveTranscriptionModelId(for: selectedModelId) else {
+            throw PluginTranscriptionError.apiError("The selected Gemini model does not support live transcription.")
+        }
+
+        let promptHints = PluginDictionaryTerms.termHints(fromPrompt: prompt)
+        let vocabulary = PluginDictionaryTerms.clippedTermHints(
+            from: dictionaryTermHints + promptHints,
+            budget: dictionaryTermsBudget
+        ).map(\.text)
+
+        return try await GeminiLiveTranscriptionSession.connect(
+            apiKey: apiKey,
+            modelId: liveModelId,
+            languageCodes: Self.resolvedLanguageCodes(from: languageSelection),
+            customVocabulary: vocabulary,
+            onProgress: onProgress
+        )
+    }
+
+    nonisolated private static func resolvedLanguageCodes(
+        from selection: PluginLanguageSelection
+    ) -> [String] {
+        var seen = Set<String>()
+        return ([selection.requestedLanguage] + selection.languageHints.map(Optional.some))
+            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+    }
+
+    private func transcribeDedicated(
+        audio: AudioData,
+        apiKey: String,
+        modelId: String,
+        language: String?,
+        prompt: String?
+    ) async throws -> PluginTranscriptionResult {
+        try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(from: audio) { uploadFile in
+            let uploadedFile = try await Self.uploadFile(uploadFile, apiKey: apiKey)
+
+            do {
+                let request = try Self.makeDedicatedTranscriptionRequest(
+                    uploadedFile: uploadedFile,
+                    apiKey: apiKey,
+                    modelId: modelId,
+                    language: language,
+                    prompt: prompt,
+                    timeout: Self.dedicatedTranscriptionRequestTimeout
+                )
+                let (data, response) = try await PluginHTTPClient.data(
+                    for: request,
+                    resourceTimeout: Self.dedicatedTranscriptionRequestTimeout
+                )
+                try Self.validateTranscriptionResponse(data: data, response: response)
+                let text = try Self.parseDedicatedTranscriptionResponse(data)
+                await Self.deleteUploadedFile(uploadedFile, apiKey: apiKey)
+                return PluginTranscriptionResult(text: text, detectedLanguage: language)
+            } catch {
+                await Self.deleteUploadedFile(uploadedFile, apiKey: apiKey)
+                throw error
+            }
+        }
+    }
+
+    private static func uploadFile(
+        _ uploadFile: PluginAudioUploadFile,
+        apiKey: String
+    ) async throws -> GeminiUploadedFile {
+        let startRequest = try makeFileUploadStartRequest(uploadFile: uploadFile, apiKey: apiKey)
+        let (startData, startResponse) = try await PluginHTTPClient.data(for: startRequest)
+        try validateTranscriptionResponse(data: startData, response: startResponse)
+
+        guard let httpResponse = startResponse as? HTTPURLResponse,
+              let uploadURLValue = httpResponse.value(forHTTPHeaderField: "x-goog-upload-url"),
+              let uploadURL = URL(string: uploadURLValue) else {
+            throw PluginTranscriptionError.apiError("Gemini Files API did not return an upload URL.")
+        }
+
+        let uploadRequest = makeFileUploadRequest(
+            uploadFile: uploadFile,
+            uploadURL: uploadURL
+        )
+        let (data, response) = try await PluginHTTPClient.data(
+            for: uploadRequest,
+            resourceTimeout: Self.dedicatedTranscriptionRequestTimeout
+        )
+        try validateTranscriptionResponse(data: data, response: response)
+
+        do {
+            let decoded = try JSONDecoder().decode(GeminiFileUploadResponse.self, from: data)
+            return GeminiUploadedFile(
+                name: decoded.file.name,
+                uri: decoded.file.uri,
+                mimeType: decoded.file.mimeType ?? uploadFile.contentType
+            )
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Gemini file upload response: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    static func makeFileUploadStartRequest(
         uploadFile: PluginAudioUploadFile,
+        apiKey: String
+    ) throws -> URLRequest {
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/upload/v1beta/files") else {
+            throw PluginTranscriptionError.apiError("Invalid Gemini Files API URL.")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.setValue("resumable", forHTTPHeaderField: "X-Goog-Upload-Protocol")
+        request.setValue("start", forHTTPHeaderField: "X-Goog-Upload-Command")
+        request.setValue(String(uploadFile.data.count), forHTTPHeaderField: "X-Goog-Upload-Header-Content-Length")
+        request.setValue(uploadFile.contentType, forHTTPHeaderField: "X-Goog-Upload-Header-Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = Self.transcriptionRequestTimeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "file": ["display_name": uploadFile.filename],
+        ])
+        return request
+    }
+
+    static func makeFileUploadRequest(
+        uploadFile: PluginAudioUploadFile,
+        uploadURL: URL
+    ) -> URLRequest {
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "POST"
+        request.setValue(String(uploadFile.data.count), forHTTPHeaderField: "Content-Length")
+        request.setValue("0", forHTTPHeaderField: "X-Goog-Upload-Offset")
+        request.setValue("upload, finalize", forHTTPHeaderField: "X-Goog-Upload-Command")
+        request.setValue(uploadFile.contentType, forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = Self.transcriptionRequestTimeout
+        request.httpBody = uploadFile.data
+        return request
+    }
+
+    static func makeDedicatedTranscriptionRequest(
+        uploadedFile: GeminiUploadedFile,
         apiKey: String,
         modelId: String,
         language: String?,
         prompt: String?,
         timeout: TimeInterval
     ) throws -> URLRequest {
-        guard let url = URL(string: "\(generateContentAPIBase)/\(modelId):generateContent") else {
-            throw PluginTranscriptionError.apiError("Invalid Gemini transcription URL.")
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/interactions") else {
+            throw PluginTranscriptionError.apiError("Invalid Gemini Interactions API URL.")
         }
 
-        let renderedPrompt = transcriptionPrompt(dictionaryPrompt: prompt, language: language)
+        var transcriptionConfig: [String: Any] = ["mode": "smart"]
+        if let language = language?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !language.isEmpty {
+            transcriptionConfig["language_codes"] = [language]
+        }
+
+        let dictionaryTerms = PluginDictionaryTerms.clippedTerms(
+            from: PluginDictionaryTerms.terms(fromPrompt: prompt),
+            budget: DictionaryTermsBudget(maxTerms: 1_000)
+        )
+        if !dictionaryTerms.isEmpty {
+            transcriptionConfig["custom_vocabulary"] = dictionaryTerms
+        }
+
         let body: [String: Any] = [
-            "contents": [[
-                "role": "user",
-                "parts": [
-                    ["text": renderedPrompt],
-                    [
-                        "inlineData": [
-                            "mimeType": uploadFile.contentType,
-                            "data": uploadFile.data.base64EncodedString(),
-                        ],
-                    ],
-                ],
+            "model": modelId,
+            "input": [[
+                "type": "audio",
+                "uri": uploadedFile.uri,
+                "mime_type": uploadedFile.mimeType,
             ]],
-            "generationConfig": generationConfig(for: modelId),
+            "generation_config": [
+                "transcription_config": transcriptionConfig,
+            ],
         ]
 
         var request = URLRequest(url: url)
@@ -312,13 +555,62 @@ final class GeminiPlugin: NSObject,
         return request
     }
 
+    static func parseDedicatedTranscriptionResponse(_ data: Data) throws -> String {
+        do {
+            let response = try JSONDecoder().decode(GeminiInteractionResponse.self, from: data)
+            let responseSteps = response.steps ?? response.outputs ?? []
+            let modelOutputSteps = responseSteps.filter { step in
+                step.type == nil || step.type == "model_output"
+            }
+            let outputContent = modelOutputSteps.flatMap { $0.content ?? [] }
+            let textBlocks = outputContent.compactMap { content -> String? in
+                guard content.type == nil || content.type == "text" else { return nil }
+                return content.text
+            }
+            let text = (response.outputText ?? textBlocks.joined(separator: ""))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            guard !text.isEmpty else {
+                let detail = response.error?.message ?? response.status ?? "empty response"
+                throw PluginTranscriptionError.apiError("Gemini transcription failed: \(detail)")
+            }
+            return text
+        } catch let error as PluginTranscriptionError {
+            throw error
+        } catch {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Gemini transcription response: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private static func deleteUploadedFile(
+        _ uploadedFile: GeminiUploadedFile,
+        apiKey: String
+    ) async {
+        let escapedName = uploadedFile.name
+            .split(separator: "/")
+            .map(String.init)
+            .map { $0.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? $0 }
+            .joined(separator: "/")
+        guard let url = URL(string: "https://generativelanguage.googleapis.com/v1beta/\(escapedName)") else {
+            return
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.timeoutInterval = 15
+        _ = try? await PluginHTTPClient.data(for: request)
+    }
+
     static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PluginTranscriptionError.networkError("Invalid Gemini response.")
         }
 
         switch httpResponse.statusCode {
-        case 200:
+        case 200..<300:
             return
         case 401, 403:
             throw PluginTranscriptionError.invalidApiKey
@@ -331,73 +623,6 @@ final class GeminiPlugin: NSObject,
         }
     }
 
-    static func parseTranscriptionResponse(_ data: Data) throws -> String {
-        struct GeminiPart: Decodable {
-            let text: String?
-        }
-        struct GeminiContent: Decodable {
-            let parts: [GeminiPart]?
-        }
-        struct GeminiCandidate: Decodable {
-            let content: GeminiContent?
-        }
-        struct GeminiResponse: Decodable {
-            let candidates: [GeminiCandidate]?
-        }
-
-        do {
-            let decoded = try JSONDecoder().decode(GeminiResponse.self, from: data)
-            let text = decoded.candidates?.first?.content?.parts?
-                .compactMap(\.text)
-                .joined(separator: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let text, !text.isEmpty else {
-                throw PluginTranscriptionError.apiError("Empty response from Gemini.")
-            }
-            return text
-        } catch let error as PluginTranscriptionError {
-            throw error
-        } catch {
-            throw PluginTranscriptionError.apiError("Failed to parse Gemini response: \(error.localizedDescription)")
-        }
-    }
-
-    static func transcriptionPrompt(dictionaryPrompt: String?, language: String?) -> String {
-        var sections = [
-            """
-            Transcribe the attached audio for technical dictation. Preserve proper nouns, model names, framework names, identifiers, CLI flags, version numbers, punctuation, and casing exactly when they are spoken. Use digits for numbers in technical contexts. Output only the transcription.
-            """,
-        ]
-
-        let terms = PluginDictionaryTerms.terms(fromPrompt: dictionaryPrompt)
-        if let termPrompt = PluginDictionaryTerms.prompt(from: terms, maxLength: 4_000) {
-            sections.append("User dictionary terms: \(termPrompt)")
-        }
-
-        if let language = language?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !language.isEmpty {
-            sections.append("Language hint: \(language)")
-        }
-
-        return sections.joined(separator: "\n\n")
-    }
-
-    private static func generationConfig(for modelId: String) -> [String: Any] {
-        var config: [String: Any] = [
-            "temperature": 0.2,
-            "maxOutputTokens": 2048,
-            "responseMimeType": "text/plain",
-        ]
-
-        if modelId.hasPrefix("gemini-3") {
-            config["thinkingConfig"] = ["thinkingLevel": "MINIMAL"]
-        } else if modelId.hasPrefix("gemini-2.5") {
-            config["thinkingConfig"] = ["thinkingBudget": 0]
-        }
-
-        return config
-    }
-
     private static func transcriptionErrorMessage(from data: Data) -> String {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let error = json["error"] as? [String: Any],
@@ -408,9 +633,13 @@ final class GeminiPlugin: NSObject,
         return message
     }
 
-    private static func resolvedTranscriptionModelId(_ storedModelId: String?, host: HostServices) -> String {
+    private static func resolvedTranscriptionModelId(
+        _ storedModelId: String?,
+        availableModels: [GeminiFetchedTranscriptionModel],
+        host: HostServices
+    ) -> String {
         let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let supportedIds = Set(defaultTranscriptionModels.map(\.id))
+        let supportedIds = Set(availableModels.map(\.id))
         let modelId = trimmedModelId.flatMap { supportedIds.contains($0) ? $0 : nil }
             ?? defaultTranscriptionModelId
 
@@ -419,6 +648,11 @@ final class GeminiPlugin: NSObject,
         }
 
         return modelId
+    }
+
+    private func liveTranscriptionModelId(for modelId: String?) -> String? {
+        guard let modelId else { return nil }
+        return resolvedTranscriptionModels.first(where: { $0.id == modelId })?.liveModelId
     }
 
     // MARK: - Settings View
@@ -454,11 +688,7 @@ final class GeminiPlugin: NSObject,
 
     func validateApiKey(_ key: String) async -> Bool {
         guard !key.isEmpty,
-              let url = URL(string: Self.compatibleModelsEndpoint) else { return false }
-
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 10
+              let request = Self.makeModelsRequest(apiKey: key, pageSize: 1) else { return false }
 
         do {
             let (_, response) = try await PluginHTTPClient.data(for: request)
@@ -479,46 +709,156 @@ final class GeminiPlugin: NSObject,
         host?.notifyCapabilitiesChanged()
     }
 
-    fileprivate func fetchLLMModels() async -> [GeminiFetchedModel] {
-        guard let apiKey = _apiKey, !apiKey.isEmpty,
-              let url = URL(string: Self.compatibleModelsEndpoint) else { return [] }
+    fileprivate func setFetchedTranscriptionModels(_ models: [GeminiFetchedTranscriptionModel]) {
+        let compatibleModels = Self.compatibleTranscriptionModels(from: models)
+        _fetchedTranscriptionModels = compatibleModels
+        if let data = try? JSONEncoder().encode(compatibleModels) {
+            host?.setUserDefault(data, forKey: Self.cachedTranscriptionModelsKey)
+        }
 
-        var request = URLRequest(url: url)
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.timeoutInterval = 15
+        if let selectedModelId,
+           !resolvedTranscriptionModels.contains(where: { $0.id == selectedModelId }) {
+            selectModel(Self.defaultTranscriptionModelId)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func setFetchedModelCatalog(_ catalog: GeminiModelCatalog) {
+        setFetchedLLMModels(catalog.llmModels)
+        setFetchedTranscriptionModels(catalog.transcriptionModels)
+        host?.setUserDefault(Date(), forKey: Self.modelCatalogRefreshDateKey)
+    }
+
+    func fetchModelCatalog() async -> GeminiModelCatalog {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else { return .empty }
+        return await Self.fetchModelCatalog(apiKey: apiKey)
+    }
+
+    nonisolated private static func fetchModelCatalog(apiKey: String) async -> GeminiModelCatalog {
+        var apiModels: [GeminiAPIModel] = []
+        var nextPageToken: String?
 
         do {
-            let (data, response) = try await PluginHTTPClient.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse,
-                  httpResponse.statusCode == 200 else { return [] }
-            return try Self.decodeCompatibleLLMModels(from: data)
+            repeat {
+                guard let request = Self.makeModelsRequest(
+                    apiKey: apiKey,
+                    pageSize: 1_000,
+                    pageToken: nextPageToken
+                ) else { return .empty }
+
+                let (data, response) = try await PluginHTTPClient.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse,
+                      httpResponse.statusCode == 200 else { return .empty }
+
+                let page = try JSONDecoder().decode(GeminiModelsPage.self, from: data)
+                apiModels.append(contentsOf: page.models)
+                nextPageToken = page.nextPageToken?.trimmingCharacters(in: .whitespacesAndNewlines)
+                if nextPageToken?.isEmpty == true {
+                    nextPageToken = nil
+                }
+            } while nextPageToken != nil
+
+            return Self.makeModelCatalog(from: apiModels)
         } catch {
-            return []
+            return .empty
         }
     }
 
-    nonisolated static func decodeCompatibleLLMModels(from data: Data) throws -> [GeminiFetchedModel] {
-        let decoded = try JSONDecoder().decode(GeminiCompatibleModelsResponse.self, from: data)
-        var seenIds = Set<String>()
-
-        return decoded.data
-            .compactMap { model -> GeminiFetchedModel? in
-                let normalizedId = normalizedCompatibleModelId(model.id)
-                guard isCompatibleChatModelId(normalizedId),
-                      seenIds.insert(normalizedId).inserted else { return nil }
-                return GeminiFetchedModel(id: normalizedId, displayName: model.displayName)
-            }
-            .sorted { $0.id < $1.id }
+    fileprivate func fetchLLMModels() async -> [GeminiFetchedModel] {
+        (await fetchModelCatalog()).llmModels
     }
 
-    nonisolated private static func normalizedCompatibleModelId(_ id: String) -> String {
+    fileprivate func fetchTranscriptionModels() async -> [GeminiFetchedTranscriptionModel] {
+        (await fetchModelCatalog()).transcriptionModels
+    }
+
+    nonisolated static func decodeModelCatalog(from data: Data) throws -> GeminiModelCatalog {
+        let page = try JSONDecoder().decode(GeminiModelsPage.self, from: data)
+        return makeModelCatalog(from: page.models)
+    }
+
+    nonisolated private static func makeModelCatalog(from models: [GeminiAPIModel]) -> GeminiModelCatalog {
+        var seenLLMIds = Set<String>()
+        let llmModels = models
+            .compactMap { model -> GeminiFetchedModel? in
+                let id = normalizedModelId(model.name)
+                guard isCompatibleChatModel(model, normalizedId: id),
+                      seenLLMIds.insert(id).inserted else { return nil }
+                return GeminiFetchedModel(id: id, displayName: model.displayName)
+            }
+            .sorted { $0.id < $1.id }
+
+        let availableIds = Set(models.map { normalizedModelId($0.name) })
+        var seenTranscriptionIds = Set<String>()
+        let transcriptionModels = models
+            .compactMap { model -> GeminiFetchedTranscriptionModel? in
+                let id = normalizedModelId(model.name)
+                guard isDedicatedTranscriptionModelId(id),
+                      seenTranscriptionIds.insert(id).inserted else { return nil }
+
+                let liveModelId = "\(id)-live"
+                return GeminiFetchedTranscriptionModel(
+                    id: id,
+                    displayName: model.displayName,
+                    liveModelId: availableIds.contains(liveModelId) ? liveModelId : nil
+                )
+            }
+            .sorted { $0.id < $1.id }
+
+        return GeminiModelCatalog(
+            llmModels: llmModels,
+            transcriptionModels: transcriptionModels
+        )
+    }
+
+    nonisolated private static func normalizedModelId(_ id: String) -> String {
         guard id.hasPrefix(modelIdPrefix) else { return id }
         return String(id.dropFirst(modelIdPrefix.count))
     }
 
-    nonisolated private static func isCompatibleChatModelId(_ id: String) -> Bool {
+    nonisolated private static func isCompatibleChatModel(
+        _ model: GeminiAPIModel,
+        normalizedId id: String
+    ) -> Bool {
         guard id.hasPrefix("gemini-") else { return false }
-        return !excludedCompatibleModelTokens.contains { id.contains($0) }
+        guard model.supportedGenerationMethods.contains(where: {
+            $0.caseInsensitiveCompare("generateContent") == .orderedSame
+        }) else { return false }
+        return !excludedCompatibleModelTokens.contains { id.localizedCaseInsensitiveContains($0) }
+    }
+
+    nonisolated private static func isDedicatedTranscriptionModelId(_ id: String) -> Bool {
+        id.hasPrefix("gemini-")
+            && id.localizedCaseInsensitiveContains("-transcribe")
+            && !id.localizedCaseInsensitiveContains("-transcribe-live")
+    }
+
+    nonisolated private static func compatibleTranscriptionModels(
+        from models: [GeminiFetchedTranscriptionModel]
+    ) -> [GeminiFetchedTranscriptionModel] {
+        var seenIds = Set<String>()
+        return models.filter {
+            isDedicatedTranscriptionModelId($0.id) && seenIds.insert($0.id).inserted
+        }
+    }
+
+    nonisolated private static func makeModelsRequest(
+        apiKey: String,
+        pageSize: Int,
+        pageToken: String? = nil
+    ) -> URLRequest? {
+        guard var components = URLComponents(string: modelsEndpoint) else { return nil }
+        var queryItems = [URLQueryItem(name: "pageSize", value: String(pageSize))]
+        if let pageToken, !pageToken.isEmpty {
+            queryItems.append(URLQueryItem(name: "pageToken", value: pageToken))
+        }
+        components.queryItems = queryItems
+        guard let url = components.url else { return nil }
+
+        var request = URLRequest(url: url)
+        request.setValue(apiKey, forHTTPHeaderField: "x-goog-api-key")
+        request.timeoutInterval = 15
+        return request
     }
 
     /// Validates the persisted selection against the current model list.
@@ -537,36 +877,425 @@ final class GeminiPlugin: NSObject,
         }
     }
 
-    private func refreshCompatibleModelsIfNeeded() {
-        guard _fetchedLLMModels.isEmpty,
-              _apiKey?.isEmpty == false else { return }
+    private func refreshModelCatalogIfNeeded() {
+        guard _apiKey?.isEmpty == false else { return }
 
-        Task { [weak self] in
-            guard let self else { return }
+        let lastRefreshDate = host?.userDefault(forKey: Self.modelCatalogRefreshDateKey) as? Date
+        let cacheIsFresh = lastRefreshDate.map {
+            Date().timeIntervalSince($0) < Self.modelCatalogRefreshInterval
+        } ?? false
+        guard !cacheIsFresh || (_fetchedLLMModels.isEmpty && _fetchedTranscriptionModels.isEmpty) else {
+            return
+        }
 
-            let models = await self.fetchLLMModels()
-            guard !models.isEmpty else { return }
+        guard let apiKey = _apiKey else { return }
+        modelCatalogRefreshTask?.cancel()
+        modelCatalogRefreshTask = Task { [weak self, apiKey] in
+            let catalog = await Self.fetchModelCatalog(apiKey: apiKey)
+            guard !Task.isCancelled, !catalog.isEmpty, let self else { return }
 
             await MainActor.run {
-                self.setFetchedLLMModels(models)
+                self.setFetchedModelCatalog(catalog)
             }
         }
     }
 }
 
-// MARK: - OpenAI-Compatible Models API
+// MARK: - Gemini Live Transcription
 
-private struct GeminiCompatibleModelsResponse: Decodable {
-    let data: [GeminiCompatibleModel]
+actor GeminiLiveTranscriptionSession: LiveTranscriptionSession {
+    private static let webSocketEndpoint =
+        "wss://generativelanguage.googleapis.com/ws/google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+    private static let pcmChunkSampleCount = 1_600
+    private static let setupTimeout: Duration = .seconds(10)
+    private static let finishTimeout: Duration = .seconds(2)
+
+    private let urlSession: URLSession
+    private let webSocketTask: URLSessionWebSocketTask
+    private let onProgress: @Sendable (String) -> Bool
+    private var receiveTask: Task<Void, Never>?
+    private var collector = GeminiLiveTranscriptCollector()
+    private var setupComplete = false
+    private var finalRevision = 0
+    private var latestError: String?
+    private var finished = false
+    private var cancelled = false
+
+    private init(
+        urlSession: URLSession,
+        webSocketTask: URLSessionWebSocketTask,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) {
+        self.urlSession = urlSession
+        self.webSocketTask = webSocketTask
+        self.onProgress = onProgress
+    }
+
+    static func connect(
+        apiKey: String,
+        modelId: String,
+        languageCodes: [String],
+        customVocabulary: [String],
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> GeminiLiveTranscriptionSession {
+        try ensureNetworkAccessIsAllowed()
+        guard var components = URLComponents(string: webSocketEndpoint) else {
+            throw PluginTranscriptionError.apiError("Invalid Gemini Live API URL.")
+        }
+        components.queryItems = [URLQueryItem(name: "key", value: apiKey)]
+        guard let url = components.url else {
+            throw PluginTranscriptionError.apiError("Invalid Gemini Live API URL.")
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 600
+        let urlSession = URLSession(configuration: configuration)
+        let webSocketTask = urlSession.webSocketTask(with: url)
+        let session = GeminiLiveTranscriptionSession(
+            urlSession: urlSession,
+            webSocketTask: webSocketTask,
+            onProgress: onProgress
+        )
+
+        do {
+            try await session.start(
+                modelId: modelId,
+                languageCodes: languageCodes,
+                customVocabulary: customVocabulary
+            )
+            return session
+        } catch {
+            await session.cancel()
+            throw error
+        }
+    }
+
+    private func start(
+        modelId: String,
+        languageCodes: [String],
+        customVocabulary: [String]
+    ) async throws {
+        webSocketTask.resume()
+        receiveTask = Task { [weak self] in
+            guard let self else { return }
+            await self.receiveLoop()
+        }
+
+        let setupMessage = try Self.makeSetupMessage(
+            modelId: modelId,
+            languageCodes: languageCodes,
+            customVocabulary: customVocabulary
+        )
+        try await webSocketTask.send(.string(setupMessage))
+        try await waitForSetup()
+    }
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !finished, !cancelled else { return }
+        if let latestError {
+            throw PluginTranscriptionError.apiError(latestError)
+        }
+
+        var offset = 0
+        while offset < samples.count {
+            let end = min(offset + Self.pcmChunkSampleCount, samples.count)
+            let pcmData = Self.pcm16Data(from: samples[offset..<end])
+            let message = try Self.makeRealtimeAudioMessage(pcmData)
+            do {
+                try await webSocketTask.send(.string(message))
+            } catch {
+                latestError = error.localizedDescription
+                throw PluginTranscriptionError.networkError(error.localizedDescription)
+            }
+            offset = end
+        }
+    }
+
+    func finish() async throws -> PluginTranscriptionResult {
+        if finished {
+            return try finalResult()
+        }
+        finished = true
+
+        let revisionBeforeFinish = finalRevision
+        do {
+            try await webSocketTask.send(.string(Self.audioStreamEndMessage))
+        } catch {
+            if collector.resultText.isEmpty {
+                throw PluginTranscriptionError.networkError(error.localizedDescription)
+            }
+        }
+
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: Self.finishTimeout)
+        while finalRevision == revisionBeforeFinish,
+              latestError == nil,
+              clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        closeSocket(code: .normalClosure)
+        return try finalResult()
+    }
+
+    func cancel() async {
+        guard !cancelled else { return }
+        cancelled = true
+        closeSocket(code: .goingAway)
+    }
+
+    private func waitForSetup() async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: Self.setupTimeout)
+        while !setupComplete, latestError == nil, clock.now < deadline {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+
+        if let latestError {
+            throw PluginTranscriptionError.apiError(latestError)
+        }
+        guard setupComplete else {
+            throw PluginTranscriptionError.networkError("Timed out while connecting to Gemini Live transcription.")
+        }
+    }
+
+    private func receiveLoop() async {
+        while !Task.isCancelled {
+            do {
+                let message = try await webSocketTask.receive()
+                try handle(message)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !cancelled, !finished else { return }
+                latestError = error.localizedDescription
+                return
+            }
+        }
+    }
+
+    private func handle(_ message: URLSessionWebSocketTask.Message) throws {
+        let data: Data
+        switch message {
+        case .data(let messageData):
+            data = messageData
+        case .string(let text):
+            data = Data(text.utf8)
+        @unknown default:
+            return
+        }
+
+        let response = try JSONDecoder().decode(GeminiLiveResponse.self, from: data)
+        if response.setupComplete != nil {
+            setupComplete = true
+        }
+        if let message = response.error?.message, !message.isEmpty {
+            latestError = message
+        }
+
+        guard let serverContent = response.serverContent else { return }
+        let finalText = serverContent.inputTranscription?.text
+        let preview = collector.apply(
+            interimText: serverContent.interimInputTranscription?.text,
+            finalText: finalText
+        )
+        if finalText?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            finalRevision += 1
+        }
+        if let preview, !preview.isEmpty {
+            _ = onProgress(preview)
+        }
+    }
+
+    private func finalResult() throws -> PluginTranscriptionResult {
+        let text = collector.resultText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.isEmpty, let latestError {
+            throw PluginTranscriptionError.apiError(latestError)
+        }
+        guard !text.isEmpty else {
+            throw PluginTranscriptionError.apiError("Gemini Live transcription returned no text.")
+        }
+        return PluginTranscriptionResult(text: text)
+    }
+
+    private func closeSocket(code: URLSessionWebSocketTask.CloseCode) {
+        receiveTask?.cancel()
+        receiveTask = nil
+        webSocketTask.cancel(with: code, reason: nil)
+        urlSession.finishTasksAndInvalidate()
+    }
+
+    static func makeSetupMessage(
+        modelId: String,
+        languageCodes: [String],
+        customVocabulary: [String]
+    ) throws -> String {
+        var transcriptionConfig: [String: Any] = ["mode": "SMART"]
+        if !languageCodes.isEmpty {
+            transcriptionConfig["languageCodes"] = languageCodes
+        }
+        if !customVocabulary.isEmpty {
+            transcriptionConfig["customVocabulary"] = Array(customVocabulary.prefix(1_000))
+        }
+
+        let body: [String: Any] = [
+            "setup": [
+                "model": "models/\(modelId)",
+                "generationConfig": ["responseModalities": ["TEXT"]],
+                "inputAudioTranscription": transcriptionConfig,
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw PluginTranscriptionError.apiError("Failed to encode Gemini Live setup message.")
+        }
+        return text
+    }
+
+    static func makeRealtimeAudioMessage(_ pcmData: Data) throws -> String {
+        let body: [String: Any] = [
+            "realtimeInput": [
+                "audio": [
+                    "data": pcmData.base64EncodedString(),
+                    "mimeType": "audio/pcm;rate=16000",
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body, options: [.sortedKeys])
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw PluginTranscriptionError.apiError("Failed to encode Gemini Live audio message.")
+        }
+        return text
+    }
+
+    static let audioStreamEndMessage = #"{"realtimeInput":{"audioStreamEnd":true}}"#
+
+    static func pcm16Data(from samples: ArraySlice<Float>) -> Data {
+        var data = Data(capacity: samples.count * MemoryLayout<Int16>.size)
+        for sample in samples {
+            let clamped = max(-1, min(1, sample))
+            var value = Int16(clamped * Float(Int16.max)).littleEndian
+            withUnsafeBytes(of: &value) { data.append(contentsOf: $0) }
+        }
+        return data
+    }
+
+    private static func ensureNetworkAccessIsAllowed() throws {
+        #if DEBUG
+        if ProcessInfo.processInfo.arguments.contains("--store-screenshots") {
+            throw URLError(.notConnectedToInternet)
+        }
+        #endif
+    }
 }
 
-private struct GeminiCompatibleModel: Decodable {
-    let id: String
-    let displayName: String?
+struct GeminiLiveTranscriptCollector: Sendable {
+    private var committedText = ""
+    private var interimText = ""
 
-    enum CodingKeys: String, CodingKey {
-        case id
-        case displayName = "display_name"
+    var resultText: String {
+        Self.combined(committed: committedText, interim: interimText)
+    }
+
+    mutating func apply(interimText newInterim: String?, finalText newFinal: String?) -> String? {
+        if let final = Self.normalized(newFinal), !final.isEmpty {
+            if committedText.isEmpty || final.hasPrefix(committedText) {
+                committedText = final
+            } else if !committedText.hasSuffix(final) {
+                committedText = Self.joined(committedText, final)
+            }
+            interimText = ""
+            return resultText
+        }
+
+        if let interim = Self.normalized(newInterim), !interim.isEmpty {
+            interimText = interim
+            return resultText
+        }
+        return nil
+    }
+
+    private static func combined(committed: String, interim: String) -> String {
+        guard !committed.isEmpty else { return interim }
+        guard !interim.isEmpty else { return committed }
+        if interim.hasPrefix(committed) { return interim }
+        if committed.hasSuffix(interim) { return committed }
+        return joined(committed, interim)
+    }
+
+    private static func joined(_ lhs: String, _ rhs: String) -> String {
+        guard !lhs.isEmpty else { return rhs }
+        guard !rhs.isEmpty else { return lhs }
+        if lhs.last?.isWhitespace == true || rhs.first?.isWhitespace == true {
+            return lhs + rhs
+        }
+        return lhs + " " + rhs
+    }
+
+    private static func normalized(_ text: String?) -> String? {
+        text?.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+private struct GeminiLiveResponse: Decodable, Sendable {
+    let setupComplete: EmptyObject?
+    let serverContent: ServerContent?
+    let error: APIError?
+
+    struct EmptyObject: Decodable, Sendable {}
+
+    struct ServerContent: Decodable, Sendable {
+        let interimInputTranscription: Transcription?
+        let inputTranscription: Transcription?
+    }
+
+    struct Transcription: Decodable, Sendable {
+        let text: String?
+    }
+
+    struct APIError: Decodable, Sendable {
+        let message: String?
+    }
+}
+
+// MARK: - Native Models API
+
+private struct GeminiModelsPage: Decodable, Sendable {
+    let models: [GeminiAPIModel]
+    let nextPageToken: String?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        models = try container.decodeIfPresent([GeminiAPIModel].self, forKey: .models) ?? []
+        nextPageToken = try container.decodeIfPresent(String.self, forKey: .nextPageToken)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case models
+        case nextPageToken
+    }
+}
+
+private struct GeminiAPIModel: Decodable, Sendable {
+    let name: String
+    let displayName: String?
+    let supportedGenerationMethods: [String]
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        displayName = try container.decodeIfPresent(String.self, forKey: .displayName)
+        supportedGenerationMethods = try container.decodeIfPresent(
+            [String].self,
+            forKey: .supportedGenerationMethods
+        ) ?? []
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case displayName
+        case supportedGenerationMethods
     }
 }
 
@@ -577,6 +1306,75 @@ struct GeminiFetchedModel: Codable, Sendable {
     let displayName: String?
 }
 
+struct GeminiFetchedTranscriptionModel: Codable, Sendable {
+    let id: String
+    let displayName: String?
+    let liveModelId: String?
+
+    init(id: String, displayName: String?, liveModelId: String? = nil) {
+        self.id = id
+        self.displayName = displayName
+        self.liveModelId = liveModelId
+    }
+}
+
+struct GeminiModelCatalog: Sendable {
+    let llmModels: [GeminiFetchedModel]
+    let transcriptionModels: [GeminiFetchedTranscriptionModel]
+
+    static let empty = GeminiModelCatalog(llmModels: [], transcriptionModels: [])
+
+    var isEmpty: Bool {
+        llmModels.isEmpty && transcriptionModels.isEmpty
+    }
+}
+
+struct GeminiUploadedFile: Sendable, Equatable {
+    let name: String
+    let uri: String
+    let mimeType: String
+}
+
+private struct GeminiFileUploadResponse: Decodable, Sendable {
+    let file: File
+
+    struct File: Decodable, Sendable {
+        let name: String
+        let uri: String
+        let mimeType: String?
+    }
+}
+
+private struct GeminiInteractionResponse: Decodable, Sendable {
+    let status: String?
+    let outputText: String?
+    let steps: [Step]?
+    let outputs: [Step]?
+    let error: APIError?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case outputText = "output_text"
+        case steps
+        case outputs
+        case error
+    }
+
+    struct Step: Decodable, Sendable {
+        let type: String?
+        let content: [Content]?
+    }
+
+    struct Content: Decodable, Sendable {
+        let type: String?
+        let text: String?
+    }
+
+    struct APIError: Decodable, Sendable {
+        let message: String?
+    }
+}
+
 // MARK: - Settings View
 
 private struct GeminiSettingsView: View {
@@ -585,10 +1383,12 @@ private struct GeminiSettingsView: View {
     @State private var isValidating = false
     @State private var validationResult: Bool?
     @State private var showApiKey = false
-    @State private var selectedModel: String = ""
+    @State private var selectedLLMModel: String = ""
+    @State private var selectedTranscriptionModel: String = ""
     @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
     @State private var llmTemperatureValue: Double = 0.3
     @State private var fetchedLLMModels: [GeminiFetchedModel] = []
+    @State private var fetchedTranscriptionModels: [GeminiFetchedTranscriptionModel] = []
     private let bundle = Bundle(for: GeminiPlugin.self)
 
     var body: some View {
@@ -664,7 +1464,7 @@ private struct GeminiSettingsView: View {
                         Spacer()
 
                         Button {
-                            refreshLLMModels()
+                            refreshModels()
                         } label: {
                             Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
                         }
@@ -672,18 +1472,41 @@ private struct GeminiSettingsView: View {
                         .controlSize(.small)
                     }
 
-                    Picker("Model", selection: $selectedModel) {
+                    Picker("Model", selection: $selectedLLMModel) {
                         ForEach(plugin.supportedModels, id: \.id) { model in
                             Text(model.displayName).tag(model.id)
                         }
                     }
                     .labelsHidden()
-                    .onChange(of: selectedModel) {
-                        plugin.selectLLMModel(selectedModel)
+                    .onChange(of: selectedLLMModel) {
+                        plugin.selectLLMModel(selectedLLMModel)
                     }
 
                     if fetchedLLMModels.isEmpty {
                         Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Transcription Model", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Transcription Model", selection: $selectedTranscriptionModel) {
+                        ForEach(plugin.transcriptionModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedTranscriptionModel) {
+                        plugin.selectModel(selectedTranscriptionModel)
+                    }
+
+                    if fetchedTranscriptionModels.isEmpty {
+                        Text("Using built-in transcription models until the Gemini catalog is available.", bundle: bundle)
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -731,13 +1554,12 @@ private struct GeminiSettingsView: View {
             if let key = plugin._apiKey, !key.isEmpty {
                 apiKeyInput = key
             }
-            selectedModel = plugin.selectedLLMModelId ?? plugin.defaultLLMModelId ?? ""
+            selectedLLMModel = plugin.selectedLLMModelId ?? plugin.defaultLLMModelId ?? ""
+            selectedTranscriptionModel = plugin.selectedModelId ?? ""
             llmTemperatureMode = plugin.llmTemperatureMode
             llmTemperatureValue = plugin.llmTemperatureValue
             fetchedLLMModels = plugin._fetchedLLMModels
-            if plugin.isAvailable, fetchedLLMModels.isEmpty {
-                refreshLLMModels()
-            }
+            fetchedTranscriptionModels = plugin._fetchedTranscriptionModels
         }
     }
 
@@ -752,14 +1574,11 @@ private struct GeminiSettingsView: View {
         Task {
             let isValid = await plugin.validateApiKey(trimmedKey)
             if isValid {
-                let models = await plugin.fetchLLMModels()
+                let catalog = await plugin.fetchModelCatalog()
                 await MainActor.run {
                     isValidating = false
                     validationResult = true
-                    if !models.isEmpty {
-                        fetchedLLMModels = models
-                        plugin.setFetchedLLMModels(models)
-                    }
+                    applyModelCatalog(catalog)
                 }
             } else {
                 await MainActor.run {
@@ -770,20 +1589,31 @@ private struct GeminiSettingsView: View {
         }
     }
 
-    private func refreshLLMModels() {
+    private func refreshModels() {
         Task {
-            let models = await plugin.fetchLLMModels()
+            let catalog = await plugin.fetchModelCatalog()
             await MainActor.run {
-                if !models.isEmpty {
-                    fetchedLLMModels = models
-                    plugin.setFetchedLLMModels(models)
-                    if !models.contains(where: { $0.id == selectedModel }),
-                       let fallback = plugin.defaultLLMModelId {
-                        selectedModel = fallback
-                        plugin.selectLLMModel(fallback)
-                    }
-                }
+                applyModelCatalog(catalog)
             }
+        }
+    }
+
+    private func applyModelCatalog(_ catalog: GeminiModelCatalog) {
+        guard !catalog.isEmpty else { return }
+        plugin.setFetchedModelCatalog(catalog)
+
+        fetchedLLMModels = catalog.llmModels
+        if !plugin.supportedModels.contains(where: { $0.id == selectedLLMModel }),
+           let fallback = plugin.defaultLLMModelId {
+            selectedLLMModel = fallback
+            plugin.selectLLMModel(fallback)
+        }
+
+        fetchedTranscriptionModels = catalog.transcriptionModels
+        if !plugin.transcriptionModels.contains(where: { $0.id == selectedTranscriptionModel }),
+           let fallback = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id {
+            selectedTranscriptionModel = fallback
+            plugin.selectModel(fallback)
         }
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -267,6 +267,37 @@ final class GeminiPlugin: NSObject,
         ]
     }
 
+    private static let transcriptionLanguageCodeOverrides: [String: String] = [
+        "ar": "ar-EG",
+        "cs": "cs-CZ",
+        "da": "da-DK",
+        "de": "de-DE",
+        "el": "el-GR",
+        "en": "en-US",
+        "es": "es-419",
+        "fi": "fi-FI",
+        "fr": "fr-FR",
+        "he": "he-IL",
+        "hi": "hi-IN",
+        "hu": "hu-HU",
+        "id": "id-ID",
+        "it": "it-IT",
+        "ja": "ja-JP",
+        "ko": "ko-KR",
+        "nl": "nl-NL",
+        "no": "nb-NO",
+        "pl": "pl-PL",
+        "pt": "pt-BR",
+        "ro": "ro-RO",
+        "ru": "ru-RU",
+        "sv": "sv-SE",
+        "th": "th-TH",
+        "tr": "tr-TR",
+        "uk": "uk-UA",
+        "vi": "vi-VN",
+        "zh": "cmn-Hans-CN",
+    ]
+
     func transcribe(
         audio: AudioData,
         language: String?,
@@ -389,13 +420,26 @@ final class GeminiPlugin: NSObject,
         )
     }
 
-    nonisolated private static func resolvedLanguageCodes(
+    nonisolated static func resolvedLanguageCodes(
         from selection: PluginLanguageSelection
     ) -> [String] {
         var seen = Set<String>()
         return ([selection.requestedLanguage] + selection.languageHints.map(Optional.some))
-            .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty && seen.insert($0.lowercased()).inserted }
+            .compactMap(resolvedTranscriptionLanguageCode)
+            .filter { seen.insert($0.lowercased()).inserted }
+    }
+
+    nonisolated static func resolvedTranscriptionLanguageCode(_ language: String?) -> String? {
+        guard let language else { return nil }
+        let normalized = language
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "_", with: "-")
+        guard !normalized.isEmpty,
+              normalized.caseInsensitiveCompare("auto") != .orderedSame else {
+            return nil
+        }
+        guard !normalized.contains("-") else { return normalized }
+        return transcriptionLanguageCodeOverrides[normalized.lowercased()] ?? normalized
     }
 
     private func transcribeDedicated(
@@ -521,9 +565,8 @@ final class GeminiPlugin: NSObject,
         }
 
         var transcriptionConfig: [String: Any] = ["mode": "smart"]
-        if let language = language?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !language.isEmpty {
-            transcriptionConfig["language_codes"] = [language]
+        if let languageCode = resolvedTranscriptionLanguageCode(language) {
+            transcriptionConfig["language_codes"] = [languageCode]
         }
 
         let dictionaryTerms = PluginDictionaryTerms.clippedTerms(

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Localizable.xcstrings
@@ -89,6 +89,28 @@
         }
       }
     },
+    "Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしモデル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录模型"
+          }
+        }
+      }
+    },
     "Remove": {
       "localizations": {
         "de": {
@@ -195,6 +217,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "正在使用默认模型。点击刷新以获取所有可用模型。"
+          }
+        }
+      }
+    },
+    "Using built-in transcription models until the Gemini catalog is available.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bis der Gemini-Katalog verfügbar ist, werden die integrierten Transkriptionsmodelle verwendet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gemini カタログが利用可能になるまで、内蔵の文字起こしモデルを使用します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Gemini 目录可用之前，将使用内置转录模型。"
           }
         }
       }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -332,6 +332,53 @@ final class GeminiPluginTests: XCTestCase {
         )
     }
 
+    func testModelCatalogFetchRejectsRepeatedPaginationToken() async throws {
+        let host = try PluginTestHostServices(
+            defaults: try Self.configuredDefaults(),
+            secrets: ["api-key": "gemini-key"]
+        )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        let page = Data(
+            """
+            {
+              "models": [{
+                "name": "models/gemini-2.5-pro",
+                "displayName": "Gemini 2.5 Pro",
+                "supportedGenerationMethods": ["generateContent"]
+              }],
+              "nextPageToken": "repeated-page"
+            }
+            """.utf8
+        )
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    page,
+                    Self.httpResponse(
+                        url: "https://generativelanguage.googleapis.com/v1beta/models",
+                        statusCode: 200
+                    )
+                ),
+                .success(
+                    page,
+                    Self.httpResponse(
+                        url: "https://generativelanguage.googleapis.com/v1beta/models",
+                        statusCode: 200
+                    )
+                ),
+            ])
+        }
+
+        let catalog = await plugin.fetchModelCatalog()
+
+        XCTAssertTrue(catalog.isEmpty)
+        XCTAssertEqual(try XCTUnwrap(store.sessions.first).requestedRequests.count, 2)
+    }
+
     func testActivationAutomaticallyRefreshesAndCachesModelCatalog() async throws {
         let store = PluginHTTPClientSessionStore()
         PluginHTTPClientTestHarness.configure { _ in
@@ -558,8 +605,11 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(audio["data"] as? String, pcm.base64EncodedString())
 
         var collector = GeminiLiveTranscriptCollector()
+        XCTAssertFalse(collector.hasUncommittedInterimText)
         XCTAssertEqual(collector.apply(interimText: "Hello", finalText: nil), "Hello")
+        XCTAssertTrue(collector.hasUncommittedInterimText)
         XCTAssertEqual(collector.apply(interimText: nil, finalText: "Hello"), "Hello")
+        XCTAssertFalse(collector.hasUncommittedInterimText)
         XCTAssertEqual(collector.apply(interimText: "world", finalText: nil), "Hello world")
         XCTAssertEqual(collector.apply(interimText: nil, finalText: "world"), "Hello world")
         XCTAssertEqual(collector.resultText, "Hello world")

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -413,7 +413,7 @@ final class GeminiPluginTests: XCTestCase {
             ),
             apiKey: "gemini-key",
             modelId: "gemini-3.5-transcribe",
-            language: " de-DE ",
+            language: " de ",
             prompt: "TypeWhisper, Gemini",
             timeout: 900
         )
@@ -432,6 +432,22 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(transcriptionConfig["mode"] as? String, "smart")
         XCTAssertEqual(transcriptionConfig["language_codes"] as? [String], ["de-DE"])
         XCTAssertEqual(transcriptionConfig["custom_vocabulary"] as? [String], ["TypeWhisper", "Gemini"])
+    }
+
+    func testTranscriptionLanguageCodesUseGeminiBCP47Locales() {
+        let codes = GeminiPlugin.resolvedLanguageCodes(
+            from: PluginLanguageSelection(
+                requestedLanguage: " de ",
+                languageHints: ["en_GB", "no", "de-DE", "auto"]
+            )
+        )
+
+        XCTAssertEqual(codes, ["de-DE", "en-GB", "nb-NO"])
+        XCTAssertNil(GeminiPlugin.resolvedTranscriptionLanguageCode("auto"))
+        XCTAssertEqual(
+            GeminiPlugin.resolvedTranscriptionLanguageCode("zh"),
+            "cmn-Hans-CN"
+        )
     }
 
     func testDedicatedTranscriptionResponseParsesOutputText() throws {

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/Tests/GeminiPluginTests.swift
@@ -6,6 +6,8 @@ import TypeWhisperPluginSDK
 
 final class GeminiPluginTests: XCTestCase {
     private static let cachedLLMModelsKey = "fetchedLLMModels.v2"
+    private static let cachedTranscriptionModelsKey = "fetchedTranscriptionModels.v1"
+    private static let modelCatalogRefreshDateKey = "modelCatalogRefreshDate.v1"
     private static let selectedLLMModelKey = "selectedLLMModel"
 
     override func tearDown() {
@@ -19,6 +21,28 @@ final class GeminiPluginTests: XCTestCase {
             GeminiFetchedModel(id: "gemini-2.5-flash", displayName: "Gemini 2.5 Flash"),
             GeminiFetchedModel(id: "gemini-flash-latest", displayName: "Gemini Flash Latest"),
         ])
+    }
+
+    private static func cachedTranscriptionModelsData() throws -> Data {
+        try JSONEncoder().encode([
+            GeminiFetchedTranscriptionModel(
+                id: "gemini-3.5-transcribe",
+                displayName: "Gemini 3.5 Transcribe",
+                liveModelId: "gemini-3.5-transcribe-live"
+            ),
+        ])
+    }
+
+    private static func configuredDefaults(selectedModel: String? = nil) throws -> [String: Any] {
+        var defaults: [String: Any] = [
+            Self.cachedLLMModelsKey: try Self.cachedModelsData(),
+            Self.cachedTranscriptionModelsKey: try Self.cachedTranscriptionModelsData(),
+            Self.modelCatalogRefreshDateKey: Date(),
+        ]
+        if let selectedModel {
+            defaults["selectedModel"] = selectedModel
+        }
+        return defaults
     }
 
     func testPreferredModelIdReflectsSelectedLLMModel() throws {
@@ -115,36 +139,54 @@ final class GeminiPluginTests: XCTestCase {
         XCTAssertEqual(plugin.providerId, "gemini")
         XCTAssertEqual(plugin.providerDisplayName, "Gemini")
         XCTAssertFalse(plugin.supportsTranslation)
-        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertTrue(plugin.supportsStreaming)
         XCTAssertEqual(plugin.dictionaryTermsSupport, .supported)
-        XCTAssertEqual(plugin.selectedModelId, "gemini-flash-lite-latest")
-        XCTAssertEqual(
-            plugin.transcriptionModels.map(\.id),
-            [
-                "gemini-flash-lite-latest",
-                "gemini-flash-latest",
-                "gemini-3.1-flash-lite",
-                "gemini-3.5-flash",
-                "gemini-2.5-flash-lite",
-                "gemini-2.5-flash",
-            ]
-        )
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-flash-lite-latest")
+        XCTAssertEqual(plugin.dictionaryTermsBudget.maxTerms, 1_000)
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["gemini-3.5-transcribe"])
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.5-transcribe")
     }
 
-    func testSelectedTranscriptionModelPersistsAcrossActivation() throws {
+    func testUnsupportedFlashSelectionFallsBackAndPersistsDefault() throws {
         let host = try PluginTestHostServices()
         let plugin = GeminiPlugin()
         plugin.activate(host: host)
 
         plugin.selectModel("gemini-2.5-flash")
-        plugin.deactivate()
 
-        let reloaded = GeminiPlugin()
-        reloaded.activate(host: host)
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.5-transcribe")
+    }
 
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-2.5-flash")
-        XCTAssertEqual(reloaded.selectedModelId, "gemini-2.5-flash")
+    func testUnsupportedFlashSelectionCannotDisableDedicatedStreaming() throws {
+        let host = try PluginTestHostServices()
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+        let notificationsBeforeSelection = host.capabilitiesChangedCount
+
+        XCTAssertTrue(plugin.supportsStreaming)
+        plugin.selectModel("gemini-flash-lite-latest")
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertTrue(plugin.supportsStreaming)
+        XCTAssertEqual(host.capabilitiesChangedCount, notificationsBeforeSelection + 1)
+    }
+
+    func testKnownTranscriptionModelKeepsLivePairWhenCatalogOmitsLiveEntry() throws {
+        let cachedTranscriptionModels = try JSONEncoder().encode([
+            GeminiFetchedTranscriptionModel(
+                id: "gemini-3.5-transcribe",
+                displayName: "Gemini 3.5 Transcribe"
+            ),
+        ])
+        let host = try PluginTestHostServices(defaults: [
+            Self.cachedTranscriptionModelsKey: cachedTranscriptionModels,
+        ])
+        let plugin = GeminiPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertTrue(plugin.supportsStreaming)
     }
 
     func testInvalidStoredTranscriptionModelFallsBackAndPersistsDefault() throws {
@@ -153,102 +195,358 @@ final class GeminiPluginTests: XCTestCase {
 
         plugin.activate(host: host)
 
-        XCTAssertEqual(plugin.selectedModelId, "gemini-flash-lite-latest")
-        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-flash-lite-latest")
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.5-transcribe")
     }
 
-    func testTranscriptionRequestUsesGenerateContentJSONAudioPromptAndLanguage() throws {
-        let request = try GeminiPlugin.makeTranscriptionRequest(
-            uploadFile: Self.m4aUpload(),
-            apiKey: "gemini-key",
-            modelId: "gemini-flash-lite-latest",
-            language: " de ",
-            prompt: "Qwen3, MLX, proxy_read_timeout",
-            timeout: 60
-        )
+    func testCachedFlashModelsAreRemovedAndStoredSelectionMigrates() throws {
+        let cachedModels = try JSONEncoder().encode([
+            GeminiFetchedTranscriptionModel(
+                id: "gemini-3.5-transcribe",
+                displayName: "Gemini 3.5 Transcribe",
+                liveModelId: "gemini-3.5-transcribe-live"
+            ),
+            GeminiFetchedTranscriptionModel(
+                id: "gemini-2.5-flash",
+                displayName: "Gemini 2.5 Flash"
+            ),
+        ])
+        let host = try PluginTestHostServices(defaults: [
+            Self.cachedTranscriptionModelsKey: cachedModels,
+            "selectedModel": "gemini-2.5-flash",
+            Self.modelCatalogRefreshDateKey: Date(),
+        ])
+        let plugin = GeminiPlugin()
 
-        XCTAssertEqual(request.httpMethod, "POST")
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["gemini-3.5-transcribe"])
+        XCTAssertEqual(plugin.selectedModelId, "gemini-3.5-transcribe")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "gemini-3.5-transcribe")
+        let cleanedCache = try XCTUnwrap(
+            host.userDefault(forKey: Self.cachedTranscriptionModelsKey) as? Data
+        )
         XCTAssertEqual(
-            request.url?.absoluteString,
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent"
+            try JSONDecoder().decode([GeminiFetchedTranscriptionModel].self, from: cleanedCache)
+                .map(\.id),
+            ["gemini-3.5-transcribe"]
         )
-        XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
-        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
-        XCTAssertEqual(request.timeoutInterval, 60)
-
-        let body = try Self.jsonBody(from: request)
-        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
-        XCTAssertEqual(contents.first?["role"] as? String, "user")
-
-        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
-        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
-        XCTAssertTrue(promptText.contains("technical dictation"))
-        XCTAssertTrue(promptText.contains("User dictionary terms: Qwen3, MLX, proxy_read_timeout"))
-        XCTAssertTrue(promptText.contains("Language hint: de"))
-
-        let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
-        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/mp4")
-        XCTAssertEqual(inlineData["data"] as? String, Data("m4a".utf8).base64EncodedString())
-
-        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
-        XCTAssertEqual(generationConfig["temperature"] as? Double, 0.2)
-        XCTAssertEqual(generationConfig["maxOutputTokens"] as? Int, 2048)
-        XCTAssertEqual(generationConfig["responseMimeType"] as? String, "text/plain")
-        XCTAssertNil(generationConfig["thinkingConfig"])
     }
 
-    func testPinnedGeminiThreeTranscriptionRequestUsesMinimalThinkingLevel() throws {
-        let request = try GeminiPlugin.makeTranscriptionRequest(
-            uploadFile: Self.m4aUpload(),
-            apiKey: "gemini-key",
-            modelId: "gemini-3.1-flash-lite",
-            language: nil,
-            prompt: nil,
-            timeout: 60
+    func testNativeModelCatalogSeparatesChatAndTranscriptionModels() throws {
+        let response = Data(
+            """
+            {
+              "models": [
+                {
+                  "name": "models/gemini-2.5-pro",
+                  "displayName": "Gemini 2.5 Pro",
+                  "supportedGenerationMethods": ["generateContent"]
+                },
+                {
+                  "name": "models/gemini-3.5-transcribe",
+                  "displayName": "Gemini 3.5 Transcribe"
+                },
+                {
+                  "name": "models/gemini-3.5-transcribe-live",
+                  "displayName": "Gemini 3.5 Transcribe Live"
+                },
+                {
+                  "name": "models/gemini-2.5-flash-image",
+                  "displayName": "Gemini Image",
+                  "supportedGenerationMethods": ["generateContent"]
+                }
+              ]
+            }
+            """.utf8
         )
 
-        let body = try Self.jsonBody(from: request)
-        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        let catalog = try GeminiPlugin.decodeModelCatalog(from: response)
+
+        XCTAssertEqual(catalog.llmModels.map(\.id), ["gemini-2.5-pro"])
+        XCTAssertEqual(catalog.transcriptionModels.map(\.id), ["gemini-3.5-transcribe"])
         XCTAssertEqual(
-            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingLevel"] as? String,
-            "MINIMAL"
+            catalog.transcriptionModels.first?.liveModelId,
+            "gemini-3.5-transcribe-live"
         )
     }
 
-    func testPinnedGeminiTwoPointFiveTranscriptionRequestUsesZeroThinkingBudget() throws {
-        let request = try GeminiPlugin.makeTranscriptionRequest(
-            uploadFile: Self.m4aUpload(),
-            apiKey: "gemini-key",
-            modelId: "gemini-2.5-flash",
-            language: nil,
-            prompt: nil,
-            timeout: 60
+    func testModelCatalogFetchFollowsPagination() async throws {
+        let host = try PluginTestHostServices(
+            defaults: try Self.configuredDefaults(),
+            secrets: ["api-key": "gemini-key"]
         )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
 
-        let body = try Self.jsonBody(from: request)
-        let generationConfig = try XCTUnwrap(body["generationConfig"] as? [String: Any])
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "models": [{
+                            "name": "models/gemini-2.5-pro",
+                            "displayName": "Gemini 2.5 Pro",
+                            "supportedGenerationMethods": ["generateContent"]
+                          }],
+                          "nextPageToken": "page-two"
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models", statusCode: 200)
+                ),
+                .success(
+                    Data(
+                        """
+                        {
+                          "models": [
+                            { "name": "models/gemini-3.5-transcribe", "displayName": "Gemini 3.5 Transcribe" },
+                            { "name": "models/gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models", statusCode: 200)
+                ),
+            ])
+        }
+
+        let catalog = await plugin.fetchModelCatalog()
+
+        XCTAssertEqual(catalog.llmModels.map(\.id), ["gemini-2.5-pro"])
+        XCTAssertEqual(catalog.transcriptionModels.map(\.id), ["gemini-3.5-transcribe"])
+        let requests = try XCTUnwrap(store.sessions.first).requestedRequests
+        XCTAssertEqual(requests.count, 2)
         XCTAssertEqual(
-            (generationConfig["thinkingConfig"] as? [String: Any])?["thinkingBudget"] as? Int,
-            0
+            URLComponents(url: try XCTUnwrap(requests[0].url), resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "pageSize" })?.value,
+            "1000"
+        )
+        XCTAssertEqual(
+            URLComponents(url: try XCTUnwrap(requests[1].url), resolvingAgainstBaseURL: false)?
+                .queryItems?.first(where: { $0.name == "pageToken" })?.value,
+            "page-two"
         )
     }
 
-    func testTranscriptionRequestOmitsEmptyLanguageAndDictionaryTerms() throws {
-        let request = try GeminiPlugin.makeTranscriptionRequest(
-            uploadFile: Self.m4aUpload(),
-            apiKey: "gemini-key",
-            modelId: "gemini-flash-lite-latest",
-            language: " ",
-            prompt: " ",
-            timeout: 60
+    func testActivationAutomaticallyRefreshesAndCachesModelCatalog() async throws {
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "models": [
+                            {
+                              "name": "models/gemini-2.5-pro",
+                              "displayName": "Gemini 2.5 Pro",
+                              "supportedGenerationMethods": ["generateContent"]
+                            },
+                            { "name": "models/gemini-3.5-transcribe", "displayName": "Gemini 3.5 Transcribe" },
+                            { "name": "models/gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models", statusCode: 200)
+                ),
+            ])
+        }
+
+        let host = try PluginTestHostServices(secrets: ["api-key": "gemini-key"])
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        for _ in 0..<40 where host.userDefault(forKey: Self.modelCatalogRefreshDateKey) == nil {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+
+        let llmData = try XCTUnwrap(host.userDefault(forKey: Self.cachedLLMModelsKey) as? Data)
+        let transcriptionData = try XCTUnwrap(
+            host.userDefault(forKey: Self.cachedTranscriptionModelsKey) as? Data
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode([GeminiFetchedModel].self, from: llmData).map(\.id),
+            ["gemini-2.5-pro"]
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode([GeminiFetchedTranscriptionModel].self, from: transcriptionData)
+                .map(\.id),
+            ["gemini-3.5-transcribe"]
+        )
+        XCTAssertEqual(store.sessions.first?.requestedRequests.first?.url?.path, "/v1beta/models")
+    }
+
+    func testDedicatedTranscriptionRequestsUseFilesAndInteractionsAPIs() throws {
+        let upload = Self.m4aUpload()
+        let startRequest = try GeminiPlugin.makeFileUploadStartRequest(
+            uploadFile: upload,
+            apiKey: "gemini-key"
         )
 
-        let body = try Self.jsonBody(from: request)
-        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
-        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
-        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
-        XCTAssertFalse(promptText.contains("User dictionary terms:"))
-        XCTAssertFalse(promptText.contains("Language hint:"))
+        XCTAssertEqual(startRequest.url?.path, "/upload/v1beta/files")
+        XCTAssertEqual(startRequest.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
+        XCTAssertEqual(startRequest.value(forHTTPHeaderField: "X-Goog-Upload-Protocol"), "resumable")
+        XCTAssertEqual(startRequest.value(forHTTPHeaderField: "X-Goog-Upload-Command"), "start")
+        XCTAssertEqual(
+            (try Self.jsonBody(from: startRequest)["file"] as? [String: String])?["display_name"],
+            "audio.m4a"
+        )
+
+        let uploadRequest = GeminiPlugin.makeFileUploadRequest(
+            uploadFile: upload,
+            uploadURL: URL(string: "https://upload.example.test/session")!
+        )
+        XCTAssertEqual(uploadRequest.httpBody, upload.data)
+        XCTAssertEqual(uploadRequest.value(forHTTPHeaderField: "X-Goog-Upload-Command"), "upload, finalize")
+
+        let interactionRequest = try GeminiPlugin.makeDedicatedTranscriptionRequest(
+            uploadedFile: GeminiUploadedFile(
+                name: "files/audio-123",
+                uri: "https://generativelanguage.googleapis.com/v1beta/files/audio-123",
+                mimeType: "audio/mp4"
+            ),
+            apiKey: "gemini-key",
+            modelId: "gemini-3.5-transcribe",
+            language: " de-DE ",
+            prompt: "TypeWhisper, Gemini",
+            timeout: 900
+        )
+
+        XCTAssertEqual(interactionRequest.url?.path, "/v1beta/interactions")
+        XCTAssertEqual(interactionRequest.timeoutInterval, 900)
+        let body = try Self.jsonBody(from: interactionRequest)
+        XCTAssertEqual(body["model"] as? String, "gemini-3.5-transcribe")
+        let input = try XCTUnwrap(body["input"] as? [[String: Any]])
+        XCTAssertEqual(input.first?["type"] as? String, "audio")
+        XCTAssertEqual(input.first?["mime_type"] as? String, "audio/mp4")
+        let generationConfig = try XCTUnwrap(body["generation_config"] as? [String: Any])
+        let transcriptionConfig = try XCTUnwrap(
+            generationConfig["transcription_config"] as? [String: Any]
+        )
+        XCTAssertEqual(transcriptionConfig["mode"] as? String, "smart")
+        XCTAssertEqual(transcriptionConfig["language_codes"] as? [String], ["de-DE"])
+        XCTAssertEqual(transcriptionConfig["custom_vocabulary"] as? [String], ["TypeWhisper", "Gemini"])
+    }
+
+    func testDedicatedTranscriptionResponseParsesOutputText() throws {
+        let data = Data(#"{"status":"completed","output_text":" hello from transcribe \n"}"#.utf8)
+        XCTAssertEqual(try GeminiPlugin.parseDedicatedTranscriptionResponse(data), "hello from transcribe")
+    }
+
+    func testDedicatedTranscribeUploadsRunsInteractionAndDeletesFile() async throws {
+        let host = try PluginTestHostServices(
+            defaults: try Self.configuredDefaults(selectedModel: "gemini-3.5-transcribe"),
+            secrets: ["api-key": "gemini-key"]
+        )
+        let plugin = GeminiPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            switch store.sessions.count {
+            case 0:
+                return store.makeSession(outcomes: [
+                    .success(
+                        Data(),
+                        Self.httpResponse(
+                            url: "https://generativelanguage.googleapis.com/upload/v1beta/files",
+                            statusCode: 200,
+                            headers: ["x-goog-upload-url": "https://upload.example.test/session-123"]
+                        )
+                    ),
+                    .success(
+                        Data(#"{}"#.utf8),
+                        Self.httpResponse(
+                            url: "https://generativelanguage.googleapis.com/v1beta/files/audio-123",
+                            statusCode: 200
+                        )
+                    ),
+                ])
+            case 1:
+                return store.makeSession(outcomes: [
+                    .success(
+                        Data(
+                            #"{"file":{"name":"files/audio-123","uri":"https://generativelanguage.googleapis.com/v1beta/files/audio-123","mimeType":"audio/mp4"}}"#.utf8
+                        ),
+                        Self.httpResponse(url: "https://upload.example.test/session-123", statusCode: 200)
+                    ),
+                ])
+            default:
+                return store.makeSession(outcomes: [
+                    .success(
+                        Data(#"{"output_text":"dedicated transcript"}"#.utf8),
+                        Self.httpResponse(
+                            url: "https://generativelanguage.googleapis.com/v1beta/interactions",
+                            statusCode: 200
+                        )
+                    ),
+                ])
+            }
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "en-US",
+            translate: false,
+            prompt: "TypeWhisper"
+        )
+
+        XCTAssertEqual(result.text, "dedicated transcript")
+        XCTAssertEqual(result.detectedLanguage, "en-US")
+        XCTAssertEqual(store.sessions.count, 3)
+        XCTAssertEqual(
+            store.sessions[0].requestedRequests.map { $0.url?.path },
+            ["/upload/v1beta/files", "/v1beta/files/audio-123"]
+        )
+        XCTAssertEqual(store.sessions[1].requestedRequests.first?.url?.host, "upload.example.test")
+        XCTAssertEqual(store.sessions[2].requestedRequests.first?.url?.path, "/v1beta/interactions")
+    }
+
+    func testLiveSetupAudioEncodingAndTranscriptReconciliation() throws {
+        let setupMessage = try GeminiLiveTranscriptionSession.makeSetupMessage(
+            modelId: "gemini-3.5-transcribe-live",
+            languageCodes: ["de-DE", "en-US"],
+            customVocabulary: ["TypeWhisper", "Gemini"]
+        )
+        let setupBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(setupMessage.utf8)) as? [String: Any]
+        )
+        let setup = try XCTUnwrap(setupBody["setup"] as? [String: Any])
+        XCTAssertEqual(setup["model"] as? String, "models/gemini-3.5-transcribe-live")
+        let transcriptionConfig = try XCTUnwrap(
+            setup["inputAudioTranscription"] as? [String: Any]
+        )
+        XCTAssertEqual(transcriptionConfig["mode"] as? String, "SMART")
+        XCTAssertEqual(transcriptionConfig["languageCodes"] as? [String], ["de-DE", "en-US"])
+        XCTAssertEqual(
+            transcriptionConfig["customVocabulary"] as? [String],
+            ["TypeWhisper", "Gemini"]
+        )
+
+        let pcm = GeminiLiveTranscriptionSession.pcm16Data(from: [-1, 0, 1][...])
+        XCTAssertEqual(pcm.count, 6)
+        let audioMessage = try GeminiLiveTranscriptionSession.makeRealtimeAudioMessage(pcm)
+        let audioBody = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(audioMessage.utf8)) as? [String: Any]
+        )
+        let realtimeInput = try XCTUnwrap(audioBody["realtimeInput"] as? [String: Any])
+        let audio = try XCTUnwrap(realtimeInput["audio"] as? [String: Any])
+        XCTAssertEqual(audio["mimeType"] as? String, "audio/pcm;rate=16000")
+        XCTAssertEqual(audio["data"] as? String, pcm.base64EncodedString())
+
+        var collector = GeminiLiveTranscriptCollector()
+        XCTAssertEqual(collector.apply(interimText: "Hello", finalText: nil), "Hello")
+        XCTAssertEqual(collector.apply(interimText: nil, finalText: "Hello"), "Hello")
+        XCTAssertEqual(collector.apply(interimText: "world", finalText: nil), "Hello world")
+        XCTAssertEqual(collector.apply(interimText: nil, finalText: "world"), "Hello world")
+        XCTAssertEqual(collector.resultText, "Hello world")
     }
 
     func testTranscribeFailsWithoutAPIKey() async throws {
@@ -273,7 +571,7 @@ final class GeminiPluginTests: XCTestCase {
 
     func testTranscribeRejectsTranslateRequests() async throws {
         let host = try PluginTestHostServices(
-            defaults: [Self.cachedLLMModelsKey: try Self.cachedModelsData()],
+            defaults: try Self.configuredDefaults(),
             secrets: ["api-key": "gemini-key"]
         )
         let plugin = GeminiPlugin()
@@ -295,128 +593,10 @@ final class GeminiPluginTests: XCTestCase {
         }
     }
 
-    func testTranscribeSendsGenerateContentRequestAndParsesText() async throws {
-        let host = try PluginTestHostServices(
-            defaults: [
-                Self.cachedLLMModelsKey: try Self.cachedModelsData(),
-                "selectedModel": "gemini-flash-lite-latest",
-            ],
-            secrets: ["api-key": "gemini-key"]
-        )
-        let plugin = GeminiPlugin()
-        plugin.activate(host: host)
-
-        let store = PluginHTTPClientSessionStore()
-        PluginHTTPClientTestHarness.configure { _ in
-            store.makeSession(outcomes: [
-                .success(
-                    Data(
-                        """
-                        {
-                          "candidates": [
-                            {
-                              "content": {
-                                "parts": [
-                                  { "text": " hello from gemini \\n" }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                        """.utf8
-                    ),
-                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 200)
-                ),
-            ])
-        }
-
-        let result = try await plugin.transcribe(
-            audio: Self.audio(),
-            language: "en",
-            translate: false,
-            prompt: "TypeWhisper, Qwen3"
-        )
-
-        XCTAssertEqual(result.text, "hello from gemini")
-        XCTAssertEqual(result.detectedLanguage, "en")
-
-        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
-        XCTAssertEqual(request.url?.path, "/v1beta/models/gemini-flash-lite-latest:generateContent")
-        XCTAssertEqual(request.value(forHTTPHeaderField: "x-goog-api-key"), "gemini-key")
-
-        let body = try Self.jsonBody(from: request)
-        let contents = try XCTUnwrap(body["contents"] as? [[String: Any]])
-        let parts = try XCTUnwrap(contents.first?["parts"] as? [[String: Any]])
-        let promptText = try XCTUnwrap(parts.first?["text"] as? String)
-        XCTAssertTrue(promptText.contains("TypeWhisper, Qwen3"))
-        let inlineData = try XCTUnwrap(parts.last?["inlineData"] as? [String: Any])
-        XCTAssertEqual(inlineData["mimeType"] as? String, "audio/mp4")
-    }
-
-    func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
-        let host = try PluginTestHostServices(
-            defaults: [
-                Self.cachedLLMModelsKey: try Self.cachedModelsData(),
-                "selectedModel": "gemini-flash-lite-latest",
-            ],
-            secrets: ["api-key": "gemini-key"]
-        )
-        let plugin = GeminiPlugin()
-        plugin.activate(host: host)
-
-        let store = PluginHTTPClientSessionStore()
-        PluginHTTPClientTestHarness.configure { _ in
-            store.makeSession(outcomes: [
-                .success(
-                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
-                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 415)
-                ),
-                .success(
-                    Data(
-                        """
-                        {
-                          "candidates": [
-                            {
-                              "content": {
-                                "parts": [
-                                  { "text": " fallback transcript " }
-                                ]
-                              }
-                            }
-                          ]
-                        }
-                        """.utf8
-                    ),
-                    Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-flash-lite-latest:generateContent", statusCode: 200)
-                ),
-            ])
-        }
-
-        let result = try await plugin.transcribe(
-            audio: Self.audio(),
-            language: "de",
-            translate: false,
-            prompt: "TypeWhisper"
-        )
-
-        XCTAssertEqual(result.text, "fallback transcript")
-        let requests = store.sessions[0].requestedRequests
-        XCTAssertEqual(requests.count, 2)
-        let firstBody = try Self.jsonBody(from: requests[0])
-        let firstParts = try XCTUnwrap((firstBody["contents"] as? [[String: Any]])?.first?["parts"] as? [[String: Any]])
-        XCTAssertEqual((firstParts.last?["inlineData"] as? [String: Any])?["mimeType"] as? String, "audio/mp4")
-        let retryBody = try Self.jsonBody(from: requests[1])
-        let retryParts = try XCTUnwrap((retryBody["contents"] as? [[String: Any]])?.first?["parts"] as? [[String: Any]])
-        XCTAssertEqual((retryParts.last?["inlineData"] as? [String: Any])?["mimeType"] as? String, "audio/wav")
-        let retryPrompt = try XCTUnwrap(retryParts.first?["text"] as? String)
-        XCTAssertTrue(retryPrompt.contains("TypeWhisper"))
-        XCTAssertTrue(retryPrompt.contains("Language hint: de"))
-    }
-
     func testTranscriptionHTTPErrorMapping() {
         XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
             data: Data(#"{"error":{"message":"bad key"}}"#.utf8),
-            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 401)
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/interactions", statusCode: 401)
         )) { error in
             guard let pluginError = error as? PluginTranscriptionError,
                   case .invalidApiKey = pluginError else {
@@ -426,7 +606,7 @@ final class GeminiPluginTests: XCTestCase {
 
         XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
             data: Data(#"{"error":{"message":"too large"}}"#.utf8),
-            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 413)
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/interactions", statusCode: 413)
         )) { error in
             guard let pluginError = error as? PluginTranscriptionError,
                   case .fileTooLarge = pluginError else {
@@ -436,7 +616,7 @@ final class GeminiPluginTests: XCTestCase {
 
         XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
             data: Data(#"{"error":{"message":"slow down"}}"#.utf8),
-            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 429)
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/interactions", statusCode: 429)
         )) { error in
             guard let pluginError = error as? PluginTranscriptionError,
                   case .rateLimited = pluginError else {
@@ -446,7 +626,7 @@ final class GeminiPluginTests: XCTestCase {
 
         XCTAssertThrowsError(try GeminiPlugin.validateTranscriptionResponse(
             data: Data(#"{"error":{"message":"server failed"}}"#.utf8),
-            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite:generateContent", statusCode: 500)
+            response: Self.httpResponse(url: "https://generativelanguage.googleapis.com/v1beta/interactions", statusCode: 500)
         )) { error in
             guard let pluginError = error as? PluginTranscriptionError,
                   case .apiError(let message) = pluginError else {
@@ -475,12 +655,16 @@ final class GeminiPluginTests: XCTestCase {
         return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
     }
 
-    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+    private static func httpResponse(
+        url: String,
+        statusCode: Int,
+        headers: [String: String]? = nil
+    ) -> HTTPURLResponse {
         HTTPURLResponse(
             url: URL(string: url)!,
             statusCode: statusCode,
             httpVersion: nil,
-            headerFields: nil
+            headerFields: headers
         )!
     }
 }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemini",
     "name": "Gemini",
-    "version": "1.0.21",
+    "version": "1.1.0",
     "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -134,6 +134,25 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.recordings.isEmpty)
     }
 
+    func testPrivacyQuietModeDefersInitialRecordingsLoadUntilRequested() throws {
+        let defaults = try makeDefaults()
+        defaults.set(true, forKey: UserDefaultsKeys.devPrivacyQuietMode)
+        let probe = BlockingRecordingsLoader()
+        defer { probe.release.signal() }
+
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recordingsLoader: probe.load
+        )
+
+        XCTAssertEqual(probe.started.wait(timeout: .now() + 0.1), .timedOut)
+
+        viewModel.loadRecordingsIfNeeded()
+
+        XCTAssertEqual(probe.started.wait(timeout: .now() + 1), .success)
+        XCTAssertFalse(probe.ranOnMainThread)
+    }
+
     func testRecorderLoadIgnoresOlderResultThatFinishesLast() async throws {
         let directory = makeTemporaryDirectory()
         let olderURL = directory.appendingPathComponent("Older.wav")

--- a/TypeWhisperTests/AudioRecorderViewModelTests.swift
+++ b/TypeWhisperTests/AudioRecorderViewModelTests.swift
@@ -153,6 +153,25 @@ final class AudioRecorderViewModelTests: XCTestCase {
         XCTAssertFalse(probe.ranOnMainThread)
     }
 
+    func testPrivacyQuietModeDefersDirectRecordingsRefreshUntilRequested() throws {
+        let defaults = try makeDefaults()
+        defaults.set(true, forKey: UserDefaultsKeys.devPrivacyQuietMode)
+        let probe = BlockingRecordingsLoader()
+        defer { probe.release.signal() }
+
+        let viewModel = makeViewModel(
+            defaults: defaults,
+            recordingsLoader: probe.load
+        )
+
+        viewModel.loadRecordings()
+        XCTAssertEqual(probe.started.wait(timeout: .now() + 0.1), .timedOut)
+
+        viewModel.loadRecordingsIfNeeded()
+        XCTAssertEqual(probe.started.wait(timeout: .now() + 1), .success)
+        XCTAssertFalse(probe.ranOnMainThread)
+    }
+
     func testRecorderLoadIgnoresOlderResultThatFinishesLast() async throws {
         let directory = makeTemporaryDirectory()
         let olderURL = directory.appendingPathComponent("Older.wav")

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -10409,28 +10409,33 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
-    func testGeminiPluginCompatibleModelDecodingNormalizesIdsAndFiltersToChatModels() throws {
+    func testGeminiPluginNativeModelCatalogDecodingSeparatesChatAndTranscriptionModels() throws {
         let response = Data(
             """
             {
-              "object": "list",
-              "data": [
-                { "id": "models/gemini-2.5-pro", "object": "model", "display_name": "Gemini 2.5 Pro" },
-                { "id": "models/gemini-3-flash-preview", "object": "model", "display_name": "Gemini 3 Flash Preview" },
-                { "id": "models/gemini-2.5-flash-image", "object": "model", "display_name": "Nano Banana" },
-                { "id": "models/gemini-embedding-2-preview", "object": "model", "display_name": "Gemini Embedding 2 Preview" },
-                { "id": "models/gemini-2.5-flash-native-audio-latest", "object": "model", "display_name": "Gemini 2.5 Flash Native Audio Latest" },
-                { "id": "models/gemma-4-31b-it", "object": "model", "display_name": "Gemma 4 31B IT" }
+              "models": [
+                { "name": "models/gemini-2.5-pro", "displayName": "Gemini 2.5 Pro", "supportedGenerationMethods": ["generateContent"] },
+                { "name": "models/gemini-3-flash-preview", "displayName": "Gemini 3 Flash Preview", "supportedGenerationMethods": ["generateContent"] },
+                { "name": "models/gemini-3.5-transcribe", "displayName": "Gemini 3.5 Transcribe" },
+                { "name": "models/gemini-3.5-transcribe-live", "displayName": "Gemini 3.5 Transcribe Live" },
+                { "name": "models/gemini-2.5-flash-image", "displayName": "Nano Banana", "supportedGenerationMethods": ["generateContent"] },
+                { "name": "models/gemini-embedding-2-preview", "displayName": "Gemini Embedding 2 Preview", "supportedGenerationMethods": ["embedContent"] },
+                { "name": "models/gemini-2.5-flash-native-audio-latest", "displayName": "Gemini 2.5 Flash Native Audio Latest", "supportedGenerationMethods": ["generateContent"] },
+                { "name": "models/gemma-4-31b-it", "displayName": "Gemma 4 31B IT", "supportedGenerationMethods": ["generateContent"] }
               ]
             }
             """.utf8
         )
 
-        let models = try GeminiPlugin.decodeCompatibleLLMModels(from: response)
+        let catalog = try GeminiPlugin.decodeModelCatalog(from: response)
 
-        XCTAssertEqual(models.map(\.id), ["gemini-2.5-pro", "gemini-3-flash-preview"])
-        XCTAssertEqual(models.first?.displayName, "Gemini 2.5 Pro")
-        XCTAssertEqual(models.last?.displayName, "Gemini 3 Flash Preview")
+        XCTAssertEqual(catalog.llmModels.map(\.id), ["gemini-2.5-pro", "gemini-3-flash-preview"])
+        XCTAssertEqual(catalog.llmModels.first?.displayName, "Gemini 2.5 Pro")
+        XCTAssertEqual(catalog.transcriptionModels.map(\.id), ["gemini-3.5-transcribe"])
+        XCTAssertEqual(
+            catalog.transcriptionModels.first?.liveModelId,
+            "gemini-3.5-transcribe-live"
+        )
     }
 
     @MainActor


### PR DESCRIPTION
## Context

Google introduced dedicated Gemini 3.5 Transcribe models for batch and live speech-to-text. The Gemini plugin previously exposed general-purpose Flash models as transcription choices, even though they are not dedicated transcription models, and it did not keep its native model catalog refreshed automatically.

The dev build also enabled `devPrivacyQuietMode`, but the recorder still read `~/Documents/TypeWhisper Recordings` during startup and could trigger a Documents permission prompt before the recorder UI was opened.

## What changed

- bump GeminiPlugin to 1.1.0
- fetch and cache the native Gemini model catalog automatically, including pagination and a 24-hour refresh window
- keep LLM and transcription model catalogs separate
- normalize TypeWhisper language choices to the BCP-47 locale codes required by Gemini Transcribe
- expose only dedicated `gemini-*-transcribe` models for transcription and migrate stale Flash selections to `gemini-3.5-transcribe`
- add batch transcription through the Gemini Files and Interactions APIs
- add live transcription through the paired `gemini-3.5-transcribe-live` model
- add separate LLM and transcription model controls in plugin settings
- defer the recorder's Documents access in dev privacy-quiet launches until the recorder view is explicitly opened

## Test plan

```sh
swift test --package-path TypeWhisperPluginSDK --filter GeminiPluginTests
```

```sh
xcodebuild -project TypeWhisper.xcodeproj -scheme GeminiPlugin -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

```sh
xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testPrivacyQuietModeDefersInitialRecordingsLoadUntilRequested \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testPrivacyQuietModeDefersDirectRecordingsRefreshUntilRequested \
  -only-testing:TypeWhisperTests/AudioRecorderViewModelTests/testRecorderFilesAreLoadedOffMainThreadDuringInitialization \
  -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testGeminiPluginNativeModelCatalogDecodingSeparatesChatAndTranscriptionModels \
  -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testGeminiPluginActivationIgnoresLegacyCacheAndDoesNotExposeInvalidSelection test
```

```sh
git diff --check
jq empty TypeWhisperPluginSDK/Plugins/GeminiPlugin/Localizable.xcstrings TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gemini model discovery with separate language and transcription catalogs.
  * Added dedicated transcription support with file uploads, language selection, vocabulary hints, and improved error handling.
  * Added live transcription with streaming audio, progress updates, cancellation, and transcript reconciliation.
  * Added independent model selection and automatic catalog refresh.

* **Bug Fixes**
  * Improved startup privacy by deferring recording access when quiet mode is enabled.
  * Prevented duplicate initial recording loads.

* **Localization**
  * Added German, Japanese, and Simplified Chinese translations for Gemini transcription settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
