### PR TITLE
Require TypeWhisper 1.6 for Cohere

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cohere",
     "name": "Cohere",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Cohere source manifest minimum host version from 0.12.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json`
- `git diff --check origin/main...HEAD`