### PR TITLE
Fix Deepgram live dictation streaming

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -274,6 +274,7 @@ private final class RawWebSocket: @unchecked Sendable {
 private actor TranscriptCollector {
     private var finals: [String] = []
     private var interim: String = ""
+    private var _error: String?
 
     func addFinal(_ text: String) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -287,6 +288,12 @@ private actor TranscriptCollector {
         interim = text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    func setError(_ message: String) {
+        _error = message
+    }
+
+    var error: String? { _error }
+
     func currentText() -> String {
         var parts = finals
         if !interim.isEmpty {
@@ -298,12 +305,202 @@ private actor TranscriptCollector {
     func finalResult() -> String {
         finals.joined(separator: " ")
     }
+
+    func finalTranscriptionResult(fallbackLanguage: String?) -> PluginTranscriptionResult {
+        let finalText = finalResult()
+        return PluginTranscriptionResult(
+            text: finalText.isEmpty ? currentText() : finalText,
+            detectedLanguage: fallbackLanguage
+        )
+    }
+}
+
+// MARK: - Live STT Session
+
+private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
+    private struct State {
+        var finished = false
+        var cancelled = false
+    }
+
+    private static let finishTimeoutNanoseconds: UInt64 = 2_000_000_000
+    private static let logger = Logger(subsystem: "com.typewhisper.deepgram", category: "LiveSession")
+
+    private let webSocket: RawWebSocket
+    private let receiveTask: Task<Void, Never>
+    private let collector: TranscriptCollector
+    private let language: String?
+    private let state = OSAllocatedUnfairLock(initialState: State())
+
+    private init(
+        webSocket: RawWebSocket,
+        receiveTask: Task<Void, Never>,
+        collector: TranscriptCollector,
+        language: String?
+    ) {
+        self.webSocket = webSocket
+        self.receiveTask = receiveTask
+        self.collector = collector
+        self.language = language
+    }
+
+    static func connect(
+        webSocket: RawWebSocket,
+        language: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> DeepgramLiveTranscriptionSession {
+        try await webSocket.connect()
+
+        let collector = TranscriptCollector()
+        let receiveTask = Task { [webSocket, collector, onProgress] in
+            do {
+                while !Task.isCancelled {
+                    let frame = try await webSocket.receiveFrame()
+                    if frame.opcode == .close { break }
+                    guard frame.opcode == .text,
+                          let json = try? JSONSerialization.jsonObject(with: frame.payload) as? [String: Any] else {
+                        continue
+                    }
+
+                    if let type = json["type"] as? String {
+                        if type == "Error" {
+                            await collector.setError(DeepgramPlugin.webSocketErrorMessage(from: json))
+                            break
+                        }
+                        if type != "Results" { continue }
+                    }
+
+                    let transcript = DeepgramPlugin.extractWSTranscript(from: json)
+                    if DeepgramPlugin.isFinalResult(json) {
+                        await collector.addFinal(transcript)
+                    } else {
+                        await collector.setInterim(transcript)
+                    }
+
+                    let currentText = await collector.currentText()
+                    if !currentText.isEmpty {
+                        _ = onProgress(currentText)
+                    }
+                }
+            } catch RawWebSocket.WSError.closed {
+                return
+            } catch is CancellationError {
+                return
+            } catch {
+                if Task.isCancelled { return }
+                await collector.setError(error.localizedDescription)
+            }
+        }
+
+        return DeepgramLiveTranscriptionSession(
+            webSocket: webSocket,
+            receiveTask: receiveTask,
+            collector: collector,
+            language: language
+        )
+    }
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !state.withLock({ $0.finished || $0.cancelled }) else { return }
+        if let error = await collector.error {
+            throw PluginTranscriptionError.apiError(error)
+        }
+
+        let data = DeepgramPlugin.floatToPCM16(samples)
+        guard !data.isEmpty else { return }
+
+        do {
+            try await webSocket.sendBinary(data)
+        } catch {
+            let normalizedError = Self.normalizedError(error)
+            await collector.setError(normalizedError.localizedDescription)
+            throw normalizedError
+        }
+    }
+
+    func finish() async throws -> PluginTranscriptionResult {
+        let shouldFinish = state.withLock { state in
+            guard !state.finished else { return false }
+            state.finished = true
+            return !state.cancelled
+        }
+
+        if shouldFinish {
+            do {
+                try await webSocket.sendText(#"{"type":"CloseStream"}"#)
+            } catch {
+                let normalizedError = Self.normalizedError(error)
+                await collector.setError(normalizedError.localizedDescription)
+                receiveTask.cancel()
+                webSocket.cancel()
+                throw normalizedError
+            }
+
+            let finishedCleanly = await waitForReceiveTask()
+            if !finishedCleanly {
+                Self.logger.warning("Live finish: Deepgram did not close within timeout; returning collected transcript")
+            }
+        }
+
+        receiveTask.cancel()
+        webSocket.cancel()
+
+        if let error = await collector.error {
+            throw PluginTranscriptionError.apiError(error)
+        }
+        return await collector.finalTranscriptionResult(fallbackLanguage: language)
+    }
+
+    func cancel() async {
+        let shouldCancel = state.withLock { state in
+            guard !state.cancelled else { return false }
+            state.cancelled = true
+            return true
+        }
+        guard shouldCancel else { return }
+
+        receiveTask.cancel()
+        webSocket.cancel()
+    }
+
+    private func waitForReceiveTask() async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask { [receiveTask] in
+                await receiveTask.value
+                return true
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: Self.finishTimeoutNanoseconds)
+                return false
+            }
+
+            let finishedCleanly = await group.next() ?? false
+            if !finishedCleanly {
+                receiveTask.cancel()
+                webSocket.cancel()
+            }
+            group.cancelAll()
+            return finishedCleanly
+        }
+    }
+
+    private static func normalizedError(_ error: Error) -> PluginTranscriptionError {
+        if let pluginError = error as? PluginTranscriptionError {
+            return pluginError
+        }
+        return .networkError(error.localizedDescription)
+    }
 }
 
 // MARK: - Plugin Entry Point
 
 @objc(DeepgramPlugin)
-final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, @unchecked Sendable {
+final class DeepgramPlugin: NSObject,
+    LiveTranscriptionCapablePlugin,
+    LiveTranscriptionProgressModeProviding,
+    DictionaryTermsCapabilityProviding,
+    DictionaryTermsBudgetProviding,
+    @unchecked Sendable {
     static let pluginId = "com.typewhisper.deepgram"
     static let pluginName = "Deepgram"
     private static let logger = Logger(subsystem: "com.typewhisper.deepgram", category: "Plugin")
@@ -360,6 +557,7 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
 
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
+    var liveTranscriptionProgressMode: LiveTranscriptionProgressMode { .completeSnapshot }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: Self.maxDictionaryTerms) }
 
@@ -488,6 +686,32 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         }
     }
 
+    func createLiveTranscriptionSession(
+        language: String?,
+        translate: Bool,
+        prompt: String?,
+        onProgress: @Sendable @escaping (String) -> Bool
+    ) async throws -> any LiveTranscriptionSession {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+
+        let webSocket = try makeStreamingWebSocket(
+            language: language,
+            modelId: modelId,
+            prompt: prompt,
+            apiKey: apiKey
+        )
+        return try await DeepgramLiveTranscriptionSession.connect(
+            webSocket: webSocket,
+            language: language,
+            onProgress: onProgress
+        )
+    }
+
     // MARK: - REST Implementation
 
     private func transcribeREST(
@@ -544,46 +768,11 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         apiKey: String,
         onProgress: @Sendable @escaping (String) -> Bool
     ) async throws -> PluginTranscriptionResult {
-        // Build query string for path
-        var queryItems = [
-            URLQueryItem(name: "model", value: modelId),
-            URLQueryItem(name: "encoding", value: "linear16"),
-            URLQueryItem(name: "sample_rate", value: "16000"),
-            URLQueryItem(name: "channels", value: "1"),
-            URLQueryItem(name: "smart_format", value: "true"),
-            URLQueryItem(name: "punctuate", value: "true"),
-            URLQueryItem(name: "interim_results", value: "true"),
-            URLQueryItem(name: "endpointing", value: "300"),
-        ]
-        if let lang = language, !lang.isEmpty {
-            queryItems.append(URLQueryItem(name: "language", value: lang))
-        } else {
-            queryItems.append(URLQueryItem(name: "detect_language", value: "true"))
-        }
-        queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
-
-        let baseURL = effectiveBaseURL
-        guard let urlComponents = URLComponents(string: baseURL),
-              let host = urlComponents.host else {
-            throw PluginTranscriptionError.apiError("Invalid base URL")
-        }
-        let usesTLS = baseURL.hasPrefix("https://")
-        let port = urlComponents.port ?? (usesTLS ? 443 : 80)
-
-        // Build the path+query for the HTTP upgrade request
-        var pathComponents = URLComponents()
-        pathComponents.path = "/v1/listen"
-        pathComponents.queryItems = queryItems
-        guard let pathWithQuery = pathComponents.string else {
-            throw PluginTranscriptionError.apiError("Invalid query parameters")
-        }
-
-        let ws = RawWebSocket(
-            host: host,
-            port: port,
-            usesTLS: usesTLS,
-            path: pathWithQuery,
-            headers: [(effectiveAuthHeader, authHeaderValue(apiKey: apiKey))]
+        let ws = try makeStreamingWebSocket(
+            language: language,
+            modelId: modelId,
+            prompt: prompt,
+            apiKey: apiKey
         )
 
         try await ws.connect()
@@ -652,6 +841,55 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
         return PluginTranscriptionResult(text: finalText, detectedLanguage: language)
     }
 
+    private func makeStreamingWebSocket(
+        language: String?,
+        modelId: String,
+        prompt: String?,
+        apiKey: String
+    ) throws -> RawWebSocket {
+        // Build query string for path
+        var queryItems = [
+            URLQueryItem(name: "model", value: modelId),
+            URLQueryItem(name: "encoding", value: "linear16"),
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "channels", value: "1"),
+            URLQueryItem(name: "smart_format", value: "true"),
+            URLQueryItem(name: "punctuate", value: "true"),
+            URLQueryItem(name: "interim_results", value: "true"),
+            URLQueryItem(name: "endpointing", value: "300"),
+        ]
+        if let lang = language, !lang.isEmpty {
+            queryItems.append(URLQueryItem(name: "language", value: lang))
+        } else {
+            queryItems.append(URLQueryItem(name: "detect_language", value: "true"))
+        }
+        queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
+
+        let baseURL = effectiveBaseURL
+        guard let urlComponents = URLComponents(string: baseURL),
+              let host = urlComponents.host else {
+            throw PluginTranscriptionError.apiError("Invalid base URL")
+        }
+        let usesTLS = baseURL.hasPrefix("https://")
+        let port = urlComponents.port ?? (usesTLS ? 443 : 80)
+
+        // Build the path+query for the HTTP upgrade request
+        var pathComponents = URLComponents()
+        pathComponents.path = "/v1/listen"
+        pathComponents.queryItems = queryItems
+        guard let pathWithQuery = pathComponents.string else {
+            throw PluginTranscriptionError.apiError("Invalid query parameters")
+        }
+
+        return RawWebSocket(
+            host: host,
+            port: port,
+            usesTLS: usesTLS,
+            path: pathWithQuery,
+            headers: [(effectiveAuthHeader, authHeaderValue(apiKey: apiKey))]
+        )
+    }
+
     internal static func dictionaryQueryItems(prompt: String?, modelId: String) -> [URLQueryItem] {
         let terms = PluginDictionaryTerms.terms(fromPrompt: prompt)
         guard !terms.isEmpty else { return [] }
@@ -697,6 +935,13 @@ final class DeepgramPlugin: NSObject, TranscriptionEnginePlugin, DictionaryTerms
     fileprivate static func isFinalResult(_ json: [String: Any]?) -> Bool {
         guard let json else { return false }
         return json["is_final"] as? Bool ?? false
+    }
+
+    fileprivate static func webSocketErrorMessage(from json: [String: Any]) -> String {
+        (json["description"] as? String)
+            ?? (json["message"] as? String)
+            ?? (json["error"] as? String)
+            ?? "Unknown Deepgram streaming error"
     }
 
     // MARK: - Audio Conversion

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -1148,37 +1148,59 @@ private struct DeepgramSettingsView: View {
             Divider()
 
             // Advanced Section
-            DisclosureGroup(String(localized: "Advanced", bundle: bundle), isExpanded: $showAdvanced) {
-                VStack(alignment: .leading, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Custom Base URL", bundle: bundle)
-                            .font(.subheadline)
-
-                        TextField("https://api.deepgram.com", text: $customBaseURL)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .onChange(of: customBaseURL) {
-                                plugin.setCustomBaseURL(customBaseURL)
-                            }
+            VStack(alignment: .leading, spacing: 0) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.16)) {
+                        showAdvanced.toggle()
                     }
+                } label: {
+                    HStack(spacing: 10) {
+                        Text("Advanced", bundle: bundle)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Custom Auth Header", bundle: bundle)
-                            .font(.subheadline)
+                        Spacer()
 
-                        TextField("Authorization", text: $customAuthHeader)
-                            .textFieldStyle(.roundedBorder)
-                            .font(.system(.body, design: .monospaced))
-                            .onChange(of: customAuthHeader) {
-                                plugin.setCustomAuthHeader(customAuthHeader)
-                            }
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                            .rotationEffect(.degrees(showAdvanced ? 90 : 0))
                     }
-
-                    Text("For Cloudflare AI Gateway or custom proxies", bundle: bundle)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    .padding(.vertical, 4)
+                    .contentShape(Rectangle())
                 }
-                .padding(.top, 8)
+                .buttonStyle(.plain)
+
+                if showAdvanced {
+                    VStack(alignment: .leading, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Custom Base URL", bundle: bundle)
+                                .font(.subheadline)
+
+                            TextField("https://api.deepgram.com", text: $customBaseURL)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .onChange(of: customBaseURL) {
+                                    plugin.setCustomBaseURL(customBaseURL)
+                                }
+                        }
+
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Custom Auth Header", bundle: bundle)
+                                .font(.subheadline)
+
+                            TextField("Authorization", text: $customAuthHeader)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.system(.body, design: .monospaced))
+                                .onChange(of: customAuthHeader) {
+                                    plugin.setCustomAuthHeader(customAuthHeader)
+                                }
+                        }
+
+                        Text("For Cloudflare AI Gateway or custom proxies", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.top, 8)
+                }
             }
 
             Text("API keys are stored securely in the Keychain", bundle: bundle)

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -328,6 +328,7 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
 
     private let webSocket: RawWebSocket
     private let receiveTask: Task<Void, Never>
+    private let receiveCompletion: AsyncStream<Void>
     private let collector: TranscriptCollector
     private let language: String?
     private let state = OSAllocatedUnfairLock(initialState: State())
@@ -335,11 +336,13 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
     private init(
         webSocket: RawWebSocket,
         receiveTask: Task<Void, Never>,
+        receiveCompletion: AsyncStream<Void>,
         collector: TranscriptCollector,
         language: String?
     ) {
         self.webSocket = webSocket
         self.receiveTask = receiveTask
+        self.receiveCompletion = receiveCompletion
         self.collector = collector
         self.language = language
     }
@@ -352,7 +355,9 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
         try await webSocket.connect()
 
         let collector = TranscriptCollector()
-        let receiveTask = Task { [webSocket, collector, onProgress] in
+        let (receiveCompletion, receiveCompletionContinuation) = AsyncStream<Void>.makeStream()
+        let receiveTask = Task { [webSocket, collector, onProgress, receiveCompletionContinuation] in
+            defer { receiveCompletionContinuation.finish() }
             do {
                 while !Task.isCancelled {
                     let frame = try await webSocket.receiveFrame()
@@ -395,6 +400,7 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
         return DeepgramLiveTranscriptionSession(
             webSocket: webSocket,
             receiveTask: receiveTask,
+            receiveCompletion: receiveCompletion,
             collector: collector,
             language: language
         )
@@ -445,10 +451,11 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
         receiveTask.cancel()
         webSocket.cancel()
 
-        if let error = await collector.error {
+        let result = await collector.finalTranscriptionResult(fallbackLanguage: language)
+        if result.text.isEmpty, let error = await collector.error {
             throw PluginTranscriptionError.apiError(error)
         }
-        return await collector.finalTranscriptionResult(fallbackLanguage: language)
+        return result
     }
 
     func cancel() async {
@@ -465,8 +472,9 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
 
     private func waitForReceiveTask() async -> Bool {
         await withTaskGroup(of: Bool.self) { group in
-            group.addTask { [receiveTask] in
-                await receiveTask.value
+            group.addTask { [receiveCompletion] in
+                var iterator = receiveCompletion.makeAsyncIterator()
+                _ = await iterator.next()
                 return true
             }
             group.addTask {
@@ -624,6 +632,43 @@ final class DeepgramPlugin: NSObject,
         if let language, !language.isEmpty {
             queryItems.append(URLQueryItem(name: "language", value: language))
         }
+        queryItems.append(contentsOf: dictionaryQueryItems(prompt: prompt, modelId: modelId))
+        components.queryItems = queryItems
+
+        guard let requestURL = components.url else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
+        }
+        return requestURL
+    }
+
+    static func streamingRequestURL(
+        baseURL: String,
+        modelId: String,
+        language: String?,
+        prompt: String?
+    ) throws -> URL {
+        guard var components = URLComponents(string: "\(baseURL)/v1/listen"),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              let host = components.host,
+              !host.isEmpty else {
+            throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
+        }
+
+        var queryItems = [
+            URLQueryItem(name: "model", value: modelId),
+            URLQueryItem(name: "encoding", value: "linear16"),
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "channels", value: "1"),
+            URLQueryItem(name: "smart_format", value: "true"),
+            URLQueryItem(name: "punctuate", value: "true"),
+            URLQueryItem(name: "interim_results", value: "true"),
+            URLQueryItem(name: "endpointing", value: "300"),
+        ]
+        queryItems.append(URLQueryItem(
+            name: "language",
+            value: language.flatMap { $0.isEmpty ? nil : $0 } ?? "multi"
+        ))
         queryItems.append(contentsOf: dictionaryQueryItems(prompt: prompt, modelId: modelId))
         components.queryItems = queryItems
 
@@ -847,38 +892,25 @@ final class DeepgramPlugin: NSObject,
         prompt: String?,
         apiKey: String
     ) throws -> RawWebSocket {
-        // Build query string for path
-        var queryItems = [
-            URLQueryItem(name: "model", value: modelId),
-            URLQueryItem(name: "encoding", value: "linear16"),
-            URLQueryItem(name: "sample_rate", value: "16000"),
-            URLQueryItem(name: "channels", value: "1"),
-            URLQueryItem(name: "smart_format", value: "true"),
-            URLQueryItem(name: "punctuate", value: "true"),
-            URLQueryItem(name: "interim_results", value: "true"),
-            URLQueryItem(name: "endpointing", value: "300"),
-        ]
-        if let lang = language, !lang.isEmpty {
-            queryItems.append(URLQueryItem(name: "language", value: lang))
-        } else {
-            queryItems.append(URLQueryItem(name: "detect_language", value: "true"))
+        let requestURL = try Self.streamingRequestURL(
+            baseURL: effectiveBaseURL,
+            modelId: modelId,
+            language: language,
+            prompt: prompt
+        )
+        guard let urlComponents = URLComponents(url: requestURL, resolvingAgainstBaseURL: false),
+              let scheme = urlComponents.scheme?.lowercased(),
+              let host = urlComponents.host,
+              !host.isEmpty else {
+            throw PluginTranscriptionError.apiError("Invalid streaming URL")
         }
-        queryItems.append(contentsOf: Self.dictionaryQueryItems(prompt: prompt, modelId: modelId))
-
-        let baseURL = effectiveBaseURL
-        guard let urlComponents = URLComponents(string: baseURL),
-              let host = urlComponents.host else {
-            throw PluginTranscriptionError.apiError("Invalid base URL")
-        }
-        let usesTLS = baseURL.hasPrefix("https://")
+        let usesTLS = scheme == "https"
         let port = urlComponents.port ?? (usesTLS ? 443 : 80)
 
         // Build the path+query for the HTTP upgrade request
-        var pathComponents = URLComponents()
-        pathComponents.path = "/v1/listen"
-        pathComponents.queryItems = queryItems
-        guard let pathWithQuery = pathComponents.string else {
-            throw PluginTranscriptionError.apiError("Invalid query parameters")
+        var pathWithQuery = urlComponents.percentEncodedPath
+        if let query = urlComponents.percentEncodedQuery, !query.isEmpty {
+            pathWithQuery += "?\(query)"
         }
 
         return RawWebSocket(

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -40,6 +40,7 @@ private final class RawWebSocket: @unchecked Sendable {
 
     private let streamTask: URLSessionStreamTask
     private let hostName: String
+    private let hostHeader: String
     private let usesTLS: Bool
     private let path: String
     private let extraHeaders: [(String, String)]
@@ -47,8 +48,16 @@ private final class RawWebSocket: @unchecked Sendable {
 
     private let buffer = OSAllocatedUnfairLock(initialState: Data())
 
-    init(host: String, port: Int, usesTLS: Bool, path: String, headers: [(String, String)]) {
+    init(
+        host: String,
+        hostHeader: String,
+        port: Int,
+        usesTLS: Bool,
+        path: String,
+        headers: [(String, String)]
+    ) {
         self.hostName = host
+        self.hostHeader = hostHeader
         self.usesTLS = usesTLS
         self.path = path
         self.extraHeaders = headers
@@ -75,7 +84,7 @@ private final class RawWebSocket: @unchecked Sendable {
         let wsKey = Data(keyBytes).base64EncodedString()
 
         var request = "GET \(path) HTTP/1.1\r\n"
-        request += "Host: \(hostName)\r\n"
+        request += "Host: \(hostHeader)\r\n"
         request += "Upgrade: websocket\r\n"
         request += "Connection: Upgrade\r\n"
         request += "Sec-WebSocket-Key: \(wsKey)\r\n"
@@ -269,6 +278,79 @@ private final class RawWebSocket: @unchecked Sendable {
     }
 }
 
+// MARK: - Serialized Live Audio Output
+
+actor DeepgramLiveOutboundOperationQueue {
+    typealias AudioSender = @Sendable (Data) async throws -> Void
+    typealias CloseStreamSender = @Sendable () async throws -> Void
+    typealias Canceller = @Sendable () -> Void
+
+    private let sendAudio: AudioSender
+    private let sendCloseStream: CloseStreamSender
+    private let cancelSocket: Canceller
+    private var tailTask: Task<Void, Error>?
+    private var isFinishing = false
+    private var isCancelled = false
+
+    init(
+        sendAudio: @escaping AudioSender,
+        sendCloseStream: @escaping CloseStreamSender,
+        cancel: @escaping Canceller
+    ) {
+        self.sendAudio = sendAudio
+        self.sendCloseStream = sendCloseStream
+        self.cancelSocket = cancel
+    }
+
+    func appendAudio(samples: [Float]) async throws {
+        guard !isFinishing, !isCancelled else { return }
+
+        let data = DeepgramPlugin.floatToPCM16(samples)
+        guard !data.isEmpty else { return }
+
+        let sendAudio = self.sendAudio
+        let task = enqueue {
+            try await sendAudio(data)
+        }
+        try await task.value
+    }
+
+    func finishIfNeeded() async throws -> Bool {
+        guard !isFinishing else { return false }
+        isFinishing = true
+        guard !isCancelled else { return false }
+
+        let sendCloseStream = self.sendCloseStream
+        let task = enqueue {
+            try await sendCloseStream()
+        }
+        try await task.value
+        return true
+    }
+
+    func cancel() {
+        guard !isCancelled else { return }
+        isCancelled = true
+        tailTask?.cancel()
+        cancelSocket()
+    }
+
+    private func enqueue(
+        _ operation: @escaping @Sendable () async throws -> Void
+    ) -> Task<Void, Error> {
+        let previousTask = tailTask
+        let task = Task {
+            if let previousTask {
+                try await previousTask.value
+            }
+            try Task.checkCancellation()
+            try await operation()
+        }
+        tailTask = task
+        return task
+    }
+}
+
 // MARK: - Transcript Collector
 
 private actor TranscriptCollector {
@@ -318,29 +400,23 @@ private actor TranscriptCollector {
 // MARK: - Live STT Session
 
 private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, @unchecked Sendable {
-    private struct State {
-        var finished = false
-        var cancelled = false
-    }
-
     private static let finishTimeoutNanoseconds: UInt64 = 2_000_000_000
     private static let logger = Logger(subsystem: "com.typewhisper.deepgram", category: "LiveSession")
 
-    private let webSocket: RawWebSocket
+    private let outbound: DeepgramLiveOutboundOperationQueue
     private let receiveTask: Task<Void, Never>
     private let receiveCompletion: AsyncStream<Void>
     private let collector: TranscriptCollector
     private let language: String?
-    private let state = OSAllocatedUnfairLock(initialState: State())
 
     private init(
-        webSocket: RawWebSocket,
+        outbound: DeepgramLiveOutboundOperationQueue,
         receiveTask: Task<Void, Never>,
         receiveCompletion: AsyncStream<Void>,
         collector: TranscriptCollector,
         language: String?
     ) {
-        self.webSocket = webSocket
+        self.outbound = outbound
         self.receiveTask = receiveTask
         self.receiveCompletion = receiveCompletion
         self.collector = collector
@@ -398,7 +474,17 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
         }
 
         return DeepgramLiveTranscriptionSession(
-            webSocket: webSocket,
+            outbound: DeepgramLiveOutboundOperationQueue(
+                sendAudio: { [webSocket] data in
+                    try await webSocket.sendBinary(data)
+                },
+                sendCloseStream: { [webSocket] in
+                    try await webSocket.sendText(#"{"type":"CloseStream"}"#)
+                },
+                cancel: { [webSocket] in
+                    webSocket.cancel()
+                }
+            ),
             receiveTask: receiveTask,
             receiveCompletion: receiveCompletion,
             collector: collector,
@@ -407,16 +493,12 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
     }
 
     func appendAudio(samples: [Float]) async throws {
-        guard !state.withLock({ $0.finished || $0.cancelled }) else { return }
         if let error = await collector.error {
             throw PluginTranscriptionError.apiError(error)
         }
 
-        let data = DeepgramPlugin.floatToPCM16(samples)
-        guard !data.isEmpty else { return }
-
         do {
-            try await webSocket.sendBinary(data)
+            try await outbound.appendAudio(samples: samples)
         } catch {
             let normalizedError = Self.normalizedError(error)
             await collector.setError(normalizedError.localizedDescription)
@@ -425,23 +507,23 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
     }
 
     func finish() async throws -> PluginTranscriptionResult {
-        let shouldFinish = state.withLock { state in
-            guard !state.finished else { return false }
-            state.finished = true
-            return !state.cancelled
+        let shouldWaitForResults: Bool
+        do {
+            shouldWaitForResults = try await outbound.finishIfNeeded()
+        } catch {
+            let normalizedError = Self.normalizedError(error)
+            await collector.setError(normalizedError.localizedDescription)
+            receiveTask.cancel()
+            await outbound.cancel()
+
+            let result = await collector.finalTranscriptionResult(fallbackLanguage: language)
+            if !result.text.isEmpty {
+                return result
+            }
+            throw normalizedError
         }
 
-        if shouldFinish {
-            do {
-                try await webSocket.sendText(#"{"type":"CloseStream"}"#)
-            } catch {
-                let normalizedError = Self.normalizedError(error)
-                await collector.setError(normalizedError.localizedDescription)
-                receiveTask.cancel()
-                webSocket.cancel()
-                throw normalizedError
-            }
-
+        if shouldWaitForResults {
             let finishedCleanly = await waitForReceiveTask()
             if !finishedCleanly {
                 Self.logger.warning("Live finish: Deepgram did not close within timeout; returning collected transcript")
@@ -449,7 +531,7 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
         }
 
         receiveTask.cancel()
-        webSocket.cancel()
+        await outbound.cancel()
 
         let result = await collector.finalTranscriptionResult(fallbackLanguage: language)
         if result.text.isEmpty, let error = await collector.error {
@@ -459,15 +541,8 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
     }
 
     func cancel() async {
-        let shouldCancel = state.withLock { state in
-            guard !state.cancelled else { return false }
-            state.cancelled = true
-            return true
-        }
-        guard shouldCancel else { return }
-
         receiveTask.cancel()
-        webSocket.cancel()
+        await outbound.cancel()
     }
 
     private func waitForReceiveTask() async -> Bool {
@@ -485,7 +560,7 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
             let finishedCleanly = await group.next() ?? false
             if !finishedCleanly {
                 receiveTask.cancel()
-                webSocket.cancel()
+                await outbound.cancel()
             }
             group.cancelAll()
             return finishedCleanly
@@ -616,7 +691,7 @@ final class DeepgramPlugin: NSObject,
         language: String?,
         prompt: String?
     ) throws -> URL {
-        guard var components = URLComponents(string: "\(baseURL)/v1/listen"),
+        guard var components = URLComponents(string: baseURL),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
               let host = components.host,
@@ -624,11 +699,17 @@ final class DeepgramPlugin: NSObject,
             throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
         }
 
-        var queryItems = [
+        let basePath = components.percentEncodedPath
+        components.percentEncodedPath = basePath.hasSuffix("/")
+            ? "\(basePath)v1/listen"
+            : "\(basePath)/v1/listen"
+
+        var queryItems = components.queryItems ?? []
+        queryItems.append(contentsOf: [
             URLQueryItem(name: "model", value: modelId),
             URLQueryItem(name: "smart_format", value: "true"),
             URLQueryItem(name: "punctuate", value: "true"),
-        ]
+        ])
         if let language, !language.isEmpty {
             queryItems.append(URLQueryItem(name: "language", value: language))
         }
@@ -647,7 +728,7 @@ final class DeepgramPlugin: NSObject,
         language: String?,
         prompt: String?
     ) throws -> URL {
-        guard var components = URLComponents(string: "\(baseURL)/v1/listen"),
+        guard var components = URLComponents(string: baseURL),
               let scheme = components.scheme?.lowercased(),
               scheme == "http" || scheme == "https",
               let host = components.host,
@@ -655,7 +736,13 @@ final class DeepgramPlugin: NSObject,
             throw PluginTranscriptionError.apiError("Invalid base URL: \(baseURL)")
         }
 
-        var queryItems = [
+        let basePath = components.percentEncodedPath
+        components.percentEncodedPath = basePath.hasSuffix("/")
+            ? "\(basePath)v1/listen"
+            : "\(basePath)/v1/listen"
+
+        var queryItems = components.queryItems ?? []
+        queryItems.append(contentsOf: [
             URLQueryItem(name: "model", value: modelId),
             URLQueryItem(name: "encoding", value: "linear16"),
             URLQueryItem(name: "sample_rate", value: "16000"),
@@ -664,7 +751,7 @@ final class DeepgramPlugin: NSObject,
             URLQueryItem(name: "punctuate", value: "true"),
             URLQueryItem(name: "interim_results", value: "true"),
             URLQueryItem(name: "endpointing", value: "300"),
-        ]
+        ])
         queryItems.append(URLQueryItem(
             name: "language",
             value: language.flatMap { $0.isEmpty ? nil : $0 } ?? "multi"
@@ -906,6 +993,7 @@ final class DeepgramPlugin: NSObject,
         }
         let usesTLS = scheme == "https"
         let port = urlComponents.port ?? (usesTLS ? 443 : 80)
+        let hostHeader = Self.webSocketHostHeader(host: host, port: port, usesTLS: usesTLS)
 
         // Build the path+query for the HTTP upgrade request
         var pathWithQuery = urlComponents.percentEncodedPath
@@ -915,11 +1003,18 @@ final class DeepgramPlugin: NSObject,
 
         return RawWebSocket(
             host: host,
+            hostHeader: hostHeader,
             port: port,
             usesTLS: usesTLS,
             path: pathWithQuery,
             headers: [(effectiveAuthHeader, authHeaderValue(apiKey: apiKey))]
         )
+    }
+
+    internal static func webSocketHostHeader(host: String, port: Int, usesTLS: Bool) -> String {
+        let formattedHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        let defaultPort = usesTLS ? 443 : 80
+        return port == defaultPort ? formattedHost : "\(formattedHost):\(port)"
     }
 
     internal static func dictionaryQueryItems(prompt: String?, modelId: String) -> [URLQueryItem] {

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.deepgram",
     "name": "Deepgram",
-    "version": "1.0.13",
+    "version": "1.0.14",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1638,6 +1638,51 @@ final class PluginDictionaryGuardTests: XCTestCase {
         )
     }
 
+    func testDeepgramStreamingRequestURLUsesMultilingualFallbackAndPreservesEndpoint() throws {
+        let prompt = PluginDictionaryTerms.prompt(from: ["TypeWhisper", "Deepgram"], maxLength: 10_000)
+        let url = try DeepgramPlugin.streamingRequestURL(
+            baseURL: "http://localhost:8080/deepgram",
+            modelId: "nova-3",
+            language: nil,
+            prompt: prompt
+        )
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        let queryItems = components.queryItems ?? []
+        let firstValue = { (name: String) in
+            queryItems.first(where: { $0.name == name })?.value
+        }
+
+        XCTAssertEqual(components.scheme, "http")
+        XCTAssertEqual(components.host, "localhost")
+        XCTAssertEqual(components.port, 8080)
+        XCTAssertEqual(components.path, "/deepgram/v1/listen")
+        XCTAssertEqual(firstValue("model"), "nova-3")
+        XCTAssertEqual(firstValue("language"), "multi")
+        XCTAssertNil(firstValue("detect_language"))
+        XCTAssertEqual(
+            queryItems.filter { $0.name == "keyterm" }.compactMap(\.value),
+            ["TypeWhisper", "Deepgram"]
+        )
+    }
+
+    func testDeepgramStreamingRequestURLRejectsUnsupportedSchemes() {
+        for baseURL in ["not a URL", "file:///tmp/deepgram", "ftp://example.com"] {
+            XCTAssertThrowsError(
+                try DeepgramPlugin.streamingRequestURL(
+                    baseURL: baseURL,
+                    modelId: "nova-3",
+                    language: nil,
+                    prompt: nil
+                ),
+                baseURL
+            ) { error in
+                guard case PluginTranscriptionError.apiError = error else {
+                    return XCTFail("Expected apiError for \(baseURL), got \(error)")
+                }
+            }
+        }
+    }
+
     @available(macOS 26, *)
     func testSpeechAnalyzerAnalysisContextLimitsDictionaryTermsTo100() {
         let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1638,10 +1638,10 @@ final class PluginDictionaryGuardTests: XCTestCase {
         )
     }
 
-    func testDeepgramStreamingRequestURLUsesMultilingualFallbackAndPreservesEndpoint() throws {
+    func testDeepgramStreamingRequestURLUsesMultilingualFallbackAndPreservesProxyURL() throws {
         let prompt = PluginDictionaryTerms.prompt(from: ["TypeWhisper", "Deepgram"], maxLength: 10_000)
         let url = try DeepgramPlugin.streamingRequestURL(
-            baseURL: "http://localhost:8080/deepgram",
+            baseURL: "http://localhost:8080/deepgram?gateway=true",
             modelId: "nova-3",
             language: nil,
             prompt: prompt
@@ -1656,6 +1656,7 @@ final class PluginDictionaryGuardTests: XCTestCase {
         XCTAssertEqual(components.host, "localhost")
         XCTAssertEqual(components.port, 8080)
         XCTAssertEqual(components.path, "/deepgram/v1/listen")
+        XCTAssertEqual(firstValue("gateway"), "true")
         XCTAssertEqual(firstValue("model"), "nova-3")
         XCTAssertEqual(firstValue("language"), "multi")
         XCTAssertNil(firstValue("detect_language"))
@@ -1663,6 +1664,58 @@ final class PluginDictionaryGuardTests: XCTestCase {
             queryItems.filter { $0.name == "keyterm" }.compactMap(\.value),
             ["TypeWhisper", "Deepgram"]
         )
+    }
+
+    func testDeepgramWebSocketHostHeaderIncludesOnlyNonDefaultPorts() {
+        XCTAssertEqual(
+            DeepgramPlugin.webSocketHostHeader(host: "api.deepgram.com", port: 443, usesTLS: true),
+            "api.deepgram.com"
+        )
+        XCTAssertEqual(
+            DeepgramPlugin.webSocketHostHeader(host: "proxy.example", port: 8443, usesTLS: true),
+            "proxy.example:8443"
+        )
+        XCTAssertEqual(
+            DeepgramPlugin.webSocketHostHeader(host: "::1", port: 8080, usesTLS: false),
+            "[::1]:8080"
+        )
+    }
+
+    func testDeepgramLiveOutboundSerializesAudioBeforeFinalization() async throws {
+        let audioStarted = DeepgramOutboundTestGate()
+        let allowAudioToFinish = DeepgramOutboundTestGate()
+        let events = DeepgramOutboundTestEvents()
+        let outbound = DeepgramLiveOutboundOperationQueue(
+            sendAudio: { _ in
+                await events.append("audio-start")
+                await audioStarted.open()
+                await allowAudioToFinish.wait()
+                await events.append("audio-end")
+            },
+            sendCloseStream: {
+                await events.append("close-stream")
+            },
+            cancel: {}
+        )
+
+        let appendTask = Task {
+            try await outbound.appendAudio(samples: [0.25, -0.25])
+        }
+        await audioStarted.wait()
+        let finishTask = Task {
+            try await outbound.finishIfNeeded()
+        }
+
+        try await Task.sleep(for: .milliseconds(25))
+        let eventsWhileAudioIsPending = await events.snapshot()
+        XCTAssertEqual(eventsWhileAudioIsPending, ["audio-start"])
+
+        await allowAudioToFinish.open()
+        try await appendTask.value
+        let didFinish = try await finishTask.value
+        XCTAssertTrue(didFinish)
+        let finalEvents = await events.snapshot()
+        XCTAssertEqual(finalEvents, ["audio-start", "audio-end", "close-stream"])
     }
 
     func testDeepgramStreamingRequestURLRejectsUnsupportedSchemes() {
@@ -2833,5 +2886,39 @@ final class OpenAIPluginTokenParameterTests: XCTestCase {
 
     func testLegacyChatCompletionsKeepTemperature() {
         XCTAssertEqual(OpenAIPlugin.chatCompletionTemperature(for: "gpt-4o", reasoningEffort: nil), 0.3)
+    }
+}
+
+private actor DeepgramOutboundTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        for waiter in pendingWaiters {
+            waiter.resume()
+        }
+    }
+}
+
+private actor DeepgramOutboundTestEvents {
+    private var events: [String] = []
+
+    func append(_ event: String) {
+        events.append(event)
+    }
+
+    func snapshot() -> [String] {
+        events
     }
 }

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1558,6 +1558,14 @@ final class PluginDictionaryGuardTests: XCTestCase {
         XCTAssertTrue(DeepgramPlugin().supportedLanguages.contains("multi"))
     }
 
+    func testDeepgramAdvertisesLiveDictationTranscription() {
+        let plugin: Any = DeepgramPlugin()
+
+        XCTAssertTrue(plugin is any LiveTranscriptionCapablePlugin)
+        let progressProvider = plugin as? any LiveTranscriptionProgressModeProviding
+        XCTAssertEqual(progressProvider?.liveTranscriptionProgressMode, .completeSnapshot)
+    }
+
     func testDeepgramDictionaryQueryItemsLimitDictionaryTermsTo100AndPreserveOrder() {
         let prompt = PluginDictionaryTerms.prompt(from: makeLongTerms(count: 150, length: 10), maxLength: 10_000)
         let queryItems = DeepgramPlugin.dictionaryQueryItems(prompt: prompt, modelId: "nova-2")


### PR DESCRIPTION
## Summary

- expose Deepgram as a true live transcription provider for dictation
- stream incremental PCM audio over the existing raw WebSocket transport
- harden live shutdown, multilingual fallback, and custom proxy endpoint handling
- make the full Advanced settings row clickable, not only its disclosure icon
- bump the Deepgram plugin manifest from `1.0.13` to `1.0.14`

## Issue context

Deepgram advertised streaming support but did not implement `LiveTranscriptionCapablePlugin`, so dictation fell back to periodic batch previews and re-transcribed the full recording after stop.

Closes #1235

## Test plan

- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginDictionaryGuardTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild build -project TypeWhisper.xcodeproj -scheme DeepgramPlugin -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- Built, installed, enabled, and launched the signed Deepgram `1.0.14` plugin in the stable TypeWhisper dev app.
- Manually verified live dictation streaming one-to-one in the app with both `nova-3` and `nova-2`.
- Manually verified that clicking anywhere on the Advanced settings row toggles its expanded state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Deepgram live transcription sessions with progress updates and complete transcript snapshots.
* **Bug Fixes**
  * Improved streaming completion, cancellation, and transcript recovery when finalization encounters an error.
  * Preserved custom endpoint paths and query parameters while strengthening HTTP(S) URL validation.
  * Improved WebSocket connection handling, including host formatting for IPv6 and non-default ports.
* **Chores**
  * Updated the Deepgram plugin manifest version to 1.0.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
