### PR TITLE
fix(plugins): restore Gemma 4 compatibility with TypeWhisper 1.6

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -250,6 +250,73 @@ jobs:
             MARKETING_VERSION="$PLUGIN_VERSION" \
             "${EXTRA_SETTINGS[@]}"
 
+      - name: Verify plugin SDK compatibility with minHostVersion
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
+          MIN_HOST_VERSION=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["minHostVersion"])' "$MANIFEST")
+          HOST_TAG="v${MIN_HOST_VERSION}"
+          HOST_ASSET_NAME="TypeWhisper-v${MIN_HOST_VERSION}.zip"
+          WORKDIR="$RUNNER_TEMP/min-host-sdk-${TARGET}"
+          mkdir -p "$WORKDIR/app"
+
+          if ! HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,assets); then
+            echo "::error::No published TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION} (${HOST_TAG})"
+            exit 1
+          fi
+
+          if ! jq -e --arg asset "$HOST_ASSET_NAME" \
+            '[.assets[] | select(.name == $asset)] | length == 1' \
+            <<<"$HOST_RELEASE_JSON" >/dev/null; then
+            echo "::error::Release ${HOST_TAG} must contain exactly one ${HOST_ASSET_NAME} asset"
+            exit 1
+          fi
+
+          RESOLVED_TAG=$(jq -r '.tagName' <<<"$HOST_RELEASE_JSON")
+          gh release download "$RESOLVED_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern "$HOST_ASSET_NAME" \
+            --dir "$WORKDIR"
+
+          HOST_ZIP="$WORKDIR/$HOST_ASSET_NAME"
+          EXPECTED_DIGEST=$(jq -r --arg asset "$HOST_ASSET_NAME" \
+            '.assets[] | select(.name == $asset) | .digest // ""' \
+            <<<"$HOST_RELEASE_JSON")
+          if [[ "$EXPECTED_DIGEST" == sha256:* ]]; then
+            ACTUAL_DIGEST="sha256:$(shasum -a 256 "$HOST_ZIP" | awk '{print $1}')"
+            if [ "$ACTUAL_DIGEST" != "$EXPECTED_DIGEST" ]; then
+              echo "::error::Host asset digest mismatch: expected ${EXPECTED_DIGEST}, got ${ACTUAL_DIGEST}"
+              exit 1
+            fi
+          fi
+
+          ditto -x -k "$HOST_ZIP" "$WORKDIR/app"
+          HOST_SDK=$(find "$WORKDIR/app" \
+            -path '*TypeWhisperPluginSDK.framework/Versions/A/TypeWhisperPluginSDK' \
+            -type f -print -quit)
+          BUILD_SDK=$(find build \
+            -path '*TypeWhisperPluginSDK.framework/Versions/A/TypeWhisperPluginSDK' \
+            -type f -print -quit)
+          PLUGIN_BINARY="build/Release/${TARGET}.bundle/Contents/MacOS/${TARGET}"
+
+          if [ -z "$HOST_SDK" ]; then
+            echo "::error::TypeWhisperPluginSDK.framework not found in host release ${RESOLVED_TAG}"
+            exit 1
+          fi
+          if [ -z "$BUILD_SDK" ]; then
+            echo "::error::TypeWhisperPluginSDK.framework used for the plugin build was not found"
+            exit 1
+          fi
+
+          python3 scripts/check_plugin_sdk_symbol_compatibility.py \
+            --plugin-binary "$PLUGIN_BINARY" \
+            --build-sdk "$BUILD_SDK" \
+            --host-sdk "$HOST_SDK" \
+            --min-host-version "$MIN_HOST_VERSION"
+
       - name: Import Signing Certificate
         env:
           MACOS_SIGNING_P12: ${{ secrets.MACOS_SIGNING_P12 }}

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -263,8 +263,14 @@ jobs:
 
           if ! HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
             --repo "$GITHUB_REPOSITORY" \
-            --json tagName,assets); then
+            --json tagName,isDraft,isPrerelease,assets); then
             echo "::error::No published TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION} (${HOST_TAG})"
+            exit 1
+          fi
+
+          if ! jq -e '.isDraft == false and .isPrerelease == false' \
+            <<<"$HOST_RELEASE_JSON" >/dev/null; then
+            echo "::error::Host release ${HOST_TAG} must be published and stable (not a draft or prerelease)"
             exit 1
           fi
 

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -7724,7 +7724,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = Gemma4Plugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.gemma4;
 				PRODUCT_NAME = Gemma4Plugin;
 				SDKROOT = macosx;
@@ -7748,7 +7748,7 @@
 				INFOPLIST_KEY_NSPrincipalClass = Gemma4Plugin;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1.6;
 				PRODUCT_BUNDLE_IDENTIFIER = com.typewhisper.gemma4;
 				PRODUCT_NAME = Gemma4Plugin;
 				SDKROOT = macosx;

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/Gemma4Plugin.swift
@@ -10,6 +10,17 @@ import Tokenizers
 @_spi(FirstPartyPlugins) import TypeWhisperPluginSDK
 import os
 
+// Keep this policy plugin-local because the SDK network guard was added after TypeWhisper 1.6.0.
+enum Gemma4NetworkAccessPolicy {
+    static func ensureAccessIsAllowed(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws {
+        guard !arguments.contains("--store-screenshots") else {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
 private struct Gemma4DownloadProgressReport: Equatable {
     let completedUnitCount: Int64
     let totalUnitCount: Int64
@@ -601,7 +612,7 @@ final class Gemma4Plugin: NSObject, ObservableObject, LLMProviderPlugin, LLMTemp
         let downloadedDirectory = usableModelDirectory(for: modelDef)
         let isAlreadyDownloaded = downloadedDirectory != nil
         if !isAlreadyDownloaded {
-            try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+            try Gemma4NetworkAccessPolicy.ensureAccessIsAllowed()
         }
         let loadGeneration = beginModelLoad(for: modelDef, isAlreadyDownloaded: isAlreadyDownloaded)
         startModelLoadTimeout(generation: loadGeneration, modelName: modelDef.displayName)

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -66,6 +66,11 @@ Plugins can subscribe to events without modifying the transcription pipeline:
 
 `category` may be one of `transcription`, `tts`, `llm`, `post-processor`, `action`, `memory`, or `utility`.
 
+`minHostVersion` must name a published stable TypeWhisper release. The official
+plugin release workflow builds the bundle and compares every shipped architecture's
+SDK imports with the `TypeWhisperPluginSDK.framework` embedded in that host release.
+The release fails before signing and publication when a required SDK symbol is absent.
+
 ### Host Services
 
 Each plugin receives a `HostServices` object providing:

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -31,7 +31,7 @@ Create `Contents/Resources/manifest.json` in your bundle:
 
 - `id` - Unique reverse-domain identifier
 - `principalClass` - Must match `@objc(ClassName)` on your plugin class
-- `minHostVersion` - Minimum TypeWhisper version required; new releases must use `1.6.0` or newer
+- `minHostVersion` - Minimum published stable TypeWhisper version required; new releases must use `1.6.0` or newer. Official releases verify the built plugin's SDK imports against the framework shipped by this exact host release.
 - `sdkCompatibilityVersion` - Must match `PluginSDKCompatibility.currentVersion` for marketplace/external plugins
 - `minOSVersion` - Minimum macOS version required (plugin is skipped on older systems)
 

--- a/TypeWhisperTests/MLXPluginModelStorageTests.swift
+++ b/TypeWhisperTests/MLXPluginModelStorageTests.swift
@@ -7,6 +7,40 @@ import TypeWhisperPluginSDK
 final class MLXPluginModelStorageTests: XCTestCase {
     private let commit = String(repeating: "b", count: 40)
 
+    func testGemma4SourceAvoidsSDKSymbolsUnavailableInHost16() throws {
+        let pluginDirectory = TestSupport.repoRoot.appendingPathComponent(
+            "TypeWhisperPluginSDK/Plugins/Gemma4Plugin"
+        )
+        let sourceURLs = try FileManager.default.contentsOfDirectory(
+            at: pluginDirectory,
+            includingPropertiesForKeys: nil
+        ).filter { $0.pathExtension == "swift" }
+
+        for sourceURL in sourceURLs {
+            let source = try String(contentsOf: sourceURL, encoding: .utf8)
+            XCTAssertFalse(
+                source.contains("PluginHTTPClient.ensureNetworkAccessIsAllowed"),
+                "\(sourceURL.lastPathComponent) must remain loadable by the declared TypeWhisper 1.6.0 host"
+            )
+        }
+    }
+
+    func testGemma4NetworkPolicyAllowsNormalRuntime() {
+        XCTAssertNoThrow(
+            try Gemma4NetworkAccessPolicy.ensureAccessIsAllowed(arguments: ["TypeWhisper"])
+        )
+    }
+
+    func testGemma4NetworkPolicyBlocksScreenshotAutomation() {
+        XCTAssertThrowsError(
+            try Gemma4NetworkAccessPolicy.ensureAccessIsAllowed(
+                arguments: ["TypeWhisper", "--store-screenshots"]
+            )
+        ) { error in
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
+    }
+
     func testGemma4LLMRuntimeAcceptsCurrentAndLegacyConfigurationTypes() async throws {
         for modelType in ["gemma4", "gemma4_text", "gemma4_unified"] {
             let isRegistered = await LLMTypeRegistry.shared.contains(modelType)

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -134,7 +134,7 @@ final class PluginManifestValidationTests: XCTestCase {
             ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.8"),
             ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.14"),
             ("TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json", "1.0.10"),
-            ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.5"),
+            ("TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json", "1.1.6"),
         ]
 
         for (relativePath, expectedVersion) in manifestExpectations {

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -84,6 +84,8 @@ are met:
 - The app release build passes.
 - There are no first-party build warnings.
 - Plugin manifests validate successfully.
+- Every plugin release build imports only symbols exported by the
+  `TypeWhisperPluginSDK.framework` shipped in its declared `minHostVersion`.
 - README, security guidance, support matrix, and plugin documentation are up to date.
 - The applicable release-candidate or daily line ran on real machines for
   multiple days without P0/P1 blockers before the stable tag.

--- a/scripts/check_plugin_sdk_symbol_compatibility.py
+++ b/scripts/check_plugin_sdk_symbol_compatibility.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Verify a plugin only imports symbols exported by its minimum host SDK.
+
+Plugins are built against the SDK on ``main`` but are loaded against the
+``TypeWhisperPluginSDK.framework`` embedded in the installed host app. A plugin
+that imports a newer SDK symbol cannot be opened by an older host even when its
+manifest claims that host through ``minHostVersion``.
+
+The checker compares each plugin architecture against both the SDK used for the
+build and the SDK shipped by the declared minimum host. Intersecting plugin
+imports with build-SDK exports identifies Swift, Objective-C, and C SDK symbols;
+the Swift module-name fallback also keeps diagnostics useful for older artifacts
+when only a host SDK is available during investigation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+SDK_MODULE_MANGLING = "20TypeWhisperPluginSDK"
+
+
+def parse_undefined_symbols(nm_output: str) -> set[str]:
+    """Parse ``nm -u`` output into undefined symbol names."""
+    symbols: set[str] = set()
+    for raw_line in nm_output.splitlines():
+        line = raw_line.strip()
+        if not line or line.endswith(":"):
+            continue
+        symbols.add(line.split()[-1])
+    return symbols
+
+
+def parse_exported_symbols(nm_output: str) -> set[str]:
+    """Parse ``nm -gU`` output into exported symbol names."""
+    symbols: set[str] = set()
+    for raw_line in nm_output.splitlines():
+        line = raw_line.strip()
+        if not line or line.endswith(":"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        symbols.add(parts[-1])
+    return symbols
+
+
+def swift_sdk_symbols(symbols: set[str]) -> set[str]:
+    """Return symbols whose Swift mangling identifies the Plugin SDK module."""
+    return {symbol for symbol in symbols if SDK_MODULE_MANGLING in symbol}
+
+
+def imported_sdk_symbols(
+    plugin_undefined: set[str],
+    build_sdk_exported: set[str],
+) -> set[str]:
+    """Return plugin imports owned by the SDK used for the plugin build."""
+    return (plugin_undefined & build_sdk_exported) | swift_sdk_symbols(
+        plugin_undefined
+    )
+
+
+def missing_sdk_symbols(
+    plugin_undefined: set[str],
+    build_sdk_exported: set[str],
+    host_sdk_exported: set[str],
+) -> list[str]:
+    """Return build-SDK imports absent from the minimum host SDK."""
+    return sorted(
+        imported_sdk_symbols(plugin_undefined, build_sdk_exported)
+        - host_sdk_exported
+    )
+
+
+def architectures_to_check(
+    plugin_architectures: list[str],
+    build_sdk_architectures: set[str],
+    host_sdk_architectures: set[str],
+) -> list[str]:
+    """Require SDK slices for every architecture shipped in the plugin."""
+    missing_from_build = sorted(
+        set(plugin_architectures) - build_sdk_architectures
+    )
+    missing_from_host = sorted(set(plugin_architectures) - host_sdk_architectures)
+    errors: list[str] = []
+    if missing_from_build:
+        errors.append(
+            "build SDK is missing plugin architecture(s): "
+            + ", ".join(missing_from_build)
+        )
+    if missing_from_host:
+        errors.append(
+            "minimum host SDK is missing plugin architecture(s): "
+            + ", ".join(missing_from_host)
+        )
+    if errors:
+        raise ValueError("; ".join(errors))
+    return plugin_architectures
+
+
+def _run(command: list[str]) -> str:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"command failed: {' '.join(command)}\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def architectures(binary: Path) -> list[str]:
+    """Return the Mach-O architectures in a binary."""
+    return _run(["lipo", "-archs", str(binary)]).split()
+
+
+def undefined_symbols(binary: Path, architecture: str) -> set[str]:
+    """Return undefined symbols for one binary architecture."""
+    return parse_undefined_symbols(
+        _run(["nm", "-arch", architecture, "-u", str(binary)])
+    )
+
+
+def exported_symbols(binary: Path, architecture: str) -> set[str]:
+    """Return globally exported symbols for one binary architecture."""
+    return parse_exported_symbols(
+        _run(["nm", "-arch", architecture, "-gU", str(binary)])
+    )
+
+
+def demangle(symbols: list[str]) -> dict[str, str]:
+    """Best-effort Swift demangling for readable failure output."""
+    if not symbols:
+        return {}
+    try:
+        result = subprocess.run(
+            ["xcrun", "swift-demangle", "--compact", *symbols],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return {}
+    if result.returncode != 0:
+        return {}
+    demangled = result.stdout.splitlines()
+    if len(demangled) != len(symbols):
+        return {}
+    return dict(zip(symbols, demangled))
+
+
+def check(
+    plugin_binary: Path,
+    build_sdk: Path,
+    host_sdk: Path,
+    min_host_version: str,
+) -> int:
+    """Compare SDK imports and exports for every plugin architecture."""
+    try:
+        plugin_architectures = architectures(plugin_binary)
+        checked_architectures = architectures_to_check(
+            plugin_architectures,
+            set(architectures(build_sdk)),
+            set(architectures(host_sdk)),
+        )
+    except (RuntimeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    failures = 0
+    for architecture in checked_architectures:
+        try:
+            plugin_undefined = undefined_symbols(plugin_binary, architecture)
+            build_exports = exported_symbols(build_sdk, architecture)
+            host_exports = exported_symbols(host_sdk, architecture)
+        except RuntimeError as error:
+            print(f"error: {error}", file=sys.stderr)
+            return 1
+
+        required = imported_sdk_symbols(plugin_undefined, build_exports)
+        missing = missing_sdk_symbols(
+            plugin_undefined,
+            build_exports,
+            host_exports,
+        )
+        if not missing:
+            print(
+                f"{architecture}: OK - {len(required)} Plugin SDK import(s) "
+                f"exist in host {min_host_version}"
+            )
+            continue
+
+        failures += 1
+        readable = demangle(missing)
+        print(
+            f"{architecture}: {len(missing)} Plugin SDK symbol(s) missing "
+            f"from host {min_host_version}:",
+            file=sys.stderr,
+        )
+        for symbol in missing:
+            print(f"  {readable.get(symbol, symbol)}", file=sys.stderr)
+
+    if failures:
+        print(
+            "\nThe plugin cannot load on the host version declared by its "
+            "manifest.\nRaise minHostVersion to the first host release that "
+            "exports these symbols,\nor remove the newer SDK API usage from "
+            "the plugin.",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and run the compatibility check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--plugin-binary",
+        required=True,
+        type=Path,
+        help="Built plugin executable",
+    )
+    parser.add_argument(
+        "--build-sdk",
+        required=True,
+        type=Path,
+        help="TypeWhisperPluginSDK binary used to link the plugin",
+    )
+    parser.add_argument(
+        "--host-sdk",
+        required=True,
+        type=Path,
+        help="TypeWhisperPluginSDK binary from the minHostVersion release",
+    )
+    parser.add_argument(
+        "--min-host-version",
+        required=True,
+        help="minHostVersion declared in the plugin manifest",
+    )
+    args = parser.parse_args(argv)
+
+    for path in (args.plugin_binary, args.build_sdk, args.host_sdk):
+        if not path.is_file():
+            print(f"error: not a file: {path}", file=sys.stderr)
+            return 1
+
+    return check(
+        args.plugin_binary,
+        args.build_sdk,
+        args.host_sdk,
+        args.min_host_version,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -38,6 +38,7 @@ done < <(git ls-files 'scripts/*.sh')
 
 log "running Python script tests"
 python3 scripts/test_assemble_community_plugin_registry.py
+python3 scripts/test_check_plugin_sdk_symbol_compatibility.py
 python3 scripts/test_plugin_registry_metadata.py
 python3 scripts/test_verify_appcast_publication.py
 

--- a/scripts/test_check_plugin_sdk_symbol_compatibility.py
+++ b/scripts/test_check_plugin_sdk_symbol_compatibility.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Tests for plugin/host Plugin SDK symbol compatibility checking."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_plugin_sdk_symbol_compatibility import (
+    architectures_to_check,
+    imported_sdk_symbols,
+    missing_sdk_symbols,
+    parse_exported_symbols,
+    parse_undefined_symbols,
+    swift_sdk_symbols,
+)
+
+
+ENSURE_NETWORK_ACCESS = (
+    "_$s20TypeWhisperPluginSDK0C10HTTPClientO28ensureNetworkAccessIsAllowedyyKFZ"
+)
+HTTP_CLIENT_DATA = (
+    "_$s20TypeWhisperPluginSDK0C10HTTPClientO4data3for10Foundation4DataV_"
+    "So13NSURLResponseCtAF10URLRequestV_tYaKFZ"
+)
+SDK_OBJC_CLASS = "_OBJC_CLASS_$_TypeWhisperSDKObject"
+FOUNDATION_OBJC_CLASS = "_OBJC_CLASS_$_NSURLSession"
+
+
+class ParseUndefinedSymbolsTests(unittest.TestCase):
+    def test_parses_bare_and_annotated_symbol_names(self) -> None:
+        output = (
+            f"{ENSURE_NETWORK_ACCESS}\n"
+            f"                 U {FOUNDATION_OBJC_CLASS}\n"
+        )
+        self.assertEqual(
+            parse_undefined_symbols(output),
+            {ENSURE_NETWORK_ACCESS, FOUNDATION_OBJC_CLASS},
+        )
+
+    def test_skips_architecture_headers_and_blank_lines(self) -> None:
+        output = (
+            "Gemma4Plugin (for architecture arm64):\n"
+            "\n"
+            f"  {ENSURE_NETWORK_ACCESS}\n"
+        )
+        self.assertEqual(parse_undefined_symbols(output), {ENSURE_NETWORK_ACCESS})
+
+
+class ParseExportedSymbolsTests(unittest.TestCase):
+    def test_parses_address_type_name_triples(self) -> None:
+        output = (
+            f"0000000000003d3c T {HTTP_CLIENT_DATA}\n"
+            "000000000004b5b0 S _$s20TypeWhisperPluginSDK0C17HTTPClientSessionMp\n"
+        )
+        self.assertEqual(
+            parse_exported_symbols(output),
+            {HTTP_CLIENT_DATA, "_$s20TypeWhisperPluginSDK0C17HTTPClientSessionMp"},
+        )
+
+    def test_ignores_headers_and_short_lines(self) -> None:
+        output = (
+            "TypeWhisperPluginSDK (for architecture x86_64):\n"
+            "malformed\n"
+            f"0000000000003d3c T {HTTP_CLIENT_DATA}\n"
+        )
+        self.assertEqual(parse_exported_symbols(output), {HTTP_CLIENT_DATA})
+
+
+class SDKSymbolTests(unittest.TestCase):
+    def test_swift_filter_keeps_only_plugin_sdk_module_symbols(self) -> None:
+        symbols = {
+            ENSURE_NETWORK_ACCESS,
+            "_$s10ArgmaxCore12ModelManagerCMa",
+            FOUNDATION_OBJC_CLASS,
+        }
+        self.assertEqual(swift_sdk_symbols(symbols), {ENSURE_NETWORK_ACCESS})
+
+    def test_imported_symbols_include_swift_objc_and_c_sdk_exports(self) -> None:
+        plugin_undefined = {
+            ENSURE_NETWORK_ACCESS,
+            SDK_OBJC_CLASS,
+            FOUNDATION_OBJC_CLASS,
+        }
+        build_exports = {ENSURE_NETWORK_ACCESS, SDK_OBJC_CLASS}
+        self.assertEqual(
+            imported_sdk_symbols(plugin_undefined, build_exports),
+            {ENSURE_NETWORK_ACCESS, SDK_OBJC_CLASS},
+        )
+
+    def test_missing_symbols_reports_only_sdk_imports_absent_from_host(self) -> None:
+        plugin_undefined = {
+            ENSURE_NETWORK_ACCESS,
+            HTTP_CLIENT_DATA,
+            FOUNDATION_OBJC_CLASS,
+        }
+        build_exports = {ENSURE_NETWORK_ACCESS, HTTP_CLIENT_DATA}
+        host_exports = {HTTP_CLIENT_DATA}
+        self.assertEqual(
+            missing_sdk_symbols(plugin_undefined, build_exports, host_exports),
+            [ENSURE_NETWORK_ACCESS],
+        )
+
+    def test_missing_symbols_passes_when_host_exports_every_sdk_import(self) -> None:
+        plugin_undefined = {HTTP_CLIENT_DATA, FOUNDATION_OBJC_CLASS}
+        build_exports = {HTTP_CLIENT_DATA}
+        host_exports = {HTTP_CLIENT_DATA, ENSURE_NETWORK_ACCESS}
+        self.assertEqual(
+            missing_sdk_symbols(plugin_undefined, build_exports, host_exports),
+            [],
+        )
+
+    def test_missing_symbols_result_is_sorted(self) -> None:
+        first = "_$s20TypeWhisperPluginSDK1ayyF"
+        second = "_$s20TypeWhisperPluginSDK1byyF"
+        self.assertEqual(
+            missing_sdk_symbols(
+                {second, first},
+                {second, first},
+                set(),
+            ),
+            [first, second],
+        )
+
+
+class ArchitectureTests(unittest.TestCase):
+    def test_checks_every_plugin_architecture(self) -> None:
+        self.assertEqual(
+            architectures_to_check(
+                ["x86_64", "arm64"],
+                {"x86_64", "arm64"},
+                {"x86_64", "arm64"},
+            ),
+            ["x86_64", "arm64"],
+        )
+
+    def test_rejects_architecture_missing_from_build_sdk(self) -> None:
+        with self.assertRaisesRegex(ValueError, "build SDK is missing.*x86_64"):
+            architectures_to_check(
+                ["x86_64", "arm64"],
+                {"arm64"},
+                {"x86_64", "arm64"},
+            )
+
+    def test_rejects_architecture_missing_from_minimum_host_sdk(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "minimum host SDK is missing.*arm64"
+        ):
+            architectures_to_check(
+                ["arm64"],
+                {"arm64"},
+                {"x86_64"},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Issue context

Gemma 4 1.1.5 declares TypeWhisper 1.6.0 as its minimum host, but the published binary imports `PluginHTTPClient.ensureNetworkAccessIsAllowed()`, which was added to the SDK after 1.6.0. Loading therefore fails at `dlopen` on TypeWhisper 1.6.0 and the marketplace install rolls back.

Closes #1241.

## What changed

- keep the screenshot-automation network guard local to Gemma 4 so the plugin remains loadable by its declared 1.6.0 host
- bump Gemma 4 to 1.1.6
- add a release-time ABI gate that downloads the exact published `minHostVersion` app artifact, verifies its digest, and compares every plugin architecture's imported SDK symbols with the SDK exports shipped by that host
- cover the generic checker, Gemma 4 source/runtime policy, manifest version, and release documentation

## Test plan

- `python3 scripts/test_check_plugin_sdk_symbol_compatibility.py`
- `swift test --package-path TypeWhisperPluginSDK`
- `scripts/check_release_binary_instrumentation.sh --self-test`
- `scripts/check_release_signing.sh --self-test`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/typewhisper-gemma4-tests -only-testing:TypeWhisperTests/MLXPluginModelStorageTests/testGemma4SourceAvoidsSDKSymbolsUnavailableInHost16 -only-testing:TypeWhisperTests/MLXPluginModelStorageTests/testGemma4NetworkPolicyAllowsNormalRuntime -only-testing:TypeWhisperTests/MLXPluginModelStorageTests/testGemma4NetworkPolicyBlocksScreenshotAutomation -only-testing:TypeWhisperTests/MLXPluginModelStorageTests/testGemma4LLMRuntimeAcceptsCurrentAndLegacyConfigurationTypes -only-testing:TypeWhisperTests/PluginManifestValidationTests/testMLXStoragePluginReleasesRequireHost16 -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `release_root=$(mktemp -d /tmp/typewhisper-gemma4-release-build.XXXXXX) && xcodebuild build -project TypeWhisper.xcodeproj -target Gemma4Plugin -configuration Release SYMROOT="$release_root/build" CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.1.6`

The compatibility check was also run directly against the SDK in the published TypeWhisper 1.6.0 app asset. It passes for both `x86_64` and `arm64` on the 1.1.6 universal release build. Running the same checker against the published 1.1.5 artifact reproduces the missing `ensureNetworkAccessIsAllowed()` symbol on both architectures. The signed local development bundle was installed and smoke-tested in the development app.

`PYTHONDONTWRITEBYTECODE=1 scripts/pr-preflight.sh origin/main` reaches the localization completeness step after all Python checks pass, then reports the same 40 missing `zh-Hans` strings in `AuthenticatedCLIPlugin` on an unchanged `origin/main` worktree. That baseline issue is unrelated to this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the Gemma 4 plugin to version 1.1.6.
  * Prevented model downloads during screenshot capture while preserving normal network access.

* **Bug Fixes**
  * Added release checks to detect SDK incompatibilities and unsupported architectures before publication.

* **Documentation**
  * Clarified minimum host version requirements and SDK compatibility validation.

* **Tests**
  * Added coverage for SDK compatibility, symbol parsing, architecture support, and screenshot network restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->