### PR TITLE
Require TypeWhisper 1.6 for Filler Words

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "com.typewhisper.filler-words",
   "name": "Filler Words",
   "version": "1.0.1",
-  "minHostVersion": "1.0.0",
+  "minHostVersion": "1.6.0",
   "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Filler Words source manifest minimum host version from 1.0.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json`
- `git diff --check origin/main...HEAD`