### PR TITLE
Require TypeWhisper 1.6 for Google Cloud Speech-to-Text

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.google-cloud-stt",
     "name": "Google Cloud Speech-to-Text",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Google Cloud Speech-to-Text source manifest minimum host version from 0.12.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json`
- `git diff --check origin/main...HEAD`