### PR TITLE
Require TypeWhisper 1.6 for Claude

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.claude",
     "name": "Claude",
     "version": "1.1.1",
-    "minHostVersion": "0.9.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Claude source manifest minimum host version from 0.9.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json`
- `git diff --check origin/main...HEAD`