### PR TITLE
Add Finder transcription actions

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -358,6 +358,10 @@
 		AA00000000000000000196 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000186 /* Assets.xcassets */; };
 		AA00000000000000000197 /* WidgetDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000180 /* WidgetDataService.swift */; };
 		AA00000000000000000198 /* TypeWhisperWidgetExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E1A000000000000000000001 /* ActionRequestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000020 /* ActionRequestHandler.swift */; };
+		E1A000000000000000000002 /* TypeWhisperTranscribeAction.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000023 /* TypeWhisperTranscribeAction.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		E1A000000000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000024 /* Assets.xcassets */; };
+		E1A000000000000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000025 /* InfoPlist.xcstrings */; };
 		5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA00000000000000000199 /* VoxtralPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000191 /* VoxtralPlugin.swift */; };
 		AA00000000000000000200 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000192 /* manifest.json */; };
@@ -579,6 +583,13 @@
 			remoteGlobalIDString = DD00000000000000000014;
 			remoteInfo = TypeWhisperWidgetExtension;
 		};
+		E1A000000000000000000010 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE00000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E1A000000000000000000050;
+			remoteInfo = TypeWhisperTranscribeAction;
+		};
 		5E7A00000000000000000003 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = EE00000000000000000001 /* Project object */;
@@ -629,6 +640,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				AA00000000000000000198 /* TypeWhisperWidgetExtension.appex in Embed App Extensions */,
+				E1A000000000000000000002 /* TypeWhisperTranscribeAction.appex in Embed App Extensions */,
 			);
 			name = "Embed App Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -917,6 +929,12 @@
 		BB00000000000000000187 /* TypeWhisperWidgetExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TypeWhisperWidgetExtension.entitlements; sourceTree = "<group>"; };
 		BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TypeWhisperWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000189 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E1A000000000000000000020 /* ActionRequestHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionRequestHandler.swift; sourceTree = "<group>"; };
+		E1A000000000000000000021 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		E1A000000000000000000022 /* TypeWhisperTranscribeAction.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TypeWhisperTranscribeAction.entitlements; sourceTree = "<group>"; };
+		E1A000000000000000000023 /* TypeWhisperTranscribeAction.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = TypeWhisperTranscribeAction.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E1A000000000000000000024 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		E1A000000000000000000025 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000190 /* VoxtralPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VoxtralPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000191 /* VoxtralPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoxtralPlugin.swift; sourceTree = "<group>"; };
 		BB00000000000000000192 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
@@ -1592,6 +1610,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E1A000000000000000000040 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -1674,6 +1699,7 @@
 				CC00000000000000000044 /* Gemma4Plugin */,
 				CC00000000000000000045 /* SpeechmaticsPlugin */,
 				CC00000000000000000025 /* TypeWhisperWidgetExtension */,
+				E1A000000000000000000030 /* TypeWhisperTranscribeAction */,
 				CC00000000000000000026 /* TypeWhisperWidgetShared */,
 				CC00000000000000000090 /* Products */,
 				573FF8BBD9BCC48AA1BBD1CD /* Frameworks */,
@@ -2177,6 +2203,18 @@
 			path = TypeWhisperWidgetExtension;
 			sourceTree = "<group>";
 		};
+		E1A000000000000000000030 /* TypeWhisperTranscribeAction */ = {
+			isa = PBXGroup;
+			children = (
+				E1A000000000000000000020 /* ActionRequestHandler.swift */,
+				E1A000000000000000000024 /* Assets.xcassets */,
+				E1A000000000000000000025 /* InfoPlist.xcstrings */,
+				E1A000000000000000000022 /* TypeWhisperTranscribeAction.entitlements */,
+				E1A000000000000000000021 /* Info.plist */,
+			);
+			path = TypeWhisperTranscribeAction;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000026 /* TypeWhisperWidgetShared */ = {
 			isa = PBXGroup;
 			children = (
@@ -2633,6 +2671,7 @@
 				BB00000000000000000294 /* SpeechmaticsPlugin.bundle */,
 				RESS00000000000000004 /* Reson8Plugin.bundle */,
 				BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */,
+				E1A000000000000000000023 /* TypeWhisperTranscribeAction.appex */,
 				5CA4DB761B06383B5B8CF082 /* GoogleCloudSTTPlugin.bundle */,
 				E6F8E5940EF4832A7B8D735D /* TypeWhisperTests.xctest */,
 			);
@@ -2772,6 +2811,7 @@
 			dependencies = (
 				GG00000000000000000001 /* PBXTargetDependency */,
 				GG00000000000000000009 /* PBXTargetDependency */,
+				E1A000000000000000000060 /* PBXTargetDependency */,
 				5E7A00000000000000000004 /* PBXTargetDependency */,
 				1C1000000000000000000045 /* PBXTargetDependency */,
 			);
@@ -3099,6 +3139,23 @@
 			name = TypeWhisperWidgetExtension;
 			productName = TypeWhisperWidgetExtension;
 			productReference = BB00000000000000000188 /* TypeWhisperWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+		E1A000000000000000000050 /* TypeWhisperTranscribeAction */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E1A000000000000000000080 /* Build configuration list for PBXNativeTarget "TypeWhisperTranscribeAction" */;
+			buildPhases = (
+				E1A000000000000000000042 /* Sources */,
+				E1A000000000000000000040 /* Frameworks */,
+				E1A000000000000000000041 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TypeWhisperTranscribeAction;
+			productName = TypeWhisperTranscribeAction;
+			productReference = E1A000000000000000000023 /* TypeWhisperTranscribeAction.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
 		DD00000000000000000015 /* VoxtralPlugin */ = {
@@ -3808,6 +3865,9 @@
 					DD00000000000000000002 = {
 						CreatedOnToolsVersion = 16.0;
 					};
+					E1A000000000000000000050 = {
+						CreatedOnToolsVersion = 26.0;
+					};
 					D10000000000000000000001 = {
 						CreatedOnToolsVersion = 16.0;
 					};
@@ -3894,6 +3954,7 @@
 				DD00000000000000000034 /* SpeechmaticsPlugin */,
 				RESN00000000000000001 /* Reson8Plugin */,
 				DD00000000000000000014 /* TypeWhisperWidgetExtension */,
+				E1A000000000000000000050 /* TypeWhisperTranscribeAction */,
 				40F22D3F350BA09ADEFBD2CB /* TypeWhisperTests */,
 				F3E17BDD5CED7E75F4153E95 /* GoogleCloudSTTPlugin */,
 			);
@@ -4353,6 +4414,15 @@
 			files = (
 				AA00000000000000000307 /* manifest.json in Resources */,
 				AA00000000000000000308 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E1A000000000000000000041 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1A000000000000000000003 /* Assets.xcassets in Resources */,
+				E1A000000000000000000004 /* InfoPlist.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5087,6 +5157,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E1A000000000000000000042 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E1A000000000000000000001 /* ActionRequestHandler.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -5110,6 +5188,11 @@
 			isa = PBXTargetDependency;
 			target = DD00000000000000000014 /* TypeWhisperWidgetExtension */;
 			targetProxy = HH00000000000000000009 /* PBXContainerItemProxy */;
+		};
+		E1A000000000000000000060 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E1A000000000000000000050 /* TypeWhisperTranscribeAction */;
+			targetProxy = E1A000000000000000000010 /* PBXContainerItemProxy */;
 		};
 		5E7A00000000000000000004 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -6077,6 +6160,60 @@
 				SWIFT_EMIT_LOC_STRINGS = NO;
 				SWIFT_VERSION = 6.0;
 				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
+		E1A000000000000000000070 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = TypeWhisperTranscribeAction/TypeWhisperTranscribeAction.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TypeWhisperTranscribeAction/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 1.7.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.dev.transcribe-action;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		E1A000000000000000000071 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_ENTITLEMENTS = TypeWhisperTranscribeAction/TypeWhisperTranscribeAction.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = "$(MARKETING_VERSION)";
+				DEAD_CODE_STRIPPING = YES;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SELECTED_FILES = readonly;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = TypeWhisperTranscribeAction/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				MARKETING_VERSION = 1.7.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.mac.transcribe-action;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_STRICT_CONCURRENCY = targeted;
+				SWIFT_VERSION = 6.0;
 			};
 			name = Release;
 		};
@@ -7947,6 +8084,15 @@
 			buildConfigurations = (
 				XX00000000000000000057 /* Debug */,
 				XX00000000000000000058 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E1A000000000000000000080 /* Build configuration list for PBXNativeTarget "TypeWhisperTranscribeAction" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E1A000000000000000000070 /* Debug */,
+				E1A000000000000000000071 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -3884,6 +3884,7 @@
 				en,
 				de,
 				ja,
+				"zh-Hans",
 				Base,
 			);
 			mainGroup = CC00000000000000000001;

--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -226,6 +226,57 @@ enum MenuBarIconState {
     }
 }
 
+@MainActor
+final class FinderTranscriptionService: NSObject {
+    typealias EnqueueFiles = @MainActor ([URL]) -> Void
+    typealias PresentFileTranscription = @MainActor () -> Void
+
+    private let enqueueFiles: EnqueueFiles
+    private let presentFileTranscription: PresentFileTranscription
+
+    init(
+        enqueueFiles: @escaping EnqueueFiles = { FileTranscriptionViewModel.shared.addFiles($0) },
+        presentFileTranscription: @escaping PresentFileTranscription = {
+            SettingsNavigationCoordinator.shared.navigate(to: .fileTranscription)
+            ManagedAppWindowOpener.shared.open(id: "settings")
+        }
+    ) {
+        self.enqueueFiles = enqueueFiles
+        self.presentFileTranscription = presentFileTranscription
+    }
+
+    static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
+        let objects = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [NSURL]
+        return FileTranscriptionViewModel.supportedFileURLs(objects?.map { $0 as URL } ?? [])
+    }
+
+    @discardableResult
+    func handle(_ pasteboard: NSPasteboard) -> String? {
+        let urls = Self.fileURLs(from: pasteboard)
+        guard !urls.isEmpty else {
+            return "No supported audio or video files were selected."
+        }
+
+        enqueueFiles(urls)
+        presentFileTranscription()
+        return nil
+    }
+
+    @objc(transcribeFiles:userData:error:)
+    func transcribeFiles(
+        _ pasteboard: NSPasteboard,
+        userData _: String?,
+        error errorPointer: AutoreleasingUnsafeMutablePointer<NSString?>?
+    ) {
+        if let errorMessage = handle(pasteboard) {
+            errorPointer?.pointee = errorMessage as NSString
+        }
+    }
+}
+
 private struct MenuBarExtraLabel: View {
     @Environment(\.openWindow) private var openWindow
     @ObservedObject private var dictation = DictationViewModel.shared
@@ -641,6 +692,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     private var workspaceWakeObserver: NSObjectProtocol?
     private var hasInteractiveForegroundContent = false
     private var pluginScreenshotCaptureController: PluginSettingsScreenshotCaptureController?
+    private let finderTranscriptionService = FinderTranscriptionService()
     private lazy var updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
 
     var updateChecker: UpdateChecker {
@@ -698,6 +750,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
         ServiceContainer.shared.calendarMeetingAutomationController
             .installNotificationRouterIfNeeded()
+
+        NSApp.servicesProvider = finderTranscriptionService
+        NSUpdateDynamicServices()
 
         UpdateChecker.shared = updateChecker
         applyActivationPolicy()

--- a/TypeWhisper/Resources/Info.plist
+++ b/TypeWhisper/Resources/Info.plist
@@ -41,6 +41,32 @@
 	<string>public.app-category.productivity</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>TypeWhisper Local needs microphone access for speech-to-text transcription.</string>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Transcribe with TypeWhisper</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>transcribeFiles</string>
+			<key>NSPortName</key>
+			<string>TypeWhisper</string>
+			<key>NSRequiredContext</key>
+			<dict>
+				<key>NSApplicationIdentifier</key>
+				<string>com.apple.finder</string>
+			</dict>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.audio</string>
+				<string>public.movie</string>
+			</array>
+			<key>NSServiceDescription</key>
+			<string>Queue selected audio and video files for transcription in TypeWhisper.</string>
+		</dict>
+	</array>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>TypeWhisper detects the current browser URL to apply language profiles automatically.</string>
 	<key>NSCalendarsFullAccessUsageDescription</key>

--- a/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
+++ b/TypeWhisper/ViewModels/FileTranscriptionViewModel.swift
@@ -268,15 +268,28 @@ final class FileTranscriptionViewModel: ObservableObject {
     }
 
     func addFiles(_ urls: [URL]) {
-        let validExtensions = AudioFileService.supportedExtensions
-        let existingURLs = Set(files.map(\.url))
+        let existingURLs = Set(files.map { $0.url.standardizedFileURL })
 
-        let newFiles = urls
-            .filter { validExtensions.contains($0.pathExtension.lowercased()) }
+        let newFiles = Self.supportedFileURLs(urls)
             .filter { !existingURLs.contains($0) }
             .map { FileItem(url: $0) }
 
         files.append(contentsOf: newFiles)
+    }
+
+    static func supportedFileURLs(_ urls: [URL]) -> [URL] {
+        var seenURLs = Set<URL>()
+
+        return urls.compactMap { url in
+            guard url.isFileURL,
+                  AudioFileService.supportedExtensions.contains(url.pathExtension.lowercased()) else {
+                return nil
+            }
+
+            let standardizedURL = url.standardizedFileURL
+            guard seenURLs.insert(standardizedURL).inserted else { return nil }
+            return standardizedURL
+        }
     }
 
     @discardableResult

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -1,10 +1,57 @@
 import Foundation
+import AppKit
 import TypeWhisperPluginSDK
 import XCTest
 @testable import TypeWhisper
 
 @MainActor
 final class FileTranscriptionViewModelTests: XCTestCase {
+    func testFinderTranscriptionServiceFiltersAndRoutesSupportedFiles() {
+        let audioURL = makeTemporaryFile(named: "meeting.MP3")
+        let videoURL = makeTemporaryFile(named: "recording.mov")
+        let unsupportedURL = makeTemporaryFile(named: "notes.txt")
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        pasteboard.writeObjects([
+            audioURL as NSURL,
+            unsupportedURL as NSURL,
+            videoURL as NSURL,
+            audioURL as NSURL,
+        ])
+
+        var enqueuedURLs: [URL] = []
+        var presentationCount = 0
+        let service = FinderTranscriptionService(
+            enqueueFiles: { enqueuedURLs = $0 },
+            presentFileTranscription: { presentationCount += 1 }
+        )
+
+        let error = service.handle(pasteboard)
+
+        XCTAssertNil(error)
+        XCTAssertEqual(enqueuedURLs, [audioURL, videoURL].map { $0.standardizedFileURL })
+        XCTAssertEqual(presentationCount, 1)
+    }
+
+    func testFinderTranscriptionServiceRejectsSelectionWithoutSupportedMedia() {
+        let pasteboard = NSPasteboard.withUniqueName()
+        pasteboard.clearContents()
+        pasteboard.writeObjects([makeTemporaryFile(named: "notes.txt") as NSURL])
+
+        var didEnqueue = false
+        var didPresent = false
+        let service = FinderTranscriptionService(
+            enqueueFiles: { _ in didEnqueue = true },
+            presentFileTranscription: { didPresent = true }
+        )
+
+        let error = service.handle(pasteboard)
+
+        XCTAssertEqual(error, "No supported audio or video files were selected.")
+        XCTAssertFalse(didEnqueue)
+        XCTAssertFalse(didPresent)
+    }
+
     func testImportedPluginMediaCanBeAddedToTranscriptionQueue() throws {
         let previousPluginManager = PluginManager.shared
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()

--- a/TypeWhisperTranscribeAction/ActionRequestHandler.swift
+++ b/TypeWhisperTranscribeAction/ActionRequestHandler.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Foundation
+import UniformTypeIdentifiers
+
+private final class LoadedFileURLs: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [URL] = []
+
+    func append(_ url: URL) {
+        lock.withLock {
+            storage.append(url)
+        }
+    }
+
+    var values: [URL] {
+        lock.withLock { storage }
+    }
+}
+
+final class ActionRequestHandler: NSObject, NSExtensionRequestHandling {
+    private static let serviceName = "Transcribe with TypeWhisper"
+
+    func beginRequest(with context: NSExtensionContext) {
+        let inputItems = context.inputItems.compactMap { $0 as? NSExtensionItem }
+        let attachments = inputItems.flatMap { $0.attachments ?? [] }
+
+        guard !attachments.isEmpty else {
+            cancel(context, message: "No audio or video files were selected.")
+            return
+        }
+
+        let loadedURLs = LoadedFileURLs()
+        let loadingGroup = DispatchGroup()
+
+        for attachment in attachments {
+            guard let typeIdentifier = supportedTypeIdentifier(in: attachment) else {
+                continue
+            }
+
+            loadingGroup.enter()
+            attachment.loadInPlaceFileRepresentation(forTypeIdentifier: typeIdentifier) { url, _, _ in
+                if let url {
+                    loadedURLs.append(url)
+                }
+                loadingGroup.leave()
+            }
+        }
+
+        loadingGroup.notify(queue: .main) { [inputItems] in
+            let urls = loadedURLs.values
+            guard !urls.isEmpty else {
+                self.cancel(context, message: "The selected files could not be opened.")
+                return
+            }
+
+            let pasteboard = NSPasteboard.withUniqueName()
+            let pasteboardURLs = urls.map { $0 as NSURL }
+            guard pasteboard.writeObjects(pasteboardURLs),
+                  NSPerformService(Self.serviceName, pasteboard) else {
+                self.cancel(context, message: "TypeWhisper could not receive the selected files.")
+                return
+            }
+
+            context.completeRequest(returningItems: inputItems, completionHandler: nil)
+        }
+    }
+
+    private func supportedTypeIdentifier(in provider: NSItemProvider) -> String? {
+        provider.registeredTypeIdentifiers.first { identifier in
+            guard let type = UTType(identifier) else { return false }
+            return type.conforms(to: .audio) || type.conforms(to: .movie)
+        }
+    }
+
+    private func cancel(_ context: NSExtensionContext, message: String) {
+        context.cancelRequest(withError: NSError(
+            domain: "com.typewhisper.mac.transcribe-action",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message]
+        ))
+    }
+}

--- a/TypeWhisperTranscribeAction/Assets.xcassets/Contents.json
+++ b/TypeWhisperTranscribeAction/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TypeWhisperTranscribeAction/Assets.xcassets/FinderActionIcon.imageset/Contents.json
+++ b/TypeWhisperTranscribeAction/Assets.xcassets/FinderActionIcon.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "FinderActionIcon.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/TypeWhisperTranscribeAction/Assets.xcassets/FinderActionIcon.imageset/FinderActionIcon.svg
+++ b/TypeWhisperTranscribeAction/Assets.xcassets/FinderActionIcon.imageset/FinderActionIcon.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+  <g fill="#000000">
+    <rect x="16" y="80" width="32" height="96" rx="16"/>
+    <rect x="64" y="48" width="32" height="160" rx="16"/>
+    <rect x="112" y="16" width="32" height="224" rx="16"/>
+    <rect x="160" y="48" width="32" height="160" rx="16"/>
+    <rect x="208" y="80" width="32" height="96" rx="16"/>
+  </g>
+</svg>

--- a/TypeWhisperTranscribeAction/Info.plist
+++ b/TypeWhisperTranscribeAction/Info.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Transcribe with TypeWhisper</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>SUBQUERY (extensionItems, $extensionItem, $extensionItem.attachments.@count &gt;= 1 AND $extensionItem.attachments.@count &lt;= 100 AND SUBQUERY ($extensionItem.attachments, $attachment, ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.audio" OR ANY $attachment.registeredTypeIdentifiers UTI-CONFORMS-TO "public.movie").@count == $extensionItem.attachments.@count).@count == 1</string>
+			<key>NSExtensionServiceAllowsFinderPreviewItem</key>
+			<true/>
+			<key>NSExtensionServiceFinderPreviewIconName</key>
+			<string>FinderActionIcon</string>
+			<key>NSExtensionServiceFinderPreviewLabel</key>
+			<string>Transcribe with TypeWhisper</string>
+			<key>NSExtensionServiceRoleType</key>
+			<string>NSExtensionServiceRoleTypeViewer</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ActionRequestHandler</string>
+	</dict>
+</dict>
+</plist>

--- a/TypeWhisperTranscribeAction/InfoPlist.xcstrings
+++ b/TypeWhisperTranscribeAction/InfoPlist.xcstrings
@@ -1,0 +1,66 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "CFBundleDisplayName" : {
+      "comment" : "Display name of the Finder transcription action extension.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit TypeWhisper transkribieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transcribe with TypeWhisper"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisperで文字起こし"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 TypeWhisper 转录"
+          }
+        }
+      }
+    },
+    "NSExtensionServiceFinderPreviewLabel" : {
+      "comment" : "Label of the action in Finder's Quick Actions menu.",
+      "extractionState" : "manual",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mit TypeWhisper transkribieren"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Transcribe with TypeWhisper"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "TypeWhisperで文字起こし"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "使用 TypeWhisper 转录"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.1"
+}

--- a/TypeWhisperTranscribeAction/TypeWhisperTranscribeAction.entitlements
+++ b/TypeWhisperTranscribeAction/TypeWhisperTranscribeAction.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/check_release_signing.sh
+++ b/scripts/check_release_signing.sh
@@ -5,6 +5,7 @@ team_id="2D8ALY3LCL"
 bundle_id="com.typewhisper.mac"
 helper_bundle_id="com.typewhisper.typewhisper-mac"
 widget_bundle_id="com.typewhisper.mac.widgets"
+action_bundle_id="com.typewhisper.mac.transcribe-action"
 app_group="$team_id.com.typewhisper.mac"
 icloud_container="iCloud.com.typewhisper.sync"
 require_notarization=false
@@ -179,12 +180,17 @@ if [[ -z "$app_path" || ! -d "$app_path" ]]; then
 fi
 
 widget_path="$app_path/Contents/PlugIns/TypeWhisperWidgetExtension.appex"
+action_path="$app_path/Contents/PlugIns/TypeWhisperTranscribeAction.appex"
 helper_path="$app_path/Contents/XPCServices/TypeWhisperICloudBridge.xpc"
 main_profile_path="$app_path/Contents/embedded.provisionprofile"
 helper_profile_path="$helper_path/Contents/embedded.provisionprofile"
 info_plist="$app_path/Contents/Info.plist"
 if [[ ! -d "$widget_path" ]]; then
   echo "error: widget extension is missing" >&2
+  exit 1
+fi
+if [[ ! -d "$action_path" ]]; then
+  echo "error: Finder transcription action is missing" >&2
   exit 1
 fi
 if [[ ! -d "$helper_path" ]]; then
@@ -201,9 +207,11 @@ trap cleanup EXIT
 decoded_profile="$temporary_dir/profile.plist"
 main_entitlements="$temporary_dir/main-entitlements.plist"
 widget_entitlements="$temporary_dir/widget-entitlements.plist"
+action_entitlements="$temporary_dir/action-entitlements.plist"
 helper_entitlements="$temporary_dir/helper-entitlements.plist"
 codesign -d --entitlements :- "$app_path" > "$main_entitlements" 2>/dev/null
 codesign -d --entitlements :- "$widget_path" > "$widget_entitlements" 2>/dev/null
+codesign -d --entitlements :- "$action_path" > "$action_entitlements" 2>/dev/null
 codesign -d --entitlements :- "$helper_path" > "$helper_entitlements" 2>/dev/null
 
 actual_bundle_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$info_plist")"
@@ -387,7 +395,47 @@ if plutil -convert xml1 -o - "$widget_entitlements" | widget_has_forbidden_entit
   exit 1
 fi
 
-plists_to_check=("$info_plist" "$main_entitlements" "$widget_entitlements" "$helper_entitlements")
+action_info_plist="$action_path/Contents/Info.plist"
+action_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$action_info_plist")"
+action_extension_point="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionPointIdentifier' "$action_info_plist")"
+action_finder_icon="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionAttributes:NSExtensionServiceFinderPreviewIconName' "$action_info_plist")"
+action_sandbox="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.app-sandbox' "$action_entitlements")"
+action_read_only="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.files.user-selected.read-only' "$action_entitlements")"
+[[ "$action_id" == "$action_bundle_id" ]] || {
+  echo "error: Finder transcription action bundle identifier is '$action_id'" >&2
+  exit 1
+}
+[[ "$action_extension_point" == "com.apple.services" ]] || {
+  echo "error: Finder transcription action extension point is '$action_extension_point'" >&2
+  exit 1
+}
+if [[ "$action_finder_icon" != "FinderActionIcon" || ! -f "$action_path/Contents/Resources/Assets.car" ]]; then
+  echo "error: Finder transcription action icon is missing or incorrectly configured" >&2
+  exit 1
+fi
+for locale in de ja zh-Hans; do
+  localized_action_info="$action_path/Contents/Resources/$locale.lproj/InfoPlist.strings"
+  if [[ ! -f "$localized_action_info" ]] ||
+    ! /usr/libexec/PlistBuddy \
+      -c 'Print :NSExtensionServiceFinderPreviewLabel' \
+      "$localized_action_info" >/dev/null 2>&1; then
+    echo "error: Finder transcription action localization is missing for '$locale'" >&2
+    exit 1
+  fi
+done
+if [[ "$action_sandbox" != "true" || "$action_read_only" != "true" ]] ||
+  ! plist_boolean_is_true \
+    "$action_info_plist" \
+    "NSExtension:NSExtensionAttributes:NSExtensionServiceAllowsFinderPreviewItem"; then
+  echo "error: Finder transcription action sandbox, file access, or Finder visibility is incorrect" >&2
+  exit 1
+fi
+if plutil -convert xml1 -o - "$action_entitlements" | widget_has_forbidden_entitlement; then
+  echo "error: Finder transcription action contains main-app-only entitlements" >&2
+  exit 1
+fi
+
+plists_to_check=("$info_plist" "$main_entitlements" "$widget_entitlements" "$action_info_plist" "$action_entitlements" "$helper_entitlements")
 if [[ -f "$decoded_profile" ]]; then
   plists_to_check+=("$decoded_profile")
 fi
@@ -401,6 +449,7 @@ done
 codesign --verify --deep --strict --verbose=2 "$app_path"
 signature_details="$(codesign -dvvv "$app_path" 2>&1)"
 widget_signature_details="$(codesign -dvvv "$widget_path" 2>&1)"
+action_signature_details="$(codesign -dvvv "$action_path" 2>&1)"
 helper_signature_details="$(codesign -dvvv "$helper_path" 2>&1)"
 main_designated_requirement="$(codesign -dr - "$app_path" 2>&1)"
 grep -Fq "Authority=Developer ID Application:" <<< "$signature_details" || {
@@ -433,6 +482,10 @@ contains_hardened_runtime_flag <<< "$signature_details" || {
 }
 contains_hardened_runtime_flag <<< "$widget_signature_details" || {
   echo "error: widget does not have the hardened runtime enabled" >&2
+  exit 1
+}
+contains_hardened_runtime_flag <<< "$action_signature_details" || {
+  echo "error: Finder transcription action does not have the hardened runtime enabled" >&2
   exit 1
 }
 contains_hardened_runtime_flag <<< "$helper_signature_details" || {

--- a/scripts/check_release_signing.sh
+++ b/scripts/check_release_signing.sh
@@ -91,6 +91,11 @@ contains_hardened_runtime_flag() {
   grep -Eq 'flags=0x[0-9a-fA-F]+\(.*runtime.*\)'
 }
 
+asset_catalog_contains_name() {
+  local expected_name="$1"
+  grep -E "\"Name\"[[:space:]]*:[[:space:]]*\"${expected_name}\"" >/dev/null
+}
+
 self_test() {
   (
     wildcard_plist="$(mktemp "${TMPDIR:-/tmp}/typewhisper-wildcard-test.XXXXXX")"
@@ -145,6 +150,14 @@ self_test() {
   fi
   if printf '%s\n' 'CodeDirectory flags=0x0(none)' | contains_hardened_runtime_flag; then
     echo "self-test failed: missing hardened runtime was accepted" >&2
+    return 1
+  fi
+  if ! printf '%s\n' '{"Name":"FinderActionIcon"}' | asset_catalog_contains_name FinderActionIcon; then
+    echo "self-test failed: compiled asset name was not detected" >&2
+    return 1
+  fi
+  if printf '%s\n' '{"Name":"OtherIcon"}' | asset_catalog_contains_name FinderActionIcon; then
+    echo "self-test failed: missing compiled asset name was accepted" >&2
     return 1
   fi
   echo "release signing self-test passed"
@@ -399,6 +412,7 @@ action_info_plist="$action_path/Contents/Info.plist"
 action_id="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$action_info_plist")"
 action_extension_point="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionPointIdentifier' "$action_info_plist")"
 action_finder_icon="$(/usr/libexec/PlistBuddy -c 'Print :NSExtension:NSExtensionAttributes:NSExtensionServiceFinderPreviewIconName' "$action_info_plist")"
+action_assets="$action_path/Contents/Resources/Assets.car"
 action_sandbox="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.app-sandbox' "$action_entitlements")"
 action_read_only="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.files.user-selected.read-only' "$action_entitlements")"
 [[ "$action_id" == "$action_bundle_id" ]] || {
@@ -409,7 +423,9 @@ action_read_only="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.security.files.
   echo "error: Finder transcription action extension point is '$action_extension_point'" >&2
   exit 1
 }
-if [[ "$action_finder_icon" != "FinderActionIcon" || ! -f "$action_path/Contents/Resources/Assets.car" ]]; then
+if [[ "$action_finder_icon" != "FinderActionIcon" || ! -f "$action_assets" ]] ||
+  ! xcrun assetutil --info "$action_assets" 2>/dev/null |
+    asset_catalog_contains_name "$action_finder_icon"; then
   echo "error: Finder transcription action icon is missing or incorrectly configured" >&2
   exit 1
 fi


### PR DESCRIPTION
## Issue context

Finder users should be able to send existing audio and video recordings directly into TypeWhisper's existing File Transcription flow. This implements both Finder entry points requested in #1216 while keeping summaries tracked separately in #1215.

Closes #1216

## Summary

- register a Finder Service that routes supported media selections into File Transcription
- embed a sandboxed Finder Action extension so the same action is also available under Quick Actions
- add a branded TypeWhisper template icon and localized labels for English, German, Japanese, and Simplified Chinese
- share supported-file filtering and URL deduplication with the existing file picker and drag-and-drop flow
- extend release signing and binary-instrumentation validation for the embedded extension

## Test plan

- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' -derivedDataPath /Users/marco/Projects/typewhisper-mac-dev/DerivedData APP_GROUP_ID=2D8ALY3LCL.com.typewhisper.mac DEVELOPMENT_TEAM=2D8ALY3LCL CODE_SIGN_STYLE=Automatic 'CODE_SIGN_IDENTITY=Apple Development' -allowProvisioningUpdates -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests/testFinderTranscriptionServiceFiltersAndRoutesSupportedFiles -only-testing:TypeWhisperTests/FileTranscriptionViewModelTests/testFinderTranscriptionServiceRejectsSelectionWithoutSupportedMedia test`
- [x] `swift test --package-path TypeWhisperPluginSDK` (672 tests, 2 skipped, 0 failures)
- [x] `scripts/check_release_signing.sh --self-test`
- [x] `scripts/check_release_binary_instrumentation.sh --self-test`
- [x] `plutil -lint TypeWhisper/Resources/Info.plist TypeWhisperTranscribeAction/Info.plist TypeWhisperTranscribeAction/TypeWhisperTranscribeAction.entitlements`
- [x] `jq empty TypeWhisperTranscribeAction/Assets.xcassets/Contents.json TypeWhisperTranscribeAction/Assets.xcassets/FinderActionIcon.imageset/Contents.json`
- [x] `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-mac-dev.sh --run /Users/marco/.t3/worktrees/typewhisper-mac/t3code-377f4399`
- [x] manually verified Finder Service invocation and Quick Action registration, icon asset, compiled localizations, deep signature, and extension registration
- [ ] `scripts/pr-preflight.sh origin/main` reaches localization validation, then reports 40 missing Simplified Chinese strings in `AuthenticatedCLIPlugin/Localizable.xcstrings`; the identical baseline failure was reproduced from a clean `origin/main` worktree


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Finder Quick Action to send selected audio and video files to TypeWhisper for transcription.
  * Added support for processing multiple files at once.
  * Added localized Finder action labels in English, German, Japanese, and Simplified Chinese.

* **Bug Fixes**
  * Improved file validation by excluding unsupported items and removing duplicates before transcription.
  * Added clearer handling when no supported files are selected or files cannot be loaded.

* **Tests**
  * Added coverage for Finder selections, filtering, deduplication, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->