### PR TITLE
Require TypeWhisper 1.6 for Gladia

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gladia",
     "name": "Gladia",
     "version": "1.0.0",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Gladia source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json`
- `git diff --check origin/main...HEAD`