### PR TITLE
Treat multi-provider empty LLM output as intentional, not as failure

### DIFF
--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -481,6 +481,7 @@ class PromptProcessingService: ObservableObject {
 
         var failures: [LLMFallbackAttemptFailure] = []
         var emptyResultCount = 0
+        var firstEmptyCandidate: LLMFallbackPriorityItem?
         for (index, candidate) in candidates.enumerated() {
             try Task.checkCancellation()
             let providerId = normalizeProviderId(candidate.providerId)
@@ -562,6 +563,9 @@ class PromptProcessingService: ObservableObject {
 
                 if case LLMFallbackAttemptError.emptyResult = error {
                     emptyResultCount += 1
+                    if firstEmptyCandidate == nil {
+                        firstEmptyCandidate = candidate
+                    }
                 }
                 let failure = LLMFallbackAttemptFailure(
                     providerId: providerId,
@@ -584,6 +588,38 @@ class PromptProcessingService: ObservableObject {
         if emptyResultCount >= 2, emptyResultCount == failures.count {
             logger.info("All \(emptyResultCount, privacy: .public) LLM attempts returned an empty result; treating empty output as intentional")
             return ""
+        }
+
+        // Mixed outcome: at least one provider ran and answered "empty" while the
+        // rest failed with infrastructure errors (rate limit, network, parse) that
+        // carry no opinion about the content. Confirm the lone empty opinion by
+        // re-running its provider once - empty twice is intent, not a glitch.
+        // Requires other failures alongside the empty one: a single provider
+        // glitching to empty on its own keeps the protective failure semantics.
+        if let candidate = firstEmptyCandidate, failures.count > emptyResultCount {
+            logger.info("Confirming lone empty LLM opinion with a retry against \(candidate.providerId, privacy: .public)")
+            if let retryResult = try? await processSingleProvider(
+                providerId: normalizeProviderId(candidate.providerId),
+                requestedModelId: candidate.modelId,
+                requestedEffortId: candidate.effortId,
+                prompt: effectivePrompt,
+                text: inputText(for: processingKind, providerId: normalizeProviderId(candidate.providerId), fallbackText: text),
+                temperatureDirective: temperatureDirective,
+                onLocalProviderUsed: { provider in
+                    let identity = ObjectIdentifier(provider)
+                    guard localProviderIdentities.insert(identity).inserted else { return }
+                    localProvidersUsed.append(provider)
+                    modelManagerService?.beginAutoUnloadProtectedUse(of: provider)
+                }
+            ) {
+                let retryText = outputText(retryResult, for: processingKind, providerId: normalizeProviderId(candidate.providerId))
+                if retryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    logger.info("Empty output confirmed by retry; treating empty output as intentional")
+                    return ""
+                }
+                logger.info("Retry produced content after an initial empty result")
+                return retryText
+            }
         }
 
         throw LLMFallbackExhaustedError(failures: failures)

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -514,6 +514,36 @@ class PromptProcessingService: ObservableObject {
                     providerId: providerId
                 )
                 guard !result.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                    // An explicit provider (no fallback list) has no second
+                    // opinion available, so verify an empty result by re-running
+                    // the same provider once: empty twice in a row is the
+                    // prompt's intended output (e.g. an artifact-only transcript
+                    // reduced to nothing), a lone empty is treated as a glitch.
+                    if !usesFallbackList {
+                        logger.info("Explicit provider returned an empty result; retrying once to confirm intent")
+                        let retryResult = try await processSingleProvider(
+                            providerId: providerId,
+                            requestedModelId: candidate.modelId,
+                            requestedEffortId: candidate.effortId,
+                            prompt: effectivePrompt,
+                            text: attemptText,
+                            temperatureDirective: temperatureDirective,
+                            onLocalProviderUsed: { provider in
+                                let identity = ObjectIdentifier(provider)
+                                guard localProviderIdentities.insert(identity).inserted else { return }
+                                localProvidersUsed.append(provider)
+                                modelManagerService?.beginAutoUnloadProtectedUse(of: provider)
+                            }
+                        )
+                        try Task.checkCancellation()
+                        let retryText = outputText(retryResult, for: processingKind, providerId: providerId)
+                        if retryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                            logger.info("Explicit provider returned empty twice; treating empty output as intentional")
+                            return ""
+                        }
+                        logger.info("Prompt processing complete after empty-retry in \(ContinuousClock.now - totalStart), result length: \(retryText.count)")
+                        return retryText
+                    }
                     throw LLMFallbackAttemptError.emptyResult
                 }
 

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -585,8 +585,11 @@ class PromptProcessingService: ObservableObject {
         // intended output instead of failing the pipeline onto the raw text.
         // A single empty attempt keeps the protective failure semantics, since one
         // provider glitching to empty would otherwise silently discard content.
-        if emptyResultCount >= 2, emptyResultCount == failures.count {
-            logger.info("All \(emptyResultCount, privacy: .public) LLM attempts returned an empty result; treating empty output as intentional")
+        // Providers that failed with infrastructure errors (rate limit, network,
+        // parse) cast no vote either way, so two independent empty opinions are
+        // consensus even when a third provider never got to answer.
+        if emptyResultCount >= 2 {
+            logger.info("\(emptyResultCount, privacy: .public) of \(failures.count, privacy: .public) LLM attempts independently returned an empty result; treating empty output as intentional")
             return ""
         }
 

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -480,6 +480,7 @@ class PromptProcessingService: ObservableObject {
         }
 
         var failures: [LLMFallbackAttemptFailure] = []
+        var emptyResultCount = 0
         for (index, candidate) in candidates.enumerated() {
             try Task.checkCancellation()
             let providerId = normalizeProviderId(candidate.providerId)
@@ -529,6 +530,9 @@ class PromptProcessingService: ObservableObject {
                     throw error
                 }
 
+                if case LLMFallbackAttemptError.emptyResult = error {
+                    emptyResultCount += 1
+                }
                 let failure = LLMFallbackAttemptFailure(
                     providerId: providerId,
                     modelId: candidate.modelId,
@@ -538,6 +542,18 @@ class PromptProcessingService: ObservableObject {
                 failures.append(failure)
                 logger.warning("LLM fallback \(index + 1, privacy: .public) failed for \(providerId, privacy: .public): \(failure.reason, privacy: .private(mask: .hash))")
             }
+        }
+
+        // If several providers each ran successfully and independently returned an
+        // empty result, that is consensus, not malfunction: the processing prompt
+        // intentionally reduced the input to nothing (e.g. a silence-hallucination
+        // artifact stripped by the user's instructions). Surface empty as the
+        // intended output instead of failing the pipeline onto the raw text.
+        // A single empty attempt keeps the protective failure semantics, since one
+        // provider glitching to empty would otherwise silently discard content.
+        if emptyResultCount >= 2, emptyResultCount == failures.count {
+            logger.info("All \(emptyResultCount, privacy: .public) LLM attempts returned an empty result; treating empty output as intentional")
+            return ""
         }
 
         throw LLMFallbackExhaustedError(failures: failures)

--- a/TypeWhisper/Services/PromptProcessingService.swift
+++ b/TypeWhisper/Services/PromptProcessingService.swift
@@ -481,6 +481,7 @@ class PromptProcessingService: ObservableObject {
 
         var failures: [LLMFallbackAttemptFailure] = []
         var emptyResultCount = 0
+        var emptyProviderIds: Set<String> = []
         var firstEmptyCandidate: LLMFallbackPriorityItem?
         for (index, candidate) in candidates.enumerated() {
             try Task.checkCancellation()
@@ -563,6 +564,7 @@ class PromptProcessingService: ObservableObject {
 
                 if case LLMFallbackAttemptError.emptyResult = error {
                     emptyResultCount += 1
+                    emptyProviderIds.insert(providerId)
                     if firstEmptyCandidate == nil {
                         firstEmptyCandidate = candidate
                     }
@@ -578,50 +580,72 @@ class PromptProcessingService: ObservableObject {
             }
         }
 
-        // If several providers each ran successfully and independently returned an
-        // empty result, that is consensus, not malfunction: the processing prompt
-        // intentionally reduced the input to nothing (e.g. a silence-hallucination
-        // artifact stripped by the user's instructions). Surface empty as the
-        // intended output instead of failing the pipeline onto the raw text.
-        // A single empty attempt keeps the protective failure semantics, since one
-        // provider glitching to empty would otherwise silently discard content.
+        // Consensus is counted in independent providers, not attempts: the
+        // fallback list may carry several models of one provider, and one
+        // plugin answering empty twice is a single (possibly deterministic)
+        // opinion, so that alone keeps the protective failure semantics.
         // Providers that failed with infrastructure errors (rate limit, network,
-        // parse) cast no vote either way, so two independent empty opinions are
-        // consensus even when a third provider never got to answer.
-        if emptyResultCount >= 2 {
-            logger.info("\(emptyResultCount, privacy: .public) of \(failures.count, privacy: .public) LLM attempts independently returned an empty result; treating empty output as intentional")
+        // parse) cast no vote either way, so two distinct providers answering
+        // empty are consensus even when a third never got to answer: the prompt
+        // intentionally reduced the input to nothing (e.g. a silence-hallucination
+        // artifact stripped by the user's instructions), and empty is surfaced as
+        // the intended output instead of failing the pipeline onto the raw text.
+        if emptyProviderIds.count >= 2 {
+            logger.info("\(emptyProviderIds.count, privacy: .public) independent LLM providers returned an empty result; treating empty output as intentional")
             return ""
         }
 
-        // Mixed outcome: at least one provider ran and answered "empty" while the
-        // rest failed with infrastructure errors (rate limit, network, parse) that
-        // carry no opinion about the content. Confirm the lone empty opinion by
-        // re-running its provider once - empty twice is intent, not a glitch.
-        // Requires other failures alongside the empty one: a single provider
-        // glitching to empty on its own keeps the protective failure semantics.
-        if let candidate = firstEmptyCandidate, failures.count > emptyResultCount {
-            logger.info("Confirming lone empty LLM opinion with a retry against \(candidate.providerId, privacy: .public)")
-            if let retryResult = try? await processSingleProvider(
-                providerId: normalizeProviderId(candidate.providerId),
-                requestedModelId: candidate.modelId,
-                requestedEffortId: candidate.effortId,
-                prompt: effectivePrompt,
-                text: inputText(for: processingKind, providerId: normalizeProviderId(candidate.providerId), fallbackText: text),
-                temperatureDirective: temperatureDirective,
-                onLocalProviderUsed: { provider in
-                    let identity = ObjectIdentifier(provider)
-                    guard localProviderIdentities.insert(identity).inserted else { return }
-                    localProvidersUsed.append(provider)
-                    modelManagerService?.beginAutoUnloadProtectedUse(of: provider)
-                }
-            ) {
-                let retryText = outputText(retryResult, for: processingKind, providerId: normalizeProviderId(candidate.providerId))
+        // Mixed outcome: exactly one provider answered "empty" while every other
+        // attempt failed with an infrastructure error that carries no opinion
+        // about the content. No independent second opinion is obtainable, so the
+        // lone opinion is confirmed by re-running the same provider once - the
+        // same, deliberately weaker, same-provider semantics the explicit
+        // workflow-provider path uses above: empty twice is intent, a lone empty
+        // stays a glitch. A single provider glitching to empty with no other
+        // attempt made keeps the protective failure semantics unchanged.
+        if let candidate = firstEmptyCandidate, emptyProviderIds.count == 1, failures.count > emptyResultCount {
+            let retryProviderId = normalizeProviderId(candidate.providerId)
+            logger.info("Confirming lone empty LLM opinion with a retry against \(retryProviderId, privacy: .public)")
+            do {
+                let retryResult = try await processSingleProvider(
+                    providerId: retryProviderId,
+                    requestedModelId: candidate.modelId,
+                    requestedEffortId: candidate.effortId,
+                    prompt: effectivePrompt,
+                    text: inputText(for: processingKind, providerId: retryProviderId, fallbackText: text),
+                    temperatureDirective: temperatureDirective,
+                    onLocalProviderUsed: { provider in
+                        let identity = ObjectIdentifier(provider)
+                        guard localProviderIdentities.insert(identity).inserted else { return }
+                        localProvidersUsed.append(provider)
+                        modelManagerService?.beginAutoUnloadProtectedUse(of: provider)
+                    }
+                )
+                try Task.checkCancellation()
+                let retryText = outputText(retryResult, for: processingKind, providerId: retryProviderId)
                 if retryText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     logger.info("Empty output confirmed by retry; treating empty output as intentional")
                     return ""
                 }
                 logger.info("Retry produced content after an initial empty result")
                 return retryText
+            } catch {
+                // Cancellation is never converted into an exhausted-fallback
+                // failure or into text for insertion.
+                if Task.isCancelled {
+                    throw CancellationError()
+                }
+                if Self.isCancellation(error) {
+                    throw error
+                }
+                let failure = LLMFallbackAttemptFailure(
+                    providerId: retryProviderId,
+                    modelId: candidate.modelId,
+                    effortId: candidate.effortId,
+                    reason: Self.failureReason(for: error)
+                )
+                failures.append(failure)
+                logger.warning("Empty-confirmation retry failed for \(retryProviderId, privacy: .public): \(failure.reason, privacy: .private(mask: .hash))")
             }
         }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -1415,12 +1415,14 @@ final class OpenAICompatiblePlugin: NSObject,
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
               let first = choices.first,
-              let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let message = first["message"] as? [String: Any] else {
             throw PluginChatError.apiError("Failed to parse response")
         }
 
-        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Reasoning models return `content: null` or typed parts for an empty
+        // visible answer; the shared helper treats those as valid, not malformed.
+        return PluginOpenAIChatHelper.chatMessageContent(from: message)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func processResponse(

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -408,12 +408,14 @@ final class OpenRouterPlugin: NSObject,
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
               let first = choices.first,
-              let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let message = first["message"] as? [String: Any] else {
             throw PluginChatError.apiError("Failed to parse response")
         }
 
-        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Reasoning models on OpenRouter (gpt-5.x, gpt-oss) return `content: null`
+        // or an array of typed parts; the shared helper treats those as valid.
+        return PluginOpenAIChatHelper.chatMessageContent(from: message)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -1269,12 +1269,30 @@ public struct PluginOpenAIChatHelper: Sendable {
         guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let choices = json["choices"] as? [[String: Any]],
               let first = choices.first,
-              let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
+              let message = first["message"] as? [String: Any] else {
             throw PluginChatError.apiError("Failed to parse response")
         }
 
-        return content.trimmingCharacters(in: .whitespacesAndNewlines)
+        return Self.chatMessageContent(from: message).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Extracts assistant text from an OpenAI-compatible chat `message`.
+    /// Reasoning-capable models (e.g. gpt-oss on Cerebras, some OpenRouter
+    /// models) return `content: null` when the visible answer is empty - that
+    /// is a valid empty response, not a malformed one. Some providers also
+    /// return `content` as an array of typed parts. Reasoning text is never
+    /// promoted to content.
+    static func chatMessageContent(from message: [String: Any]) -> String {
+        if let text = message["content"] as? String {
+            return text
+        }
+        if let parts = message["content"] as? [[String: Any]] {
+            return parts.compactMap { part in
+                (part["text"] as? String) ?? ((part["type"] as? String) == "text" ? part["content"] as? String : nil)
+            }.joined()
+        }
+        // null or absent content: an intentionally empty visible answer
+        return ""
     }
 
     public func process(

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -1282,7 +1282,7 @@ public struct PluginOpenAIChatHelper: Sendable {
     /// is a valid empty response, not a malformed one. Some providers also
     /// return `content` as an array of typed parts. Reasoning text is never
     /// promoted to content.
-    static func chatMessageContent(from message: [String: Any]) -> String {
+    public static func chatMessageContent(from message: [String: Any]) -> String {
         if let text = message["content"] as? String {
             return text
         }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -1287,8 +1287,12 @@ public struct PluginOpenAIChatHelper: Sendable {
             return text
         }
         if let parts = message["content"] as? [[String: Any]] {
-            return parts.compactMap { part in
-                (part["text"] as? String) ?? ((part["type"] as? String) == "text" ? part["content"] as? String : nil)
+            // Only typed text parts contribute. A `reasoning` (or any other
+            // typed) part may also carry a `text` field and must never be
+            // promoted into the visible answer.
+            return parts.compactMap { part -> String? in
+                guard (part["type"] as? String) == "text" else { return nil }
+                return (part["text"] as? String) ?? (part["content"] as? String)
             }.joined()
         }
         // null or absent content: an intentionally empty visible answer

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
@@ -200,4 +200,37 @@ final class OpenAIChatHelperTests: XCTestCase {
 
         XCTAssertEqual(message, "Something went wrong")
     }
+    func testChatMessageContentReadsPlainString() {
+        XCTAssertEqual(
+            PluginOpenAIChatHelper.chatMessageContent(from: ["content": "hello"]),
+            "hello"
+        )
+    }
+
+    func testChatMessageContentTreatsNullContentAsEmptyAnswer() {
+        // Reasoning-capable models return content: null when the visible answer
+        // is empty - a valid empty response, previously "Failed to parse response".
+        XCTAssertEqual(
+            PluginOpenAIChatHelper.chatMessageContent(from: ["content": NSNull(), "reasoning": "thinking..."]),
+            ""
+        )
+        XCTAssertEqual(
+            PluginOpenAIChatHelper.chatMessageContent(from: ["role": "assistant"]),
+            ""
+        )
+    }
+
+    func testChatMessageContentJoinsTypedContentParts() {
+        let message: [String: Any] = ["content": [
+            ["type": "text", "text": "Hello "],
+            ["type": "text", "text": "world"],
+        ]]
+        XCTAssertEqual(PluginOpenAIChatHelper.chatMessageContent(from: message), "Hello world")
+    }
+
+    func testChatMessageContentDoesNotPromoteReasoningText() {
+        let message: [String: Any] = ["content": NSNull(), "reasoning_content": "chain of thought"]
+        XCTAssertEqual(PluginOpenAIChatHelper.chatMessageContent(from: message), "")
+    }
+
 }

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAIChatHelperTests.swift
@@ -233,4 +233,15 @@ final class OpenAIChatHelperTests: XCTestCase {
         XCTAssertEqual(PluginOpenAIChatHelper.chatMessageContent(from: message), "")
     }
 
+    func testChatMessageContentIgnoresTypedReasoningPartsEvenWhenTheyCarryText() {
+        let message: [String: Any] = ["content": [
+            ["type": "reasoning", "text": "let me think"],
+            ["type": "text", "text": "Answer"],
+            ["type": "reasoning", "content": "more thinking"],
+            ["type": "text", "content": " two"],
+            ["text": "untyped part is not promoted"],
+        ]]
+        XCTAssertEqual(PluginOpenAIChatHelper.chatMessageContent(from: message), "Answer two")
+    }
+
 }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -8980,6 +8980,33 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testMixedFailuresWithLoneEmptyOpinionConfirmedByRetry() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // One provider answers "empty", the rest fail with infrastructure errors
+        // that carry no opinion about the content. The lone empty opinion is
+        // confirmed by re-running its provider; empty twice is intent.
+        let emptyProvider = MockLLMProviderPlugin()
+        emptyProvider.configuredProviderId = "empty-opinion"
+        emptyProvider.queuedProcessOutcomes = [.response(""), .response("")]
+        let broken = MockLLMProviderPlugin()
+        broken.configuredProviderId = "broken-parse"
+        broken.queuedProcessOutcomes = [.apiFailure("Failed to parse response")]
+
+        Self.installLLMFallbackTestProviders([emptyProvider, broken], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+        service.addLLMFallback(providerId: emptyProvider.providerId)
+        service.addLLMFallback(providerId: broken.providerId)
+
+        let result = try await service.process(prompt: "Strip artifacts", text: "Thank you for watching!")
+        XCTAssertEqual(result, "")
+        XCTAssertEqual(emptyProvider.processCallCount, 2)
+    }
+
+    @MainActor
     func testExplicitWorkflowProviderAcceptsEmptyOutputConfirmedByRetry() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -8980,6 +8980,57 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testExplicitWorkflowProviderAcceptsEmptyOutputConfirmedByRetry() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // An explicit workflow provider bypasses the global fallback list, so an
+        // intentional empty result (artifact-only transcript stripped by the
+        // workflow's instructions) is confirmed by re-running the same provider.
+        let explicit = MockLLMProviderPlugin()
+        explicit.configuredProviderId = "explicit-empty"
+        explicit.queuedProcessOutcomes = [.response(""), .response("  \n")]
+
+        Self.installLLMFallbackTestProviders([explicit], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+
+        let result = try await service.processWorkflow(
+            prompt: "Strip artifacts",
+            text: "Thank you for watching!",
+            behavior: WorkflowBehavior(providerId: explicit.providerId)
+        )
+        XCTAssertEqual(result, "")
+        XCTAssertEqual(explicit.processCallCount, 2)
+    }
+
+    @MainActor
+    func testExplicitWorkflowProviderRecoversWhenRetryReturnsContent() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // A lone empty from a glitching provider must not discard content when
+        // the confirmation retry produces a real result.
+        let flaky = MockLLMProviderPlugin()
+        flaky.configuredProviderId = "flaky-empty"
+        flaky.queuedProcessOutcomes = [.response(""), .response("recovered text")]
+
+        Self.installLLMFallbackTestProviders([flaky], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+
+        let result = try await service.processWorkflow(
+            prompt: "Fix grammar",
+            text: "hello world",
+            behavior: WorkflowBehavior(providerId: flaky.providerId)
+        )
+        XCTAssertEqual(result, "recovered text")
+        XCTAssertEqual(flaky.processCallCount, 2)
+    }
+
+    @MainActor
     func testPromptProcessingStillFailsOnSingleEmptyOutput() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -8953,6 +8953,59 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testPromptProcessingAcceptsEmptyOutputWhenMultipleProvidersAgree() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // The processing prompt may legitimately reduce the input to nothing
+        // (e.g. a silence-hallucination artifact the user's instructions strip).
+        // When independent providers agree on empty, that is the intended
+        // output, not a malfunction to fail over from.
+        let emptyOne = MockLLMProviderPlugin()
+        emptyOne.configuredProviderId = "empty-one"
+        emptyOne.queuedProcessOutcomes = [.response("")]
+        let emptyTwo = MockLLMProviderPlugin()
+        emptyTwo.configuredProviderId = "empty-two"
+        emptyTwo.queuedProcessOutcomes = [.response("  \n")]
+
+        Self.installLLMFallbackTestProviders([emptyOne, emptyTwo], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+        service.addLLMFallback(providerId: emptyOne.providerId)
+        service.addLLMFallback(providerId: emptyTwo.providerId)
+
+        let result = try await service.process(prompt: "Strip artifacts", text: "Thank you for watching!")
+        XCTAssertEqual(result, "")
+    }
+
+    @MainActor
+    func testPromptProcessingStillFailsOnSingleEmptyOutput() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // One provider glitching to empty must keep the protective failure
+        // semantics — otherwise a model malfunction silently discards content.
+        let emptyOnly = MockLLMProviderPlugin()
+        emptyOnly.configuredProviderId = "empty-only"
+        emptyOnly.queuedProcessOutcomes = [.response("")]
+
+        Self.installLLMFallbackTestProviders([emptyOnly], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+        service.addLLMFallback(providerId: emptyOnly.providerId)
+
+        do {
+            _ = try await service.process(prompt: "Fix grammar", text: "hello world")
+            XCTFail("A single empty attempt must still fail")
+        } catch let error as LLMFallbackExhaustedError {
+            XCTAssertEqual(error.failures.count, 1)
+            XCTAssertTrue(error.failures[0].reason.contains("empty"))
+        }
+    }
+
+    @MainActor
     func testExplicitWorkflowProviderDoesNotCallGlobalFallbackList() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -9007,6 +9007,79 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testTwoEmptyModelsOfTheSameProviderAreNotConsensus() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        // The fallback list may carry several models of one provider. One plugin
+        // deterministically answering empty twice is a single opinion, so real
+        // text must not be discarded on its say-so alone.
+        let provider = MockLLMProviderPlugin()
+        provider.configuredProviderId = "single-plugin"
+        provider.models = [
+            PluginModelInfo(id: "model-a", displayName: "Model A"),
+            PluginModelInfo(id: "model-b", displayName: "Model B"),
+        ]
+        provider.queuedProcessOutcomes = [.response(""), .response("")]
+
+        Self.installLLMFallbackTestProviders([provider], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+        service.addLLMFallback(providerId: provider.providerId, modelId: "model-a")
+        service.addLLMFallback(providerId: provider.providerId, modelId: "model-b")
+
+        do {
+            _ = try await service.process(prompt: "Fix grammar", text: "hello world")
+            XCTFail("Two empty answers from one provider must not count as consensus")
+        } catch let error as LLMFallbackExhaustedError {
+            XCTAssertEqual(error.failures.count, 2)
+            XCTAssertTrue(error.failures.allSatisfy { $0.reason.contains("empty") })
+        }
+        XCTAssertEqual(provider.processCallCount, 2, "no confirmation retry when every attempt was the same provider")
+    }
+
+    @MainActor
+    func testMixedOutcomeConfirmationRetryPreservesCancellation() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        defer { TestSupport.remove(appSupportDirectory) }
+        let isolatedDefaults = Self.makeEmptyLLMFallbackDefaults()
+        defer { isolatedDefaults.defaults.removePersistentDomain(forName: isolatedDefaults.suiteName) }
+
+        let emptyProvider = MockLLMProviderPlugin()
+        emptyProvider.configuredProviderId = "empty-opinion"
+        // First call answers empty, the confirmation retry hangs until cancelled.
+        emptyProvider.queuedProcessOutcomes = [.response(""), .waitForCancellation]
+        let broken = MockLLMProviderPlugin()
+        broken.configuredProviderId = "broken-parse"
+        broken.queuedProcessOutcomes = [.apiFailure("Failed to parse response")]
+
+        Self.installLLMFallbackTestProviders([emptyProvider, broken], appSupportDirectory: appSupportDirectory)
+        let service = PromptProcessingService(userDefaults: isolatedDefaults.defaults)
+        service.addLLMFallback(providerId: emptyProvider.providerId)
+        service.addLLMFallback(providerId: broken.providerId)
+
+        let processing = Task { @MainActor in
+            try await service.process(prompt: "Strip artifacts", text: "Thank you for watching!")
+        }
+        let deadline = ContinuousClock.now + .seconds(5)
+        while emptyProvider.processCallCount < 2, ContinuousClock.now < deadline {
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(emptyProvider.processCallCount, 2, "the confirmation retry must be in flight")
+        processing.cancel()
+
+        do {
+            let text = try await processing.value
+            XCTFail("A cancelled confirmation retry must not produce text for insertion (got \(text.debugDescription))")
+        } catch is CancellationError {
+            // expected
+        } catch let error as LLMFallbackExhaustedError {
+            XCTFail("Cancellation must not be reported as exhausted fallbacks: \(error)")
+        }
+    }
+
+    @MainActor
     func testExplicitWorkflowProviderAcceptsEmptyOutputConfirmedByRetry() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         defer { TestSupport.remove(appSupportDirectory) }


### PR DESCRIPTION
## Summary

Fixes #1233. An empty LLM result is unconditionally treated as a failed attempt (`LLMFallbackAttemptError.emptyResult`), so a processing prompt that *intentionally* reduces its input to nothing — e.g. stripping a silence-hallucination artifact like "Thank you for watching!" — walks the entire fallback chain, every provider "failing" with the same empty answer, and surfaces as a post-processing failure: error toast plus the raw hallucination inserted as fallback text.

Change: track empty-result attempts in the fallback walk. When **two or more** providers each ran successfully and independently returned empty (and nothing failed any other way), return `""` as the intended output instead of throwing `LLMFallbackExhaustedError`. A **single** empty attempt keeps the existing protective failure semantics, since one provider glitching to empty would otherwise silently discard real content. Downstream already handles empty final text gracefully (nothing inserted, auto-enter suppressed).

Side benefit: this removes the deterministic error-toast path that (on my machine) reliably feeds the display-cycle crash in #1229 when a new dictation starts while the toast is animating.

Closes #1233

## Test Plan

Two new tests in `TypeWhisperIntegrationTests`: `testPromptProcessingAcceptsEmptyOutputWhenMultipleProvidersAgree` (two mock providers returning ""/whitespace → `process` returns "" without throwing) and `testPromptProcessingStillFailsOnSingleEmptyOutput` (one empty attempt still throws `LLMFallbackExhaustedError`). Existing `testPromptProcessingReportsAggregateErrorAfterFallbackListExhaustion` unchanged and green.

```
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

226 tests, 0 failures. Also running this as my daily build (Groq → Cerebras → OpenRouter chain); silent dictations now end quietly instead of pasting "Thank you for watching!" with an error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty AI responses by requiring agreement from distinct providers.
  * A single provider’s empty response is confirmed with a retry when appropriate.
  * Cancellation during confirmation now propagates correctly.
  * Improved compatibility with null, missing, and typed chat content.
  * Reasoning-only content is no longer displayed as answer text; only visible text parts are shown.

* **Tests**
  * Added coverage for provider consensus, retries, cancellation, and varied chat response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->