### PR TITLE
Require TypeWhisper 1.6 for Live Transcript

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.livetranscript",
     "name": "Live Transcript",
     "version": "1.0.3",
-    "minHostVersion": "1.1.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Live Transcript source manifest minimum host version from 1.1.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json`
- `git diff --check origin/main...HEAD`