### PR TITLE
Disable SwiftUI sizing propagation for settings hosts

### DIFF
--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -305,6 +305,19 @@ private struct SettingsModernShell: View {
 // sidebars — it owns both resize and collapse natively, so neither is fighting
 // a SwiftUI layout pass, and VoiceOver/keyboard resize support comes for free.
 @available(macOS 15, *)
+@MainActor
+enum SettingsHostingControllerFactory {
+    static func make<Content: View>(rootView: Content) -> NSHostingController<Content> {
+        let hostingController = NSHostingController(rootView: rootView)
+        // NSSplitViewController owns the sidebar and detail sizes. Prevent
+        // SwiftUI from feeding content-size constraints back into AppKit while
+        // either hosted hierarchy is already updating its layout.
+        hostingController.sizingOptions = []
+        return hostingController
+    }
+}
+
+@available(macOS 15, *)
 private struct SettingsSplitView: NSViewControllerRepresentable {
     @Binding var selectedTab: SettingsTab
     @Binding var sidebarSearchText: String
@@ -316,7 +329,7 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
         let splitViewController = NSSplitViewController()
         splitViewController.splitView.dividerStyle = .thin
 
-        let sidebarHostingController = NSHostingController(
+        let sidebarHostingController = SettingsHostingControllerFactory.make(
             rootView: SettingsSidebarContent(
                 selectedTab: $selectedTab,
                 sidebarSearchText: $sidebarSearchText,
@@ -329,7 +342,7 @@ private struct SettingsSplitView: NSViewControllerRepresentable {
         sidebarItem.canCollapse = true
         sidebarItem.isCollapsed = !isSidebarVisible
 
-        let detailHostingController = NSHostingController(
+        let detailHostingController = SettingsHostingControllerFactory.make(
             rootView: AnyView(
                 detail(selectedTab)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/TypeWhisperTests/PremiumSettingsWindowManagerTests.swift
+++ b/TypeWhisperTests/PremiumSettingsWindowManagerTests.swift
@@ -166,6 +166,18 @@ final class PremiumSettingsWindowManagerTests: XCTestCase {
     }
 }
 
+@available(macOS 15, *)
+@MainActor
+final class SettingsHostingControllerTests: XCTestCase {
+    func testSettingsSplitHostsDoNotPropagateSwiftUISizingIntoAppKitConstraints() {
+        let hostingController = SettingsHostingControllerFactory.make(
+            rootView: Text("Settings detail")
+        )
+
+        XCTAssertEqual(hostingController.sizingOptions, [])
+    }
+}
+
 @MainActor
 private final class TrackingWindow: NSWindow {
     private(set) var frontCount = 0


### PR DESCRIPTION
## Summary

- let the AppKit split view own the sidebar and detail sizes instead of reflecting SwiftUI content bounds back into window constraints
- create both settings `NSHostingController` instances through one sizing-policy factory
- add regression coverage for the disabled SwiftUI sizing propagation

## Issue context

Issue #1227 includes four intermittent `EXC_BREAKPOINT` crash reports with the same AppKit/SwiftUI constraint-update stack. The original crash was not reproduced locally. Two reported crashes happened while scrolling settings, while the Notch host already disables sizing propagation in the affected 1.6.0 build. The remaining macOS 15–26 settings bridge embeds two hosting controllers with the default sizing policy, so this change removes that constraint feedback path while `NSSplitViewController` owns their frames.

Closes #1227

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:TypeWhisperTests/SettingsHostingControllerTests -only-testing:TypeWhisperTests/PremiumSettingsWindowManagerTests` (6 tests passed)
- `scripts/pr-preflight.sh origin/main` (stops at 40 missing `zh-Hans` localizations in `AuthenticatedCLIPlugin`; `python3 scripts/check_localization_completeness.py` reproduces the same failure on a clean `origin/main` archive)
- Original intermittent crash reproduction: not reproduced locally; reporter validation with a test build remains the behavioral confirmation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Settings window layout on macOS 15 by preventing unwanted automatic resizing of sidebar and detail panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->