### PR TITLE
Require TypeWhisper 1.6 for Cartesia

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cartesia",
     "name": "Cartesia",
     "version": "1.0.0",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Cartesia source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json`
- `git diff --check origin/main...HEAD`