### PR TITLE
Require TypeWhisper 1.6 for ElevenLabs

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
     "version": "1.0.11",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the ElevenLabs source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json`
- `git diff --check origin/main...HEAD`