### PR TITLE
Add paste last transcription action

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The localized macOS screenshot workflow is documented in [docs/screenshot-automa
 
 - **System-wide** - Push-to-talk, toggle, or hybrid mode via global hotkey, auto-pastes into any app
 - **Modifier-key hotkeys** - Use a single modifier key (Command, Shift, Option, Control) as your hotkey
+- **Last-transcription actions** - Copy or paste your latest transcription with configurable global hotkeys
 - **Indicator styles** - Choose Notch, Overlay, or Minimal, with optional live transcript preview where supported
 - **Sound feedback** - Audio cues for recording start, transcription success, and errors
 - **Microphone selection** - Choose a specific input device with live preview and improved recovery after route changes

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -828,6 +828,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         ServiceContainer.shared.hotkeyService.onCopyLastTranscription = {
             DictationViewModel.shared.copyLastTranscriptionToClipboard()
         }
+        ServiceContainer.shared.hotkeyService.onPasteLastTranscription = {
+            DictationViewModel.shared.pasteLastTranscription()
+        }
         ServiceContainer.shared.hotkeyService.onRecorderToggle = {
             AudioRecorderViewModel.shared.toggleRecording()
         }

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -30,6 +30,7 @@ enum UserDefaultsKeys {
     static let promptPaletteHotkey = "promptPaletteHotkey"
     static let recentTranscriptionsHotkey = "recentTranscriptionsHotkey"
     static let copyLastTranscriptionHotkey = "copyLastTranscriptionHotkey"
+    static let pasteLastTranscriptionHotkey = "pasteLastTranscriptionHotkey"
     static let recorderToggleHotkey = "recorderToggleHotkey"
 
     // MARK: - Hotkeys (JSON-encoded [UnifiedHotkey] per slot)
@@ -39,6 +40,7 @@ enum UserDefaultsKeys {
     static let promptPaletteHotkeys = "promptPaletteHotkeys"
     static let recentTranscriptionsHotkeys = "recentTranscriptionsHotkeys"
     static let copyLastTranscriptionHotkeys = "copyLastTranscriptionHotkeys"
+    static let pasteLastTranscriptionHotkeys = "pasteLastTranscriptionHotkeys"
     static let recorderToggleHotkeys = "recorderToggleHotkeys"
 
     // MARK: - Model / Engine

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -19283,7 +19283,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最後の文字起こしを貼り付け"
+            "value" : "最新の文字起こしを貼り付け"
           }
         },
         "zh-Hans" : {
@@ -19305,7 +19305,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "最後の文字起こしを貼り付けるショートカット"
+            "value" : "最新の文字起こしを貼り付けるショートカット"
           }
         },
         "zh-Hans" : {

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -13151,6 +13151,28 @@
         }
       }
     },
+    "Insert your latest transcription into the focused app." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Füge deine letzte Transkription in die fokussierte App ein."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新の文字起こしをフォーカス中のアプリに挿入します。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将最近一次转录插入当前应用。"
+          }
+        }
+      }
+    },
     "Inserting text" : {
       "localizations" : {
         "de" : {
@@ -19246,6 +19268,50 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Parakeet 已可用于本地听写"
+          }
+        }
+      }
+    },
+    "Paste Last Transcription" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Letzte Transkription einfügen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後の文字起こしを貼り付け"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴上次转录"
+          }
+        }
+      }
+    },
+    "Paste last transcription shortcut" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tastenkürzel zum Einfügen der letzten Transkription"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最後の文字起こしを貼り付けるショートカット"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴上次转录的快捷键"
           }
         }
       }

--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -99,6 +99,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
     case promptPalette
     case recentTranscriptions
     case copyLastTranscription
+    case pasteLastTranscription
     case recorderToggle
 
     var defaultsKey: String {
@@ -109,6 +110,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
         case .promptPalette: return UserDefaultsKeys.promptPaletteHotkey
         case .recentTranscriptions: return UserDefaultsKeys.recentTranscriptionsHotkey
         case .copyLastTranscription: return UserDefaultsKeys.copyLastTranscriptionHotkey
+        case .pasteLastTranscription: return UserDefaultsKeys.pasteLastTranscriptionHotkey
         case .recorderToggle: return UserDefaultsKeys.recorderToggleHotkey
         }
     }
@@ -121,6 +123,7 @@ enum HotkeySlotType: String, CaseIterable, Sendable {
         case .promptPalette: return UserDefaultsKeys.promptPaletteHotkeys
         case .recentTranscriptions: return UserDefaultsKeys.recentTranscriptionsHotkeys
         case .copyLastTranscription: return UserDefaultsKeys.copyLastTranscriptionHotkeys
+        case .pasteLastTranscription: return UserDefaultsKeys.pasteLastTranscriptionHotkeys
         case .recorderToggle: return UserDefaultsKeys.recorderToggleHotkeys
         }
     }
@@ -131,7 +134,7 @@ private extension HotkeySlotType {
         switch self {
         case .hybrid, .pushToTalk, .toggle:
             true
-        case .promptPalette, .recentTranscriptions, .copyLastTranscription, .recorderToggle:
+        case .promptPalette, .recentTranscriptions, .copyLastTranscription, .pasteLastTranscription, .recorderToggle:
             false
         }
     }
@@ -208,6 +211,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     var onPromptPaletteToggle: (() -> Void)?
     var onRecentTranscriptionsToggle: (() -> Void)?
     var onCopyLastTranscription: (() -> Void)?
+    var onPasteLastTranscription: (() -> Void)?
     var onRecorderToggle: (() -> Void)?
     var onProfileDictationStart: ((UUID, UInt64) -> Void)?
     var onWorkflowDictationStart: ((UUID, UInt64) -> Void)?
@@ -2030,6 +2034,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             onCopyLastTranscription?()
             return
         }
+        if slotType == .pasteLastTranscription {
+            onPasteLastTranscription?()
+            return
+        }
         if slotType == .recorderToggle {
             onRecorderToggle?()
             return
@@ -2107,6 +2115,8 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
         case .recentTranscriptions:
             break // handled on keyDown only
         case .copyLastTranscription:
+            break // handled on keyDown only
+        case .pasteLastTranscription:
             break // handled on keyDown only
         case .recorderToggle:
             break // handled on keyDown only

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -40,6 +40,7 @@ enum SettingsBackupExporter {
         UserDefaultsKeys.promptPaletteHotkeys,
         UserDefaultsKeys.recentTranscriptionsHotkeys,
         UserDefaultsKeys.copyLastTranscriptionHotkeys,
+        UserDefaultsKeys.pasteLastTranscriptionHotkeys,
         UserDefaultsKeys.recorderToggleHotkeys,
     ]
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -267,6 +267,7 @@ final class DictationViewModel: ObservableObject {
     var promptPaletteHotkeyLabel: String { Self.loadHotkeyLabel(for: .promptPalette) }
     var recentTranscriptionsHotkeyLabel: String { Self.loadHotkeyLabel(for: .recentTranscriptions) }
     var copyLastTranscriptionHotkeyLabel: String { Self.loadHotkeyLabel(for: .copyLastTranscription) }
+    var pasteLastTranscriptionHotkeyLabel: String { Self.loadHotkeyLabel(for: .pasteLastTranscription) }
     var recorderToggleHotkeyLabel: String { Self.loadHotkeyLabel(for: .recorderToggle) }
     @Published var activeRuleName: String?
     @Published var activeRuleReasonLabel: String?
@@ -2961,6 +2962,12 @@ final class DictationViewModel: ObservableObject {
         let pasteboard = pasteboardProvider()
         pasteboard.clearContents()
         pasteboard.setString(text, forType: .string)
+    }
+
+    func pasteLastTranscription() {
+        promptPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.hide()
+        recentTranscriptionPaletteHandler.insertLatest(currentState: state)
     }
 
     func readBackLastTranscription() {

--- a/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
@@ -28,6 +28,18 @@ final class RecentTranscriptionPaletteHandler {
         paletteController.hide()
     }
 
+    func insertLatest(currentState: DictationViewModel.State) {
+        guard currentState == .idle else { return }
+        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) else {
+            showNoRecentTranscriptionsFeedback()
+            return
+        }
+
+        Task { @MainActor [weak self] in
+            await self?.insert(entry)
+        }
+    }
+
     func triggerSelection(currentState: DictationViewModel.State) {
         if paletteController.isVisible {
             paletteController.hide()
@@ -38,13 +50,7 @@ final class RecentTranscriptionPaletteHandler {
 
         let entries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.recentRecords)
         guard !entries.isEmpty else {
-            onShowNotchFeedback?(
-                String(localized: "No recent transcriptions"),
-                "clock.arrow.circlepath",
-                2.5,
-                false,
-                nil
-            )
+            showNoRecentTranscriptionsFeedback()
             return
         }
 
@@ -86,6 +92,16 @@ final class RecentTranscriptionPaletteHandler {
         } catch {
             onShowNotchFeedback?(error.localizedDescription, "xmark.circle.fill", 2.5, true, "recentTranscriptions")
         }
+    }
+
+    private func showNoRecentTranscriptionsFeedback() {
+        onShowNotchFeedback?(
+            String(localized: "No recent transcriptions"),
+            "clock.arrow.circlepath",
+            2.5,
+            false,
+            nil
+        )
     }
 
     private func subtitle(for entry: RecentTranscriptionStore.Entry) -> String {

--- a/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
@@ -7,6 +7,7 @@ final class RecentTranscriptionPaletteHandler {
     private let historyService: HistoryService
     private let recentTranscriptionStore: RecentTranscriptionStore
     private let relativeDateFormatter = RelativeDateTimeFormatter()
+    private var isInsertingLatest = false
 
     var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
     var getPreserveClipboard: (() -> Bool)?
@@ -30,13 +31,17 @@ final class RecentTranscriptionPaletteHandler {
 
     func insertLatest(currentState: DictationViewModel.State) {
         guard currentState == .idle else { return }
-        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) else {
+        guard !isInsertingLatest else { return }
+        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) else {
             showNoRecentTranscriptionsFeedback()
             return
         }
 
+        isInsertingLatest = true
         Task { @MainActor [weak self] in
-            await self?.insert(entry)
+            guard let self else { return }
+            defer { isInsertingLatest = false }
+            await insert(entry)
         }
     }
 

--- a/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
@@ -7,7 +7,7 @@ final class RecentTranscriptionPaletteHandler {
     private let historyService: HistoryService
     private let recentTranscriptionStore: RecentTranscriptionStore
     private let relativeDateFormatter = RelativeDateTimeFormatter()
-    private var isInsertingLatest = false
+    private var isInsertionInProgress = false
 
     var onShowNotchFeedback: ((String, String, TimeInterval, Bool, String?) -> Void)?
     var getPreserveClipboard: (() -> Bool)?
@@ -31,18 +31,12 @@ final class RecentTranscriptionPaletteHandler {
 
     func insertLatest(currentState: DictationViewModel.State) {
         guard currentState == .idle else { return }
-        guard !isInsertingLatest else { return }
         guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) else {
             showNoRecentTranscriptionsFeedback()
             return
         }
 
-        isInsertingLatest = true
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer { isInsertingLatest = false }
-            await insert(entry)
-        }
+        startInsertion(entry)
     }
 
     func triggerSelection(currentState: DictationViewModel.State) {
@@ -80,9 +74,18 @@ final class RecentTranscriptionPaletteHandler {
             items: items
         ) { [weak self] item in
             guard let self, let entry = entriesByID[item.id] else { return }
-            Task { @MainActor in
-                await self.insert(entry)
-            }
+            self.startInsertion(entry)
+        }
+    }
+
+    private func startInsertion(_ entry: RecentTranscriptionStore.Entry) {
+        guard !isInsertionInProgress else { return }
+        isInsertionInProgress = true
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { isInsertionInProgress = false }
+            await insert(entry)
         }
     }
 

--- a/TypeWhisper/Views/HotkeySettingsView.swift
+++ b/TypeWhisper/Views/HotkeySettingsView.swift
@@ -80,6 +80,12 @@ struct HotkeySettingsView: View {
                     title: String(localized: "Copy last transcription shortcut"),
                     subtitle: String(localized: "Copy your latest transcription to the clipboard.")
                 )
+
+                MultiHotkeySlotRecorder(
+                    slot: .pasteLastTranscription,
+                    title: String(localized: "Paste last transcription shortcut"),
+                    subtitle: String(localized: "Insert your latest transcription into the focused app.")
+                )
                 }
             }
             .formStyle(.grouped)

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -18,6 +18,7 @@ private final class MenuBarState: ObservableObject {
     @Published var dictationHotkeysPaused: Bool
     @Published var recentTranscriptionsMenuShortcut: HotkeyService.MenuShortcutDescriptor?
     @Published var copyLastTranscriptionMenuShortcut: HotkeyService.MenuShortcutDescriptor?
+    @Published var pasteLastTranscriptionMenuShortcut: HotkeyService.MenuShortcutDescriptor?
     @Published var recorderToggleMenuShortcut: HotkeyService.MenuShortcutDescriptor?
 
     private var cancellables = Set<AnyCancellable>()
@@ -43,6 +44,7 @@ private final class MenuBarState: ObservableObject {
         self.dictationHotkeysPaused = hotkeyService.dictationHotkeysPaused
         self.recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
         self.copyLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .copyLastTranscription)
+        self.pasteLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .pasteLastTranscription)
         self.recorderToggleMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recorderToggle)
         let modelStatus = Self.idleModelStatus(from: modelManager)
         self.statusText = modelStatus.text
@@ -206,6 +208,7 @@ private final class MenuBarState: ObservableObject {
     private func refreshMenuShortcuts() {
         recentTranscriptionsMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recentTranscriptions)
         copyLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .copyLastTranscription)
+        pasteLastTranscriptionMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .pasteLastTranscription)
         recorderToggleMenuShortcut = DictationSettingsHandler.loadMenuShortcutDescriptor(for: .recorderToggle)
     }
 }
@@ -221,6 +224,7 @@ enum MenuBarMenuItem: Hashable {
     case lastTranscription
     case recentTranscriptions
     case copyLastTranscription
+    case pasteLastTranscription
     case readBackLastTranscription
     case checkForUpdates
 }
@@ -459,6 +463,7 @@ struct MenuBarView: View {
             Menu {
                 recentTranscriptionsButton
                 copyLastTranscriptionButton
+                pasteLastTranscriptionButton
                 readBackLastTranscriptionButton
             } label: {
                 Label(
@@ -477,6 +482,9 @@ struct MenuBarView: View {
 
         case .copyLastTranscription:
             copyLastTranscriptionButton
+
+        case .pasteLastTranscription:
+            pasteLastTranscriptionButton
 
         case .readBackLastTranscription:
             readBackLastTranscriptionButton
@@ -514,6 +522,17 @@ struct MenuBarView: View {
             Label(String(localized: "Copy Last Transcription"), systemImage: "doc.on.doc")
         }
         .keyboardShortcut(keyboardShortcut(from: status.copyLastTranscriptionMenuShortcut))
+        .disabled(!status.canCopyLastTranscription)
+    }
+
+    @ViewBuilder
+    private var pasteLastTranscriptionButton: some View {
+        Button {
+            DictationViewModel.shared.pasteLastTranscription()
+        } label: {
+            Label(String(localized: "Paste Last Transcription"), systemImage: "text.insert")
+        }
+        .keyboardShortcut(keyboardShortcut(from: status.pasteLastTranscriptionMenuShortcut))
         .disabled(!status.canCopyLastTranscription)
     }
 

--- a/TypeWhisper/Views/SetupWizardView.swift
+++ b/TypeWhisper/Views/SetupWizardView.swift
@@ -1472,6 +1472,7 @@ struct SetupWizardView: View {
         case .promptPalette: return dictation.promptPaletteHotkeyLabel
         case .recentTranscriptions: return dictation.recentTranscriptionsHotkeyLabel
         case .copyLastTranscription: return dictation.copyLastTranscriptionHotkeyLabel
+        case .pasteLastTranscription: return dictation.pasteLastTranscriptionHotkeyLabel
         case .recorderToggle: return dictation.recorderToggleHotkeyLabel
         }
     }
@@ -1484,6 +1485,7 @@ struct SetupWizardView: View {
         case .promptPalette: return localizedAppText("Workflow Palette", de: "Workflow-Palette")
         case .recentTranscriptions: return String(localized: "Recent Transcriptions")
         case .copyLastTranscription: return String(localized: "Copy Last Transcription")
+        case .pasteLastTranscription: return String(localized: "Paste Last Transcription")
         case .recorderToggle: return String(localized: "settings.tab.recorder")
         }
     }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -144,6 +144,53 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), "Insert me")
     }
 
+    func testInsertLatestPastesNewestTranscriptionWithoutOpeningPalette() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pasteboard = NSPasteboard.withUniqueName()
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.pasteboardProvider = { pasteboard }
+
+        var pasteCount = 0
+        var returnCount = 0
+        textInsertionService.pasteSimulatorOverride = { pasteCount += 1 }
+        textInsertionService.returnSimulatorOverride = { returnCount += 1 }
+
+        let store = RecentTranscriptionStore()
+        let controller = SelectionPaletteControllerSpy()
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: store,
+            paletteController: controller
+        )
+
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Older transcription",
+            timestamp: Date().addingTimeInterval(-60),
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes"
+        )
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Newest transcription",
+            timestamp: Date(),
+            appName: "Messages",
+            appBundleIdentifier: "com.apple.MobileSMS"
+        )
+
+        handler.insertLatest(currentState: .idle)
+        try await Task.sleep(for: .milliseconds(50))
+
+        XCTAssertFalse(controller.isVisible)
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(returnCount, 0)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Newest transcription")
+    }
+
     func testWorkflowPaletteIncludesManualWorkflows() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -191,6 +191,56 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), "Newest transcription")
     }
 
+    func testInsertLatestIgnoresRapidRepeatUntilClipboardIsRestored() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        pasteboard.setString("Original clipboard", forType: .string)
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.pasteboardProvider = { pasteboard }
+        textInsertionService.focusedTextElementOverride = { nil }
+        textInsertionService.defaultPasteFallbackRestoreDelay = .milliseconds(80)
+
+        let pasteStarted = expectation(description: "synthetic paste started")
+        var pasteCount = 0
+        textInsertionService.pasteSimulatorOverride = {
+            pasteCount += 1
+            pasteStarted.fulfill()
+        }
+
+        let store = RecentTranscriptionStore()
+        store.recordTranscription(
+            id: UUID(),
+            finalText: "Newest transcription",
+            timestamp: Date(),
+            appName: "Messages",
+            appBundleIdentifier: "com.apple.MobileSMS"
+        )
+
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: store,
+            paletteController: SelectionPaletteControllerSpy()
+        )
+        handler.getPreserveClipboard = { true }
+
+        handler.insertLatest(currentState: .idle)
+        handler.insertLatest(currentState: .idle)
+
+        await fulfillment(of: [pasteStarted], timeout: 1.0)
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Newest transcription")
+
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Original clipboard")
+    }
+
     func testWorkflowPaletteIncludesManualWorkflows() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -241,6 +241,59 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
         XCTAssertEqual(pasteboard.string(forType: .string), "Original clipboard")
     }
 
+    func testPaletteSelectionCannotOverlapLatestInsertionClipboardRestore() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        pasteboard.setString("Original clipboard", forType: .string)
+
+        let textInsertionService = TextInsertionService()
+        textInsertionService.accessibilityGrantedOverride = true
+        textInsertionService.pasteboardProvider = { pasteboard }
+        textInsertionService.focusedTextElementOverride = { nil }
+        textInsertionService.defaultPasteFallbackRestoreDelay = .milliseconds(80)
+
+        let pasteStarted = expectation(description: "synthetic paste started")
+        var pasteCount = 0
+        textInsertionService.pasteSimulatorOverride = {
+            pasteCount += 1
+            pasteStarted.fulfill()
+        }
+
+        let store = RecentTranscriptionStore()
+        let id = UUID()
+        store.recordTranscription(
+            id: id,
+            finalText: "Newest transcription",
+            timestamp: Date(),
+            appName: "Messages",
+            appBundleIdentifier: "com.apple.MobileSMS"
+        )
+
+        let controller = SelectionPaletteControllerSpy()
+        let handler = RecentTranscriptionPaletteHandler(
+            textInsertionService: textInsertionService,
+            historyService: HistoryService(appSupportDirectory: appSupportDirectory),
+            recentTranscriptionStore: store,
+            paletteController: controller
+        )
+        handler.getPreserveClipboard = { true }
+
+        handler.triggerSelection(currentState: .idle)
+        handler.insertLatest(currentState: .idle)
+        controller.select(id: id)
+
+        await fulfillment(of: [pasteStarted], timeout: 1.0)
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Newest transcription")
+
+        try await Task.sleep(for: .milliseconds(150))
+        XCTAssertEqual(pasteCount, 1)
+        XCTAssertEqual(pasteboard.string(forType: .string), "Original clipboard")
+    }
+
     func testWorkflowPaletteIncludesManualWorkflows() throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -14356,6 +14356,26 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
+    func testPasteLastTranscriptionHotkeyInvokesDedicatedCallbackOnKeyDown() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+
+        service.setHotkeyForTesting(controlCommandVHotkey(), for: .pasteLastTranscription)
+
+        var callbackCount = 0
+        var startCount = 0
+        service.onPasteLastTranscription = { callbackCount += 1 }
+        service.onDictationStart = { _ in startCount += 1 }
+
+        let keyDown = try makeKeyboardEvent(keyCode: 0x09, keyDown: true, flags: [.maskCommand, .maskControl])
+
+        XCTAssertTrue(service.processEventForTesting(keyDown, source: .monitor))
+        XCTAssertEqual(callbackCount, 1)
+        XCTAssertEqual(startCount, 0)
+        XCTAssertNil(service.currentMode)
+    }
+
+    @MainActor
     func testRecorderToggleHotkeyInvokesDedicatedCallbackOnKeyDown() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
@@ -15150,6 +15170,15 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         UnifiedHotkey(
             keyCode: 0x08,
             modifierFlags: NSEvent.ModifierFlags([.command, .shift]).rawValue,
+            isFn: false
+        )
+    }
+
+    @MainActor
+    private func controlCommandVHotkey() -> UnifiedHotkey {
+        UnifiedHotkey(
+            keyCode: 0x09,
+            modifierFlags: NSEvent.ModifierFlags([.command, .control]).rawValue,
             isFn: false
         )
     }


### PR DESCRIPTION
## Summary

- add a first-party Paste Last Transcription menu action and configurable global hotkey
- reuse the existing focused-app text insertion path, including clipboard preservation
- serialize all recent-transcription insertion entry points until clipboard restoration completes
- keep Copy Last Transcription behavior unchanged
- include hotkey backup/restore, localized settings, documentation, and regression coverage

## Context

Copy Last Transcription only places text on the clipboard. Users who want one-step insertion currently have to open Recent Transcriptions or depend on external automation. This adds a dedicated direct-insertion action without changing existing copy semantics or assigning a new default shortcut.

Users can assign Control-Command-V, or another preferred shortcut, to Paste Last Transcription in Settings > Hotkeys.

## Testing

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 1,749 tests passed on the exact pushed head
- focused hotkey and recent-transcription tests on the exact pushed head — 99 tests passed
- `swift test --package-path TypeWhisperPluginSDK` — 739 tests passed, 3 expected skips
- registry metadata, appcast publication, release instrumentation, and release signing self-tests passed
- `git diff --check` passed

## Validation notes

The rapid-repeat regression test invokes Paste Last Transcription twice before the synthetic-paste restore delay completes. A second cross-entry-point regression opens Recent Transcriptions, starts Paste Last Transcription, then selects the same palette item during the restore delay. Both verify that only one paste occurs and that the user's original clipboard content is restored.

The three new strings include German, Japanese, and Simplified Chinese localizations. The repository-wide localization completeness check currently reports 60 pre-existing missing Simplified Chinese strings in `AuthenticatedCLIPlugin/Localizable.xcstrings` and `MetaPlugin/Localizable.xcstrings`; this change does not add to that baseline.

The isolated debug app launched the Hotkeys settings state and reported its native window successfully, but macOS Screen Recording denied the automated window capture, so no screenshot is attached.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable global hotkey and menu-bar action to paste the latest transcription into the focused app.
  * Added “Paste Last Transcription” to hotkey settings and the setup wizard.
  * Included the hotkey in settings backup and restore.
  * Added localized labels and guidance in German, Japanese, and Simplified Chinese.

* **Documentation**
  * Documented configuration for copying and pasting the latest transcription.

* **Tests**
  * Added coverage for pasting the newest transcription and invoking the dedicated hotkey.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
