### PR TITLE
Require TypeWhisper 1.6 for Supertonic

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SupertonicPlugin
 
 final class SupertonicPluginTests: XCTestCase {
-    func testManifestDeclaresLocalTTSPluginForHost14AndArm64() throws {
+    func testManifestDeclaresLocalTTSPluginForHost16AndArm64() throws {
         let manifestURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -21,7 +21,7 @@ final class SupertonicPluginTests: XCTestCase {
         XCTAssertEqual(manifest.category, "tts")
         XCTAssertEqual(manifest.hosting, .local)
         XCTAssertEqual(manifest.requiresAPIKey, false)
-        XCTAssertEqual(manifest.minHostVersion, "1.4.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
     }
 

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.tts.supertonic",
     "name": "Supertonic (Experimental)",
     "version": "1.0.0",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [


### PR DESCRIPTION
## Summary

- raises the Supertonic source manifest minimum host version from 1.4.0 to 1.6.0
- updates the colocated manifest regression test
- leaves existing published marketplace history unchanged

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter SupertonicPluginTests.testManifestDeclaresLocalTTSPluginForHost16AndArm64`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the plugin’s minimum required host version to 1.6.0.
  * Updated compatibility checks to reflect the new host version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->