### PR TITLE
Order clamshell microphone fallback and record routing diagnostics

### DIFF
--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -137,9 +137,9 @@ struct AudioInputDiagnosticsReport: Encodable, Equatable, Sendable {
         let transportType: UInt32?
         let transportTypeName: String?
         let transportTypeFourCC: String?
-        /// Index in CoreAudio's original device enumeration. The list below is
-        /// sorted by device ID, which hides the order that decides clamshell
-        /// fallback selection.
+        /// Index among the input-capable devices, in CoreAudio's original
+        /// enumeration order. That is the order clamshell fallback walks; the
+        /// list below is sorted by device ID, which hides it.
         let enumerationPosition: Int?
         /// Currently selected input data source(s) as FourCC strings, e.g.
         /// `imic` for the internal capsule or `emic` for the 3.5mm jack.
@@ -594,10 +594,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     private enum ClamshellFallbackRank: CaseIterable {
         /// A device on a transport we can positively identify as real hardware.
         case physical
-        /// The transport could not be resolved. Such a device may well be a real
-        /// microphone, so it outranks a known virtual one, but not a device we
-        /// can positively identify as physical. A device whose ID does not
-        /// resolve also lands here, though selection then rejects it in turn.
+        /// The transport could not be resolved, or CoreAudio reported it as
+        /// unknown. Such a device may well be a real microphone, so it outranks
+        /// a known virtual one, but not a device we can positively identify as
+        /// physical. A device whose ID does not resolve also lands here, though
+        /// selection then rejects it in turn.
         case unresolvedTransport
         /// Virtual or aggregate. Used only when nothing better is available.
         case virtualOrAggregate
@@ -631,6 +632,11 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         switch transport {
         case kAudioDeviceTransportTypeVirtual, kAudioDeviceTransportTypeAggregate:
             return .virtualOrAggregate
+        case kAudioDeviceTransportTypeUnknown:
+            // CoreAudio's sentinel for a driver that never declared a transport,
+            // so it says nothing about whether the device is real hardware. It
+            // ranks with the other unresolved cases rather than as physical.
+            return .unresolvedTransport
         default:
             return .physical
         }

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -630,7 +630,9 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         }
 
         switch transport {
-        case kAudioDeviceTransportTypeVirtual, kAudioDeviceTransportTypeAggregate:
+        case kAudioDeviceTransportTypeVirtual,
+             kAudioDeviceTransportTypeAggregate,
+             kAudioDeviceTransportTypeAutoAggregate:
             return .virtualOrAggregate
         case kAudioDeviceTransportTypeUnknown:
             // CoreAudio's sentinel for a driver that never declared a transport,
@@ -1468,7 +1470,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let transport = transportType(for: deviceID)
         let transportName = transport.map { value in transportTypeName(value) }
         let transportFourCC = transport.map { value in transportTypeFourCC(value) }
-        let isAggregate = transport == kAudioDeviceTransportTypeAggregate
+        let isAggregate = Self.isAggregateTransport(transport)
         let isVirtual = transport == kAudioDeviceTransportTypeVirtual
         let isAggregateOrVirtual = isAggregate || isVirtual
         let isSelectedByID = selectedDeviceID == deviceID
@@ -1683,12 +1685,25 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         return transportType
     }
 
+    /// Whether a transport denotes an aggregate device, of either flavour.
+    ///
+    /// CoreAudio has two: `kAudioDeviceTransportTypeAggregate` for one the user
+    /// built, and `kAudioDeviceTransportTypeAutoAggregate` for one the system
+    /// assembled on its own. Both wrap other devices rather than being hardware
+    /// in their own right, so ranking and diagnostics treat them alike.
+    private static func isAggregateTransport(_ transportType: UInt32?) -> Bool {
+        transportType == kAudioDeviceTransportTypeAggregate
+            || transportType == kAudioDeviceTransportTypeAutoAggregate
+    }
+
     private static func transportTypeName(_ transportType: UInt32) -> String {
         switch transportType {
         case kAudioDeviceTransportTypeBuiltIn:
             return "builtIn"
         case kAudioDeviceTransportTypeAggregate:
             return "aggregate"
+        case kAudioDeviceTransportTypeAutoAggregate:
+            return "autoAggregate"
         case kAudioDeviceTransportTypeVirtual:
             return "virtual"
         case kAudioDeviceTransportTypePCI:
@@ -3546,7 +3561,7 @@ extension AudioDeviceService {
 
             let transportName = snapshot.transportType.map { value in transportTypeName(value) }
             let transportFourCC = snapshot.transportType.map { value in transportTypeFourCC(value) }
-            let isAggregate = snapshot.transportType == kAudioDeviceTransportTypeAggregate
+            let isAggregate = Self.isAggregateTransport(snapshot.transportType)
             let isVirtual = snapshot.transportType == kAudioDeviceTransportTypeVirtual
             let exclusionReason = listedDevice == nil
                 ? inputDeviceExclusionReason(for: snapshot)?.rawValue ?? "notListed"

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -137,6 +137,15 @@ struct AudioInputDiagnosticsReport: Encodable, Equatable, Sendable {
         let transportType: UInt32?
         let transportTypeName: String?
         let transportTypeFourCC: String?
+        /// Index in CoreAudio's original device enumeration. The list below is
+        /// sorted by device ID, which hides the order that decides clamshell
+        /// fallback selection.
+        let enumerationPosition: Int?
+        /// Currently selected input data source(s) as FourCC strings, e.g.
+        /// `imic` for the internal capsule or `emic` for the 3.5mm jack.
+        let inputDataSourceFourCCs: [String]?
+        /// Whether routing classifies this device as the internal microphone.
+        let isInternalMicrophone: Bool
         let isDefaultInput: Bool
         let isSelected: Bool
         let isAggregate: Bool
@@ -158,6 +167,7 @@ struct AudioInputDiagnosticsReport: Encodable, Equatable, Sendable {
     let previewRawLevel: Float
     let previewError: String?
     let defaultInputDeviceID: UInt32?
+    let lidClosed: Bool
     let lastInputOnlyCaptureFailure: AudioInputCaptureFailureDiagnostics?
     let devices: [Device]
 }
@@ -392,6 +402,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             previewRawLevel: previewRawLevel,
             previewError: previewErrorValue,
             defaultInputDeviceID: defaultInputDeviceIDValue,
+            lidClosed: clamshellStateProvider.isLidClosed(),
             lastInputOnlyCaptureFailure: lastInputOnlyCaptureFailure,
             devices: devices
         )
@@ -547,7 +558,7 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             transportType: defaultInputTransport,
             lidClosed: lidClosed
         ) {
-            for device in inputDevices {
+            for device in clamshellFallbackOrderedDevices() {
                 guard let fallbackSelection = resolvedInputSelection(for: device, lidClosed: true),
                       fallbackSelection.deviceID != defaultInputDeviceID else {
                     continue
@@ -571,6 +582,58 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             deviceName: inputDevices.first(where: { $0.deviceID == defaultInputDeviceID })?.name,
             usesBluetoothTransport: usesBluetoothTransport
         )
+    }
+
+    /// Preference order for clamshell fallback candidates.
+    ///
+    /// CoreAudio enumerates devices in an arbitrary order that frequently starts
+    /// with a virtual loopback driver (screen sharing, light sync, meeting apps).
+    /// Those capture no microphone audio, so taking the first entry can hand
+    /// recording to a loopback device while a real microphone sits further down
+    /// the list. See #1163.
+    private enum ClamshellFallbackRank: CaseIterable {
+        /// A device on a transport we can positively identify as real hardware.
+        case physical
+        /// The transport could not be resolved. Such a device may well be a real
+        /// microphone, so it outranks a known virtual one, but not a device we
+        /// can positively identify as physical. A device whose ID does not
+        /// resolve also lands here, though selection then rejects it in turn.
+        case unresolvedTransport
+        /// Virtual or aggregate. Used only when nothing better is available.
+        case virtualOrAggregate
+    }
+
+    /// Devices to try when the system-default input is the internal microphone
+    /// and the lid is closed, ordered by `ClamshellFallbackRank`.
+    ///
+    /// Ordering is done by bucketing rather than sorting so that CoreAudio's
+    /// original enumeration order is preserved within each rank.
+    private func clamshellFallbackOrderedDevices() -> [AudioInputDevice] {
+        let ranked = inputDevices.map { (device: $0, rank: clamshellFallbackRank(for: $0)) }
+
+        return ClamshellFallbackRank.allCases.flatMap { rank in
+            ranked.filter { $0.rank == rank }.map(\.device)
+        }
+    }
+
+    private func clamshellFallbackRank(for device: AudioInputDevice) -> ClamshellFallbackRank {
+        // Classify through the same resolver `resolvedInputSelection` uses, so a
+        // device is ranked on the identity it would actually be selected with. A
+        // stored `deviceID` goes stale when hardware is unplugged and
+        // reconnected; resolving by UID first avoids ranking a virtual driver as
+        // physical off a reused ID. Note the resolver still falls back to the
+        // stored ID when the UID no longer resolves, matching selection.
+        guard let deviceID = resolvedAudioDeviceID(for: device),
+              let transport = transportType(for: deviceID) else {
+            return .unresolvedTransport
+        }
+
+        switch transport {
+        case kAudioDeviceTransportTypeVirtual, kAudioDeviceTransportTypeAggregate:
+            return .virtualOrAggregate
+        default:
+            return .physical
+        }
     }
 
     private func resolvedInputSelection(
@@ -1356,8 +1419,15 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         listedDevicesByUID: [String: AudioInputDevice],
         hasMicrophonePermission: Bool
     ) -> [AudioInputDiagnosticsReport.Device] {
-        var deviceIDs = Set(inputCapableAudioDeviceIDs())
+        // Enumerated once and reused for both the device set and the positions,
+        // so the two cannot disagree and the HAL is only walked once.
+        let enumeratedDeviceIDs = inputCapableAudioDeviceIDs()
+        var deviceIDs = Set(enumeratedDeviceIDs)
         deviceIDs.formUnion(listedDevicesByID.keys)
+
+        // Captured before sorting: the report lists devices by ID, but clamshell
+        // fallback walks CoreAudio's original order.
+        let enumerationPositions = enumerationPositions(of: enumeratedDeviceIDs)
 
         return deviceIDs.sorted().map { deviceID in
             inputDeviceDiagnostics(
@@ -1367,7 +1437,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
                 defaultInputDeviceID: defaultInputDeviceID,
                 listedDevicesByID: listedDevicesByID,
                 listedDevicesByUID: listedDevicesByUID,
-                hasMicrophonePermission: hasMicrophonePermission
+                hasMicrophonePermission: hasMicrophonePermission,
+                enumerationPosition: enumerationPositions[deviceID]
             )
         }
     }
@@ -1379,7 +1450,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         defaultInputDeviceID: AudioDeviceID?,
         listedDevicesByID: [AudioDeviceID: AudioInputDevice],
         listedDevicesByUID: [String: AudioInputDevice],
-        hasMicrophonePermission: Bool
+        hasMicrophonePermission: Bool,
+        enumerationPosition: Int?
     ) -> AudioInputDiagnosticsReport.Device {
         let coreAudioUID = deviceUID(for: deviceID)
         var listedDevice = listedDevicesByID[deviceID]
@@ -1410,6 +1482,8 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         let exclusionReason = listedDevice == nil
             ? inputDeviceExclusionReason(for: snapshot)?.rawValue ?? "notListed"
             : nil
+        let dataSources = inputDataSources(for: deviceID)
+        let dataSourceFourCCs = dataSources.isEmpty ? nil : dataSources.map(fourCCString)
 
         return AudioInputDiagnosticsReport.Device(
             deviceID: UInt32(deviceID),
@@ -1421,6 +1495,12 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
             transportType: transport,
             transportTypeName: transportName,
             transportTypeFourCC: transportFourCC,
+            enumerationPosition: enumerationPosition,
+            inputDataSourceFourCCs: dataSourceFourCCs,
+            isInternalMicrophone: isInternalMicrophone(
+                deviceUID: snapshot.uid,
+                transportType: transport
+            ),
             isDefaultInput: defaultInputDeviceID == deviceID,
             isSelected: isSelectedByID || isSelectedByUID,
             isAggregate: isAggregate,
@@ -1514,14 +1594,74 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
         transportType == kAudioDeviceTransportTypeBuiltIn
     }
 
+    /// Stable UID Apple assigns to the internal microphone. This is the routing
+    /// identity: the device the hardware physically mutes when the lid closes.
+    static let internalMicrophoneDeviceUID = "BuiltInMicrophoneDevice"
+
+    /// Whether a device is the internal microphone, independent of lid state.
+    ///
+    /// Separated from the clamshell check so diagnostics can report the routing
+    /// classification for every device without conflating it with lid state.
+    static func isInternalMicrophone(deviceUID: String?, transportType: UInt32?) -> Bool {
+        transportType == kAudioDeviceTransportTypeBuiltIn
+            && deviceUID == internalMicrophoneDeviceUID
+    }
+
     private static func isInternalMicrophoneUnavailableInClamshell(
         deviceUID: String?,
         transportType: UInt32?,
         lidClosed: Bool
     ) -> Bool {
-        lidClosed
-            && transportType == kAudioDeviceTransportTypeBuiltIn
-            && deviceUID == "BuiltInMicrophoneDevice"
+        lidClosed && isInternalMicrophone(deviceUID: deviceUID, transportType: transportType)
+    }
+
+    /// Currently selected input data source(s), as raw CoreAudio FourCC values.
+    ///
+    /// Collected for diagnostics only. On Apple laptops the internal capsule
+    /// reports `'imic'` and the 3.5mm jack reports `'emic'`, both on a `builtIn`
+    /// transport, which is what makes transport alone insufficient to tell them
+    /// apart (#1163). Routing identity remains UID-based; these values are
+    /// gathered so the two can be compared across real hardware first.
+    ///
+    /// CoreAudio types this property as an array, since a device can have more
+    /// than one source selected at once, so the full array is read rather than a
+    /// single value.
+    private static func inputDataSources(for deviceID: AudioDeviceID) -> [UInt32] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyDataSource,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+
+        let stride = UInt32(MemoryLayout<UInt32>.size)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size) == noErr,
+              size >= stride,
+              size % stride == 0 else {
+            return []
+        }
+
+        var values = [UInt32](repeating: 0, count: Int(size / stride))
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &values) == noErr else {
+            return []
+        }
+        // CoreAudio writes the number of bytes it actually produced back into
+        // `size`, which can be smaller than the buffer we sized from the query.
+        return Array(values.prefix(Int(size / stride)))
+    }
+
+    /// Index of each device among the input-capable devices, in CoreAudio's
+    /// original `kAudioHardwarePropertyDevices` enumeration order.
+    ///
+    /// The diagnostics device list is sorted by device ID, which hides the order
+    /// that actually decides clamshell fallback selection. Recording the original
+    /// index keeps that information in the report.
+    private static func enumerationPositions(of deviceIDs: [AudioDeviceID]) -> [AudioDeviceID: Int] {
+        var positions: [AudioDeviceID: Int] = [:]
+        for (index, deviceID) in deviceIDs.enumerated() {
+            positions[deviceID] = index
+        }
+        return positions
     }
 
     fileprivate static func transportType(for deviceID: AudioDeviceID) -> UInt32? {
@@ -1569,16 +1709,20 @@ final class AudioDeviceService: ObservableObject, @unchecked Sendable {
     }
 
     private static func transportTypeFourCC(_ transportType: UInt32) -> String {
+        fourCCString(transportType)
+    }
+
+    static func fourCCString(_ value: UInt32) -> String {
         let bytes = [
-            UInt8((transportType >> 24) & 0xFF),
-            UInt8((transportType >> 16) & 0xFF),
-            UInt8((transportType >> 8) & 0xFF),
-            UInt8(transportType & 0xFF),
+            UInt8((value >> 24) & 0xFF),
+            UInt8((value >> 16) & 0xFF),
+            UInt8((value >> 8) & 0xFF),
+            UInt8(value & 0xFF),
         ]
         if bytes.allSatisfy({ $0 >= 0x20 && $0 < 0x7F }) {
             return String(bytes.map { Character(UnicodeScalar($0)) })
         }
-        return "\(transportType)"
+        return "\(value)"
     }
 
     private static func diagnosticsErrorDescription(_ error: Error) -> String {
@@ -3412,6 +3556,12 @@ extension AudioDeviceService {
                 transportType: snapshot.transportType,
                 transportTypeName: transportName,
                 transportTypeFourCC: transportFourCC,
+                enumerationPosition: nil,
+                inputDataSourceFourCCs: nil,
+                isInternalMicrophone: isInternalMicrophone(
+                    deviceUID: snapshot.uid,
+                    transportType: snapshot.transportType
+                ),
                 isDefaultInput: false,
                 isSelected: false,
                 isAggregate: isAggregate,

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1609,6 +1609,58 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(makeService(includeUSB: false).resolvedRecordingInputSelection().deviceUID, "unknown-input")
     }
 
+    /// An automatically created aggregate wraps other devices rather than being
+    /// hardware itself, exactly like a user-built one, so it ranks with the
+    /// aggregates and not as physical.
+    func testClamshellFallbackRanksAutoAggregateWithAggregates() {
+        let internalMicID = AudioDeviceID(805)
+        let autoAggregateID = AudioDeviceID(806)
+        let usbDeviceID = AudioDeviceID(807)
+
+        func makeService(includeUSB: Bool) -> AudioDeviceService {
+            var devices = [
+                AudioInputDevice(deviceID: autoAggregateID, name: "Aggregate Device", uid: "auto-aggregate-input"),
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice")
+            ]
+            if includeUSB {
+                devices.append(AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input"))
+            }
+            let service = AudioDeviceService(
+                initialInputDevices: devices,
+                monitorDeviceChanges: false,
+                probeCompatibilities: false,
+                transportResolver: FakeAudioDeviceTransportResolver(
+                    transports: [
+                        autoAggregateID: kAudioDeviceTransportTypeAutoAggregate,
+                        internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                        usbDeviceID: kAudioDeviceTransportTypeUSB
+                    ]
+                ),
+                clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+                defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                    defaultInputDeviceID: internalMicID
+                )
+            )
+            service.audioDeviceIDResolverOverride = { uid in
+                switch uid {
+                case "auto-aggregate-input": return autoAggregateID
+                case "BuiltInMicrophoneDevice": return internalMicID
+                case "usb-input": return usbDeviceID
+                default: return nil
+                }
+            }
+            service.clearInputDevicePriorityList()
+            return service
+        }
+
+        // The auto-aggregate is enumerated first, but a real microphone wins.
+        XCTAssertEqual(makeService(includeUSB: true).resolvedRecordingInputSelection().deviceUID, "usb-input")
+
+        // Demotion is a preference, not an exclusion: with nothing better left,
+        // the auto-aggregate is still selected.
+        XCTAssertEqual(makeService(includeUSB: false).resolvedRecordingInputSelection().deviceUID, "auto-aggregate-input")
+    }
+
     /// Reaches the clamshell fallback with a NON-empty priority list: the sole
     /// priority entry is the internal mic, which the candidate loop rejects, so
     /// resolution must continue into the fallback and pick a device that was

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1366,7 +1366,10 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         }
     }
 
-    func testResolvedRecordingInputSelectionUsesFirstListedNonBuiltInClamshellFallback() {
+    /// Superseded by physical-input preference: the clamshell fallback used to
+    /// take whichever non-builtIn device CoreAudio listed first, which handed
+    /// recording to a loopback driver while a real microphone sat behind it.
+    func testResolvedRecordingInputSelectionPrefersPhysicalOverListedFirstVirtualClamshellFallback() {
         let builtInDeviceID = AudioDeviceID(730)
         let virtualDeviceID = AudioDeviceID(731)
         let usbDeviceID = AudioDeviceID(732)
@@ -1401,9 +1404,235 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
 
         let selection = service.resolvedRecordingInputSelection()
 
+        XCTAssertEqual(selection.deviceUID, "usb-input")
+        XCTAssertEqual(selection.deviceID, usbDeviceID)
+        XCTAssertEqual(selection.deviceName, "USB Microphone")
+    }
+
+    // MARK: - Clamshell fallback ordering (#1163)
+
+    /// With no priority list the resolver reaches the clamshell fallback branch.
+    /// It must not settle on a virtual loopback driver just because CoreAudio
+    /// enumerates it first; the jack microphone is the real input here.
+    func testClamshellFallbackPrefersPhysicalInputOverVirtualDeviceEnumeratedFirst() {
+        let virtualDeviceID = AudioDeviceID(750)
+        let jackMicID = AudioDeviceID(751)
+        let internalMicID = AudioDeviceID(752)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: virtualDeviceID, name: "Hue Sync Audio", uid: "virtual-input"),
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice"),
+                AudioInputDevice(deviceID: jackMicID, name: "External Microphone", uid: "BuiltInHeadphoneInputDevice")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                    internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                    jackMicID: kAudioDeviceTransportTypeBuiltIn
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: internalMicID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "virtual-input": return virtualDeviceID
+            case "BuiltInMicrophoneDevice": return internalMicID
+            case "BuiltInHeadphoneInputDevice": return jackMicID
+            default: return nil
+            }
+        }
+        service.clearInputDevicePriorityList()
+        XCTAssertTrue(service.inputDevicePriorityList.isEmpty, "test must exercise the clamshell fallback branch")
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "BuiltInHeadphoneInputDevice")
+        XCTAssertEqual(selection.deviceName, "External Microphone")
+    }
+
+    /// A virtual device is still better than nothing when no physical input
+    /// survives the closed lid.
+    func testClamshellFallbackUsesVirtualDeviceWhenNoPhysicalInputRemains() {
+        let virtualDeviceID = AudioDeviceID(753)
+        let internalMicID = AudioDeviceID(754)
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice"),
+                AudioInputDevice(deviceID: virtualDeviceID, name: "Hue Sync Audio", uid: "virtual-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                    virtualDeviceID: kAudioDeviceTransportTypeVirtual
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: internalMicID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "BuiltInMicrophoneDevice": return internalMicID
+            case "virtual-input": return virtualDeviceID
+            default: return nil
+            }
+        }
+        service.clearInputDevicePriorityList()
+
+        let selection = service.resolvedRecordingInputSelection()
+
         XCTAssertEqual(selection.deviceUID, "virtual-input")
-        XCTAssertEqual(selection.deviceID, virtualDeviceID)
-        XCTAssertEqual(selection.deviceName, "BlackHole 2ch")
+    }
+
+    /// A device whose transport cannot be resolved must not outrank one we can
+    /// positively identify as physical, but must still beat a known virtual one.
+    func testClamshellFallbackRanksUnresolvedTransportBetweenPhysicalAndVirtual() {
+        let internalMicID = AudioDeviceID(755)
+        let unknownDeviceID = AudioDeviceID(756)
+        let virtualDeviceID = AudioDeviceID(757)
+        let usbDeviceID = AudioDeviceID(758)
+
+        func makeService(includeUSB: Bool) -> AudioDeviceService {
+            var devices = [
+                AudioInputDevice(deviceID: virtualDeviceID, name: "Hue Sync Audio", uid: "virtual-input"),
+                AudioInputDevice(deviceID: unknownDeviceID, name: "Mystery Input", uid: "unknown-input"),
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice")
+            ]
+            if includeUSB {
+                devices.append(AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input"))
+            }
+            let service = AudioDeviceService(
+                initialInputDevices: devices,
+                monitorDeviceChanges: false,
+                probeCompatibilities: false,
+                transportResolver: FakeAudioDeviceTransportResolver(
+                    // "unknown-input" is deliberately absent: its transport lookup returns nil.
+                    transports: [
+                        virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                        internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                        usbDeviceID: kAudioDeviceTransportTypeUSB
+                    ]
+                ),
+                clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+                defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                    defaultInputDeviceID: internalMicID
+                )
+            )
+            service.audioDeviceIDResolverOverride = { uid in
+                switch uid {
+                case "virtual-input": return virtualDeviceID
+                case "unknown-input": return unknownDeviceID
+                case "BuiltInMicrophoneDevice": return internalMicID
+                case "usb-input": return usbDeviceID
+                default: return nil
+                }
+            }
+            service.clearInputDevicePriorityList()
+            return service
+        }
+
+        // A positively-identified physical device outranks the unresolved one,
+        // even though the unresolved one is enumerated first.
+        XCTAssertEqual(makeService(includeUSB: true).resolvedRecordingInputSelection().deviceUID, "usb-input")
+
+        // With no physical device available, the unresolved one still beats the
+        // known virtual driver.
+        XCTAssertEqual(makeService(includeUSB: false).resolvedRecordingInputSelection().deviceUID, "unknown-input")
+    }
+
+    /// Reaches the clamshell fallback with a NON-empty priority list: the sole
+    /// priority entry is the internal mic, which the candidate loop rejects, so
+    /// resolution must continue into the fallback and pick a device that was
+    /// never a candidate.
+    func testClamshellFallbackIsReachedWhenEveryPriorityCandidateIsRejected() throws {
+        let internalMicID = AudioDeviceID(759)
+        let virtualDeviceID = AudioDeviceID(760)
+        let usbDeviceID = AudioDeviceID(761)
+        UserDefaults.standard.set(
+            try JSONEncoder().encode([
+                AudioInputDevicePriorityItem(uid: "BuiltInMicrophoneDevice", name: "MacBook Pro Microphone")
+            ]),
+            forKey: UserDefaultsKeys.inputDevicePriorityList
+        )
+        let service = AudioDeviceService(
+            initialInputDevices: [
+                AudioInputDevice(deviceID: virtualDeviceID, name: "Hue Sync Audio", uid: "virtual-input"),
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice"),
+                AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input")
+            ],
+            monitorDeviceChanges: false,
+            probeCompatibilities: false,
+            transportResolver: FakeAudioDeviceTransportResolver(
+                transports: [
+                    virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                    internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                    usbDeviceID: kAudioDeviceTransportTypeUSB
+                ]
+            ),
+            clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+            defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                defaultInputDeviceID: internalMicID
+            )
+        )
+        service.audioDeviceIDResolverOverride = { uid in
+            switch uid {
+            case "virtual-input": return virtualDeviceID
+            case "BuiltInMicrophoneDevice": return internalMicID
+            case "usb-input": return usbDeviceID
+            default: return nil
+            }
+        }
+        XCTAssertEqual(service.inputDevicePriorityList.map(\.uid), ["BuiltInMicrophoneDevice"])
+
+        let selection = service.resolvedRecordingInputSelection()
+
+        XCTAssertEqual(selection.deviceUID, "usb-input")
+        XCTAssertEqual(selection.deviceName, "USB Microphone")
+    }
+
+    // MARK: - Internal microphone classification reported in diagnostics (#1163)
+
+    func testInternalMicrophoneClassificationMatchesRoutingIdentity() {
+        XCTAssertTrue(
+            AudioDeviceService.isInternalMicrophone(
+                deviceUID: AudioDeviceService.internalMicrophoneDeviceUID,
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+        )
+        // The 3.5mm jack shares the builtIn transport but is a different device.
+        XCTAssertFalse(
+            AudioDeviceService.isInternalMicrophone(
+                deviceUID: "BuiltInHeadphoneInputDevice",
+                transportType: kAudioDeviceTransportTypeBuiltIn
+            )
+        )
+        // Transport still matters: a non-builtIn device is never the internal mic.
+        XCTAssertFalse(
+            AudioDeviceService.isInternalMicrophone(
+                deviceUID: AudioDeviceService.internalMicrophoneDeviceUID,
+                transportType: kAudioDeviceTransportTypeUSB
+            )
+        )
+        XCTAssertFalse(
+            AudioDeviceService.isInternalMicrophone(deviceUID: nil, transportType: nil)
+        )
+    }
+
+    func testFourCCStringRendersDataSourceValues() {
+        // 'imic' and 'emic', the values Apple reports for the internal capsule
+        // and the 3.5mm jack input respectively.
+        XCTAssertEqual(AudioDeviceService.fourCCString(0x696D_6963), "imic")
+        XCTAssertEqual(AudioDeviceService.fourCCString(0x656D_6963), "emic")
+        // Non-printable values fall back to a decimal rendering.
+        XCTAssertEqual(AudioDeviceService.fourCCString(1), "1")
     }
 
     func testResolvedRecordingInputSelectionKeepsExternalSystemDefaultWhenLidIsClosed() {

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -1548,6 +1548,67 @@ final class AudioDeviceServiceCompatibilityTests: XCTestCase {
         XCTAssertEqual(makeService(includeUSB: false).resolvedRecordingInputSelection().deviceUID, "unknown-input")
     }
 
+    /// A device that resolves to `kAudioDeviceTransportTypeUnknown` says nothing
+    /// about being real hardware, so it must rank as unresolved rather than
+    /// physical: it loses to a positively identified microphone enumerated after
+    /// it, and still beats a known virtual driver.
+    func testClamshellFallbackRanksUnknownTransportAsUnresolved() {
+        let internalMicID = AudioDeviceID(795)
+        let unknownDeviceID = AudioDeviceID(796)
+        let virtualDeviceID = AudioDeviceID(797)
+        let usbDeviceID = AudioDeviceID(798)
+
+        func makeService(includeUSB: Bool) -> AudioDeviceService {
+            var devices = [
+                AudioInputDevice(deviceID: virtualDeviceID, name: "Hue Sync Audio", uid: "virtual-input"),
+                AudioInputDevice(deviceID: unknownDeviceID, name: "Mystery Input", uid: "unknown-input"),
+                AudioInputDevice(deviceID: internalMicID, name: "MacBook Pro Microphone", uid: "BuiltInMicrophoneDevice")
+            ]
+            if includeUSB {
+                devices.append(AudioInputDevice(deviceID: usbDeviceID, name: "USB Microphone", uid: "usb-input"))
+            }
+            let service = AudioDeviceService(
+                initialInputDevices: devices,
+                monitorDeviceChanges: false,
+                probeCompatibilities: false,
+                transportResolver: FakeAudioDeviceTransportResolver(
+                    // Unlike the sibling test above, "unknown-input" resolves: it
+                    // reports CoreAudio's unknown-transport sentinel rather than
+                    // failing the lookup.
+                    transports: [
+                        virtualDeviceID: kAudioDeviceTransportTypeVirtual,
+                        unknownDeviceID: kAudioDeviceTransportTypeUnknown,
+                        internalMicID: kAudioDeviceTransportTypeBuiltIn,
+                        usbDeviceID: kAudioDeviceTransportTypeUSB
+                    ]
+                ),
+                clamshellStateProvider: FakeClamshellStateProvider(lidClosed: true),
+                defaultInputDeviceController: FakeAudioInputDeviceDefaultController(
+                    defaultInputDeviceID: internalMicID
+                )
+            )
+            service.audioDeviceIDResolverOverride = { uid in
+                switch uid {
+                case "virtual-input": return virtualDeviceID
+                case "unknown-input": return unknownDeviceID
+                case "BuiltInMicrophoneDevice": return internalMicID
+                case "usb-input": return usbDeviceID
+                default: return nil
+                }
+            }
+            service.clearInputDevicePriorityList()
+            return service
+        }
+
+        // The USB microphone is enumerated last, so it only wins if the
+        // unknown-transport device ahead of it is not ranked physical.
+        XCTAssertEqual(makeService(includeUSB: true).resolvedRecordingInputSelection().deviceUID, "usb-input")
+
+        // With no positively identified microphone, the unknown-transport device
+        // still outranks the virtual driver enumerated before it.
+        XCTAssertEqual(makeService(includeUSB: false).resolvedRecordingInputSelection().deviceUID, "unknown-input")
+    }
+
     /// Reaches the clamshell fallback with a NON-empty priority list: the sole
     /// priority entry is the internal mic, which the candidate loop rejects, so
     /// resolution must continue into the fallback and pick a device that was


### PR DESCRIPTION
## Summary

Follow-up to #1171 for #1163, covering the two items agreed in [this comment](https://github.com/TypeWhisper/typewhisper-mac/issues/1163#issuecomment-5457622317).

**1. The clamshell fallback selected by CoreAudio enumeration order.**

When the lid is closed and the system default input is the internal microphone, the fallback loop walked `inputDevices` in raw `kAudioHardwarePropertyDevices` order and took the first input that resolved. That order is arbitrary and frequently starts with a virtual loopback driver (screen sharing, light sync, meeting apps), which captures no microphone audio. A real microphone further down the list lost to it.

Measured on a MacBookPro18,4 (M1 Max), macOS 26.5.2, lid closed:

```
enumerationPosition | dataSourceFourCCs | device
 0 | nil          | Hue Sync Audio            (virtual, 4ch, captures no mic audio)
 1 | emic         | External Microphone       (uid BuiltInHeadphoneInputDevice)
 2 | imic         | MacBook Pro Microphone    (uid BuiltInMicrophoneDevice)
 3 | 0            | Microsoft Teams Audio     (virtual)
```

Candidates are now ranked `physical` → `unresolvedTransport` → `virtualOrAggregate`. Two notes on the implementation:

- Ordering is done by bucketing rather than sorting, so CoreAudio's original order is preserved within each rank.
- Classification goes through `resolvedAudioDeviceID(for:)`, the same resolver `resolvedInputSelection` uses, so a device is ranked on the identity it would actually be selected with. A stored `deviceID` goes stale across a replug, and ranking off a reused ID can classify a virtual driver as physical. Note that resolver still falls back to the stored ID when the UID no longer resolves; ranking deliberately matches selection rather than diverging from it.

A device whose ID or transport cannot be resolved is ranked between the two: it may well be a real microphone, so it beats a known virtual device, but it does not outrank one we can positively identify as physical.

**2. Diagnostics could not answer whether the lid was closed.**

#1163 arrived with a complete diagnostics export attached, and that export could not answer the single question that determines whether the bug is reachable. Added:

- `lidClosed` on the report.
- `enumerationPosition` per device. The device list is sorted by device ID, which hid the very ordering that decides fallback selection. In the table above the virtual driver is at position 0 while its device ID is not the lowest, so ID order does not reveal it.
- `inputDataSourceFourCCs` per device. `kAudioDevicePropertyDataSource` is documented as an array of the currently selected source IDs, so the full array is read rather than a single value.
- `isInternalMicrophone` per device, the routing classification.

**Routing identity is unchanged.** As requested, the UID-based predicate still decides routing, and the data-source values are collected for observation only. `isInternalMicrophoneUnavailableInClamshell` is split into an `isInternalMicrophone(deviceUID:transportType:)` identity plus the lid check, purely so diagnostics can report the classification without conflating it with lid state. The conjunction and the UID literal are unchanged, now hoisted to `internalMicrophoneDeviceUID`.

One existing test changed meaning: `testResolvedRecordingInputSelectionUsesFirstListedNonBuiltInClamshellFallback` asserted that a BlackHole loopback device wins the fallback over a USB microphone, which is the behaviour being corrected. It is renamed and its assertion flipped.

Not covered here, and happy to follow up if wanted: the new diagnostics fields have no unit test, because `diagnosticsReport()` reaches into CoreAudio directly (real default-device controller, microphone permission, and a HAL capture probe per device) with no injection seam. I prototyped a test for `lidClosed` and it destabilised the suite by opening capture sessions on real hardware, so I dropped it rather than ship something flaky. Adding that seam looked like scope creep here. The fields were verified on-device instead, which is the table above.

Refs #1163. Deliberately not marked as closing it, since the data-source routing decision is still open there and this PR is what makes the evidence collectable. Happy for you to close it on merge if you would rather track that separately.

Unrelated observation while working in this file, not changed here to keep the diff focused: `isBuiltInTransportType` (`AudioDeviceService.swift:1592`) has had no callers since #1171 replaced its last use. Glad to remove it here or in a separate PR, whichever you prefer.

## Test Plan

- [x] Ran `scripts/pr-preflight.sh`
- [x] Built and ran locally
- [x] Tested the changed functionality manually
- [x] No regressions in existing features

```bash
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO \
  CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Result: 1663 tests, 0 failures, run three times.

New regression coverage in `AudioDeviceServiceCompatibilityTests`:

- physical input preferred over a virtual device enumerated first
- virtual device still used when no physical input remains
- unresolved transport ranked between physical and virtual, asserted from both sides
- fallback reached with a non-empty priority list whose only entry is rejected
- internal-microphone classification matches the routing identity
- FourCC rendering of `imic` / `emic`

Verified manually on a MacBookPro18,4 in clamshell with a microphone in the 3.5mm jack: the jack microphone is selected for recording rather than the Hue Sync virtual driver.

Also ran the checks `Build DMG` performs on pull requests, since they gate this repo:

| Check | Result |
| --- | --- |
| Release build (`generic/platform=macOS`) | BUILD SUCCEEDED |
| `scripts/check_first_party_warnings.sh build.log` | no first-party warnings |
| `scripts/check_release_binary_instrumentation.sh --self-test` | pass |
| `scripts/check_release_binary_instrumentation.sh` on the release binary | pass |

One note on preflight: `scripts/pr-preflight.sh` exits 1 on this branch, but it also exits 1 on a pristine `origin/main` worktree, failing on `TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/Localizable.xcstrings` with "40 strings are missing complete zh-Hans localizations". That file is untouched here, so the failure is pre-existing rather than introduced by this change.

No user-facing strings are added, so there is nothing new to localize.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio diagnostics now include device enumeration order, input data sources, and internal microphone identification.
  * Added clearer reporting for audio device details, data-source values, and unresolved transport types.

* **Bug Fixes**
  * Improved clamshell fallback selection to prioritize physical or unresolved microphones over virtual and aggregate devices while preserving device order.
  * Improved internal microphone detection and handling of automatically generated aggregate devices.

* **Tests**
  * Expanded coverage for device prioritization, fallback behavior, microphone classification, aggregate handling, and diagnostic formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->