### PR TITLE
Fix notch indicator window left stuck blank after dismissal race

### DIFF
--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -47,6 +47,10 @@ class NotchIndicatorPanel: NSPanel {
     private var dismissTask: Task<Void, Never>?
     private var isActionFeedbackInteractive = false
     private var isMeetingCountdownPresented = false
+    /// True while a deferred dismissal is in flight: content already blanked,
+    /// `orderOut` pending. Callers that only want to refresh an already-visible
+    /// panel (not change visibility policy) must not resurrect it in this window.
+    private var isDismissing = false
 
     private var isFeedbackInteractive: Bool {
         isActionFeedbackInteractive || isMeetingCountdownPresented
@@ -219,6 +223,7 @@ class NotchIndicatorPanel: NSPanel {
     func show() {
         showTask?.cancel()
         dismissTask?.cancel()
+        isDismissing = false
 
         let wasVisible = isVisible
         placePanel()
@@ -271,7 +276,13 @@ class NotchIndicatorPanel: NSPanel {
             in: screenFrame
         )
 
-        setFrame(panelFrame, display: true)
+        // display: false — a synchronous display pass here re-enters the display
+        // cycle on the NSHostingView content and can raise
+        // NSInternalInconsistencyException from _postWindowNeedsUpdateConstraints
+        // (via NSHostingView.invalidateSafeAreaCornerInsets) when placement is
+        // triggered from a display-cycle observer such as the screen-parameters
+        // notification. The next regular display cycle picks up the new frame.
+        setFrame(panelFrame, display: false)
         ignoresMouseEvents = !isFeedbackInteractive
         FloatingPanelSpacePolicy.orderIndicatorFront(
             self,
@@ -299,7 +310,11 @@ class NotchIndicatorPanel: NSPanel {
         }
         guard isActionFeedbackInteractive != isInteractive else { return }
         isActionFeedbackInteractive = isInteractive
-        if isVisible {
+        // This callback only wants to resize/re-arm an already-visible panel.
+        // While a dismissal is in flight the window is still ordered in but its
+        // content is blanked; calling show() here cancelled the pending orderOut
+        // and left an empty panel stuck over the notch.
+        if isVisible, !isDismissing {
             show()
         }
     }
@@ -323,20 +338,27 @@ class NotchIndicatorPanel: NSPanel {
 
         guard isVisible else {
             notchGeometry.isPresented = false
+            isDismissing = false
             orderOut(nil)
             return
         }
 
+        isDismissing = true
         withAnimation(.easeInOut(duration: 0.18)) {
             notchGeometry.isPresented = false
         }
 
         dismissTask = Task { @MainActor [weak self] in
             try? await Task.sleep(for: Self.presentationAnimationDuration)
-            guard !Task.isCancelled else { return }
-            guard let self, !self.notchGeometry.isPresented else { return }
-            self.orderOut(nil)
+            guard !Task.isCancelled, let self else { return }
             self.dismissTask = nil
+            guard !self.notchGeometry.isPresented else {
+                // A show() re-presented the panel during the animation window;
+                // it also cleared isDismissing. Leave the window up.
+                return
+            }
+            self.orderOut(nil)
+            self.isDismissing = false
         }
     }
 }

--- a/TypeWhisper/Views/NotchIndicatorPanel.swift
+++ b/TypeWhisper/Views/NotchIndicatorPanel.swift
@@ -301,7 +301,16 @@ class NotchIndicatorPanel: NSPanel {
         if displayModeProvider() == .activeScreen {
             cachedScreen = nil
         }
-        placePanel()
+        // Hop to the next runloop turn: this refresh is driven by
+        // display-cycle-adjacent triggers (screen-parameter changes, the global
+        // mouse monitor), and re-placing the hosting-view-backed window
+        // synchronously from inside the display cycle raises
+        // NSInternalInconsistencyException from _postWindowNeedsUpdateConstraints
+        // (via NSHostingView.invalidateSafeAreaCornerInsets).
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.isVisible, self.notchGeometry.isPresented else { return }
+            self.placePanel()
+        }
     }
 
     func updateFeedbackInteraction(isInteractive: Bool) {

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1603,6 +1603,41 @@ final class NotchIndicatorPanelLifecycleTests: XCTestCase {
         XCTAssertTrue(panel.isVisible)
     }
 
+    func testFeedbackInteractionChangeDoesNotCancelInFlightDismissal() async throws {
+        let panel = try makePanel()
+        defer { panel.orderOut(nil) }
+
+        panel.show()
+        await Task.yield()
+        panel.updateFeedbackInteraction(isInteractive: true)
+        XCTAssertTrue(panel.isVisible)
+
+        // Dictation ends while an action-feedback toast is up: the state sink
+        // dismisses, then the feedback sink flips interaction back off inside
+        // the dismissal animation window. That second callback must not
+        // resurrect the panel — previously it cancelled the pending orderOut
+        // and left a blank window stuck over the notch.
+        panel.dismiss()
+        panel.updateFeedbackInteraction(isInteractive: false)
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertFalse(panel.isVisible)
+    }
+
+    func testShowAfterFeedbackInteractionChangeDuringDismissalStillPresents() async throws {
+        let panel = try makePanel()
+        defer { panel.orderOut(nil) }
+
+        panel.show()
+        await Task.yield()
+        panel.dismiss()
+        panel.updateFeedbackInteraction(isInteractive: true)
+        panel.show()
+        try await Task.sleep(for: .milliseconds(300))
+
+        XCTAssertTrue(panel.isVisible)
+    }
+
     private func makePanel() throws -> NotchIndicatorPanel {
         guard let screen = NSScreen.screens.first else {
             throw XCTSkip("Notch indicator panel tests require an available screen")


### PR DESCRIPTION
## Summary

Fixes #1231: after a dictation that ends with an action-feedback toast, the notch overlay window could be left permanently on screen with blank content. `dismiss()` blanks the SwiftUI content immediately but defers `orderOut` by 220 ms; the feedback-interaction sink (`CombineLatest($state, $actionFeedbackMessage)`) then fires inside that window with `isInteractive: false`, sees `isVisible == true`, and calls `show()` — cancelling the pending teardown and re-fronting a now-empty panel. The stuck window is then re-asserted by the global-click placement refresh indefinitely. Regression from the interaction of the deferred dismissal (#861) and the feedback-interaction `show()` (#1034); the overlay/minimal panels dismiss synchronously and are immune.

Changes in `NotchIndicatorPanel`:

1. **`isDismissing` flag across the deferred teardown.** `updateFeedbackInteraction` only ever wants to resize an already-visible panel, so it now refuses to resurrect one whose dismissal is in flight. A direct `show()` (new activity, visibility policy) still legitimately cancels a dismissal, exactly as `testShowCancelsInFlightDismissalForNewActivity` specifies.
2. **The deferred teardown reconciles instead of silently bailing** — if content was legitimately re-presented during the animation window it leaves the panel up; otherwise it orders out and clears state.
3. **`placePanel()` no longer forces a synchronous display pass** (`setFrame(_:display: false)`). Placement runs from display-cycle-adjacent triggers (the screen-parameters notification, the global mouse-down monitor), and the synchronous pass re-enters the display cycle on the hosting view — matching the `NSHostingView.invalidateSafeAreaCornerInsets` → `_postWindowNeedsUpdateConstraints` `NSInternalInconsistencyException` signature in #1229. This is the only window in the app whose frame derives from `NSScreen.safeAreaInsets`, so this change plausibly resolves that crash as well (left open pending field confirmation rather than claimed here).

Closes #1231

## Test Plan

Two new tests in `NotchIndicatorPanelLifecycleTests`: `testFeedbackInteractionChangeDoesNotCancelInFlightDismissal` (the regression: dismiss + interaction-off inside the animation window → panel must actually hide) and `testShowAfterFeedbackInteractionChangeDuringDismissalStillPresents` (a real `show()` during dismissal still wins). Existing lifecycle tests unchanged and green.

```
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/NotchIndicatorPanelLifecycleTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

All 4 lifecycle tests pass; full suite run locally alongside #1221/#1230 with no failures. I hit the stuck-blank window daily (notch style + learned-dictionary corrections) and am running this fix as my daily build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the indicator panel could reappear unexpectedly while being dismissed.
  * Ensured panel updates and feedback interaction changes preserve the correct visible or hidden state.
  * Improved behavior when the panel is shown again during an in-progress dismissal.

* **Tests**
  * Added coverage for dismissal, feedback interaction changes, and re-presenting the panel during dismissal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->