### PR TITLE
Require TypeWhisper 1.6 for Apple Speech

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.speechanalyzer",
     "name": "Apple Speech",
     "version": "1.0.15",
-    "minHostVersion": "0.12.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "26.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the Apple Speech source manifest minimum host version from 0.12.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json`
- `git diff --check origin/main...HEAD`