### PR TITLE
Fix Gemma 4 current configuration compatibility

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -533,7 +533,6 @@
 		AA00000000000000000313 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000298 /* Localizable.xcstrings */; };
 		AA00000000000000000304 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000044 /* TypeWhisperPluginSDK */; };
 		AA00000000000000000305 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000045 /* MLXLLM */; };
-		AA00000000000000000313 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000047 /* MLXVLM */; };
 		AA00000000000000000314 /* Transformers in Frameworks */ = {isa = PBXBuildFile; productRef = PP00000000000000000048 /* Transformers */; };
 		AA00000000000000000306 /* SpeechmaticsPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000291 /* SpeechmaticsPlugin.swift */; };
 		AA00000000000000000307 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000292 /* manifest.json */; };
@@ -1597,7 +1596,6 @@
 			files = (
 				AA00000000000000000304 /* TypeWhisperPluginSDK in Frameworks */,
 				AA00000000000000000305 /* MLXLLM in Frameworks */,
-				AA00000000000000000313 /* MLXVLM in Frameworks */,
 				AA00000000000000000314 /* Transformers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3799,7 +3797,6 @@
 			packageProductDependencies = (
 				PP00000000000000000044 /* TypeWhisperPluginSDK */,
 				PP00000000000000000045 /* MLXLLM */,
-				PP00000000000000000047 /* MLXVLM */,
 				PP00000000000000000048 /* Transformers */,
 			);
 			productName = Gemma4Plugin;

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.4",
+    "version": "1.1.5",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [

--- a/TypeWhisperTests/MLXPluginModelStorageTests.swift
+++ b/TypeWhisperTests/MLXPluginModelStorageTests.swift
@@ -1,10 +1,48 @@
 import Foundation
+import MLXLLM
 import XCTest
 @testable import TypeWhisper
 import TypeWhisperPluginSDK
 
 final class MLXPluginModelStorageTests: XCTestCase {
     private let commit = String(repeating: "b", count: 40)
+
+    func testGemma4LLMRuntimeAcceptsCurrentAndLegacyConfigurationTypes() async throws {
+        for modelType in ["gemma4", "gemma4_text", "gemma4_unified"] {
+            let isRegistered = await LLMTypeRegistry.shared.contains(modelType)
+            XCTAssertTrue(isRegistered, "Missing Gemma 4 LLM model type: \(modelType)")
+        }
+
+        let configurations = [
+            """
+            {
+              "model_type": "gemma4",
+              "vocab_size": 262144,
+              "text_config": { "model_type": "gemma4_text" },
+              "audio_config": { "model_type": "gemma4_audio" },
+              "vision_config": { "model_type": "gemma4_vision" }
+            }
+            """,
+            """
+            {
+              "model_type": "gemma4_unified",
+              "vocab_size": 262144,
+              "text_config": { "model_type": "gemma4_unified_text" },
+              "audio_config": { "model_type": "gemma4_unified_audio" },
+              "vision_config": { "model_type": "gemma4_unified_vision" }
+            }
+            """,
+        ]
+
+        for configuration in configurations {
+            XCTAssertNoThrow(
+                try JSONDecoder().decode(
+                    Gemma4Configuration.self,
+                    from: Data(configuration.utf8)
+                )
+            )
+        }
+    }
 
     func testModelCatalogsRecognizeLegacyAndCanonicalLayouts() throws {
         try assertCatalogRecognizesBothLayouts(

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -134,7 +134,7 @@ final class PluginManifestValidationTests: XCTestCase {
             ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.8"),
             ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.14"),
             ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.10"),
-            ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.4"),
+            ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.5"),
         ]
 
         for (relativePath, expectedVersion) in manifestExpectations {


### PR DESCRIPTION
## Context

Issue #1237 reports that the published Gemma 4 plugin cannot load the current `mlx-community/gemma-4-e2b-it-4bit` configuration because its model type names changed from the legacy `gemma4_unified*` family to `gemma4`, `gemma4_text`, `gemma4_audio`, and `gemma4_vision`.

## Changes

- Link Gemma4Plugin only against the text-oriented MLXLLM runtime and remove its unused MLXVLM dependency.
- Add regression coverage for the current and legacy Gemma 4 configuration model types.
- Bump the Gemma 4 plugin version to 1.1.5 so the corrected artifact can replace 1.1.4.

## Test plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination "platform=macOS,arch=arm64" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:TypeWhisperTests/MLXPluginModelStorageTests/testGemma4LLMRuntimeAcceptsCurrentAndLegacyConfigurationTypes -only-testing:TypeWhisperTests/PluginManifestValidationTests/testMLXStoragePluginReleasesRequireHost16`
- [x] `xcodebuild -project TypeWhisper.xcodeproj -scheme Gemma4Plugin -configuration Debug -destination "platform=macOS,arch=arm64" build`
- [x] Install the signed development plugin and relaunch TypeWhisper-Dev.

Closes #1237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the Gemma 4 plugin to version 1.1.5.
  * Improved compatibility with current and legacy Gemma 4 model configurations.
  * Confirmed support for Gemma 4 model variants, including unified and text models.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->