### PR TITLE
Require TypeWhisper 1.6 for MemPalace

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.mempalace.memory",
     "name": "MemPalace",
     "version": "0.3.5",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": ["arm64"],


### PR DESCRIPTION
## Summary

- raises the MemPalace source manifest minimum host version from 1.4.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/MemPalacePlugin/manifest.json`
- `git diff --check origin/main...HEAD`