### PR TITLE
Require TypeWhisper 1.6 for Groq

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.groq",
     "name": "Groq",
     "version": "1.0.24",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -173,13 +173,13 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }
 
-    func testGroqPluginReleaseRequiresHost15() throws {
+    func testGroqPluginReleaseRequiresHost16() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.version, "1.0.24")
-        XCTAssertEqual(manifest.minHostVersion, "1.5.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }
 


### PR DESCRIPTION
## Summary

- raises the Groq source manifest minimum host version from 1.5.0 to 1.6.0
- updates the focused manifest regression test
- leaves existing published marketplace history unchanged

## Test plan

- `xcodebuild -quiet test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/PluginManifestValidationTests/testGroqPluginReleaseRequiresHost16`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Groq plugin to require host version 1.6.0 or later.
* **Tests**
  * Updated plugin validation checks to reflect the new minimum host version requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->