### PR TITLE
Require TypeWhisper 1.6 for AssemblyAI

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
     "version": "1.1.0",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the AssemblyAI source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json`
- `git diff --check origin/main...HEAD`