### PR TITLE
feat: add OrcaRouter LLM provider plugin

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -519,6 +519,10 @@
 		AA00000000000000000289 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000275 /* manifest.json */; };
 		AA00000000000000000290 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000276 /* Localizable.xcstrings */; };
 		AA00000000000000000291 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000041 /* TypeWhisperPluginSDK */; };
+		CA00000000000000000001 /* OrcaRouterPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000011 /* OrcaRouterPlugin.swift */; };
+		CA00000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000012 /* manifest.json */; };
+		CA00000000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000013 /* Localizable.xcstrings */; };
+		CA00000000000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = CA00000000000000000042 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000292 /* SonioxPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000278 /* SonioxPlugin.swift */; };
 		AA00000000000000000293 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000279 /* manifest.json */; };
 		AA00000000000000000294 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000280 /* Localizable.xcstrings */; };
@@ -1165,6 +1169,10 @@
 		BB00000000000000000275 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		BB00000000000000000276 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		BB00000000000000000277 /* OpenRouterPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OpenRouterPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		CA00000000000000000011 /* OrcaRouterPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrcaRouterPlugin.swift; sourceTree = "<group>"; };
+		CA00000000000000000012 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		CA00000000000000000013 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		CA00000000000000000014 /* OrcaRouterPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OrcaRouterPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		BB00000000000000000286 /* LicenseService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseService.swift; sourceTree = "<group>"; };
 		BB00000000000000000287 /* LicenseSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LicenseSettingsView.swift; sourceTree = "<group>"; };
 		BB00000000000000000288 /* WelcomeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeSheet.swift; sourceTree = "<group>"; };
@@ -1567,6 +1575,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CA00000000000000000043 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA00000000000000000004 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		B44AC50D02E0B348403BEE41 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1693,6 +1709,7 @@
 				CC00000000000000000041 /* GladiaPlugin */,
 				CC00000000000000000040 /* ElevenLabsPlugin */,
 				CC00000000000000000091 /* OpenRouterPlugin */,
+				CA00000000000000000021 /* OrcaRouterPlugin */,
 				CC00000000000000000042 /* SonioxPlugin */,
 				9A584149706C7567496E0220 /* XAIPlugin */,
 				CC00000000000000000043 /* CoherePlugin */,
@@ -2531,6 +2548,17 @@
 			path = TypeWhisperPluginSDK/Plugins/OpenRouterPlugin;
 			sourceTree = "<group>";
 		};
+		CA00000000000000000021 /* OrcaRouterPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				CA00000000000000000011 /* OrcaRouterPlugin.swift */,
+				CA00000000000000000012 /* manifest.json */,
+				CA00000000000000000013 /* Localizable.xcstrings */,
+			);
+			name = OrcaRouterPlugin;
+			path = TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin;
+			sourceTree = "<group>";
+		};
 		CC00000000000000000040 /* ElevenLabsPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2664,6 +2692,7 @@
 				BB00000000000000000270 /* GladiaPlugin.bundle */,
 				BB00000000000000000266 /* ElevenLabsPlugin.bundle */,
 				BB00000000000000000277 /* OpenRouterPlugin.bundle */,
+				CA00000000000000000014 /* OrcaRouterPlugin.bundle */,
 				BB00000000000000000281 /* SonioxPlugin.bundle */,
 				9A584149706C7567496E0213 /* XAIPlugin.bundle */,
 				BB00000000000000000285 /* CoherePlugin.bundle */,
@@ -3703,6 +3732,26 @@
 			productReference = BB00000000000000000277 /* OpenRouterPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		CA00000000000000000031 /* OrcaRouterPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = CA00000000000000000051 /* Build configuration list for PBXNativeTarget "OrcaRouterPlugin" */;
+			buildPhases = (
+				CA00000000000000000041 /* Sources */,
+				CA00000000000000000043 /* Frameworks */,
+				CA00000000000000000044 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = OrcaRouterPlugin;
+			packageProductDependencies = (
+				CA00000000000000000042 /* TypeWhisperPluginSDK */,
+			);
+			productName = OrcaRouterPlugin;
+			productReference = CA00000000000000000014 /* OrcaRouterPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		DD00000000000000000028 /* ElevenLabsPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = FF00000000000000000138 /* Build configuration list for PBXNativeTarget "ElevenLabsPlugin" */;
@@ -3948,6 +3997,7 @@
 				DD00000000000000000029 /* GladiaPlugin */,
 				DD00000000000000000028 /* ElevenLabsPlugin */,
 				DD00000000000000000030 /* OpenRouterPlugin */,
+				CA00000000000000000031 /* OrcaRouterPlugin */,
 				DD00000000000000000031 /* SonioxPlugin */,
 				9A584149706C7567496E0230 /* XAIPlugin */,
 				DD00000000000000000032 /* CoherePlugin */,
@@ -4361,6 +4411,15 @@
 			files = (
 				AA00000000000000000289 /* manifest.json in Resources */,
 				AA00000000000000000290 /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA00000000000000000044 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA00000000000000000002 /* manifest.json in Resources */,
+				CA00000000000000000003 /* Localizable.xcstrings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5130,6 +5189,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000288 /* OpenRouterPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CA00000000000000000041 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				CA00000000000000000001 /* OrcaRouterPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7906,6 +7973,54 @@
 			};
 			name = Release;
 		};
+		CA00000000000000000052 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = OrcaRouter;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = OrcaRouterPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.orcarouter;
+				PRODUCT_NAME = OrcaRouterPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		CA00000000000000000053 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = OrcaRouter;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = OrcaRouterPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.orcarouter;
+				PRODUCT_NAME = OrcaRouterPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -8395,6 +8510,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		CA00000000000000000051 /* Build configuration list for PBXNativeTarget "OrcaRouterPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				CA00000000000000000052 /* Debug */,
+				CA00000000000000000053 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -8704,6 +8828,10 @@
 			productName = TypeWhisperPluginSDK;
 		};
 		PP00000000000000000041 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		CA00000000000000000042 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -46,6 +46,16 @@ let package = Package(
             ]
         ),
         .target(
+            name: "OrcaRouterPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/OrcaRouterPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+            ]
+        ),
+        .target(
             name: "OpenRouterPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/OpenRouterPlugin",
@@ -397,6 +407,15 @@ let package = Package(
                 "OpenAIPlugin",
             ],
             path: "Plugins/OpenAIPlugin/Tests"
+        ),
+        .testTarget(
+            name: "OrcaRouterPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "OrcaRouterPlugin",
+            ],
+            path: "Plugins/OrcaRouterPlugin/Tests"
         ),
         .testTarget(
             name: "OpenRouterPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/Localizable.xcstrings
@@ -1,0 +1,248 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel werden sicher im Schlüsselbund gespeichert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーはキーチェーンに安全に保存されます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥安全存储在钥匙串中"
+          }
+        }
+      }
+    },
+    "Get API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel erstellen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーを作成"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 API 密钥"
+          }
+        }
+      }
+    },
+    "Invalid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なAPIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无效的 API 密钥"
+          }
+        }
+      }
+    },
+    "LLM Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM-Modell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLMモデル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM 模型"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Using default models. Press Refresh to fetch all available models.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardmodelle werden verwendet. Aktualisieren drücken, um alle verfügbaren Modelle abzurufen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準モデルが使用されます。更新を押して、利用可能なすべてのモデルを取得してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在使用默认模型。点击刷新以获取所有可用模型。"
+          }
+        }
+      }
+    },
+    "Valid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なAPIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有效的 API 密钥"
+          }
+        }
+      }
+    },
+    "Validating...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wird überprüft ..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "验证中..."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/OrcaRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/OrcaRouterPlugin.swift
@@ -1,0 +1,464 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+@objc(OrcaRouterPlugin)
+final class OrcaRouterPlugin: NSObject, LLMProviderPlugin, LLMTemperatureControllableProvider, LLMModelSelectable, LLMProviderIdentityProviding, @unchecked Sendable {
+    static let pluginId = "com.typewhisper.orcarouter"
+    static let pluginName = "OrcaRouter"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
+    fileprivate var _fetchedModels: [OrcaRouterFetchedModel] = []
+
+    private let chatHelper = PluginOpenAIChatHelper(
+        baseURL: "https://api.orcarouter.ai/v1"
+    )
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: "api-key")
+        if let data = host.userDefault(forKey: "fetchedModels") as? Data,
+           let models = try? JSONDecoder().decode([OrcaRouterFetchedModel].self, from: data) {
+            _fetchedModels = models
+        }
+        _selectedLLMModelId = host.userDefault(forKey: "selectedLLMModel") as? String
+        _llmTemperatureModeRaw = host.userDefault(forKey: "llmTemperatureMode") as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: "llmTemperatureValue") as? Double
+            ?? 0.3
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - LLMProviderIdentityProviding
+
+    var providerId: String { "orcarouter" }
+    var providerDisplayName: String { "OrcaRouter" }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "OrcaRouter" }
+
+    var isAvailable: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    // The auto router is always available as a fallback so the plugin is usable
+    // before the model list has been fetched.
+    private static let fallbackModels: [PluginModelInfo] = [
+        PluginModelInfo(id: "orcarouter/auto", displayName: "Auto Router"),
+        PluginModelInfo(id: "orcarouter/fusion", displayName: "Fusion"),
+        PluginModelInfo(id: "orcarouter/fusion-flash", displayName: "Fusion Flash"),
+        PluginModelInfo(id: "orcarouter/fusion-mini", displayName: "Fusion Mini"),
+    ]
+
+    var supportedModels: [PluginModelInfo] {
+        if _fetchedModels.isEmpty {
+            return Self.fallbackModels
+        }
+        return _fetchedModels.map {
+            PluginModelInfo(id: $0.id, displayName: Self.displayNames[$0.id] ?? $0.id)
+        }
+    }
+
+    private static let displayNames: [String: String] = [
+        "orcarouter/auto": "Auto Router",
+        "orcarouter/free": "Free",
+        "orcarouter/fusion": "Fusion",
+        "orcarouter/fusion-flash": "Fusion Flash",
+        "orcarouter/fusion-mini": "Fusion Mini",
+    ]
+
+    func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginChatError.notConfigured
+        }
+        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        return try await chatHelper.process(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            requestTimeout: 60
+        )
+    }
+
+    func selectLLMModel(_ modelId: String) {
+        _selectedLLMModelId = modelId
+        host?.setUserDefault(modelId, forKey: "selectedLLMModel")
+    }
+
+    var selectedLLMModelId: String? { _selectedLLMModelId }
+    @objc var preferredModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: "llmTemperatureMode")
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: "llmTemperatureValue")
+    }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(OrcaRouterSettingsView(plugin: self))
+    }
+
+    // Internal methods for settings
+
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: key)
+            } catch {
+                print("[OrcaRouterPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: "api-key", value: "")
+            } catch {
+                print("[OrcaRouterPlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func validateApiKey(_ key: String) async -> Bool {
+        guard !key.isEmpty,
+              let url = URL(string: "https://api.orcarouter.ai/v1/models") else { return false }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    fileprivate func setFetchedModels(_ models: [OrcaRouterFetchedModel]) {
+        _fetchedModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: "fetchedModels")
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    fileprivate func fetchModels() async -> [OrcaRouterFetchedModel] {
+        guard let apiKey = _apiKey, !apiKey.isEmpty,
+              let url = URL(string: "https://api.orcarouter.ai/v1/models") else { return [] }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return [] }
+
+            struct ModelsResponse: Decodable {
+                let data: [OrcaRouterAPIModel]
+            }
+
+            struct OrcaRouterAPIModel: Decodable {
+                let id: String
+                let ownedBy: String?
+
+                enum CodingKeys: String, CodingKey {
+                    case id
+                    case ownedBy = "owned_by"
+                }
+            }
+
+            let decoded = try JSONDecoder().decode(ModelsResponse.self, from: data)
+            return decoded.data
+                .filter { Self.isTextLLM($0.id) }
+                .map { OrcaRouterFetchedModel(id: $0.id, displayName: nil) }
+                .sorted { $0.id < $1.id }
+        } catch {
+            return []
+        }
+    }
+
+    private static func isTextLLM(_ modelId: String) -> Bool {
+        let lowered = modelId.lowercased()
+        let excluded = ["embed", "tts", "audio", "image-gen", "dall-e", "stable-diffusion",
+                        "moderation", "video"]
+        return !excluded.contains(where: { lowered.contains($0) })
+    }
+}
+
+// MARK: - Fetched Model
+
+struct OrcaRouterFetchedModel: Codable, Sendable {
+    let id: String
+    let displayName: String?
+
+    init(id: String, displayName: String?) {
+        self.id = id
+        self.displayName = displayName
+    }
+}
+
+// MARK: - Settings View
+
+private struct OrcaRouterSettingsView: View {
+    let plugin: OrcaRouterPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedModel: String = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
+    @State private var fetchedModels: [OrcaRouterFetchedModel] = []
+    private let bundle = Bundle(for: OrcaRouterPlugin.self)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // API Key Section
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key", bundle: bundle)
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isAvailable {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+
+                Link(String(localized: "Get API Key", bundle: bundle),
+                     destination: URL(string: "https://www.orcarouter.ai")!)
+                    .font(.caption)
+            }
+
+            if plugin.isAvailable {
+                Divider()
+
+                // LLM Model Selection
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("LLM Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    Picker("LLM Model", selection: $selectedModel) {
+                        ForEach(plugin.supportedModels, id: \.id) { model in
+                            Text(model.displayName).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedModel) {
+                        plugin.selectLLMModel(selectedModel)
+                    }
+
+                    if fetchedModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+            selectedModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
+            fetchedModels = plugin._fetchedModels
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            if isValid {
+                let models = await plugin.fetchModels()
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = true
+                    if !models.isEmpty {
+                        fetchedModels = models
+                        plugin.setFetchedModels(models)
+                    }
+                }
+            } else {
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = false
+                }
+            }
+        }
+    }
+
+    private func refreshModels() {
+        Task {
+            let models = await plugin.fetchModels()
+            await MainActor.run {
+                if !models.isEmpty {
+                    fetchedModels = models
+                    plugin.setFetchedModels(models)
+                    if !models.contains(where: { $0.id == selectedModel }),
+                       let first = models.first {
+                        selectedModel = first.id
+                        plugin.selectLLMModel(first.id)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/Tests/OrcaRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/Tests/OrcaRouterPluginTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import XCTest
+import TypeWhisperPluginSDK
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import OrcaRouterPlugin
+
+final class OrcaRouterPluginTests: XCTestCase {
+    func testProviderIdentityAndAvailability() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OrcaRouterPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.providerId, "orcarouter")
+        XCTAssertEqual(plugin.providerName, "OrcaRouter")
+        XCTAssertEqual(plugin.providerDisplayName, "OrcaRouter")
+        XCTAssertFalse(plugin.isAvailable)
+    }
+
+    func testPreferredModelIdReflectsSelectedLLMModel() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OrcaRouterPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertNil(
+            (plugin as? LLMModelSelectable)?.preferredModelId ?? nil,
+            "preferredModelId must be nil until the user selects a model"
+        )
+
+        let target = try XCTUnwrap(plugin.supportedModels.first?.id)
+        plugin.selectLLMModel(target)
+
+        let preferred = (plugin as? LLMModelSelectable)?.preferredModelId
+        XCTAssertEqual(preferred, target)
+    }
+
+    func testFallbackModelsExposeAutoRouterFirst() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OrcaRouterPlugin()
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.supportedModels.first?.id, "orcarouter/auto")
+        XCTAssertEqual(plugin.supportedModels.first?.displayName, "Auto Router")
+        XCTAssertTrue(plugin.supportedModels.contains { $0.id == "orcarouter/fusion" })
+    }
+
+    func testSelectedModelPersistsAcrossActivation() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OrcaRouterPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectLLMModel("orcarouter/fusion-mini")
+        plugin.deactivate()
+
+        let reloaded = OrcaRouterPlugin()
+        reloaded.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "orcarouter/fusion-mini")
+        XCTAssertEqual(reloaded.selectedLLMModelId, "orcarouter/fusion-mini")
+    }
+
+    func testFetchedModelsOverrideFallbacks() throws {
+        let host = try PluginTestHostServices()
+        let plugin = OrcaRouterPlugin()
+        plugin.activate(host: host)
+
+        let fetched = [
+            OrcaRouterFetchedModel(id: "anthropic/claude-opus-4.8", displayName: nil),
+            OrcaRouterFetchedModel(id: "openai/gpt-oss-120b", displayName: nil),
+        ]
+        plugin.setFetchedModels(fetched)
+
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["anthropic/claude-opus-4.8", "openai/gpt-oss-120b"])
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/manifest.json
@@ -1,0 +1,19 @@
+{
+    "id": "com.typewhisper.orcarouter",
+    "name": "OrcaRouter",
+    "version": "1.0.0",
+    "minHostVersion": "1.6.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Access 200+ LLMs from OpenAI, Anthropic, Google and more through the OrcaRouter AI gateway, with adaptive routing, automatic failover and zero-markup inference. Requires API key.",
+    "descriptions": {
+        "de": "Zugriff auf über 200 LLMs von OpenAI, Anthropic, Google und mehr über das OrcaRouter-AI-Gateway mit adaptivem Routing, automatischem Failover und Inferenz ohne Aufschlag. Erfordert API-Key.",
+        "ja": "OrcaRouter AIゲートウェイを通じてOpenAI、Anthropic、Googleなどの200以上のLLMにアクセスできます。適応型ルーティング、自動フェイルオーバー、ゼロマークアップ推論に対応し、APIキーが必要です。"
+    },
+    "category": "llm",
+    "iconSystemName": "arrow.triangle.branch",
+    "principalClass": "OrcaRouterPlugin",
+    "requiresAPIKey": true,
+    "detailsURL": "https://www.orcarouter.ai"
+}


### PR DESCRIPTION
## Summary

This adds **OrcaRouter** as a first-class LLM provider plugin, so users of TypeWhisper's plugin system ("Extend TypeWhisper with custom LLM providers") can route prompts through the OrcaRouter gateway instead of treating it as an anonymous OpenAI-compatible base URL.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a first-class provider means this project's users can use that stack directly. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The plugin follows the same shape as the bundled `CerebrasPlugin`: an `LLMProviderPlugin` that uses `PluginOpenAIChatHelper` against the provider's `/v1` base URL, with temperature control and a settings view to validate the API key and refresh the model list.

### Changes

- **New `OrcaRouterPlugin` bundle** (`TypeWhisperPluginSDK/Plugins/OrcaRouterPlugin/`) implementing `LLMProviderPlugin`, `LLMTemperatureControllableProvider`, `LLMModelSelectable`, and `LLMProviderIdentityProviding` (`providerId = "orcarouter"`).
- **Live model discovery** via `GET https://api.orcarouter.ai/v1/models`, filtered to text LLMs, persisted in defaults with the Cerebras-style `FetchedModel` pattern; falls back to `orcarouter/auto` + Fusion family models when the list hasn't been fetched.
- **Chat completions** via `POST /v1/chat/completions` (`PluginOpenAIChatHelper`), which is OpenAI-compatible.
- **Registered** in `TypeWhisperPluginSDK/Package.swift` (target + test target) and as an Xcode bundle target in `TypeWhisper.xcodeproj` (sources, resources, frameworks, build configurations).
- **Plugin manifest + localizations + tests** mirroring the bundled provider convention; manifest declares `minHostVersion 1.6.0`, `sdkCompatibilityVersion v1`, `requiresAPIKey true`.

### Test Plan

- `git diff --check` clean; `check_localization_completeness.py`, `test_assemble_community_plugin_registry.py`, and `test_plugin_registry_metadata.py` pass.
- `swift test --package-path TypeWhisperPluginSDK` is not runnable in this environment (macOS/Xcode-only toolchain); all new tests follow the existing `CerebrasPluginTests` pattern and the manifest validates against `PluginManifestValidationTests` conventions.
- **L3 live test against the real API**: `GET /v1/models` returned `200` (204 models, 188 text LLMs), and `POST /v1/chat/completions` with `model: "orcarouter/fusion-mini"` returned `200` with content. The plugin's `validateApiKey`, `fetchModels`, and `process` paths were exercised end-to-end.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OrcaRouter as an LLM provider plugin.
  * Added API key management, model selection, model refresh, and temperature controls.
  * Added fallback models when available models cannot be retrieved.
  * Added localized settings and plugin descriptions in English, German, Japanese, and Simplified Chinese.
  * Added plugin availability and compatibility metadata.

* **Tests**
  * Added coverage for provider identity, model selection, persistence, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->