### PR TITLE
Require TypeWhisper 1.6 for System Voice

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.tts.system",
     "name": "System Voice",
     "version": "1.0.0",
-    "minHostVersion": "1.3.0",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Summary

- raises the System Voice source manifest minimum host version from 1.3.0 to 1.6.0
- aligns future releases with the supported TypeWhisper host baseline
- leaves existing published marketplace history unchanged

## Test plan

- `jq -e '.minHostVersion == "1.6.0"' TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json`
- `git diff --check origin/main...HEAD`