### PR TITLE
Bound the final-transcription phase with a deadline

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -216,6 +216,9 @@ final class ServiceContainer: ObservableObject {
                     excluding: primaryEngineId,
                     task: task
                 )
+            },
+            recoveryHedgeThresholdProvider: { [recoveryViewModel] in
+                recoveryViewModel.automaticHedgeThreshold
             }
         )
         audioRecorderViewModel = AudioRecorderViewModel(

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -150,6 +150,8 @@ enum UserDefaultsKeys {
     static let dictationRecoveryModel = "dictationRecoveryModel"
     static let dictationRecoveryLanguage = "dictationRecoveryLanguage"
     static let dictationRecoveryAutomaticFallbackEnabled = "dictationRecoveryAutomaticFallbackEnabled"
+    static let dictationRecoveryHedgeEnabled = "dictationRecoveryHedgeEnabled"
+    static let dictationRecoveryHedgeThresholdSeconds = "dictationRecoveryHedgeThresholdSeconds"
     static let dictationRecoveryRetentionDays = "dictationRecoveryRetentionDays"
 
     // MARK: - Watch Folder

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -183,6 +183,8 @@ enum SettingsBackupExporter {
         // Dictation Recovery
         var dictationRecoveryLanguage: String? = nil
         var dictationRecoveryAutomaticFallbackEnabled: Bool? = nil
+        var dictationRecoveryHedgeEnabled: Bool? = nil
+        var dictationRecoveryHedgeThresholdSeconds: Double? = nil
         var dictationRecoveryRetentionDays: Int? = nil
         // File Transcription
         var fileTranscriptionLanguage: String? = nil
@@ -230,6 +232,8 @@ enum SettingsBackupExporter {
             if requireSecondEscapeToCancelRecording != nil { count += 1 }
             if dictationRecoveryLanguage != nil { count += 1 }
             if dictationRecoveryAutomaticFallbackEnabled != nil { count += 1 }
+            if dictationRecoveryHedgeEnabled != nil { count += 1 }
+            if dictationRecoveryHedgeThresholdSeconds != nil { count += 1 }
             if dictationRecoveryRetentionDays != nil { count += 1 }
             if fileTranscriptionLanguage != nil { count += 1 }
             if recorderMicEnabled != nil { count += 1 }
@@ -576,6 +580,8 @@ enum SettingsBackupExporter {
                 requireSecondEscapeToCancelRecording: userDefaults.object(forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording) as? Bool,
                 dictationRecoveryLanguage: userDefaults.string(forKey: UserDefaultsKeys.dictationRecoveryLanguage),
                 dictationRecoveryAutomaticFallbackEnabled: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled) as? Bool,
+                dictationRecoveryHedgeEnabled: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryHedgeEnabled) as? Bool,
+                dictationRecoveryHedgeThresholdSeconds: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryHedgeThresholdSeconds) as? Double,
                 dictationRecoveryRetentionDays: userDefaults.object(forKey: UserDefaultsKeys.dictationRecoveryRetentionDays) == nil
                     ? nil
                     : DictationRecoveryRetentionPolicy.load(from: userDefaults).rawValue,
@@ -857,6 +863,8 @@ enum SettingsBackupExporter {
         apply(preferences.requireSecondEscapeToCancelRecording, forKey: UserDefaultsKeys.requireSecondEscapeToCancelRecording)
         apply(preferences.dictationRecoveryLanguage, forKey: UserDefaultsKeys.dictationRecoveryLanguage)
         apply(preferences.dictationRecoveryAutomaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
+        apply(preferences.dictationRecoveryHedgeEnabled, forKey: UserDefaultsKeys.dictationRecoveryHedgeEnabled)
+        apply(preferences.dictationRecoveryHedgeThresholdSeconds, forKey: UserDefaultsKeys.dictationRecoveryHedgeThresholdSeconds)
         apply(preferences.dictationRecoveryRetentionDays, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
         if preferences.dictationRecoveryRetentionDays != nil {
             recoveryRetentionPolicyDidChange?(DictationRecoveryRetentionPolicy.load(from: userDefaults))

--- a/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationRecoveryViewModel.swift
@@ -76,6 +76,25 @@ final class DictationRecoveryViewModel: ObservableObject {
             defaults.set(automaticFallbackEnabled, forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
         }
     }
+    @Published var hedgeEnabled: Bool {
+        didSet {
+            defaults.set(hedgeEnabled, forKey: UserDefaultsKeys.dictationRecoveryHedgeEnabled)
+        }
+    }
+    @Published var hedgeThresholdSeconds: Double {
+        didSet {
+            defaults.set(hedgeThresholdSeconds, forKey: UserDefaultsKeys.dictationRecoveryHedgeThresholdSeconds)
+        }
+    }
+
+    /// Threshold after which a still-running primary transcription should race the
+    /// recovery fallback engine, or nil when hedging is off. The engine/licensing
+    /// gates live in `automaticFallbackConfiguration` — hedging only activates when
+    /// that returns a configuration.
+    var automaticHedgeThreshold: TimeInterval? {
+        guard hedgeEnabled, automaticFallbackEnabled, hedgeThresholdSeconds > 0 else { return nil }
+        return hedgeThresholdSeconds
+    }
     @Published var retentionPolicy: DictationRecoveryRetentionPolicy {
         didSet {
             defaults.set(retentionPolicy.rawValue, forKey: UserDefaultsKeys.dictationRecoveryRetentionDays)
@@ -138,6 +157,9 @@ final class DictationRecoveryViewModel: ObservableObject {
         self.selectedEngine = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryEngine)
         self.selectedModel = defaults.string(forKey: UserDefaultsKeys.dictationRecoveryModel)
         self.automaticFallbackEnabled = defaults.bool(forKey: UserDefaultsKeys.dictationRecoveryAutomaticFallbackEnabled)
+        self.hedgeEnabled = defaults.bool(forKey: UserDefaultsKeys.dictationRecoveryHedgeEnabled)
+        let storedHedgeThreshold = defaults.double(forKey: UserDefaultsKeys.dictationRecoveryHedgeThresholdSeconds)
+        self.hedgeThresholdSeconds = storedHedgeThreshold > 0 ? storedHedgeThreshold : 3.0
         self.retentionPolicy = retentionPolicy
         self.isInitialized = true
 

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -131,6 +131,17 @@ final class DictationViewModel: ObservableObject {
         _ dictionaryTermHints: [PluginDictionaryTermHint],
         _ normalizeNumbers: Bool?
     ) async throws -> TranscriptionResult
+    typealias RecoveryHedgeThresholdProvider = @MainActor () -> TimeInterval?
+    typealias PrimaryTranscriptionRunner = @MainActor (
+        _ samples: [Float],
+        _ languageSelection: LanguageSelection,
+        _ task: TranscriptionTask,
+        _ engineOverrideId: String?,
+        _ cloudModelOverride: String?,
+        _ prompt: String?,
+        _ dictionaryTermHints: [PluginDictionaryTermHint],
+        _ normalizeNumbers: Bool?
+    ) async throws -> TranscriptionResult
 
     private struct FinalTranscriptionOutput {
         let result: TranscriptionResult
@@ -321,6 +332,8 @@ final class DictationViewModel: ObservableObject {
     private let postProcessingPipeline: PostProcessingPipeline
     private let recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider
     private let recoveryFallbackRunner: RecoveryFallbackRunner
+    private let recoveryHedgeThresholdProvider: RecoveryHedgeThresholdProvider
+    private let primaryTranscriptionRunner: PrimaryTranscriptionRunner
     private var matchedWorkflow: Workflow?
     private var activeWorkflowMatch: WorkflowMatchResult?
     private var forcedWorkflowId: UUID?
@@ -421,7 +434,9 @@ final class DictationViewModel: ObservableObject {
         mediaPlaybackService: MediaPlaybackService,
         usageStatisticsRecorder: UsageStatisticsRecording? = nil,
         recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider? = nil,
-        recoveryFallbackRunner: RecoveryFallbackRunner? = nil
+        recoveryFallbackRunner: RecoveryFallbackRunner? = nil,
+        recoveryHedgeThresholdProvider: RecoveryHedgeThresholdProvider? = nil,
+        primaryTranscriptionRunner: PrimaryTranscriptionRunner? = nil
     ) {
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
@@ -459,6 +474,19 @@ final class DictationViewModel: ObservableObject {
         self.errorLogService = errorLogService
         self.mediaPlaybackService = mediaPlaybackService
         self.recoveryFallbackConfigurationProvider = recoveryFallbackConfigurationProvider ?? { _, _ in nil }
+        self.recoveryHedgeThresholdProvider = recoveryHedgeThresholdProvider ?? { nil }
+        self.primaryTranscriptionRunner = primaryTranscriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride, prompt, dictionaryTermHints, normalizeNumbers in
+            try await modelManager.transcribe(
+                audioSamples: samples,
+                languageSelection: languageSelection,
+                task: task,
+                engineOverrideId: engineOverrideId,
+                cloudModelOverride: cloudModelOverride,
+                prompt: prompt,
+                dictionaryTermHints: dictionaryTermHints,
+                normalizeNumbers: normalizeNumbers
+            )
+        }
         self.recoveryFallbackRunner = recoveryFallbackRunner ?? { [modelManager] samples, languageSelection, task, configuration, prompt, dictionaryTermHints, normalizeNumbers in
             try await modelManager.transcribe(
                 audioSamples: samples,
@@ -2220,16 +2248,32 @@ final class DictationViewModel: ObservableObject {
         dictionaryTermHints: [PluginDictionaryTermHint],
         normalizeNumbers: Bool?
     ) async throws -> FinalTranscriptionOutput {
+        let fallbackConfiguration = recoveryFallbackConfigurationProvider(primaryEngineId, task)
         do {
-            let result = try await modelManager.transcribe(
-                audioSamples: audioSamples,
-                languageSelection: languageSelection,
-                task: task,
-                engineOverrideId: primaryEngineId,
-                cloudModelOverride: primaryCloudModelOverride,
-                prompt: prompt,
-                dictionaryTermHints: dictionaryTermHints,
-                normalizeNumbers: normalizeNumbers
+            if let configuration = fallbackConfiguration,
+               let hedgeThreshold = recoveryHedgeThresholdProvider() {
+                return try await hedgedTranscription(
+                    audioSamples: audioSamples,
+                    languageSelection: languageSelection,
+                    task: task,
+                    primaryEngineId: primaryEngineId,
+                    primaryCloudModelOverride: primaryCloudModelOverride,
+                    prompt: prompt,
+                    dictionaryTermHints: dictionaryTermHints,
+                    normalizeNumbers: normalizeNumbers,
+                    configuration: configuration,
+                    threshold: hedgeThreshold
+                )
+            }
+            let result = try await primaryTranscriptionRunner(
+                audioSamples,
+                languageSelection,
+                task,
+                primaryEngineId,
+                primaryCloudModelOverride,
+                prompt,
+                dictionaryTermHints,
+                normalizeNumbers
             )
             return finalTranscriptionOutput(
                 result: result,
@@ -2237,10 +2281,13 @@ final class DictationViewModel: ObservableObject {
                 modelId: primaryCloudModelOverride,
                 usedRecoveryFallback: false
             )
+        } catch let failure as AutomaticRecoveryFallbackFailure {
+            // The hedge already ran the fallback; don't retry it below.
+            throw failure
         } catch {
             let primaryError = error
             guard shouldAttemptAutomaticRecoveryFallback(after: primaryError),
-                  let configuration = recoveryFallbackConfigurationProvider(primaryEngineId, task) else {
+                  let configuration = fallbackConfiguration else {
                 throw primaryError
             }
 
@@ -2278,6 +2325,151 @@ final class DictationViewModel: ObservableObject {
                     fallbackDescription: error.localizedDescription
                 )
             }
+        }
+    }
+
+    private enum HedgedTranscriptionEvent {
+        case primary(Result<TranscriptionResult, Error>)
+        case fallback(Result<TranscriptionResult, Error>)
+        case fallbackSkipped
+    }
+
+    private enum HedgedTranscriptionOutcome {
+        case primaryWon(TranscriptionResult)
+        case fallbackWon(TranscriptionResult)
+        case primaryFailedBeforeHedge(Error)
+        case bothFailed(primary: Error, fallback: Error)
+    }
+
+    /// Races the primary engine against the recovery fallback engine: the fallback
+    /// request is dispatched only after `threshold` elapses with the primary still
+    /// running, the first successful transcription wins, and the loser is cancelled.
+    /// A primary failure before the hedge fires is rethrown so the caller's
+    /// sequential error-path fallback applies unchanged.
+    private func hedgedTranscription(
+        audioSamples: [Float],
+        languageSelection: LanguageSelection,
+        task: TranscriptionTask,
+        primaryEngineId: String?,
+        primaryCloudModelOverride: String?,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        normalizeNumbers: Bool?,
+        configuration: DictationRecoveryFallbackConfiguration,
+        threshold: TimeInterval
+    ) async throws -> FinalTranscriptionOutput {
+        let fallbackPrompt = dictionaryService.getTermsForPrompt(providerId: configuration.engineId)
+        let fallbackDictionaryTermHints = dictionaryService.getTermHints(providerId: configuration.engineId)
+
+        let primaryOperation: @MainActor () async throws -> TranscriptionResult = { [primaryTranscriptionRunner] in
+            try await primaryTranscriptionRunner(
+                audioSamples,
+                languageSelection,
+                task,
+                primaryEngineId,
+                primaryCloudModelOverride,
+                prompt,
+                dictionaryTermHints,
+                normalizeNumbers
+            )
+        }
+        let fallbackOperation: @MainActor () async throws -> TranscriptionResult = { [recoveryFallbackRunner] in
+            try await recoveryFallbackRunner(
+                audioSamples,
+                languageSelection,
+                task,
+                configuration,
+                fallbackPrompt,
+                fallbackDictionaryTermHints,
+                normalizeNumbers
+            )
+        }
+
+        let fallbackEngineId = configuration.engineId
+        let outcome = await withTaskGroup(of: HedgedTranscriptionEvent.self) { group -> HedgedTranscriptionOutcome in
+            let start = ContinuousClock.now
+            group.addTask {
+                do { return .primary(.success(try await primaryOperation())) } catch { return .primary(.failure(error)) }
+            }
+            group.addTask { [logger] in
+                do {
+                    try await Task.sleep(nanoseconds: UInt64(threshold * 1_000_000_000))
+                } catch {
+                    return .fallbackSkipped
+                }
+                logger.info(
+                    "Primary transcription exceeded hedge threshold (\(threshold, format: .fixed(precision: 1))s); racing recovery fallback engine \(fallbackEngineId, privacy: .public)"
+                )
+                do { return .fallback(.success(try await fallbackOperation())) } catch { return .fallback(.failure(error)) }
+            }
+
+            var primaryError: Error?
+            var fallbackError: Error?
+            while let event = await group.next() {
+                switch event {
+                case .primary(.success(let result)):
+                    group.cancelAll()
+                    return .primaryWon(result)
+                case .fallback(.success(let result)):
+                    group.cancelAll()
+                    return .fallbackWon(result)
+                case .primary(.failure(let error)):
+                    let hedgeDispatched = ContinuousClock.now - start >= .seconds(threshold)
+                    guard hedgeDispatched, shouldAttemptAutomaticRecoveryFallback(after: error) else {
+                        group.cancelAll()
+                        return .primaryFailedBeforeHedge(error)
+                    }
+                    if let fallbackError {
+                        return .bothFailed(primary: error, fallback: fallbackError)
+                    }
+                    primaryError = error
+                case .fallback(.failure(let error)):
+                    if let primaryError {
+                        return .bothFailed(primary: primaryError, fallback: error)
+                    }
+                    fallbackError = error
+                case .fallbackSkipped:
+                    if let primaryError {
+                        return .primaryFailedBeforeHedge(primaryError)
+                    }
+                }
+            }
+            // Both children finished without a winner (primary failed while the
+            // hedge was pending and the fallback then errored or was skipped).
+            if let primaryError {
+                return .primaryFailedBeforeHedge(primaryError)
+            }
+            return .primaryFailedBeforeHedge(CancellationError())
+        }
+
+        switch outcome {
+        case .primaryWon(let result):
+            return finalTranscriptionOutput(
+                result: result,
+                engineId: primaryEngineId,
+                modelId: primaryCloudModelOverride,
+                usedRecoveryFallback: false
+            )
+        case .fallbackWon(let result):
+            logger.info(
+                "Hedged recovery fallback won the race with engine \(configuration.engineId, privacy: .public)"
+            )
+            return finalTranscriptionOutput(
+                result: result,
+                engineId: configuration.engineId,
+                modelId: configuration.modelId,
+                usedRecoveryFallback: true
+            )
+        case .primaryFailedBeforeHedge(let error):
+            throw error
+        case .bothFailed(let primary, let fallback):
+            logger.error(
+                "Hedged transcription failed on both engines; primary: \(primary.localizedDescription, privacy: .public), fallback: \(fallback.localizedDescription, privacy: .public)"
+            )
+            throw AutomaticRecoveryFallbackFailure(
+                primaryDescription: primary.localizedDescription,
+                fallbackDescription: fallback.localizedDescription
+            )
         }
     }
 
@@ -3426,3 +3618,27 @@ func paddedSamplesForFinalTranscription(_ samples: [Float], rawDuration: TimeInt
 
     return paddedSamples
 }
+
+#if DEBUG
+extension DictationViewModel {
+    func transcribeFinalAudioForTesting(
+        audioSamples: [Float] = [],
+        languageSelection: LanguageSelection = LanguageSelection(storedValue: nil, nilBehavior: .auto),
+        task: TranscriptionTask = .transcribe,
+        primaryEngineId: String? = nil,
+        primaryCloudModelOverride: String? = nil
+    ) async throws -> (text: String, usedRecoveryFallback: Bool) {
+        let output = try await transcribeFinalAudio(
+            audioSamples: audioSamples,
+            languageSelection: languageSelection,
+            task: task,
+            primaryEngineId: primaryEngineId,
+            primaryCloudModelOverride: primaryCloudModelOverride,
+            prompt: nil,
+            dictionaryTermHints: [],
+            normalizeNumbers: nil
+        )
+        return (output.result.text, output.usedRecoveryFallback)
+    }
+}
+#endif

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -132,6 +132,10 @@ final class DictationViewModel: ObservableObject {
         _ normalizeNumbers: Bool?
     ) async throws -> TranscriptionResult
     typealias RecoveryHedgeThresholdProvider = @MainActor () -> TimeInterval?
+    /// Upper bound, in seconds, on the whole final-transcription phase (primary,
+    /// hedge, and sequential fallback together) for a recording of the given
+    /// duration. `nil` disables the bound.
+    typealias TranscriptionDeadlineProvider = @MainActor (_ audioDurationSeconds: TimeInterval) -> TimeInterval?
     typealias PrimaryTranscriptionRunner = @MainActor (
         _ samples: [Float],
         _ languageSelection: LanguageSelection,
@@ -143,7 +147,7 @@ final class DictationViewModel: ObservableObject {
         _ normalizeNumbers: Bool?
     ) async throws -> TranscriptionResult
 
-    private struct FinalTranscriptionOutput {
+    private struct FinalTranscriptionOutput: Sendable {
         let result: TranscriptionResult
         let modelId: String?
         let modelDisplayName: String?
@@ -160,6 +164,25 @@ final class DictationViewModel: ObservableObject {
                 de: "Primäre Transkription fehlgeschlagen: \(primaryDescription). Recovery-Fallback fehlgeschlagen: \(fallbackDescription)"
             )
         }
+    }
+
+    struct TranscriptionDeadlineExceeded: LocalizedError, Equatable {
+        let seconds: TimeInterval
+
+        var errorDescription: String? {
+            let rounded = Int(seconds.rounded())
+            return localizedAppText(
+                "Transcription timed out after \(rounded) seconds. The recording was kept in Dictation Recovery.",
+                de: "Die Transkription hat nach \(rounded) Sekunden das Zeitlimit überschritten. Die Aufnahme wurde in der Diktat-Wiederherstellung behalten."
+            )
+        }
+    }
+
+    /// Default final-transcription bound: a minute of headroom plus the
+    /// recording's own length, so long recordings on slow local engines are not
+    /// cut off while a hung cloud request can never pin the app in "Transcribing".
+    nonisolated static func defaultTranscriptionDeadline(forAudioDuration duration: TimeInterval) -> TimeInterval {
+        60 + max(0, duration)
     }
 
     nonisolated(unsafe) static var _shared: DictationViewModel?
@@ -333,6 +356,7 @@ final class DictationViewModel: ObservableObject {
     private let recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider
     private let recoveryFallbackRunner: RecoveryFallbackRunner
     private let recoveryHedgeThresholdProvider: RecoveryHedgeThresholdProvider
+    private let transcriptionDeadlineProvider: TranscriptionDeadlineProvider
     private let primaryTranscriptionRunner: PrimaryTranscriptionRunner
     private var matchedWorkflow: Workflow?
     private var activeWorkflowMatch: WorkflowMatchResult?
@@ -436,7 +460,8 @@ final class DictationViewModel: ObservableObject {
         recoveryFallbackConfigurationProvider: RecoveryFallbackConfigurationProvider? = nil,
         recoveryFallbackRunner: RecoveryFallbackRunner? = nil,
         recoveryHedgeThresholdProvider: RecoveryHedgeThresholdProvider? = nil,
-        primaryTranscriptionRunner: PrimaryTranscriptionRunner? = nil
+        primaryTranscriptionRunner: PrimaryTranscriptionRunner? = nil,
+        transcriptionDeadlineProvider: TranscriptionDeadlineProvider? = nil
     ) {
         self.audioRecordingService = audioRecordingService
         self.textInsertionService = textInsertionService
@@ -475,6 +500,9 @@ final class DictationViewModel: ObservableObject {
         self.mediaPlaybackService = mediaPlaybackService
         self.recoveryFallbackConfigurationProvider = recoveryFallbackConfigurationProvider ?? { _, _ in nil }
         self.recoveryHedgeThresholdProvider = recoveryHedgeThresholdProvider ?? { nil }
+        self.transcriptionDeadlineProvider = transcriptionDeadlineProvider ?? { duration in
+            Self.defaultTranscriptionDeadline(forAudioDuration: duration)
+        }
         self.primaryTranscriptionRunner = primaryTranscriptionRunner ?? { [modelManager] samples, languageSelection, task, engineOverrideId, cloudModelOverride, prompt, dictionaryTermHints, normalizeNumbers in
             try await modelManager.transcribe(
                 audioSamples: samples,
@@ -2239,6 +2267,62 @@ final class DictationViewModel: ObservableObject {
     }
 
     private func transcribeFinalAudio(
+        audioSamples: [Float],
+        languageSelection: LanguageSelection,
+        task: TranscriptionTask,
+        primaryEngineId: String?,
+        primaryCloudModelOverride: String?,
+        prompt: String?,
+        dictionaryTermHints: [PluginDictionaryTermHint],
+        normalizeNumbers: Bool?
+    ) async throws -> FinalTranscriptionOutput {
+        let audioDuration = Double(audioSamples.count) / AudioRecordingService.targetSampleRate
+        guard let deadline = transcriptionDeadlineProvider(audioDuration), deadline > 0 else {
+            return try await transcribeFinalAudioWithoutDeadline(
+                audioSamples: audioSamples,
+                languageSelection: languageSelection,
+                task: task,
+                primaryEngineId: primaryEngineId,
+                primaryCloudModelOverride: primaryCloudModelOverride,
+                prompt: prompt,
+                dictionaryTermHints: dictionaryTermHints,
+                normalizeNumbers: normalizeNumbers
+            )
+        }
+
+        // Race the whole transcription phase against a deadline. Whichever finishes
+        // first wins and the other is cancelled, so a request that neither errors
+        // nor completes (a stalled upload, a server that accepted the audio and
+        // went silent) cannot leave the app stuck in "Transcribing..." with no way
+        // out but Escape.
+        let transcriptionOperation: @MainActor () async throws -> FinalTranscriptionOutput = { [self] in
+            try await self.transcribeFinalAudioWithoutDeadline(
+                audioSamples: audioSamples,
+                languageSelection: languageSelection,
+                task: task,
+                primaryEngineId: primaryEngineId,
+                primaryCloudModelOverride: primaryCloudModelOverride,
+                prompt: prompt,
+                dictionaryTermHints: dictionaryTermHints,
+                normalizeNumbers: normalizeNumbers
+            )
+        }
+        return try await withThrowingTaskGroup(of: FinalTranscriptionOutput.self) { group in
+            group.addTask { try await transcriptionOperation() }
+            group.addTask { [logger] in
+                try await Task.sleep(nanoseconds: UInt64(deadline * 1_000_000_000))
+                logger.error("Final transcription exceeded its deadline of \(deadline, format: .fixed(precision: 1))s; abandoning in-flight requests")
+                throw TranscriptionDeadlineExceeded(seconds: deadline)
+            }
+            defer { group.cancelAll() }
+            guard let output = try await group.next() else {
+                throw TranscriptionDeadlineExceeded(seconds: deadline)
+            }
+            return output
+        }
+    }
+
+    private func transcribeFinalAudioWithoutDeadline(
         audioSamples: [Float],
         languageSelection: LanguageSelection,
         task: TranscriptionTask,

--- a/TypeWhisper/Views/DictationRecoveryView.swift
+++ b/TypeWhisper/Views/DictationRecoveryView.swift
@@ -155,6 +155,39 @@ struct DictationRecoveryView: View {
                 }
                 .disabled(viewModel.isProcessing || !viewModel.canUseAutomaticFallback)
 
+                Toggle(isOn: $viewModel.hedgeEnabled) {
+                    Label(
+                        localizedAppText("Race this engine when the primary is slow", de: "Diese Engine starten, wenn die primäre Engine langsam ist"),
+                        systemImage: "hare"
+                    )
+                }
+                .disabled(viewModel.isProcessing || !viewModel.canUseAutomaticFallback || !viewModel.automaticFallbackEnabled)
+
+                if viewModel.hedgeEnabled {
+                    HStack {
+                        Text(localizedAppText("Start racing after", de: "Rennen starten nach"))
+                        Spacer()
+                        Stepper(
+                            value: $viewModel.hedgeThresholdSeconds,
+                            in: 1.0...15.0,
+                            step: 0.5
+                        ) {
+                            Text(localizedAppText(
+                                String(format: "%.1f seconds", viewModel.hedgeThresholdSeconds),
+                                de: String(format: "%.1f Sekunden", viewModel.hedgeThresholdSeconds)
+                            ))
+                        }
+                    }
+                    .disabled(viewModel.isProcessing || !viewModel.canUseAutomaticFallback || !viewModel.automaticFallbackEnabled)
+
+                    Text(localizedAppText(
+                        "If the primary engine hasn't answered by then, the same audio is also sent to this engine; whichever finishes first is used and the other request is cancelled. A dispatched race costs one extra API call.",
+                        de: "Antwortet die primäre Engine bis dahin nicht, wird dasselbe Audio zusätzlich an diese Engine gesendet; das schnellere Ergebnis wird verwendet, die andere Anfrage abgebrochen. Ein ausgelöstes Rennen kostet einen zusätzlichen API-Aufruf."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                }
+
                 if let message = viewModel.automaticFallbackUnavailableMessage {
                     Text(message)
                         .font(.caption)

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -11815,6 +11815,165 @@ final class TypeWhisperIntegrationTests: XCTestCase {
     }
 }
 
+// MARK: - Hedged transcription
+
+extension TypeWhisperIntegrationTests {
+    private static func hedgeTranscriptionResult(text: String, engine: String) -> TranscriptionResult {
+        TranscriptionResult(
+            text: text,
+            detectedLanguage: "en",
+            duration: 1,
+            processingTime: 0.1,
+            engineUsed: engine,
+            segments: []
+        )
+    }
+
+    @MainActor
+    private func makeHedgedDictationViewModel(
+        hedgeThreshold: TimeInterval?,
+        primaryRunner: @escaping DictationViewModel.PrimaryTranscriptionRunner,
+        fallbackRunner: @escaping DictationViewModel.RecoveryFallbackRunner
+    ) throws -> (viewModel: DictationViewModel, cleanup: () -> Void) {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+
+        EventBus.shared = EventBus()
+        PluginManager.shared = PluginManager(appSupportDirectory: appSupportDirectory)
+
+        let modelManager = ModelManagerService()
+        let audioRecordingService = AudioRecordingService()
+        let hotkeyService = HotkeyService()
+        let textInsertionService = TextInsertionService()
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let recentTranscriptionStore = RecentTranscriptionStore()
+        let profileService = ProfileService(appSupportDirectory: appSupportDirectory)
+        let workflowService = WorkflowService(appSupportDirectory: appSupportDirectory)
+        let audioDuckingService = AudioDuckingService()
+        let dictionaryService = DictionaryService(appSupportDirectory: appSupportDirectory)
+        let snippetService = SnippetService(appSupportDirectory: appSupportDirectory)
+        let soundService = SoundService()
+        let audioDeviceService = AudioDeviceService()
+        let promptActionService = PromptActionService(appSupportDirectory: appSupportDirectory)
+        let promptProcessingService = PromptProcessingService()
+        let appFormatterService = AppFormatterService()
+        let punctuationProfileStore = DictationPunctuationProfileStore(
+            defaults: UserDefaults(suiteName: UUID().uuidString)!,
+            storageKey: UUID().uuidString
+        )
+        let punctuationRulesLoader = PunctuationRulesLoader()
+        let punctuationStrategyResolver = PunctuationStrategyResolver(profileStore: punctuationProfileStore)
+        let speechFeedbackService = SpeechFeedbackService()
+        let accessibilityAnnouncementService = AccessibilityAnnouncementService()
+        let errorLogService = ErrorLogService(appSupportDirectory: appSupportDirectory)
+        let settingsViewModel = SettingsViewModel(modelManager: modelManager)
+
+        let viewModel = DictationViewModel(
+            audioRecordingService: audioRecordingService,
+            textInsertionService: textInsertionService,
+            hotkeyService: hotkeyService,
+            modelManager: modelManager,
+            settingsViewModel: settingsViewModel,
+            historyService: historyService,
+            recentTranscriptionStore: recentTranscriptionStore,
+            profileService: profileService,
+            workflowService: workflowService,
+            translationService: nil,
+            audioDuckingService: audioDuckingService,
+            dictionaryService: dictionaryService,
+            snippetService: snippetService,
+            soundService: soundService,
+            audioDeviceService: audioDeviceService,
+            promptActionService: promptActionService,
+            promptProcessingService: promptProcessingService,
+            appFormatterService: appFormatterService,
+            punctuationStrategyResolver: punctuationStrategyResolver,
+            speechPunctuationService: SpeechPunctuationService(rulesLoader: punctuationRulesLoader),
+            speechFeedbackService: speechFeedbackService,
+            accessibilityAnnouncementService: accessibilityAnnouncementService,
+            errorLogService: errorLogService,
+            mediaPlaybackService: MediaPlaybackService(startListening: false),
+            recoveryFallbackConfigurationProvider: { _, _ in
+                DictationRecoveryFallbackConfiguration(engineId: "test-fallback", modelId: "test-model")
+            },
+            recoveryFallbackRunner: fallbackRunner,
+            recoveryHedgeThresholdProvider: { hedgeThreshold },
+            primaryTranscriptionRunner: primaryRunner
+        )
+        viewModel.soundFeedbackEnabled = false
+        return (viewModel, { TestSupport.remove(appSupportDirectory) })
+    }
+
+    @MainActor
+    func testHedgeDispatchesFallbackWhenPrimaryIsSlowAndFallbackWins() async throws {
+        var fallbackCalled = false
+        let harness = try makeHedgedDictationViewModel(
+            hedgeThreshold: 0.2,
+            primaryRunner: { _, _, _, _, _, _, _, _ in
+                try await Task.sleep(nanoseconds: 10_000_000_000)
+                return Self.hedgeTranscriptionResult(text: "primary", engine: "primary")
+            },
+            fallbackRunner: { _, _, _, _, _, _, _ in
+                fallbackCalled = true
+                return Self.hedgeTranscriptionResult(text: "fallback", engine: "test-fallback")
+            }
+        )
+        defer { harness.cleanup() }
+
+        let start = ContinuousClock.now
+        let output = try await harness.viewModel.transcribeFinalAudioForTesting()
+
+        XCTAssertTrue(fallbackCalled)
+        XCTAssertTrue(output.usedRecoveryFallback)
+        XCTAssertEqual(output.text, "fallback")
+        XCTAssertLessThan(ContinuousClock.now - start, .seconds(5))
+    }
+
+    @MainActor
+    func testHedgePrimaryWinsBeforeThresholdWithoutDispatchingFallback() async throws {
+        var fallbackCalled = false
+        let harness = try makeHedgedDictationViewModel(
+            hedgeThreshold: 1.5,
+            primaryRunner: { _, _, _, _, _, _, _, _ in
+                Self.hedgeTranscriptionResult(text: "primary", engine: "primary")
+            },
+            fallbackRunner: { _, _, _, _, _, _, _ in
+                fallbackCalled = true
+                return Self.hedgeTranscriptionResult(text: "fallback", engine: "test-fallback")
+            }
+        )
+        defer { harness.cleanup() }
+
+        let output = try await harness.viewModel.transcribeFinalAudioForTesting()
+
+        XCTAssertFalse(output.usedRecoveryFallback)
+        XCTAssertEqual(output.text, "primary")
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertFalse(fallbackCalled)
+    }
+
+    @MainActor
+    func testHedgePrimaryFailureBeforeThresholdFallsBackWithoutWaiting() async throws {
+        let harness = try makeHedgedDictationViewModel(
+            hedgeThreshold: 8.0,
+            primaryRunner: { _, _, _, _, _, _, _, _ in
+                throw PluginTranscriptionError.rateLimited
+            },
+            fallbackRunner: { _, _, _, _, _, _, _ in
+                Self.hedgeTranscriptionResult(text: "fallback", engine: "test-fallback")
+            }
+        )
+        defer { harness.cleanup() }
+
+        let start = ContinuousClock.now
+        let output = try await harness.viewModel.transcribeFinalAudioForTesting()
+
+        XCTAssertTrue(output.usedRecoveryFallback)
+        XCTAssertEqual(output.text, "fallback")
+        // Must not wait out the 8s hedge threshold before falling back.
+        XCTAssertLessThan(ContinuousClock.now - start, .seconds(4))
+    }
+}
+
 final class AudioRecordingServiceInputAvailabilityTests: XCTestCase {
     func testStartRecording_throwsNoMicrophoneDetectedBeforeStartingOverride() {
         let service = AudioRecordingService()

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -11832,6 +11832,7 @@ extension TypeWhisperIntegrationTests {
     @MainActor
     private func makeHedgedDictationViewModel(
         hedgeThreshold: TimeInterval?,
+        transcriptionDeadline: TimeInterval? = nil,
         primaryRunner: @escaping DictationViewModel.PrimaryTranscriptionRunner,
         fallbackRunner: @escaping DictationViewModel.RecoveryFallbackRunner
     ) throws -> (viewModel: DictationViewModel, cleanup: () -> Void) {
@@ -11897,10 +11898,81 @@ extension TypeWhisperIntegrationTests {
             },
             recoveryFallbackRunner: fallbackRunner,
             recoveryHedgeThresholdProvider: { hedgeThreshold },
-            primaryTranscriptionRunner: primaryRunner
+            primaryTranscriptionRunner: primaryRunner,
+            transcriptionDeadlineProvider: transcriptionDeadline.map { deadline -> DictationViewModel.TranscriptionDeadlineProvider in
+                { _ in deadline }
+            }
         )
         viewModel.soundFeedbackEnabled = false
         return (viewModel, { TestSupport.remove(appSupportDirectory) })
+    }
+
+    @MainActor
+    func testTranscriptionDeadlineAbandonsHungPrimaryAndFallback() async throws {
+        var primaryCancelled = false
+        var fallbackCancelled = false
+        let harness = try makeHedgedDictationViewModel(
+            hedgeThreshold: 0.1,
+            transcriptionDeadline: 0.5,
+            primaryRunner: { _, _, _, _, _, _, _, _ in
+                do {
+                    try await Task.sleep(nanoseconds: 30_000_000_000)
+                } catch {
+                    primaryCancelled = true
+                    throw error
+                }
+                return Self.hedgeTranscriptionResult(text: "primary", engine: "primary")
+            },
+            fallbackRunner: { _, _, _, _, _, _, _ in
+                do {
+                    try await Task.sleep(nanoseconds: 30_000_000_000)
+                } catch {
+                    fallbackCancelled = true
+                    throw error
+                }
+                return Self.hedgeTranscriptionResult(text: "fallback", engine: "test-fallback")
+            }
+        )
+        defer { harness.cleanup() }
+
+        let start = ContinuousClock.now
+        do {
+            _ = try await harness.viewModel.transcribeFinalAudioForTesting()
+            XCTFail("A transcription that never completes must hit the deadline")
+        } catch let error as DictationViewModel.TranscriptionDeadlineExceeded {
+            XCTAssertEqual(error.seconds, 0.5)
+        }
+        XCTAssertLessThan(ContinuousClock.now - start, .seconds(5))
+
+        try await Task.sleep(nanoseconds: 200_000_000)
+        XCTAssertTrue(primaryCancelled, "the hung primary request must be cancelled once the deadline passes")
+        XCTAssertTrue(fallbackCancelled, "the hung fallback request must be cancelled once the deadline passes")
+    }
+
+    @MainActor
+    func testTranscriptionDeadlineDoesNotInterfereWithFastPrimary() async throws {
+        let harness = try makeHedgedDictationViewModel(
+            hedgeThreshold: 1.0,
+            transcriptionDeadline: 5.0,
+            primaryRunner: { _, _, _, _, _, _, _, _ in
+                Self.hedgeTranscriptionResult(text: "primary", engine: "primary")
+            },
+            fallbackRunner: { _, _, _, _, _, _, _ in
+                XCTFail("fallback must not run when the primary answers immediately")
+                return Self.hedgeTranscriptionResult(text: "fallback", engine: "test-fallback")
+            }
+        )
+        defer { harness.cleanup() }
+
+        let output = try await harness.viewModel.transcribeFinalAudioForTesting()
+        XCTAssertEqual(output.text, "primary")
+        XCTAssertFalse(output.usedRecoveryFallback)
+    }
+
+    func testDefaultTranscriptionDeadlineScalesWithRecordingLength() {
+        XCTAssertEqual(DictationViewModel.defaultTranscriptionDeadline(forAudioDuration: 0), 60)
+        XCTAssertEqual(DictationViewModel.defaultTranscriptionDeadline(forAudioDuration: 90), 150)
+        XCTAssertEqual(DictationViewModel.defaultTranscriptionDeadline(forAudioDuration: -5), 60)
     }
 
     @MainActor


### PR DESCRIPTION
Fixes #1245.

**Stacked on #1230** (hedged transcription) — the first commit here is #1230's; please review only the last commit, `Bound the final-transcription phase with a deadline`. I'll rebase once #1230 lands.

## Problem
A cloud transcription request that neither errors nor completes (a stalled upload, a server that accepted the audio and went silent) leaves the app in "Transcribing…" indefinitely. The 30 s request timeout only fires when no bytes flow at all, and the hedge race only helps when the primary is slow *but answers* — two engines hanging the same way are unbounded. The only way out is Escape.

## Change
`transcribeFinalAudio` now races the whole phase (primary, hedge, and the sequential fallback together) against a deadline via a throwing task group. The default bound is **60 s + the recording's own length**, so long recordings on slow local engines are not cut off, while a hung cloud request can never pin the app. When the deadline passes the in-flight requests are cancelled and a `TranscriptionDeadlineExceeded` error flows through the existing failure path: the user sees the error toast ("Transcription timed out after N seconds. The recording was kept in Dictation Recovery.") and the recovery WAV is preserved.

The bound is injectable (`transcriptionDeadlineProvider`) for tests; `nil` disables it.

## Tests
- `testTranscriptionDeadlineAbandonsHungPrimaryAndFallback` — both runners hang; the call throws `TranscriptionDeadlineExceeded` at the configured deadline and both hung runners observe cancellation.
- `testTranscriptionDeadlineDoesNotInterfereWithFastPrimary` — a fast primary completes normally and the fallback is never dispatched.
- `testDefaultTranscriptionDeadlineScalesWithRecordingLength` — the default formula.

Full suite on the combined local branch: 1681 tests, 0 failures. This branch compiles clean on top of #1230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic transcription fallback hedging, allowing a secondary engine to start when the primary engine is slow.
  * Added controls to enable hedging and configure a 1–15 second fallback threshold.
  * Added transcription time limits based on audio duration to prevent stalled processing.
  * Included hedge settings in settings backups and restores.

* **Bug Fixes**
  * Improved recovery when primary transcription is delayed or fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->