### PR TITLE
Require TypeWhisper 1.6 for OpenAI Vector Memory

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.memory.openai-vector",
     "name": "OpenAI Vector Memory",
     "version": "1.0.0",
-    "minHostVersion": "0.14.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the OpenAI Vector Memory source manifest minimum host version from 0.14.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json`
- `git diff --check origin/main...HEAD`