### PR TITLE
Require TypeWhisper 1.6 for Smallest Pulse

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.smallest-pulse",
     "name": "Smallest Pulse",
     "version": "1.0.0",
-    "minHostVersion": "1.4.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Smallest Pulse source manifest minimum host version from 1.4.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json`
- `git diff --check origin/main...HEAD`