### PR TITLE
Require TypeWhisper 1.6 for File Memory

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.memory.file",
     "name": "File Memory",
     "version": "1.0.0",
-    "minHostVersion": "0.14.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the File Memory source manifest minimum host version from 0.14.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json`
- `git diff --check origin/main...HEAD`