### PR TITLE
Keep dictation insertion pinned to the original field

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -27743,24 +27743,24 @@
         }
       }
     },
-    "Supported text fields are updated while you speak. TypeWhisper inserts the final transcript normally when direct updates are unavailable." : {
+    "Supported text fields are updated while you speak. The field focused when recording starts remains the final insertion target, including apps that require paste. If it can no longer be restored safely, the final transcript remains in Recent Transcriptions." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unterstützte Textfelder werden während des Sprechens aktualisiert. Wenn direkte Aktualisierungen nicht verfügbar sind, fügt TypeWhisper das endgültige Transkript wie gewohnt ein."
+            "value" : "Unterstützte Textfelder werden während des Sprechens aktualisiert. Das beim Aufnahmestart fokussierte Feld bleibt das endgültige Einfügeziel – auch in Apps, die Einfügen benötigen. Wenn es nicht mehr sicher wiederhergestellt werden kann, bleibt das endgültige Transkript unter „Letzte Transkriptionen“ verfügbar."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "対応するテキストフィールドは話している間に更新されます。直接更新できない場合、TypeWhisperは最終的な文字起こしを通常どおり挿入します。"
+            "value" : "対応するテキストフィールドは話している間に更新されます。録音開始時にフォーカスされていたフィールドは、ペーストが必要なアプリでも最終的な挿入先として維持されます。安全に復元できなくなった場合、最終的な文字起こしは「最近の文字起こし」に残ります。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "支持的文本字段会在您说话时更新。无法直接更新时，TypeWhisper 会照常插入最终转录。"
+            "value" : "支持的文本字段会在您说话时更新。录音开始时聚焦的字段会保持为最终插入目标，包括需要粘贴的应用。如果无法再安全恢复该字段，最终转录会保留在“最近的转录”中。"
           }
         }
       }

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -153,41 +153,6 @@ final class ChromiumAccessibilityObservationController {
     }
 }
 
-private final class LiveFieldApplicationActivationObservation: @unchecked Sendable {
-    private let notificationCenter: NotificationCenter
-    private let token: NSObjectProtocol
-
-    init(notificationCenter: NotificationCenter, token: NSObjectProtocol) {
-        self.notificationCenter = notificationCenter
-        self.token = token
-    }
-
-    deinit {
-        notificationCenter.removeObserver(token)
-    }
-}
-
-private func installLiveFieldApplicationActivationObserver(
-    onActivation: @escaping @MainActor (String?) -> Void
-) -> LiveFieldApplicationActivationObservation {
-    let notificationCenter = NSWorkspace.shared.notificationCenter
-    let token = notificationCenter.addObserver(
-        forName: NSWorkspace.didActivateApplicationNotification,
-        object: nil,
-        queue: .main
-    ) { notification in
-        let application = notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
-        let bundleIdentifier = application?.bundleIdentifier
-        Task { @MainActor in
-            onActivation(bundleIdentifier)
-        }
-    }
-    return LiveFieldApplicationActivationObservation(
-        notificationCenter: notificationCenter,
-        token: token
-    )
-}
-
 /// Inserts transcribed text into the active application via clipboard + simulated Cmd+V.
 @MainActor
 final class TextInsertionService {
@@ -227,6 +192,11 @@ final class TextInsertionService {
     var liveFieldTargetEligibilityOverride: ((AXUIElement) -> Bool)?
     var liveFieldApplicationEligibilityOverride: ((String) -> Bool)?
     var liveFieldElectronApplicationOverride: ((String) -> Bool)?
+    var liveFieldElementProcessIdentifierOverride: ((AXUIElement) -> pid_t?)?
+    var liveFieldApplicationMetadataOverride: ((pid_t) -> (name: String?, bundleId: String?, url: String?)?)?
+    var liveFieldApplicationValidationOverride: ((pid_t, String) -> Bool)?
+    var activatePinnedTargetApplicationOverride: ((pid_t) -> Bool)?
+    var focusPinnedTargetElementOverride: ((AXUIElement) -> Bool)?
     var chromiumAccessibilityObservationOverride: ((String?) -> TargetAppAccessibilityObservationLease?)?
     var setMessagingTimeoutOverride: ((AXUIElement, Float) -> Void)?
     var setSelectedRangeOverride: ((AXUIElement, NSRange) -> Bool)?
@@ -320,6 +290,11 @@ final class TextInsertionService {
         )
     }
 
+    func beginFocusedApplicationAccessibilityObservation() -> TargetAppAccessibilityObservationLease? {
+        let bundleIdentifier = captureActiveApp().bundleId
+        return beginChromiumAccessibilityObservation(bundleIdentifier: bundleIdentifier)
+    }
+
     func resolveBrowserURL(bundleId: String) async -> String? {
         await browserURLResolver.activeURL(for: bundleId)?.absoluteString
     }
@@ -392,6 +367,7 @@ final class TextInsertionService {
 
     struct LiveFieldTarget: @unchecked Sendable {
         let applicationBundleIdentifier: String
+        let applicationProcessIdentifier: pid_t
         fileprivate var element: AXUIElement
         let originalInsertionContext: InsertionContext
         fileprivate var expectedValue: String
@@ -403,6 +379,20 @@ final class TextInsertionService {
         var hasProvisionalText: Bool {
             !provisionalText.isEmpty
         }
+    }
+
+    struct PinnedInsertionTarget: @unchecked Sendable {
+        let applicationBundleIdentifier: String
+        let applicationProcessIdentifier: pid_t
+        fileprivate let element: AXUIElement
+        fileprivate let window: AXUIElement?
+        let originalInsertionContext: InsertionContext?
+    }
+
+    struct LiveFieldRecordingRequestCapture: @unchecked Sendable {
+        let activeApp: (name: String?, bundleId: String?, url: String?)
+        let pinnedTarget: PinnedInsertionTarget
+        let liveFieldTarget: LiveFieldTarget?
     }
 
     enum LiveFieldMutationResult {
@@ -579,6 +569,80 @@ final class TextInsertionService {
             logger.debug("Live field target rejected: no readable focused text element")
             return nil
         }
+        return makeLiveFieldTarget(
+            from: state,
+            applicationBundleIdentifier: expectedBundleIdentifier
+        )
+    }
+
+    /// Pins the focused AX element without running the slower active-app context
+    /// lookup. The full app and URL context is still captured after audio starts.
+    func captureLiveFieldTargetAtRecordingRequest() -> LiveFieldRecordingRequestCapture? {
+        guard isAccessibilityGranted else {
+            logger.debug("Live field target rejected: Accessibility is not granted")
+            return nil
+        }
+        guard let state = captureFocusedTextState(
+            messagingTimeout: Self.liveFieldMessagingTimeout
+        ) else {
+            logger.debug("Live field target rejected: no readable focused text element")
+            return nil
+        }
+        guard let processIdentifier = liveFieldProcessIdentifier(for: state.element),
+              let activeApp = liveFieldApplicationMetadata(for: processIdentifier),
+              let bundleIdentifier = activeApp.bundleId else {
+            logger.debug("Live field target rejected: focused element has no running application")
+            return nil
+        }
+        guard !isSecureTextElement(state.element) else {
+            logger.debug("Pinned insertion target rejected: focused element is secure")
+            return nil
+        }
+
+        let pinnedTarget = PinnedInsertionTarget(
+            applicationBundleIdentifier: bundleIdentifier,
+            applicationProcessIdentifier: processIdentifier,
+            element: state.element,
+            window: axElementAttribute(kAXWindowAttribute as CFString, from: state.element),
+            originalInsertionContext: pinnedInsertionContext(from: state)
+        )
+        let liveFieldTarget = applicationSupportsVerifiedLiveFieldUpdates(bundleIdentifier)
+            ? makeLiveFieldTarget(
+                from: state,
+                applicationBundleIdentifier: bundleIdentifier,
+                processIdentifier: processIdentifier
+            )
+            : nil
+        logger.info(
+            "Pinned insertion target captured: bundle=\(bundleIdentifier, privacy: .public), liveUpdates=\(liveFieldTarget != nil, privacy: .public)"
+        )
+        return LiveFieldRecordingRequestCapture(
+            activeApp: activeApp,
+            pinnedTarget: pinnedTarget,
+            liveFieldTarget: liveFieldTarget
+        )
+    }
+
+    private func pinnedInsertionContext(from state: FocusedTextState) -> InsertionContext? {
+        guard let value = state.value,
+              let selectedRange = state.selectedRange,
+              selectedRange.length == 0,
+              state.selectedText?.isEmpty != false,
+              Range(selectedRange, in: value) != nil else {
+            return nil
+        }
+        return insertionContext(
+            value: value,
+            selectedText: state.selectedText,
+            selectedRange: selectedRange
+        )
+    }
+
+    private func makeLiveFieldTarget(
+        from state: FocusedTextState,
+        applicationBundleIdentifier: String,
+        processIdentifier knownProcessIdentifier: pid_t? = nil
+    ) -> LiveFieldTarget? {
         guard let value = state.value else {
             logger.debug("Live field target rejected: focused element has no readable value")
             return nil
@@ -600,6 +664,11 @@ final class TextInsertionService {
             logger.debug("Live field target rejected: focused element is not eligible")
             return nil
         }
+        guard let processIdentifier = knownProcessIdentifier
+            ?? liveFieldProcessIdentifier(for: state.element) else {
+            logger.debug("Live field target rejected: focused element has no owning process")
+            return nil
+        }
 
         let insertionContext = insertionContext(
             value: value,
@@ -607,7 +676,8 @@ final class TextInsertionService {
             selectedRange: selectedRange
         )
         return LiveFieldTarget(
-            applicationBundleIdentifier: expectedBundleIdentifier,
+            applicationBundleIdentifier: applicationBundleIdentifier,
+            applicationProcessIdentifier: processIdentifier,
             element: state.element,
             originalInsertionContext: insertionContext,
             expectedValue: value,
@@ -628,6 +698,8 @@ final class TextInsertionService {
         if text == target.provisionalText {
             return .applied(observation(from: currentState))
         }
+
+        let targetWasFocused = liveFieldTargetIsFocused(target)
 
         let expectedValue = (target.expectedValue as NSString).replacingCharacters(
             in: target.ownedRange,
@@ -651,29 +723,44 @@ final class TextInsertionService {
             return .detached
         }
 
+        if targetWasFocused,
+           !liveFieldTarget(
+                target.element,
+                hasValue: expectedValue,
+                caret: expectedCaret
+           ) {
+            rebindLiveFieldTargetIfNeeded(
+                &target,
+                expectedValue: expectedValue,
+                expectedCaret: expectedCaret
+            )
+        }
+
         if var resultingState = captureFocusedTextState(
+            for: target.element,
             messagingTimeout: Self.liveFieldMessagingTimeout
         ),
-           captureActiveApp().bundleId == target.applicationBundleIdentifier,
            resultingState.value == expectedValue,
            resultingState.selectedRange != expectedCaret {
-            _ = setSelectedRange(expectedCaret, on: resultingState.element)
+            _ = setSelectedRange(expectedCaret, on: target.element)
             resultingState = captureFocusedTextState(
+                for: target.element,
                 messagingTimeout: Self.liveFieldMessagingTimeout
             ) ?? resultingState
         }
 
-        guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
+        guard liveFieldApplicationIsValid(for: target),
               let resultingState = captureFocusedTextState(
+                for: target.element,
                 messagingTimeout: Self.liveFieldMessagingTimeout
               ),
               resultingState.value == expectedValue,
               resultingState.selectedRange == expectedCaret,
               resultingState.selectedText?.isEmpty != false,
-              resultingState.element == target.element
-                || isEligibleLiveFieldTarget(resultingState.element) else {
+              resultingState.element == target.element else {
             _ = setSelectedRange(target.expectedCaret, on: target.element)
             if let unchangedState = captureFocusedTextState(
+                for: target.element,
                 messagingTimeout: Self.liveFieldMessagingTimeout
             ),
                unchangedState.element == target.element,
@@ -1240,6 +1327,17 @@ final class TextInsertionService {
         return (value as! AXUIElement)
     }
 
+    private func axElementAttribute(
+        _ attribute: CFString,
+        from element: AXUIElement
+    ) -> AXUIElement? {
+        var value: AnyObject?
+        guard AXUIElementCopyAttributeValue(element, attribute, &value) == .success else {
+            return nil
+        }
+        return axElement(from: value)
+    }
+
     private func selectedTextFromFocusedState(for element: AXUIElement) -> String? {
         if let selectedRangesText = selectedTextFromSelectedTextRangesAttribute(for: element) {
             return selectedRangesText
@@ -1407,8 +1505,11 @@ final class TextInsertionService {
     }
 
     private func verifiedLiveFieldState(for target: inout LiveFieldTarget) -> FocusedTextState? {
-        guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
-              let state = captureFocusedTextState(
+        guard liveFieldApplicationIsValid(for: target) else {
+            return nil
+        }
+        guard let state = captureFocusedTextState(
+                for: target.element,
                 messagingTimeout: Self.liveFieldMessagingTimeout
               ),
               state.value == target.expectedValue,
@@ -1416,22 +1517,220 @@ final class TextInsertionService {
               state.selectedText?.isEmpty != false else {
             return nil
         }
-
-        if state.element != target.element {
-            guard target.hasProvisionalText,
-                  isEligibleLiveFieldTarget(state.element),
-                  (target.expectedValue as NSString).substring(with: target.ownedRange)
-                    == target.provisionalText else {
-                return nil
-            }
-            target.element = state.element
-        }
         return FocusedTextState(
-            element: state.element,
+            element: target.element,
             value: target.expectedValue,
             selectedText: nil,
             selectedRange: target.expectedCaret
         )
+    }
+
+    private func liveFieldTarget(
+        _ element: AXUIElement,
+        hasValue expectedValue: String,
+        caret expectedCaret: NSRange
+    ) -> Bool {
+        guard let state = captureFocusedTextState(
+            for: element,
+            messagingTimeout: Self.liveFieldMessagingTimeout
+        ) else {
+            return false
+        }
+        return state.value == expectedValue
+            && state.selectedRange == expectedCaret
+            && state.selectedText?.isEmpty != false
+    }
+
+    private func rebindLiveFieldTargetIfNeeded(
+        _ target: inout LiveFieldTarget,
+        expectedValue: String,
+        expectedCaret: NSRange
+    ) {
+        guard captureActiveApp().bundleId == target.applicationBundleIdentifier,
+              let focusedElement = getFocusedTextElement(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+              ),
+              focusedElement != target.element,
+              liveFieldProcessIdentifier(for: focusedElement)
+                == target.applicationProcessIdentifier,
+              isEligibleLiveFieldTarget(focusedElement),
+              let focusedState = captureFocusedTextState(
+                for: focusedElement,
+                messagingTimeout: Self.liveFieldMessagingTimeout
+              ),
+              focusedState.value == expectedValue,
+              focusedState.selectedRange == expectedCaret,
+              focusedState.selectedText?.isEmpty != false else {
+            return
+        }
+        target.element = focusedElement
+    }
+
+    func liveFieldTargetIsFocused(_ target: LiveFieldTarget) -> Bool {
+        liveFieldTargetIsFocused(
+            target,
+            knownActiveBundleIdentifier: captureActiveApp().bundleId
+        )
+    }
+
+    func liveFieldTargetIsFocused(
+        _ target: LiveFieldTarget,
+        knownActiveBundleIdentifier: String?
+    ) -> Bool {
+        guard liveFieldApplicationIsValid(for: target),
+              knownActiveBundleIdentifier == target.applicationBundleIdentifier,
+              let focusedElement = getFocusedTextElement(
+                messagingTimeout: Self.liveFieldMessagingTimeout
+              ),
+              focusedElement == target.element else {
+            return false
+        }
+        return true
+    }
+
+    func pinnedInsertionTargetIsFocused(_ target: PinnedInsertionTarget) -> Bool {
+        pinnedInsertionTargetIsFocused(
+            target,
+            knownActiveBundleIdentifier: captureActiveApp().bundleId
+        )
+    }
+
+    func pinnedInsertionTargetIsFocused(
+        _ target: PinnedInsertionTarget,
+        knownActiveBundleIdentifier: String?
+    ) -> Bool {
+        guard liveFieldApplicationIsValid(
+            processIdentifier: target.applicationProcessIdentifier,
+            bundleIdentifier: target.applicationBundleIdentifier
+        ),
+        knownActiveBundleIdentifier == target.applicationBundleIdentifier,
+        let focusedElement = getFocusedTextElement(
+            messagingTimeout: Self.liveFieldMessagingTimeout
+        ) else {
+            return false
+        }
+        return focusedElement == target.element
+    }
+
+    func focusPinnedInsertionTarget(_ target: PinnedInsertionTarget) async -> Bool {
+        if pinnedInsertionTargetIsFocused(target) {
+            return true
+        }
+        guard liveFieldApplicationIsValid(
+            processIdentifier: target.applicationProcessIdentifier,
+            bundleIdentifier: target.applicationBundleIdentifier
+        ),
+        activatePinnedTargetApplication(target.applicationProcessIdentifier) else {
+            logger.info("Pinned insertion target activation failed")
+            return false
+        }
+
+        for attempt in 0..<5 {
+            if let window = target.window {
+                _ = AXUIElementPerformAction(window, kAXRaiseAction as CFString)
+                _ = AXUIElementSetAttributeValue(
+                    window,
+                    kAXMainAttribute as CFString,
+                    kCFBooleanTrue
+                )
+            }
+            _ = focusPinnedTargetElement(target.element)
+
+            if pinnedInsertionTargetIsFocused(target) {
+                logger.info("Pinned insertion target restored on attempt \(attempt + 1, privacy: .public)")
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(40))
+        }
+
+        logger.info("Pinned insertion target could not be restored safely")
+        return false
+    }
+
+    private func activatePinnedTargetApplication(_ processIdentifier: pid_t) -> Bool {
+        if let activatePinnedTargetApplicationOverride {
+            return activatePinnedTargetApplicationOverride(processIdentifier)
+        }
+        guard let application = NSRunningApplication(processIdentifier: processIdentifier),
+              !application.isTerminated else {
+            return false
+        }
+        if let sourceApplication = NSWorkspace.shared.frontmostApplication,
+           sourceApplication.processIdentifier != processIdentifier,
+           application.activate(from: sourceApplication) {
+            return true
+        }
+        return application.activate()
+    }
+
+    private func focusPinnedTargetElement(_ element: AXUIElement) -> Bool {
+        if let focusPinnedTargetElementOverride {
+            return focusPinnedTargetElementOverride(element)
+        }
+        return AXUIElementSetAttributeValue(
+            element,
+            kAXFocusedAttribute as CFString,
+            kCFBooleanTrue
+        ) == .success
+    }
+
+    private func liveFieldProcessIdentifier(for element: AXUIElement) -> pid_t? {
+        if let liveFieldElementProcessIdentifierOverride {
+            return liveFieldElementProcessIdentifierOverride(element)
+        }
+
+        var processIdentifier: pid_t = 0
+        guard AXUIElementGetPid(element, &processIdentifier) == .success,
+              processIdentifier > 0 else {
+            return nil
+        }
+        return processIdentifier
+    }
+
+    private func liveFieldApplicationMetadata(
+        for processIdentifier: pid_t
+    ) -> (name: String?, bundleId: String?, url: String?)? {
+        if let liveFieldApplicationMetadataOverride {
+            return liveFieldApplicationMetadataOverride(processIdentifier)
+        }
+
+        guard NSWorkspace.shared.frontmostApplication?.processIdentifier == processIdentifier,
+              let application = NSRunningApplication(processIdentifier: processIdentifier),
+              !application.isTerminated else {
+            return nil
+        }
+        return (
+            name: application.localizedName,
+            bundleId: application.bundleIdentifier,
+            url: nil
+        )
+    }
+
+    private func liveFieldApplicationIsValid(for target: LiveFieldTarget) -> Bool {
+        liveFieldApplicationIsValid(
+            processIdentifier: target.applicationProcessIdentifier,
+            bundleIdentifier: target.applicationBundleIdentifier
+        )
+    }
+
+    private func liveFieldApplicationIsValid(
+        processIdentifier: pid_t,
+        bundleIdentifier: String
+    ) -> Bool {
+        if let liveFieldApplicationValidationOverride {
+            return liveFieldApplicationValidationOverride(
+                processIdentifier,
+                bundleIdentifier
+            )
+        }
+
+        guard let application = NSRunningApplication(
+            processIdentifier: processIdentifier
+        ),
+        !application.isTerminated else {
+            return false
+        }
+        return application.bundleIdentifier == bundleIdentifier
     }
 
     private func applyMessagingTimeout(_ timeout: Float?, to element: AXUIElement) {
@@ -1511,6 +1810,18 @@ final class TextInsertionService {
             .contains(role)
     }
 
+    private func isSecureTextElement(_ element: AXUIElement) -> Bool {
+        var subroleValue: AnyObject?
+        guard AXUIElementCopyAttributeValue(
+            element,
+            kAXSubroleAttribute as CFString,
+            &subroleValue
+        ) == .success else {
+            return false
+        }
+        return (subroleValue as? String) == "AXSecureTextField"
+    }
+
     private func setSelectedRange(_ range: NSRange, on element: AXUIElement) -> Bool {
         if let setSelectedRangeOverride {
             return setSelectedRangeOverride(element, range)
@@ -1566,7 +1877,7 @@ final class LiveFieldTranscriptSession {
 
     enum CompletionResult {
         case applied(TextInsertionService.FocusedTextObservation)
-        case detached(hadAttemptedMutation: Bool)
+        case detached(hadAttemptedMutation: Bool, allowsFocusedFallback: Bool)
     }
 
     let sessionID: UUID
@@ -1577,7 +1888,6 @@ final class LiveFieldTranscriptSession {
     private let updateInterval: Duration
     private var pendingText: String?
     private var updateTask: Task<Void, Never>?
-    private var applicationActivationObservation: LiveFieldApplicationActivationObservation?
 
     init(
         sessionID: UUID,
@@ -1589,9 +1899,6 @@ final class LiveFieldTranscriptSession {
         self.target = target
         self.textInsertionService = textInsertionService
         self.updateInterval = updateInterval
-        self.applicationActivationObservation = installLiveFieldApplicationActivationObserver { [weak self] bundleIdentifier in
-            self?.handleApplicationActivation(bundleIdentifier: bundleIdentifier)
-        }
     }
 
     deinit {
@@ -1610,6 +1917,10 @@ final class LiveFieldTranscriptSession {
         target.hasProvisionalText
     }
 
+    var targetIsCurrentlyFocused: Bool {
+        textInsertionService.liveFieldTargetIsFocused(target)
+    }
+
     func receivePartial(_ text: String) {
         guard state == .active,
               !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -1623,7 +1934,7 @@ final class LiveFieldTranscriptSession {
     func finalize(with text: String) -> CompletionResult {
         cancelPendingUpdate()
         guard state == .active else {
-            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+            return detachedCompletionResult()
         }
 
         switch textInsertionService.replaceLiveFieldText(text, in: &target) {
@@ -1632,14 +1943,14 @@ final class LiveFieldTranscriptSession {
             return .applied(observation)
         case .detached:
             state = .detached
-            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+            return detachedCompletionResult()
         }
     }
 
     func cancel() -> CompletionResult {
         cancelPendingUpdate()
         guard state == .active else {
-            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+            return detachedCompletionResult()
         }
 
         switch textInsertionService.replaceLiveFieldText("", in: &target) {
@@ -1648,7 +1959,7 @@ final class LiveFieldTranscriptSession {
             return .applied(observation)
         case .detached:
             state = .detached
-            return .detached(hadAttemptedMutation: target.hasAttemptedMutation)
+            return detachedCompletionResult()
         }
     }
 
@@ -1672,6 +1983,10 @@ final class LiveFieldTranscriptSession {
         updateTask = nil
         guard state == .active, let pendingText else { return }
         self.pendingText = nil
+        guard targetIsCurrentlyFocused else {
+            logger.debug("Pausing live-field partial updates while the pinned target is not focused")
+            return
+        }
 
         switch textInsertionService.replaceLiveFieldText(pendingText, in: &target) {
         case .applied:
@@ -1690,12 +2005,10 @@ final class LiveFieldTranscriptSession {
         pendingText = nil
     }
 
-    private func handleApplicationActivation(bundleIdentifier: String?) {
-        guard state == .active,
-              bundleIdentifier != target.applicationBundleIdentifier else {
-            return
-        }
-        cancelPendingUpdate()
-        state = .detached
+    private func detachedCompletionResult() -> CompletionResult {
+        .detached(
+            hadAttemptedMutation: target.hasAttemptedMutation,
+            allowsFocusedFallback: textInsertionService.liveFieldTargetIsFocused(target)
+        )
     }
 }

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -205,6 +205,7 @@ final class TextInsertionService {
     var liveFieldTargetEligibilityOverride: ((AXUIElement) -> Bool)?
     var liveFieldApplicationEligibilityOverride: ((String) -> Bool)?
     var liveFieldElectronApplicationOverride: ((String) -> Bool)?
+    var secureTextElementOverride: ((AXUIElement) -> Bool)?
     var liveFieldElementProcessIdentifierOverride: ((AXUIElement) -> pid_t?)?
     var liveFieldApplicationMetadataOverride: ((pid_t) -> (name: String?, bundleId: String?, url: String?)?)?
     var liveFieldApplicationValidationOverride: ((pid_t, String) -> Bool)?
@@ -1578,6 +1579,7 @@ final class TextInsertionService {
               liveFieldProcessIdentifier(for: focusedElement)
                 == target.applicationProcessIdentifier,
               isEligibleLiveFieldTarget(focusedElement),
+              !isSecureTextElement(focusedElement),
               let focusedState = captureFocusedTextState(
                 for: focusedElement,
                 messagingTimeout: Self.liveFieldMessagingTimeout
@@ -1835,6 +1837,10 @@ final class TextInsertionService {
     }
 
     private func isSecureTextElement(_ element: AXUIElement) -> Bool {
+        if let secureTextElementOverride {
+            return secureTextElementOverride(element)
+        }
+
         var subroleValue: AnyObject?
         guard AXUIElementCopyAttributeValue(
             element,

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -667,6 +667,10 @@ final class TextInsertionService {
         applicationBundleIdentifier: String,
         processIdentifier knownProcessIdentifier: pid_t? = nil
     ) -> LiveFieldTarget? {
+        guard !isSecureTextElement(state.element) else {
+            logger.debug("Live field target rejected: focused element is secure")
+            return nil
+        }
         guard let value = state.value else {
             logger.debug("Live field target rejected: focused element has no readable value")
             return nil

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -689,7 +689,8 @@ final class TextInsertionService {
 
     func replaceLiveFieldText(
         _ text: String,
-        in target: inout LiveFieldTarget
+        in target: inout LiveFieldTarget,
+        knownTargetIsFocused: Bool? = nil
     ) -> LiveFieldMutationResult {
         guard let currentState = verifiedLiveFieldState(for: &target) else {
             return .detached
@@ -699,7 +700,7 @@ final class TextInsertionService {
             return .applied(observation(from: currentState))
         }
 
-        let targetWasFocused = liveFieldTargetIsFocused(target)
+        let targetWasFocused = knownTargetIsFocused ?? liveFieldTargetIsFocused(target)
 
         let expectedValue = (target.expectedValue as NSString).replacingCharacters(
             in: target.ownedRange,
@@ -1983,12 +1984,17 @@ final class LiveFieldTranscriptSession {
         updateTask = nil
         guard state == .active, let pendingText else { return }
         self.pendingText = nil
-        guard targetIsCurrentlyFocused else {
+        let targetIsFocused = targetIsCurrentlyFocused
+        guard targetIsFocused else {
             logger.debug("Pausing live-field partial updates while the pinned target is not focused")
             return
         }
 
-        switch textInsertionService.replaceLiveFieldText(pendingText, in: &target) {
+        switch textInsertionService.replaceLiveFieldText(
+            pendingText,
+            in: &target,
+            knownTargetIsFocused: targetIsFocused
+        ) {
         case .applied:
             if self.pendingText != nil {
                 schedulePendingUpdateIfNeeded()

--- a/TypeWhisper/Services/TextInsertionService.swift
+++ b/TypeWhisper/Services/TextInsertionService.swift
@@ -30,7 +30,7 @@ final class ChromiumAccessibilityObservationController {
         let bundleURL: URL
     }
 
-    typealias ResolveApplication = (String) -> RunningApplicationTarget?
+    typealias ResolveApplication = (String, pid_t?) -> RunningApplicationTarget?
     typealias IsElectronApplication = (URL) -> Bool
     typealias ReadManualAccessibility = (pid_t) -> (error: AXError, enabled: Bool?)
     typealias SetManualAccessibility = (pid_t, Bool) -> AXError
@@ -61,9 +61,12 @@ final class ChromiumAccessibilityObservationController {
         self.validateApplication = validateApplication ?? Self.isSameRunningApplication
     }
 
-    func beginObservation(bundleIdentifier: String?) -> TargetAppAccessibilityObservationLease? {
+    func beginObservation(
+        bundleIdentifier: String?,
+        processIdentifier: pid_t? = nil
+    ) -> TargetAppAccessibilityObservationLease? {
         guard let bundleIdentifier,
-              let target = resolveApplication(bundleIdentifier),
+              let target = resolveApplication(bundleIdentifier, processIdentifier),
               Self.chromiumBrowserBundleIdentifiers.contains(target.bundleIdentifier)
                 || isElectronApplicationAtURL(target.bundleURL) else {
             return nil
@@ -83,22 +86,32 @@ final class ChromiumAccessibilityObservationController {
     }
 
     func isElectronApplication(bundleIdentifier: String) -> Bool {
-        guard let target = resolveApplication(bundleIdentifier) else { return false }
+        guard let target = resolveApplication(bundleIdentifier, nil) else { return false }
         return isElectronApplicationAtURL(target.bundleURL)
     }
 
     private static func resolveRunningApplication(
-        bundleIdentifier: String
+        bundleIdentifier: String,
+        processIdentifier: pid_t?
     ) -> RunningApplicationTarget? {
-        let runningApplication = NSRunningApplication
-            .runningApplications(withBundleIdentifier: bundleIdentifier)
-            .first
-        let frontmostApplication = NSWorkspace.shared.frontmostApplication
-        let application = runningApplication
-            ?? (frontmostApplication?.bundleIdentifier == bundleIdentifier
-                ? frontmostApplication
-                : nil)
+        let application: NSRunningApplication?
+        if let processIdentifier {
+            let exactApplication = NSRunningApplication(processIdentifier: processIdentifier)
+            application = exactApplication?.bundleIdentifier == bundleIdentifier
+                ? exactApplication
+                : nil
+        } else {
+            let runningApplication = NSRunningApplication
+                .runningApplications(withBundleIdentifier: bundleIdentifier)
+                .first
+            let frontmostApplication = NSWorkspace.shared.frontmostApplication
+            application = runningApplication
+                ?? (frontmostApplication?.bundleIdentifier == bundleIdentifier
+                    ? frontmostApplication
+                    : nil)
+        }
         guard let application,
+              !application.isTerminated,
               let resolvedBundleIdentifier = application.bundleIdentifier,
               let bundleURL = application.bundleURL else {
             return nil
@@ -197,7 +210,8 @@ final class TextInsertionService {
     var liveFieldApplicationValidationOverride: ((pid_t, String) -> Bool)?
     var activatePinnedTargetApplicationOverride: ((pid_t) -> Bool)?
     var focusPinnedTargetElementOverride: ((AXUIElement) -> Bool)?
-    var chromiumAccessibilityObservationOverride: ((String?) -> TargetAppAccessibilityObservationLease?)?
+    var focusedApplicationProcessIdentifierOverride: (() -> pid_t?)?
+    var chromiumAccessibilityObservationOverride: ((String?, pid_t?) -> TargetAppAccessibilityObservationLease?)?
     var setMessagingTimeoutOverride: ((AXUIElement, Float) -> Void)?
     var setSelectedRangeOverride: ((AXUIElement, NSRange) -> Bool)?
     var textSelectionOverride: (() -> TextSelection?)?
@@ -280,19 +294,28 @@ final class TextInsertionService {
     }
 
     func beginChromiumAccessibilityObservation(
-        bundleIdentifier: String?
+        bundleIdentifier: String?,
+        processIdentifier: pid_t? = nil
     ) -> TargetAppAccessibilityObservationLease? {
         if let chromiumAccessibilityObservationOverride {
-            return chromiumAccessibilityObservationOverride(bundleIdentifier)
+            return chromiumAccessibilityObservationOverride(bundleIdentifier, processIdentifier)
         }
         return chromiumAccessibilityObservationController.beginObservation(
-            bundleIdentifier: bundleIdentifier
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: processIdentifier
         )
     }
 
     func beginFocusedApplicationAccessibilityObservation() -> TargetAppAccessibilityObservationLease? {
-        let bundleIdentifier = captureActiveApp().bundleId
-        return beginChromiumAccessibilityObservation(bundleIdentifier: bundleIdentifier)
+        let workspaceApplication = NSWorkspace.shared.frontmostApplication
+        let bundleIdentifier = captureActiveAppOverride?().bundleId
+            ?? workspaceApplication?.bundleIdentifier
+        let processIdentifier = focusedApplicationProcessIdentifierOverride?()
+            ?? (captureActiveAppOverride == nil ? workspaceApplication?.processIdentifier : nil)
+        return beginChromiumAccessibilityObservation(
+            bundleIdentifier: bundleIdentifier,
+            processIdentifier: processIdentifier
+        )
     }
 
     func resolveBrowserURL(bundleId: String) async -> String? {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1491,6 +1491,7 @@ final class DictationViewModel: ObservableObject {
     ) {
         clearRecordingStartCueState()
         clearDeferredRecordingContext()
+        endTargetAppAccessibilityObservation()
         restoreRecordingSideEffects()
         let errorMessage: String
         if let recordingError = error as? AudioRecordingService.AudioRecordingError,
@@ -2032,7 +2033,7 @@ final class DictationViewModel: ObservableObject {
                             .focusPinnedInsertionTarget(pinnedInsertionTarget)
                         if !shouldUseNormalInsertion {
                             showLiveFieldRecoveryFeedback()
-                            self.liveFieldTranscriptSession = nil
+                            cancelLiveFieldTranscriptSession()
                         }
                     }
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -366,6 +366,13 @@ final class DictationViewModel: ObservableObject {
     /// text is display-only and must never be promoted to the final transcription.
     private var lastPreviewFollowsDictationEngine = true
     private var liveFieldTranscriptSession: LiveFieldTranscriptSession?
+    private struct PendingLiveFieldCapture {
+        let activeApp: (name: String?, bundleId: String?, url: String?)
+        let pinnedTarget: TextInsertionService.PinnedInsertionTarget
+        let liveFieldTarget: TextInsertionService.LiveFieldTarget?
+    }
+    private var pendingLiveFieldCapture: PendingLiveFieldCapture?
+    private var pinnedInsertionTarget: TextInsertionService.PinnedInsertionTarget?
     private var isStopInFlight = false
     private var activeDictationSessionID: UUID?
     private var pendingHotkeyDictationStart: PendingHotkeyDictationStart?
@@ -962,6 +969,8 @@ final class DictationViewModel: ObservableObject {
         urlResolutionTask?.cancel()
         urlResolutionTask = nil
         lastStreamingParams = nil
+        pendingLiveFieldCapture = nil
+        pinnedInsertionTarget = nil
     }
 
     private func abortActiveRecordingImmediately(sessionMessage: String, preserveRecoveryAudio: Bool = false) {
@@ -1233,6 +1242,8 @@ final class DictationViewModel: ObservableObject {
         clearCancelWarning()
         pendingPushToTalkDiscardMessage = nil
         cancelLiveFieldTranscriptSession()
+        pendingLiveFieldCapture = nil
+        pinnedInsertionTarget = nil
         metadataCaptureTask?.cancel()
         metadataCaptureTask = nil
         urlResolutionTask?.cancel()
@@ -1262,6 +1273,8 @@ final class DictationViewModel: ObservableObject {
             hotkeyService.cancelDictation()
             return
         }
+
+        captureLiveFieldTargetAtRecordingRequestIfEligible()
 
         let resolvedInputSelection = audioDeviceService.resolvedRecordingInputSelection()
         let initialForcedWorkflow = forcedWorkflow(for: forcedWorkflowId)
@@ -1410,9 +1423,23 @@ final class DictationViewModel: ObservableObject {
         startRecordingTimer()
 
         let contextStartTimestamp = CFAbsoluteTimeGetCurrent()
-        // Match rule after the audio engine is live so app/context lookup does
-        // not delay capture of the user's first spoken words.
-        let activeApp = textInsertionService.captureActiveApp()
+        // Match the rule after the audio engine is live. When live-field insertion
+        // is enabled, reuse the target captured at the recording request so a slow
+        // microphone route cannot move the transcript to a newly focused field.
+        let liveFieldCapture = pendingLiveFieldCapture
+        pendingLiveFieldCapture = nil
+        let currentActiveApp = textInsertionService.captureActiveApp()
+        let activeApp: (name: String?, bundleId: String?, url: String?)
+        if let liveFieldCapture,
+           textInsertionService.pinnedInsertionTargetIsFocused(
+            liveFieldCapture.pinnedTarget,
+            knownActiveBundleIdentifier: currentActiveApp.bundleId
+           ) {
+            activeApp = currentActiveApp
+        } else {
+            activeApp = liveFieldCapture?.activeApp ?? currentActiveApp
+        }
+        pinnedInsertionTarget = liveFieldCapture?.pinnedTarget
         capturedActiveApp = activeApp
         capturedSelectedText = nil
         activeAppIcon = nil
@@ -1436,7 +1463,11 @@ final class DictationViewModel: ObservableObject {
         updateRecordingStartCuePayload(activeApp: activeApp)
         let contextMs = (CFAbsoluteTimeGetCurrent() - contextStartTimestamp) * 1000
 
-        beginLiveFieldTranscriptSessionIfEligible(sessionID: sessionID, activeApp: activeApp)
+        beginLiveFieldTranscriptSessionIfEligible(
+            sessionID: sessionID,
+            activeApp: activeApp,
+            preCapturedTarget: liveFieldCapture?.liveFieldTarget
+        )
         startLiveStreaming(
             allowLiveTranscription: indicatorTranscriptPreviewEnabled
                 || liveFieldTranscriptEnabled
@@ -1971,10 +2002,12 @@ final class DictationViewModel: ObservableObject {
                         actionPlugin, pluginId: actionPluginId, text: text,
                         activeApp: activeApp, language: language, originalText: result.text
                     )
+                    pinnedInsertionTarget = nil
                 } else {
                     let contextualInsertionEnabled = DictationInsertionTextFormatter.contextualInsertionEnabled()
                     let insertionContext: TextInsertionService.InsertionContext? = if contextualInsertionEnabled {
                         liveFieldTranscriptSession?.originalInsertionContext
+                            ?? pinnedInsertionTarget?.originalInsertionContext
                             ?? textInsertionService.captureInsertionContext()
                     } else {
                         nil
@@ -1992,6 +2025,19 @@ final class DictationViewModel: ObservableObject {
                     var shouldUseNormalInsertion = true
 
                     if resolvedOutputFormat == nil,
+                       liveFieldTranscriptSession != nil,
+                       let pinnedInsertionTarget,
+                       !textInsertionService.pinnedInsertionTargetIsFocused(pinnedInsertionTarget) {
+                        shouldUseNormalInsertion = await textInsertionService
+                            .focusPinnedInsertionTarget(pinnedInsertionTarget)
+                        if !shouldUseNormalInsertion {
+                            showLiveFieldRecoveryFeedback()
+                            self.liveFieldTranscriptSession = nil
+                        }
+                    }
+
+                    if shouldUseNormalInsertion,
+                       resolvedOutputFormat == nil,
                        let liveFieldTranscriptSession {
                         switch liveFieldTranscriptSession.finalize(with: insertionText) {
                         case .applied(let finalObservation):
@@ -2002,18 +2048,37 @@ final class DictationViewModel: ObservableObject {
                                 : nil
                             insertedTextForCorrectionTracking = insertionText
                             if shouldAutoEnterAfterInsertion {
-                                try? await Task.sleep(for: .milliseconds(50))
-                                textInsertionService.simulateReturn()
+                                if liveFieldTranscriptSession.targetIsCurrentlyFocused {
+                                    try? await Task.sleep(for: .milliseconds(50))
+                                    if liveFieldTranscriptSession.targetIsCurrentlyFocused {
+                                        textInsertionService.simulateReturn()
+                                    }
+                                } else {
+                                    logger.info(
+                                        "Skipping Auto Enter because the pinned live-field target is no longer focused"
+                                    )
+                                }
                             }
-                        case .detached(let hadAttemptedMutation):
+                        case .detached(let hadAttemptedMutation, let allowsFocusedFallback):
                             shouldUseNormalInsertion = !hadAttemptedMutation
-                            if hadAttemptedMutation {
+                                && (allowsFocusedFallback || pinnedInsertionTarget != nil)
+                            if !shouldUseNormalInsertion {
                                 showLiveFieldRecoveryFeedback()
                             }
                         }
                         self.liveFieldTranscriptSession = nil
                     } else if liveFieldTranscriptSession != nil {
                         shouldUseNormalInsertion = prepareLiveFieldSessionForNormalInsertion()
+                    }
+
+                    if shouldUseNormalInsertion,
+                       let pinnedInsertionTarget,
+                       !textInsertionService.pinnedInsertionTargetIsFocused(pinnedInsertionTarget) {
+                        shouldUseNormalInsertion = await textInsertionService
+                            .focusPinnedInsertionTarget(pinnedInsertionTarget)
+                        if !shouldUseNormalInsertion {
+                            showLiveFieldRecoveryFeedback()
+                        }
                     }
 
                     if shouldUseNormalInsertion {
@@ -2037,6 +2102,7 @@ final class DictationViewModel: ObservableObject {
                         insertedTextForCorrectionTracking = insertionText
                         didInsertText = true
                     }
+                    self.pinnedInsertionTarget = nil
 
                     if didInsertText {
                         logger.info("Stop timing: text inserted elapsedMs=\(stopElapsedMs(), privacy: .public)")
@@ -2345,6 +2411,8 @@ final class DictationViewModel: ObservableObject {
         metadataCaptureTask = nil
         lastStreamingParams = nil
         liveFieldTranscriptSession = nil
+        pendingLiveFieldCapture = nil
+        pinnedInsertionTarget = nil
         isStopInFlight = false
         activeDictationSessionID = nil
         pendingPushToTalkDiscardMessage = nil
@@ -2484,19 +2552,39 @@ final class DictationViewModel: ObservableObject {
         )
     }
 
+    private func captureLiveFieldTargetAtRecordingRequestIfEligible() {
+        pendingLiveFieldCapture = nil
+        guard liveFieldTranscriptEnabled else { return }
+
+        targetAppAccessibilityObservationLease = textInsertionService
+            .beginFocusedApplicationAccessibilityObservation()
+        guard let capture = textInsertionService.captureLiveFieldTargetAtRecordingRequest() else {
+            endTargetAppAccessibilityObservation()
+            return
+        }
+        pendingLiveFieldCapture = PendingLiveFieldCapture(
+            activeApp: capture.activeApp,
+            pinnedTarget: capture.pinnedTarget,
+            liveFieldTarget: capture.liveFieldTarget
+        )
+    }
+
     private func beginLiveFieldTranscriptSessionIfEligible(
         sessionID: UUID,
-        activeApp: (name: String?, bundleId: String?, url: String?)
+        activeApp: (name: String?, bundleId: String?, url: String?),
+        preCapturedTarget: TextInsertionService.LiveFieldTarget? = nil
     ) {
         liveFieldTranscriptSession = nil
         guard liveFieldTranscriptEnabled,
               effectiveActionPluginId == nil,
-              resolvedEffectiveOutputFormat(for: activeApp) == nil,
-              let target = textInsertionService.captureLiveFieldTarget(
-                expectedBundleIdentifier: activeApp.bundleId
-              ) else {
+              resolvedEffectiveOutputFormat(for: activeApp) == nil else {
             return
         }
+
+        let target = preCapturedTarget ?? textInsertionService.captureLiveFieldTarget(
+            expectedBundleIdentifier: activeApp.bundleId
+        )
+        guard let target else { return }
 
         liveFieldTranscriptSession = LiveFieldTranscriptSession(
             sessionID: sessionID,
@@ -2518,8 +2606,9 @@ final class DictationViewModel: ObservableObject {
         switch liveFieldTranscriptSession.cancel() {
         case .applied:
             return true
-        case .detached(let hadAttemptedMutation):
-            if hadAttemptedMutation {
+        case .detached(let hadAttemptedMutation, let allowsFocusedFallback):
+            if hadAttemptedMutation
+                || (!allowsFocusedFallback && pinnedInsertionTarget == nil) {
                 showLiveFieldRecoveryFeedback()
                 return false
             }
@@ -2959,9 +3048,12 @@ final class DictationViewModel: ObservableObject {
     private func beginTargetAppAccessibilityObservationIfNeeded(
         bundleIdentifier: String?
     ) {
-        endTargetAppAccessibilityObservation()
+        if targetAppAccessibilityObservationLease != nil {
+            return
+        }
         guard shouldTrackTargetAppCorrectionLearning
-                || improveTypeWhisperCaptureEnabled else {
+                || improveTypeWhisperCaptureEnabled
+                || liveFieldTranscriptEnabled else {
             return
         }
         targetAppAccessibilityObservationLease = textInsertionService

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -228,7 +228,7 @@ struct AdvancedSettingsView: View {
                 Toggle(isOn: $dictation.liveFieldTranscriptEnabled) {
                     SettingsInfoLabel(
                         title: String(localized: "Show live transcript in the active text field"),
-                        info: String(localized: "Supported text fields are updated while you speak. TypeWhisper inserts the final transcript normally when direct updates are unavailable.")
+                        info: String(localized: "Supported text fields are updated while you speak. The field focused when recording starts remains the final insertion target, including apps that require paste. If it can no longer be restored safely, the final transcript remains in Recent Transcriptions.")
                     )
                 }
 

--- a/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
+++ b/TypeWhisperTests/TargetAppCorrectionLearningServiceTests.swift
@@ -8,7 +8,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         let target = electronTarget()
         var setValues: [Bool] = []
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in true },
             readManualAccessibility: { _ in (.success, false) },
             setManualAccessibility: { _, enabled in
@@ -33,7 +33,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         let target = electronTarget()
         var setValues: [Bool] = []
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in true },
             readManualAccessibility: { _ in (.success, true) },
             setManualAccessibility: { _, enabled in
@@ -46,11 +46,39 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         XCTAssertTrue(setValues.isEmpty)
     }
 
+    func testElectronAccessibilityObservationUsesRequestedProcessIdentifier() throws {
+        let target = electronTarget()
+        var resolvedBundleIdentifiers: [String] = []
+        var resolvedProcessIdentifiers: [pid_t?] = []
+        let controller = ChromiumAccessibilityObservationController(
+            resolveApplication: { bundleIdentifier, processIdentifier in
+                resolvedBundleIdentifiers.append(bundleIdentifier)
+                resolvedProcessIdentifiers.append(processIdentifier)
+                return processIdentifier == target.processIdentifier ? target : nil
+            },
+            isElectronApplication: { _ in true },
+            readManualAccessibility: { _ in (.success, false) },
+            setManualAccessibility: { _, _ in .success },
+            validateApplication: { _ in true }
+        )
+
+        let lease = try XCTUnwrap(
+            controller.beginObservation(
+                bundleIdentifier: target.bundleIdentifier,
+                processIdentifier: target.processIdentifier
+            )
+        )
+        lease.end()
+
+        XCTAssertEqual(resolvedBundleIdentifiers, [target.bundleIdentifier])
+        XCTAssertEqual(resolvedProcessIdentifiers, [target.processIdentifier])
+    }
+
     func testElectronAccessibilityObservationFallsBackWhenAttributeIsUnsupported() {
         let target = electronTarget()
         var setValues: [Bool] = []
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in true },
             readManualAccessibility: { _ in (.attributeUnsupported, nil) },
             setManualAccessibility: { _, enabled in
@@ -71,7 +99,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         )
         var setValues: [Bool] = []
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in false },
             readManualAccessibility: { _ in (.success, false) },
             setManualAccessibility: { _, enabled in
@@ -97,7 +125,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         )
         var readCount = 0
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in false },
             readManualAccessibility: { _ in
                 readCount += 1
@@ -115,7 +143,7 @@ final class TargetAppCorrectionLearningServiceTests: XCTestCase {
         var setValues: [Bool] = []
         var isSameApplication = true
         let controller = ChromiumAccessibilityObservationController(
-            resolveApplication: { _ in target },
+            resolveApplication: { _, _ in target },
             isElectronApplication: { _ in true },
             readManualAccessibility: { _ in (.success, false) },
             setManualAccessibility: { _, enabled in

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4859,6 +4859,24 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveFieldTargetRejectsSecureTextElement() {
+        let service = TextInsertionService()
+        let element = AXUIElementCreateSystemWide()
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.focusedTextElementOverride = { element }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.secureTextElementOverride = { $0 == element }
+        service.focusedTextStateOverride = { _ in
+            (value: "Secret", selectedText: nil, selectedRange: NSRange(location: 6, length: 0))
+        }
+
+        XCTAssertNil(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+    }
+
+    @MainActor
     func testLiveFieldTargetRejectsNonEmptySelection() {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4294,6 +4294,77 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveFieldSessionCancelRemovesOwnedPartialAfterFocusMoves() async throws {
+        let service = TextInsertionService()
+        let targetElement = AXUIElementCreateApplication(4242)
+        let otherElement = AXUIElementCreateApplication(4343)
+        var activeBundleIdentifier = "com.apple.Notes"
+        var focusedElement = targetElement
+        var targetValue = "Before  after"
+        var targetRange = NSRange(location: 7, length: 0)
+        let otherValue = "Other field"
+        let otherRange = NSRange(location: 11, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { (nil, activeBundleIdentifier, nil) }
+        service.liveFieldElementProcessIdentifierOverride = { element in
+            element == targetElement ? 4242 : 4343
+        }
+        service.liveFieldApplicationValidationOverride = { processIdentifier, bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.apple.Notes"
+        }
+        service.focusedTextElementOverride = { focusedElement }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: targetValue, selectedText: nil, selectedRange: targetRange)
+                : (value: otherValue, selectedText: nil, selectedRange: otherRange)
+        }
+        service.setSelectedRangeOverride = { element, range in
+            guard element == targetElement else { return false }
+            targetRange = range
+            return true
+        }
+        service.insertTextAtOverride = { element, text in
+            guard element == targetElement else { return false }
+            targetValue = (targetValue as NSString).replacingCharacters(
+                in: targetRange,
+                with: text
+            )
+            targetRange = NSRange(
+                location: targetRange.location + (text as NSString).length,
+                length: 0
+            )
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+
+        session.receivePartial("Partial")
+        try await waitForLiveFieldUpdate("owned partial") {
+            targetValue == "Before Partial after"
+        }
+
+        activeBundleIdentifier = "com.apple.mail"
+        focusedElement = otherElement
+        guard case .applied = session.cancel() else {
+            return XCTFail("Expected the owned partial to be removed")
+        }
+
+        XCTAssertEqual(targetValue, "Before  after")
+        XCTAssertEqual(otherValue, "Other field")
+        XCTAssertEqual(session.state, .cancelled)
+    }
+
+    @MainActor
     func testLiveFieldSessionDoesNotRebindToMatchingFieldInSameApplication() async throws {
         let service = TextInsertionService()
         let targetElement = AXUIElementCreateSystemWide()
@@ -6811,6 +6882,71 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, "Audio start failed")
         XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
         XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.error, "Audio start failed")
+    }
+
+    @MainActor
+    func testApiStartRecordingFailureEndsPinnedTargetAccessibilityObservation() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        UserDefaults.standard.set(true, forKey: liveFieldKey)
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        let targetElement = AXUIElementCreateApplication(4242)
+        var observationBeginCount = 0
+        var observationEndCount = 0
+
+        context.textInsertionService.captureActiveAppOverride = {
+            ("Electron Target", "com.example.electron", nil)
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.focusedTextElementOverride = { targetElement }
+        context.textInsertionService.liveFieldElectronApplicationOverride = { _ in true }
+        context.textInsertionService.liveFieldElementProcessIdentifierOverride = { _ in 4242 }
+        context.textInsertionService.liveFieldApplicationMetadataOverride = { processIdentifier in
+            guard processIdentifier == 4242 else { return nil }
+            return ("Electron Target", "com.example.electron", nil)
+        }
+        context.textInsertionService.liveFieldApplicationValidationOverride = {
+            processIdentifier,
+            bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.example.electron"
+        }
+        context.textInsertionService.focusedTextStateOverride = { _ in
+            (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+        }
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { _ in
+            observationBeginCount += 1
+            return TargetAppAccessibilityObservationLease {
+                observationEndCount += 1
+            }
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            throw NSError(
+                domain: "TypeWhisperTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Audio start failed"]
+            )
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.status,
+            .failed
+        )
+        XCTAssertEqual(observationBeginCount, 1)
+        XCTAssertEqual(observationEndCount, 1)
     }
 
     @MainActor

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4126,6 +4126,17 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    private func configureLiveFieldIdentity(
+        _ service: TextInsertionService,
+        processIdentifier: pid_t = 4242
+    ) {
+        service.liveFieldElementProcessIdentifierOverride = { _ in processIdentifier }
+        service.liveFieldApplicationValidationOverride = { candidatePID, _ in
+            candidatePID == processIdentifier
+        }
+    }
+
+    @MainActor
     func testLiveFieldSessionRevisesOneOwnedRangeAndFinalizesInPlace() async throws {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()
@@ -4135,6 +4146,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.focusedTextStateOverride = { _ in
@@ -4186,6 +4198,486 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveFieldSessionPausesPartialUpdatesAfterFocusMovesToAnotherApplication() async throws {
+        let service = TextInsertionService()
+        let targetElement = AXUIElementCreateApplication(4242)
+        let otherElement = AXUIElementCreateApplication(4343)
+        var activeBundleIdentifier = "com.apple.Notes"
+        var focusedElement = targetElement
+        var targetValue = "Before  after"
+        var targetRange = NSRange(location: 7, length: 0)
+        var otherValue = "Other field"
+        var otherRange = NSRange(location: 11, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = {
+            activeBundleIdentifier == "com.apple.Notes"
+                ? ("Notes", activeBundleIdentifier, nil)
+                : ("Mail", activeBundleIdentifier, nil)
+        }
+        service.liveFieldElementProcessIdentifierOverride = { element in
+            element == targetElement ? 4242 : 4343
+        }
+        service.liveFieldApplicationValidationOverride = { processIdentifier, bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.apple.Notes"
+        }
+        service.focusedTextElementOverride = { focusedElement }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: targetValue, selectedText: nil, selectedRange: targetRange)
+                : (value: otherValue, selectedText: nil, selectedRange: otherRange)
+        }
+        service.setSelectedRangeOverride = { element, range in
+            if element == targetElement {
+                targetRange = range
+            } else {
+                otherRange = range
+            }
+            return true
+        }
+        service.insertTextAtOverride = { element, text in
+            if element == targetElement {
+                targetValue = (targetValue as NSString).replacingCharacters(
+                    in: targetRange,
+                    with: text
+                )
+                targetRange = NSRange(
+                    location: targetRange.location + (text as NSString).length,
+                    length: 0
+                )
+            } else {
+                otherValue = (otherValue as NSString).replacingCharacters(
+                    in: otherRange,
+                    with: text
+                )
+                otherRange = NSRange(
+                    location: otherRange.location + (text as NSString).length,
+                    length: 0
+                )
+            }
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+
+        activeBundleIdentifier = "com.apple.mail"
+        focusedElement = otherElement
+        session.receivePartial("Pinned")
+        try? await Task.sleep(for: .milliseconds(25))
+
+        XCTAssertEqual(targetValue, "Before  after")
+        XCTAssertEqual(otherValue, "Other field")
+        XCTAssertFalse(session.targetIsCurrentlyFocused)
+        XCTAssertEqual(session.state, .active)
+
+        activeBundleIdentifier = "com.apple.Notes"
+        focusedElement = targetElement
+        session.receivePartial("Pinned")
+        try await waitForLiveFieldUpdate("restored target update") {
+            targetValue == "Before Pinned after"
+        }
+
+        guard case .applied = session.finalize(with: "Final") else {
+            return XCTFail("Expected the restored original field to finalize")
+        }
+        XCTAssertEqual(targetValue, "Before Final after")
+        XCTAssertEqual(otherValue, "Other field")
+    }
+
+    @MainActor
+    func testLiveFieldSessionDoesNotRebindToMatchingFieldInSameApplication() async throws {
+        let service = TextInsertionService()
+        let targetElement = AXUIElementCreateSystemWide()
+        let otherElement = AXUIElementCreateApplication(4242)
+        XCTAssertFalse(CFEqual(targetElement, otherElement))
+        var focusedElement = targetElement
+        var targetValue = ""
+        var targetRange = NSRange(location: 0, length: 0)
+        var otherValue = ""
+        var otherRange = NSRange(location: 0, length: 0)
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        service.liveFieldElementProcessIdentifierOverride = { _ in 4242 }
+        service.liveFieldApplicationValidationOverride = { processIdentifier, bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.apple.Notes"
+        }
+        service.focusedTextElementOverride = { focusedElement }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: targetValue, selectedText: nil, selectedRange: targetRange)
+                : (value: otherValue, selectedText: nil, selectedRange: otherRange)
+        }
+        service.setSelectedRangeOverride = { element, range in
+            if element == targetElement {
+                targetRange = range
+            } else {
+                otherRange = range
+            }
+            return true
+        }
+        service.insertTextAtOverride = { element, text in
+            if element == targetElement {
+                targetValue = (targetValue as NSString).replacingCharacters(
+                    in: targetRange,
+                    with: text
+                )
+                targetRange = NSRange(
+                    location: targetRange.location + (text as NSString).length,
+                    length: 0
+                )
+            } else {
+                otherValue = (otherValue as NSString).replacingCharacters(
+                    in: otherRange,
+                    with: text
+                )
+                otherRange = NSRange(
+                    location: otherRange.location + (text as NSString).length,
+                    length: 0
+                )
+            }
+            return true
+        }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service,
+            updateInterval: .milliseconds(1)
+        )
+
+        focusedElement = otherElement
+        session.receivePartial("Original only")
+        try? await Task.sleep(for: .milliseconds(25))
+
+        XCTAssertEqual(targetValue, "")
+        XCTAssertEqual(otherValue, "")
+        XCTAssertFalse(session.targetIsCurrentlyFocused)
+    }
+
+    @MainActor
+    func testLiveFieldSessionDisallowsFocusedFallbackAfterTargetLosesFocus() throws {
+        let service = TextInsertionService()
+        let targetElement = AXUIElementCreateApplication(4242)
+        let otherElement = AXUIElementCreateApplication(4343)
+        var activeBundleIdentifier = "com.apple.Notes"
+        var focusedElement = targetElement
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { (nil, activeBundleIdentifier, nil) }
+        service.liveFieldElementProcessIdentifierOverride = { element in
+            element == targetElement ? 4242 : 4343
+        }
+        service.liveFieldApplicationValidationOverride = { processIdentifier, bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.apple.Notes"
+        }
+        service.focusedTextElementOverride = { focusedElement }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
+                : (value: "Other", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+        service.setSelectedRangeOverride = { _, _ in true }
+        service.insertTextAtOverride = { _, _ in false }
+
+        let target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.apple.Notes")
+        )
+        let session = LiveFieldTranscriptSession(
+            sessionID: UUID(),
+            target: target,
+            textInsertionService: service
+        )
+
+        activeBundleIdentifier = "com.apple.mail"
+        focusedElement = otherElement
+        guard case .detached(let hadAttemptedMutation, let allowsFocusedFallback) =
+            session.finalize(with: "Final") else {
+            return XCTFail("Expected targeted insertion to detach")
+        }
+        XCTAssertFalse(hadAttemptedMutation)
+        XCTAssertFalse(allowsFocusedFallback)
+    }
+
+    @MainActor
+    func testDictationPinsLiveFieldBeforeDelayedAudioStartChangesFocus() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("Pinned final")
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.liveFieldTranscriptEnabled = true
+        context.dictationViewModel.preserveClipboard = false
+
+        let targetElement = AXUIElementCreateApplication(4242)
+        let otherElement = AXUIElementCreateApplication(4343)
+        let pasteboard = NSPasteboard.withUniqueName()
+        var activeBundleIdentifier = "com.apple.Notes"
+        var focusedElement = targetElement
+        var targetValue = ""
+        var targetRange = NSRange(location: 0, length: 0)
+        var otherValue = "Other"
+        var otherRange = NSRange(location: 5, length: 0)
+        var activationCount = 0
+        var focusCount = 0
+
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.pasteVerificationAttempts = 0
+        context.textInsertionService.captureActiveAppOverride = {
+            activeBundleIdentifier == "com.apple.Notes"
+                ? ("Notes", activeBundleIdentifier, nil)
+                : ("Mail", activeBundleIdentifier, nil)
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.focusedTextElementOverride = { focusedElement }
+        context.textInsertionService.liveFieldTargetEligibilityOverride = { _ in true }
+        context.textInsertionService.liveFieldElementProcessIdentifierOverride = { element in
+            element == targetElement ? 4242 : 4343
+        }
+        context.textInsertionService.liveFieldApplicationMetadataOverride = { processIdentifier in
+            guard processIdentifier == 4242 else { return nil }
+            return ("Notes", "com.apple.Notes", nil)
+        }
+        context.textInsertionService.liveFieldApplicationValidationOverride = {
+            processIdentifier,
+            bundleIdentifier in
+            processIdentifier == 4242 && bundleIdentifier == "com.apple.Notes"
+        }
+        context.textInsertionService.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: targetValue, selectedText: nil, selectedRange: targetRange)
+                : (value: otherValue, selectedText: nil, selectedRange: otherRange)
+        }
+        context.textInsertionService.setSelectedRangeOverride = { element, range in
+            if element == targetElement {
+                targetRange = range
+            } else {
+                otherRange = range
+            }
+            return true
+        }
+        context.textInsertionService.insertTextAtOverride = { element, text in
+            if element == targetElement {
+                return false
+            } else {
+                otherValue = (otherValue as NSString).replacingCharacters(
+                    in: otherRange,
+                    with: text
+                )
+                otherRange = NSRange(
+                    location: otherRange.location + (text as NSString).length,
+                    length: 0
+                )
+            }
+            return true
+        }
+        context.textInsertionService.activatePinnedTargetApplicationOverride = { processIdentifier in
+            guard processIdentifier == 4242 else { return false }
+            activationCount += 1
+            activeBundleIdentifier = "com.apple.Notes"
+            return true
+        }
+        context.textInsertionService.focusPinnedTargetElementOverride = { element in
+            guard element == targetElement else { return false }
+            focusCount += 1
+            focusedElement = targetElement
+            return true
+        }
+        context.textInsertionService.pasteSimulatorOverride = {
+            guard activeBundleIdentifier == "com.apple.Notes",
+                  focusedElement == targetElement,
+                  let text = pasteboard.string(forType: .string) else {
+                return
+            }
+            targetValue = (targetValue as NSString).replacingCharacters(
+                in: targetRange,
+                with: text
+            )
+            targetRange = NSRange(
+                location: targetRange.location + (text as NSString).length,
+                length: 0
+            )
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            activeBundleIdentifier = "com.apple.mail"
+            focusedElement = otherElement
+        }
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.status,
+            .completed
+        )
+        XCTAssertEqual(targetValue, "Pinned final")
+        XCTAssertEqual(otherValue, "Other")
+        XCTAssertEqual(activationCount, 1)
+        XCTAssertEqual(focusCount, 1)
+        XCTAssertEqual(context.historyService.records.first?.appBundleIdentifier, "com.apple.Notes")
+    }
+
+    @MainActor
+    func testDictationPinsElectronFieldAndPastesAfterFocusChanges() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("Electron final")
+        dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
+        let context = try XCTUnwrap(dictationContext)
+        context.dictationViewModel.liveFieldTranscriptEnabled = true
+        context.dictationViewModel.preserveClipboard = false
+
+        let targetElement = AXUIElementCreateApplication(5252)
+        let otherElement = AXUIElementCreateApplication(5353)
+        let pasteboard = NSPasteboard.withUniqueName()
+        var activeBundleIdentifier = "com.microsoft.VSCode"
+        var focusedElement = targetElement
+        var targetValue = ""
+        var targetRange = NSRange(location: 0, length: 0)
+        var observationBeginCount = 0
+        var activationCount = 0
+
+        context.textInsertionService.pasteboardProvider = { pasteboard }
+        context.textInsertionService.pasteVerificationAttempts = 0
+        context.textInsertionService.captureActiveAppOverride = {
+            activeBundleIdentifier == "com.microsoft.VSCode"
+                ? ("Visual Studio Code", activeBundleIdentifier, nil)
+                : ("Mail", activeBundleIdentifier, nil)
+        }
+        context.textInsertionService.accessibilityGrantedOverride = true
+        context.textInsertionService.selectedTextOverride = { nil }
+        context.textInsertionService.focusedTextElementOverride = { focusedElement }
+        context.textInsertionService.liveFieldElectronApplicationOverride = { bundleIdentifier in
+            bundleIdentifier == "com.microsoft.VSCode"
+        }
+        context.textInsertionService.liveFieldElementProcessIdentifierOverride = { element in
+            element == targetElement ? 5252 : 5353
+        }
+        context.textInsertionService.liveFieldApplicationMetadataOverride = { processIdentifier in
+            guard processIdentifier == 5252 else { return nil }
+            return ("Visual Studio Code", "com.microsoft.VSCode", nil)
+        }
+        context.textInsertionService.liveFieldApplicationValidationOverride = {
+            processIdentifier,
+            bundleIdentifier in
+            processIdentifier == 5252 && bundleIdentifier == "com.microsoft.VSCode"
+        }
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { _ in
+            observationBeginCount += 1
+            return TargetAppAccessibilityObservationLease {}
+        }
+        context.textInsertionService.focusedTextStateOverride = { element in
+            element == targetElement
+                ? (value: targetValue, selectedText: nil, selectedRange: targetRange)
+                : (value: "Other", selectedText: nil, selectedRange: NSRange(location: 5, length: 0))
+        }
+        context.textInsertionService.activatePinnedTargetApplicationOverride = { processIdentifier in
+            guard processIdentifier == 5252 else { return false }
+            activationCount += 1
+            activeBundleIdentifier = "com.microsoft.VSCode"
+            return true
+        }
+        context.textInsertionService.focusPinnedTargetElementOverride = { element in
+            guard element == targetElement else { return false }
+            focusedElement = targetElement
+            return true
+        }
+        context.textInsertionService.pasteSimulatorOverride = {
+            guard activeBundleIdentifier == "com.microsoft.VSCode",
+                  focusedElement == targetElement,
+                  let text = pasteboard.string(forType: .string) else {
+                return
+            }
+            targetValue = (targetValue as NSString).replacingCharacters(
+                in: targetRange,
+                with: text
+            )
+            targetRange = NSRange(
+                location: targetRange.location + (text as NSString).length,
+                length: 0
+            )
+        }
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {
+            activeBundleIdentifier = "com.apple.mail"
+            focusedElement = otherElement
+        }
+        context.audioRecordingService.stopRecordingOverride = { _ in
+            Array(repeating: 0.25, count: Int(AudioRecordingService.targetSampleRate))
+        }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .completed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        XCTAssertEqual(
+            context.dictationViewModel.apiDictationSession(id: sessionID)?.status,
+            .completed
+        )
+        XCTAssertEqual(targetValue, "Electron final")
+        XCTAssertEqual(activationCount, 1)
+        XCTAssertEqual(observationBeginCount, 1)
+        XCTAssertEqual(
+            context.historyService.records.first?.appBundleIdentifier,
+            "com.microsoft.VSCode"
+        )
+    }
+
+    @MainActor
     func testLiveFieldSessionDetachesAfterUserChangesText() async throws {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()
@@ -4195,6 +4687,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("TextEdit", "com.apple.TextEdit", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.focusedTextStateOverride = { _ in
@@ -4238,7 +4731,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(writeCount, 1)
 
         let result = session.finalize(with: "Final")
-        guard case .detached(let hadAttemptedMutation) = result else {
+        guard case .detached(let hadAttemptedMutation, _) = result else {
             return XCTFail("Expected detached finalization")
         }
         XCTAssertTrue(hadAttemptedMutation)
@@ -4255,6 +4748,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("Mail", "com.apple.mail", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.focusedTextStateOverride = { _ in
@@ -4339,6 +4833,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.focusedTextPlaceholderOverride = { _ in value == placeholder ? placeholder : nil }
         service.liveFieldTargetEligibilityOverride = { _ in true }
@@ -4393,6 +4888,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.focusedTextStateOverride = { _ in
@@ -4419,7 +4915,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(session.state, .detached)
-        guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
+        guard case .detached(let hadAttemptedMutation, _) = session.finalize(with: "Final") else {
             return XCTFail("Expected the failed inline session to detach")
         }
         XCTAssertFalse(hadAttemptedMutation)
@@ -4433,6 +4929,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.focusedTextStateOverride = { _ in
@@ -4459,7 +4956,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         }
 
         XCTAssertEqual(session.state, .detached)
-        guard case .detached(let hadAttemptedMutation) = session.finalize(with: "Final") else {
+        guard case .detached(let hadAttemptedMutation, _) = session.finalize(with: "Final") else {
             return XCTFail("Expected ignored AX success to detach")
         }
         XCTAssertFalse(hadAttemptedMutation)
@@ -4478,13 +4975,17 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         service.accessibilityGrantedOverride = true
         service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        configureLiveFieldIdentity(service)
         service.focusedTextElementOverride = { element }
         service.liveFieldTargetEligibilityOverride = { _ in true }
         service.setMessagingTimeoutOverride = { element, timeout in
             timeoutApplications.append((element, timeout))
         }
-        service.focusedTextStateOverride = { _ in
-            (value: value, selectedText: nil, selectedRange: selectedRange)
+        service.focusedTextStateOverride = { requestedElement in
+            if element == recreatedElement, requestedElement == originalElement {
+                return nil
+            }
+            return (value: value, selectedText: nil, selectedRange: selectedRange)
         }
         service.setSelectedRangeOverride = { _, range in
             selectedRange = range
@@ -5244,12 +5745,16 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     @MainActor
     func testApiStartRecording_startsAudioBeforeContextAndDeferredSelectedTextCapture() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
         var dictationContext: DictationContext?
         defer {
             dictationContext = nil
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
             TestSupport.remove(appSupportDirectory)
         }
 
+        UserDefaults.standard.set(false, forKey: liveFieldKey)
         dictationContext = Self.makeDictationContext(appSupportDirectory: appSupportDirectory)
         let context = try XCTUnwrap(dictationContext)
 
@@ -5972,9 +6477,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let licenseSuiteName = "TypeWhisperIntegrationTests.License.\(UUID().uuidString)"
         let learningEnabledKey = UserDefaultsKeys.targetAppCorrectionLearningEnabled
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
         let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
         let saveAudioKey = UserDefaultsKeys.saveAudioWithHistory
         let originalLearningEnabled = UserDefaults.standard.object(forKey: learningEnabledKey)
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
         let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
         let originalSaveAudio = UserDefaults.standard.object(forKey: saveAudioKey)
         guard let licenseDefaults = UserDefaults(suiteName: licenseSuiteName) else {
@@ -5985,12 +6492,14 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             dictationContext = nil
             licenseDefaults.removePersistentDomain(forName: licenseSuiteName)
             Self.restoreUserDefault(originalLearningEnabled, forKey: learningEnabledKey)
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
             Self.restoreUserDefault(originalPreserveClipboard, forKey: preserveClipboardKey)
             Self.restoreUserDefault(originalSaveAudio, forKey: saveAudioKey)
             TestSupport.remove(appSupportDirectory)
         }
 
         UserDefaults.standard.set(true, forKey: learningEnabledKey)
+        UserDefaults.standard.set(false, forKey: liveFieldKey)
         UserDefaults.standard.set(false, forKey: preserveClipboardKey)
         UserDefaults.standard.set(false, forKey: saveAudioKey)
         licenseDefaults.set(LicenseStatus.active.rawValue, forKey: UserDefaultsKeys.licenseStatus)
@@ -6057,10 +6566,12 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         let learningEnabledKey = UserDefaultsKeys.targetAppCorrectionLearningEnabled
         let improveCaptureKey = UserDefaultsKeys.improveTypeWhisperCaptureEnabled
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
         let preserveClipboardKey = UserDefaultsKeys.preserveClipboard
         let saveAudioKey = UserDefaultsKeys.saveAudioWithHistory
         let originalLearningEnabled = UserDefaults.standard.object(forKey: learningEnabledKey)
         let originalImproveCapture = UserDefaults.standard.object(forKey: improveCaptureKey)
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
         let originalPreserveClipboard = UserDefaults.standard.object(forKey: preserveClipboardKey)
         let originalSaveAudio = UserDefaults.standard.object(forKey: saveAudioKey)
         var dictationContext: DictationContext?
@@ -6068,6 +6579,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             dictationContext = nil
             Self.restoreUserDefault(originalLearningEnabled, forKey: learningEnabledKey)
             Self.restoreUserDefault(originalImproveCapture, forKey: improveCaptureKey)
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
             Self.restoreUserDefault(originalPreserveClipboard, forKey: preserveClipboardKey)
             Self.restoreUserDefault(originalSaveAudio, forKey: saveAudioKey)
             TestSupport.remove(appSupportDirectory)
@@ -6075,6 +6587,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         UserDefaults.standard.set(false, forKey: learningEnabledKey)
         UserDefaults.standard.set(true, forKey: improveCaptureKey)
+        UserDefaults.standard.set(false, forKey: liveFieldKey)
         UserDefaults.standard.set(false, forKey: preserveClipboardKey)
         UserDefaults.standard.set(false, forKey: saveAudioKey)
 
@@ -6208,6 +6721,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     @MainActor
     func testApiStartRecording_pausesMediaAfterAudioStart() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
         var events: [String] = []
         let mediaPlaybackService = MockMediaPlaybackService {
             events.append("pause_media")
@@ -6215,9 +6730,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         var dictationContext: DictationContext?
         defer {
             dictationContext = nil
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
             TestSupport.remove(appSupportDirectory)
         }
 
+        UserDefaults.standard.set(false, forKey: liveFieldKey)
         dictationContext = Self.makeDictationContext(
             appSupportDirectory: appSupportDirectory,
             mediaPlaybackService: mediaPlaybackService
@@ -6244,6 +6761,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     @MainActor
     func testApiStartRecordingFailureSkipsPostAudioStartSideEffects() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let liveFieldKey = UserDefaultsKeys.liveFieldTranscriptEnabled
+        let originalLiveFieldSetting = UserDefaults.standard.object(forKey: liveFieldKey)
         var events: [String] = []
         let mediaPlaybackService = MockMediaPlaybackService {
             events.append("pause_media")
@@ -6255,9 +6774,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         var dictationContext: DictationContext?
         defer {
             dictationContext = nil
+            Self.restoreUserDefault(originalLiveFieldSetting, forKey: liveFieldKey)
             TestSupport.remove(appSupportDirectory)
         }
 
+        UserDefaults.standard.set(false, forKey: liveFieldKey)
         dictationContext = Self.makeDictationContext(
             appSupportDirectory: appSupportDirectory,
             mediaPlaybackService: mediaPlaybackService,

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -5102,6 +5102,58 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 
     @MainActor
+    func testLiveFieldTargetDoesNotRebindToSecureTextElement() throws {
+        let service = TextInsertionService()
+        let originalElement = AXUIElementCreateSystemWide()
+        let secureElement = AXUIElementCreateApplication(ProcessInfo.processInfo.processIdentifier)
+        var focusedElement = originalElement
+        var value = ""
+        var selectedRange = NSRange(location: 0, length: 0)
+        var insertionElements: [AXUIElement] = []
+
+        service.accessibilityGrantedOverride = true
+        service.captureActiveAppOverride = { ("T3 Code", "com.t3.code", nil) }
+        configureLiveFieldIdentity(service)
+        service.focusedTextElementOverride = { focusedElement }
+        service.liveFieldTargetEligibilityOverride = { _ in true }
+        service.secureTextElementOverride = { $0 == secureElement }
+        service.focusedTextStateOverride = { requestedElement in
+            if focusedElement == secureElement, requestedElement == originalElement {
+                return nil
+            }
+            return (value: value, selectedText: nil, selectedRange: selectedRange)
+        }
+        service.setSelectedRangeOverride = { _, range in
+            selectedRange = range
+            return true
+        }
+        service.insertTextAtOverride = { requestedElement, text in
+            insertionElements.append(requestedElement)
+            value = (value as NSString).replacingCharacters(in: selectedRange, with: text)
+            selectedRange = NSRange(
+                location: selectedRange.location + (text as NSString).length,
+                length: 0
+            )
+            focusedElement = secureElement
+            return true
+        }
+
+        var target = try XCTUnwrap(
+            service.captureLiveFieldTarget(expectedBundleIdentifier: "com.t3.code")
+        )
+        guard case .detached = service.replaceLiveFieldText(
+            "Sensitive transcript",
+            in: &target,
+            knownTargetIsFocused: true
+        ) else {
+            return XCTFail("Expected a secure replacement element to detach the target")
+        }
+
+        XCTAssertEqual(insertionElements.count, 1)
+        XCTAssertTrue(insertionElements.first.map { CFEqual($0, originalElement) } ?? false)
+    }
+
+    @MainActor
     func testGetTextSelectionDerivesSelectedTextFromFocusedValueAndRange() {
         let service = TextInsertionService()
         let element = AXUIElementCreateSystemWide()

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -4680,7 +4680,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             bundleIdentifier in
             processIdentifier == 5252 && bundleIdentifier == "com.microsoft.VSCode"
         }
-        context.textInsertionService.chromiumAccessibilityObservationOverride = { _ in
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { _, _ in
             observationBeginCount += 1
             return TargetAppAccessibilityObservationLease {}
         }
@@ -6596,7 +6596,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         context.textInsertionService.pasteSimulatorOverride = {}
         var accessibilityObservationBundleIdentifiers: [String?] = []
         var accessibilityObservationEndCount = 0
-        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier in
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier, _ in
             accessibilityObservationBundleIdentifiers.append(bundleIdentifier)
             return TargetAppAccessibilityObservationLease {
                 accessibilityObservationEndCount += 1
@@ -6676,7 +6676,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         context.textInsertionService.pasteSimulatorOverride = {}
         var accessibilityObservationBundleIdentifiers: [String?] = []
         var accessibilityObservationEndCount = 0
-        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier in
+        context.textInsertionService.chromiumAccessibilityObservationOverride = { bundleIdentifier, _ in
             accessibilityObservationBundleIdentifiers.append(bundleIdentifier)
             return TargetAppAccessibilityObservationLease {
                 accessibilityObservationEndCount += 1
@@ -6902,10 +6902,13 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let targetElement = AXUIElementCreateApplication(4242)
         var observationBeginCount = 0
         var observationEndCount = 0
+        var observedBundleIdentifiers: [String?] = []
+        var observedProcessIdentifiers: [pid_t?] = []
 
         context.textInsertionService.captureActiveAppOverride = {
             ("Electron Target", "com.example.electron", nil)
         }
+        context.textInsertionService.focusedApplicationProcessIdentifierOverride = { 4242 }
         context.textInsertionService.accessibilityGrantedOverride = true
         context.textInsertionService.focusedTextElementOverride = { targetElement }
         context.textInsertionService.liveFieldElectronApplicationOverride = { _ in true }
@@ -6922,8 +6925,12 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         context.textInsertionService.focusedTextStateOverride = { _ in
             (value: "", selectedText: nil, selectedRange: NSRange(location: 0, length: 0))
         }
-        context.textInsertionService.chromiumAccessibilityObservationOverride = { _ in
+        context.textInsertionService.chromiumAccessibilityObservationOverride = {
+            bundleIdentifier,
+            processIdentifier in
             observationBeginCount += 1
+            observedBundleIdentifiers.append(bundleIdentifier)
+            observedProcessIdentifiers.append(processIdentifier)
             return TargetAppAccessibilityObservationLease {
                 observationEndCount += 1
             }
@@ -6947,6 +6954,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         )
         XCTAssertEqual(observationBeginCount, 1)
         XCTAssertEqual(observationEndCount, 1)
+        XCTAssertEqual(observedBundleIdentifiers, ["com.example.electron"])
+        XCTAssertEqual(observedProcessIdentifiers, [4242])
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- pin the exact app process and accessibility text field when recording begins
- pause provisional live-field updates after focus moves, then restore the original app and field for final insertion
- use the normal verified paste path for Electron and other targets where direct accessibility updates are unavailable
- fail safely to Recent Transcriptions when the original target cannot be restored
- document the behavior in Advanced settings and add focused regression coverage

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- verify a signed development build launches with the development App Group
- start dictation in an Electron text field, move focus elsewhere, stop recording, and confirm the transcript is inserted into the original field
- repeat the same focus-change flow in Apple Notes

## Validation

- 1,675 tests passed
- real-app focus-change flow passed in Electron and Apple Notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keeps live transcription tied to the text field where recording began.
  * Supports paste-based apps and editors that recreate fields during recording.
  * Restores focus before final insertion when possible.
  * Preserves completed transcripts in Recent Transcriptions if the original field cannot be recovered.

* **Bug Fixes**
  * Prevents updates to unintended fields after focus changes or across applications.
  * Improves secure-field protection and pauses live updates when the target is unfocused.
  * Cleans up provisional text when live transcription is cancelled.
  * Improved German, Japanese, and Simplified Chinese descriptions for live transcription behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->