### PR TITLE
Require TypeWhisper 1.6 for Parakeet

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
     "version": "1.3.1",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -91,7 +91,7 @@ final class PluginManifestValidationTests: XCTestCase {
     func testSourceFootageProgressPluginsDeclareCapability() throws {
         let manifestExpectations = [
             ("TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json", "1.6.0"),
-            ("TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json", "1.5.0"),
+            ("TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json", "1.6.0"),
             ("TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json", "1.7.0"),
         ]
 


### PR DESCRIPTION
## Summary

- raises the Parakeet source manifest minimum host version from 1.5.0 to 1.6.0
- updates the focused source-footage manifest regression test
- leaves existing published marketplace history unchanged

## Test plan

- `xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/PluginManifestValidationTests/testSourceFootageProgressPluginsDeclareCapability`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Updated the Parakeet plugin to require host version 1.6.0 or later.
* **Tests**
  * Updated plugin validation checks to reflect the new minimum host version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->