### PR TITLE
Require TypeWhisper 1.6 for Reson8

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.reson8",
     "name": "Reson8",
     "version": "1.0.0",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "Y. Vos",


### PR DESCRIPTION
## Summary

- raises the Reson8 source manifest minimum host version from 0.12.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json`
- `git diff --check origin/main...HEAD`