### PR TITLE
Fix crash when opening recent transcriptions from menu bar

### DIFF
--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -258,6 +258,19 @@ enum MenuBarMenuSection: String, CaseIterable, Hashable {
     }
 }
 
+@MainActor
+enum MenuBarActionDispatcher {
+    static func performAfterMenuDismissal(
+        _ action: @escaping @MainActor @Sendable () -> Void
+    ) {
+        RunLoop.main.perform(inModes: [.default]) {
+            MainActor.assumeIsolated {
+                action()
+            }
+        }
+    }
+}
+
 private struct PluginCommandButton: View {
     let pluginId: String
     let command: PluginCommandDescriptor
@@ -481,7 +494,11 @@ struct MenuBarView: View {
     @ViewBuilder
     private var recentTranscriptionsButton: some View {
         Button {
-            DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+            // MenuBarExtra uses NSMenu tracking. Defer creating the key NSPanel
+            // until the menu action has returned and the native menu can close.
+            MenuBarActionDispatcher.performAfterMenuDismissal {
+                DictationViewModel.shared.triggerRecentTranscriptionsPalette()
+            }
         } label: {
             Label(String(localized: "Recent Transcriptions"), systemImage: "clock.arrow.circlepath")
         }

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -264,7 +264,7 @@ enum MenuBarActionDispatcher {
         _ action: @escaping @MainActor @Sendable () -> Void
     ) {
         RunLoop.main.perform(inModes: [.default]) {
-            MainActor.assumeIsolated {
+            Task { @MainActor in
                 action()
             }
         }

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -972,6 +972,22 @@ final class ManagedAppWindowRestorationTests: XCTestCase {
 }
 
 final class MenuBarGroupingTests: XCTestCase {
+    @MainActor
+    func testMenuBarActionDispatcherDefersUntilTheCurrentActionReturns() async {
+        let probe = MenuBarActionInvocationProbe()
+
+        await withCheckedContinuation { continuation in
+            MenuBarActionDispatcher.performAfterMenuDismissal {
+                probe.invocationCount += 1
+                continuation.resume()
+            }
+
+            XCTAssertEqual(probe.invocationCount, 0)
+        }
+
+        XCTAssertEqual(probe.invocationCount, 1)
+    }
+
     func testMenuBarSectionsUseExpectedOrderAndLocalizedKeys() {
         XCTAssertEqual(
             MenuBarMenuSection.allCases.map(\.titleLocalizationKey),
@@ -993,6 +1009,11 @@ final class MenuBarGroupingTests: XCTestCase {
             [.toggleDictationHotkeysPause, .transcribeFile, .lastTranscription]
         )
     }
+}
+
+@MainActor
+private final class MenuBarActionInvocationProbe {
+    var invocationCount = 0
 }
 
 final class MenuBarIconStateTests: XCTestCase {


### PR DESCRIPTION
## Issue context

Fixes the crash reported in #1224 when choosing **Last Transcription → Recent Transcriptions** from the menu bar. The action previously presented a key `NSPanel` synchronously while the native `MenuBarExtra` menu was still tracking events. It now schedules palette presentation in the default main run-loop mode, after the menu action has returned and the menu can close.

Closes #1224

## Changes

- Defer the recent-transcriptions palette until native menu tracking finishes.
- Keep the dispatch on the main actor.
- Add a regression test proving the menu action does not execute synchronously.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -only-testing:TypeWhisperTests/MenuBarGroupingTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
- [x] Build, sign, and launch the final dev app through the TypeWhisper development build workflow.
- [ ] Re-test the original menu-bar sequence on the reporter's macOS 26.5.2 environment; local macOS UI automation was unavailable for this click-through.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Recent Transcriptions menu action so its palette opens reliably after the menu closes.
  - Prevented timing issues when launching actions directly from the menu bar.
  - Improved reliability when triggering deferred actions during menu interactions.

- **Tests**
  - Added coverage confirming menu actions execute only after the current menu interaction has finished.
  - Verified deferred actions run in the correct order after the active menu action returns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->