### PR TITLE
Move XAI tests into the plugin directory

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -2521,9 +2521,18 @@
 				9A584149706C7567496E0210 /* XAIPlugin.swift */,
 				9A584149706C7567496E0211 /* manifest.json */,
 				9A584149706C7567496E0212 /* Localizable.xcstrings */,
+				9A584149706C7567496E0102 /* Tests */,
 			);
 			name = XAIPlugin;
 			path = TypeWhisperPluginSDK/Plugins/XAIPlugin;
+			sourceTree = "<group>";
+		};
+		9A584149706C7567496E0102 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				9A584149706C7567496E0101 /* XAIPluginTests.swift */,
+			);
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		CC00000000000000000043 /* CoherePlugin */ = {
@@ -2707,7 +2716,6 @@
 				BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */,
 				D4A100000000000000000004 /* RecorderTranscriptionBufferTests.swift */,
 				91B4D7E2C5A809F1632E4B7F /* StreamingHandlerTests.swift */,
-				9A584149706C7567496E0101 /* XAIPluginTests.swift */,
 				B26D2C342D877030A62CE027 /* Support */,
 				05313C25F9E79BCFC02899F2 /* TextDiffServiceTests.swift */,
 			);

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/Tests/XAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/Tests/XAIPluginTests.swift
@@ -90,7 +90,7 @@ final class XAIPluginTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.id, "com.typewhisper.xai")
-        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
         XCTAssertEqual(manifest.category, "transcription")
         XCTAssertEqual(manifest.categories, ["transcription", "llm", "tts"])
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.xai",
     "name": "xAI / Grok",
     "version": "1.0.0",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- moves `XAIPluginTests.swift` from the host test folder into `TypeWhisperPluginSDK/Plugins/XAIPlugin/Tests`
- keeps the suite in the existing `TypeWhisperTests` target while making the Xcode group match the on-disk plugin layout
- raises the XAI source manifest floor from TypeWhisper 1.5.0 to the supported 1.6.0 baseline
- leaves existing published marketplace history unchanged

## Test plan

- `xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/XAIPluginTests`
- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json`
- `git diff --check origin/main...HEAD`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the XAI plugin’s minimum compatible host version to 1.6.0.
  * Corrected the project’s test organization so XAI plugin tests are grouped with the plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->