### PR TITLE
Require TypeWhisper 1.6 for Cloudflare ASR

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cloudflare-asr",
     "name": "Cloudflare ASR",
     "version": "1.0.0",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "yunluyl",


### PR DESCRIPTION
## Summary

- raises the Cloudflare ASR source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json`
- `git diff --check origin/main...HEAD`