### PR TITLE
Require TypeWhisper 1.6 for Mistral AI

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.minerale.mistralai",
     "name": "Mistral AI",
     "version": "1.0.5",
-    "minHostVersion": "1.5.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "MinerAle",


### PR DESCRIPTION
## Summary

- raises the Mistral AI source manifest minimum host version from 1.5.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json`
- `git diff --check origin/main...HEAD`