### PR TITLE
Require TypeWhisper 1.6 for Sber SaluteSpeech

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.sber-salutespeech",
     "name": "Sber SaluteSpeech",
     "version": "0.1.1",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Sber SaluteSpeech source manifest minimum host version from 1.4.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json`
- `git diff --check origin/main...HEAD`