### PR TITLE
Fix Deepgram compatibility with TypeWhisper 1.6

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -4,6 +4,17 @@ import SwiftUI
 import os
 import TypeWhisperPluginSDK
 
+// Keep this policy plugin-local because the SDK network guard was added after TypeWhisper 1.6.0.
+enum DeepgramNetworkAccessPolicy {
+    static func ensureAccessIsAllowed(
+        arguments: [String] = ProcessInfo.processInfo.arguments
+    ) throws {
+        guard !arguments.contains("--store-screenshots") else {
+            throw URLError(.notConnectedToInternet)
+        }
+    }
+}
+
 // MARK: - Raw WebSocket Client (RFC 6455)
 // Apple's URLSessionWebSocketTask and NWConnection+NWProtocolWebSocket negotiate HTTP/2
 // via TLS ALPN, which is incompatible with Deepgram's server (advertises h2 but doesn't
@@ -68,7 +79,7 @@ private final class RawWebSocket: @unchecked Sendable {
     // MARK: - Connect + Upgrade
 
     func connect() async throws {
-        try PluginHTTPClient.ensureNetworkAccessIsAllowed()
+        try DeepgramNetworkAccessPolicy.ensureAccessIsAllowed()
         if usesTLS {
             streamTask.startSecureConnection()
         }
@@ -580,7 +591,6 @@ private final class DeepgramLiveTranscriptionSession: LiveTranscriptionSession, 
 @objc(DeepgramPlugin)
 final class DeepgramPlugin: NSObject,
     LiveTranscriptionCapablePlugin,
-    LiveTranscriptionProgressModeProviding,
     DictionaryTermsCapabilityProviding,
     DictionaryTermsBudgetProviding,
     @unchecked Sendable {
@@ -640,7 +650,6 @@ final class DeepgramPlugin: NSObject,
 
     var supportsTranslation: Bool { false }
     var supportsStreaming: Bool { true }
-    var liveTranscriptionProgressMode: LiveTranscriptionProgressMode { .completeSnapshot }
     var dictionaryTermsSupport: DictionaryTermsSupport { .supported }
     var dictionaryTermsBudget: DictionaryTermsBudget { DictionaryTermsBudget(maxTerms: Self.maxDictionaryTerms) }
 

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.deepgram",
     "name": "Deepgram",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -1562,8 +1562,33 @@ final class PluginDictionaryGuardTests: XCTestCase {
         let plugin: Any = DeepgramPlugin()
 
         XCTAssertTrue(plugin is any LiveTranscriptionCapablePlugin)
-        let progressProvider = plugin as? any LiveTranscriptionProgressModeProviding
-        XCTAssertEqual(progressProvider?.liveTranscriptionProgressMode, .completeSnapshot)
+        XCTAssertFalse(plugin is any LiveTranscriptionProgressModeProviding)
+    }
+
+    func testDeepgramRemainsLoadableByDeclaredTypeWhisper16Host() throws {
+        let sourceURL = TestSupport.repoRoot.appendingPathComponent(
+            "TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift"
+        )
+        let source = try String(contentsOf: sourceURL, encoding: .utf8)
+
+        XCTAssertFalse(source.contains("PluginHTTPClient.ensureNetworkAccessIsAllowed"))
+        XCTAssertFalse(source.contains("LiveTranscriptionProgressModeProviding"))
+    }
+
+    func testDeepgramLocalNetworkPolicyAllowsNormalRuntime() {
+        XCTAssertNoThrow(
+            try DeepgramNetworkAccessPolicy.ensureAccessIsAllowed(arguments: ["TypeWhisper"])
+        )
+    }
+
+    func testDeepgramLocalNetworkPolicyBlocksScreenshotAutomation() {
+        XCTAssertThrowsError(
+            try DeepgramNetworkAccessPolicy.ensureAccessIsAllowed(
+                arguments: ["TypeWhisper", "--store-screenshots"]
+            )
+        ) { error in
+            XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
+        }
     }
 
     func testDeepgramDictionaryQueryItemsLimitDictionaryTermsTo100AndPreserveOrder() {


### PR DESCRIPTION
## Context

Follow-up to #1235 and #1240. The published Deepgram 1.0.14 bundle declared TypeWhisper 1.6.0 compatibility but imported two SDK symbols that were added after the 1.6.0 host release, so the released bundle could not be loaded by that host.

## Changes

- keep the screenshot-network guard local to the Deepgram plugin instead of importing the newer SDK helper
- use the existing 1.6.0 live-preview stabilization path instead of importing the newer progress-mode protocol
- bump the Deepgram plugin manifest to 1.0.15
- add focused compatibility and policy regression coverage

## Test plan

- `xcodebuild build -project TypeWhisper.xcodeproj -scheme DeepgramPlugin -destination "platform=macOS" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS" -only-testing:TypeWhisperTests/PluginDictionaryGuardTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- build a universal Release bundle and compare its TypeWhisperPluginSDK imports against the SDK embedded in the published TypeWhisper 1.6.0 app with `nm -u -j`, `nm -gU -j`, and `comm -23` for both `arm64` and `x86_64` (17 imports, 0 missing on each architecture)
- preload the published 1.6.0 SDK and open the Release plugin binary with `dlopen(..., RTLD_NOW)` (SDK and plugin both load)
- install and launch with `/Users/marco/Projects/typewhisper-dev-tools/build-typewhisper-plugin-dev.sh --run --enable-plugin com.typewhisper.deepgram DeepgramPlugin /Users/marco/.t3/worktrees/typewhisper-mac/t3code-81b4e4e9`