### PR TITLE
Allow opt-in daily host validation for plugin releases

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -22,6 +22,11 @@ on:
         options:
           - official
           - community
+      allow_prerelease_host:
+        description: Allow SDK validation against the latest matching daily host release
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -38,11 +43,13 @@ jobs:
           INPUT_PLUGIN_NAME: ${{ inputs.plugin_name }}
           INPUT_PLUGIN_VERSION: ${{ inputs.plugin_version }}
           INPUT_DISTRIBUTION_SOURCE: ${{ inputs.distribution_source }}
+          INPUT_ALLOW_PRERELEASE_HOST: ${{ inputs.allow_prerelease_host }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PLUGIN_NAME="$INPUT_PLUGIN_NAME"
             PLUGIN_VERSION="$INPUT_PLUGIN_VERSION"
             DISTRIBUTION_SOURCE="$INPUT_DISTRIBUTION_SOURCE"
+            ALLOW_PRERELEASE_HOST="${INPUT_ALLOW_PRERELEASE_HOST:-false}"
             TAG="plugin-${PLUGIN_NAME}-v${PLUGIN_VERSION}"
           else
             TAG="${GITHUB_REF_NAME}"
@@ -55,6 +62,7 @@ jobs:
               exit 1
             fi
             DISTRIBUTION_SOURCE="official"
+            ALLOW_PRERELEASE_HOST="false"
           fi
           if [[ ! "$PLUGIN_NAME" =~ ^[A-Za-z0-9_-]+$ ]]; then
             echo "Invalid plugin name: $PLUGIN_NAME"
@@ -68,13 +76,18 @@ jobs:
             official|community) ;;
             *) echo "Unknown distribution source: $DISTRIBUTION_SOURCE" && exit 1 ;;
           esac
+          case "$ALLOW_PRERELEASE_HOST" in
+            true|false) ;;
+            *) echo "Invalid allow_prerelease_host value: $ALLOW_PRERELEASE_HOST" && exit 1 ;;
+          esac
           {
             echo "TAG=$TAG"
             echo "PLUGIN_NAME=$PLUGIN_NAME"
             echo "PLUGIN_VERSION=$PLUGIN_VERSION"
             echo "DISTRIBUTION_SOURCE=$DISTRIBUTION_SOURCE"
+            echo "ALLOW_PRERELEASE_HOST=$ALLOW_PRERELEASE_HOST"
           } >> "$GITHUB_ENV"
-          echo "Plugin: $PLUGIN_NAME, Version: $PLUGIN_VERSION, Source: $DISTRIBUTION_SOURCE, Tag: $TAG"
+          echo "Plugin: $PLUGIN_NAME, Version: $PLUGIN_VERSION, Source: $DISTRIBUTION_SOURCE, Tag: $TAG, Allow prerelease host: $ALLOW_PRERELEASE_HOST"
 
       - name: Resolve target name
         run: |
@@ -258,22 +271,47 @@ jobs:
           MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
           MIN_HOST_VERSION=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["minHostVersion"])' "$MANIFEST")
           HOST_TAG="v${MIN_HOST_VERSION}"
-          HOST_ASSET_NAME="TypeWhisper-v${MIN_HOST_VERSION}.zip"
           WORKDIR="$RUNNER_TEMP/min-host-sdk-${TARGET}"
           mkdir -p "$WORKDIR/app"
 
           if ! HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --json tagName,isDraft,isPrerelease,assets); then
-            echo "::error::No published TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION} (${HOST_TAG})"
+            if [ "$ALLOW_PRERELEASE_HOST" != "true" ]; then
+              echo "::error::No published TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION} (${HOST_TAG})"
+              exit 1
+            fi
+
+            HOST_TAG=$(gh release list \
+              --repo "$GITHUB_REPOSITORY" \
+              --limit 100 \
+              --json tagName,isDraft,isPrerelease,publishedAt \
+              --jq "[.[] | select(.isDraft == false and .isPrerelease == true and (.tagName | startswith(\"v${MIN_HOST_VERSION}-daily.\")))] | sort_by(.publishedAt) | last | .tagName // empty")
+            if [ -z "$HOST_TAG" ]; then
+              echo "::error::No published daily TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION}"
+              exit 1
+            fi
+
+            HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json tagName,isDraft,isPrerelease,assets)
+            echo "Using explicitly allowed daily host release ${HOST_TAG} for SDK compatibility validation"
+          fi
+
+          if ! jq -e --argjson allow_prerelease "$ALLOW_PRERELEASE_HOST" \
+            '.isDraft == false and (.isPrerelease == false or $allow_prerelease)' \
+            <<<"$HOST_RELEASE_JSON" >/dev/null; then
+            echo "::error::Host release ${HOST_TAG} must be published and stable unless allow_prerelease_host is enabled"
             exit 1
           fi
 
-          if ! jq -e '.isDraft == false and .isPrerelease == false' \
-            <<<"$HOST_RELEASE_JSON" >/dev/null; then
-            echo "::error::Host release ${HOST_TAG} must be published and stable (not a draft or prerelease)"
+          RESOLVED_TAG=$(jq -r '.tagName' <<<"$HOST_RELEASE_JSON")
+          if [ "$RESOLVED_TAG" != "v${MIN_HOST_VERSION}" ] && \
+             [[ ! "$RESOLVED_TAG" =~ ^v${MIN_HOST_VERSION//./\\.}-daily\..+$ ]]; then
+            echo "::error::Resolved host tag ${RESOLVED_TAG} does not match minHostVersion ${MIN_HOST_VERSION}"
             exit 1
           fi
+          HOST_ASSET_NAME="TypeWhisper-${RESOLVED_TAG}.zip"
 
           if ! jq -e --arg asset "$HOST_ASSET_NAME" \
             '[.assets[] | select(.name == $asset)] | length == 1' \
@@ -282,7 +320,6 @@ jobs:
             exit 1
           fi
 
-          RESOLVED_TAG=$(jq -r '.tagName' <<<"$HOST_RELEASE_JSON")
           gh release download "$RESOLVED_TAG" \
             --repo "$GITHUB_REPOSITORY" \
             --pattern "$HOST_ASSET_NAME" \

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -270,48 +270,21 @@ jobs:
         run: |
           MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
           MIN_HOST_VERSION=$(python3 -c 'import json, sys; print(json.load(open(sys.argv[1]))["minHostVersion"])' "$MANIFEST")
-          HOST_TAG="v${MIN_HOST_VERSION}"
           WORKDIR="$RUNNER_TEMP/min-host-sdk-${TARGET}"
           mkdir -p "$WORKDIR/app"
 
-          if ! HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json tagName,isDraft,isPrerelease,assets); then
-            if [ "$ALLOW_PRERELEASE_HOST" != "true" ]; then
-              echo "::error::No published TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION} (${HOST_TAG})"
-              exit 1
-            fi
-
-            HOST_TAG=$(gh release list \
-              --repo "$GITHUB_REPOSITORY" \
-              --limit 100 \
-              --json tagName,isDraft,isPrerelease,publishedAt \
-              --jq "[.[] | select(.isDraft == false and .isPrerelease == true and (.tagName | startswith(\"v${MIN_HOST_VERSION}-daily.\")))] | sort_by(.publishedAt) | last | .tagName // empty")
-            if [ -z "$HOST_TAG" ]; then
-              echo "::error::No published daily TypeWhisper release found for minHostVersion ${MIN_HOST_VERSION}"
-              exit 1
-            fi
-
-            HOST_RELEASE_JSON=$(gh release view "$HOST_TAG" \
-              --repo "$GITHUB_REPOSITORY" \
-              --json tagName,isDraft,isPrerelease,assets)
-            echo "Using explicitly allowed daily host release ${HOST_TAG} for SDK compatibility validation"
+          RESOLVE_ARGS=(
+            --repository "$GITHUB_REPOSITORY"
+            --min-host-version "$MIN_HOST_VERSION"
+          )
+          if [ "$ALLOW_PRERELEASE_HOST" = "true" ]; then
+            RESOLVE_ARGS+=(--allow-prerelease-host)
           fi
-
-          if ! jq -e --argjson allow_prerelease "$ALLOW_PRERELEASE_HOST" \
-            '.isDraft == false and (.isPrerelease == false or $allow_prerelease)' \
-            <<<"$HOST_RELEASE_JSON" >/dev/null; then
-            echo "::error::Host release ${HOST_TAG} must be published and stable unless allow_prerelease_host is enabled"
-            exit 1
-          fi
+          HOST_RELEASE_JSON=$(python3 scripts/resolve_plugin_host_release.py "${RESOLVE_ARGS[@]}")
 
           RESOLVED_TAG=$(jq -r '.tagName' <<<"$HOST_RELEASE_JSON")
-          if [ "$RESOLVED_TAG" != "v${MIN_HOST_VERSION}" ] && \
-             [[ ! "$RESOLVED_TAG" =~ ^v${MIN_HOST_VERSION//./\\.}-daily\..+$ ]]; then
-            echo "::error::Resolved host tag ${RESOLVED_TAG} does not match minHostVersion ${MIN_HOST_VERSION}"
-            exit 1
-          fi
           HOST_ASSET_NAME="TypeWhisper-${RESOLVED_TAG}.zip"
+          echo "Using host release ${RESOLVED_TAG} for SDK compatibility validation"
 
           if ! jq -e --arg asset "$HOST_ASSET_NAME" \
             '[.assets[] | select(.name == $asset)] | length == 1' \

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -40,6 +40,7 @@ log "running Python script tests"
 python3 scripts/test_assemble_community_plugin_registry.py
 python3 scripts/test_check_plugin_sdk_symbol_compatibility.py
 python3 scripts/test_plugin_registry_metadata.py
+python3 scripts/test_resolve_plugin_host_release.py
 python3 scripts/test_verify_appcast_publication.py
 
 log "checking main-app localization completeness"

--- a/scripts/resolve_plugin_host_release.py
+++ b/scripts/resolve_plugin_host_release.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from typing import Any
+
+
+class ReleaseResolutionError(RuntimeError):
+    pass
+
+
+def run_gh(arguments: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *arguments],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def require_success(
+    result: subprocess.CompletedProcess[str],
+    operation: str,
+) -> str:
+    if result.returncode == 0:
+        return result.stdout
+
+    detail = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+    raise ReleaseResolutionError(f"{operation} failed: {detail}")
+
+
+def response_status_code(headers: str) -> int | None:
+    matches = re.findall(r"^HTTP/\S+\s+(\d{3})\b", headers, flags=re.MULTILINE)
+    return int(matches[-1]) if matches else None
+
+
+def exact_release_exists(repository: str, tag: str) -> bool:
+    result = run_gh(
+        [
+            "api",
+            "--include",
+            "--silent",
+            f"repos/{repository}/releases/tags/{tag}",
+        ]
+    )
+    if result.returncode == 0:
+        return True
+    if response_status_code(result.stdout) == 404:
+        return False
+
+    detail = result.stderr.strip() or result.stdout.strip() or "unknown gh error"
+    raise ReleaseResolutionError(
+        f"lookup for host release {tag} failed without a 404: {detail}"
+    )
+
+
+def load_release(repository: str, tag: str) -> dict[str, Any]:
+    output = require_success(
+        run_gh(
+            [
+                "release",
+                "view",
+                tag,
+                "--repo",
+                repository,
+                "--json",
+                "tagName,isDraft,isPrerelease,assets",
+            ]
+        ),
+        f"loading host release {tag}",
+    )
+    try:
+        release = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise ReleaseResolutionError(
+            f"host release {tag} returned invalid JSON: {error}"
+        ) from error
+    if not isinstance(release, dict):
+        raise ReleaseResolutionError(f"host release {tag} did not return an object")
+    return release
+
+
+def list_releases(repository: str) -> list[dict[str, Any]]:
+    output = require_success(
+        run_gh(
+            [
+                "release",
+                "list",
+                "--repo",
+                repository,
+                "--limit",
+                "100",
+                "--json",
+                "tagName,isDraft,isPrerelease,publishedAt",
+            ]
+        ),
+        "listing host releases",
+    )
+    try:
+        releases = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise ReleaseResolutionError(
+            f"host release list returned invalid JSON: {error}"
+        ) from error
+    if not isinstance(releases, list):
+        raise ReleaseResolutionError("host release list did not return an array")
+    return [release for release in releases if isinstance(release, dict)]
+
+
+def validate_release(
+    release: dict[str, Any],
+    minimum_host_version: str,
+    *,
+    expected_kind: str,
+) -> None:
+    tag = release.get("tagName")
+    stable_tag = f"v{minimum_host_version}"
+    daily_prefix = f"{stable_tag}-daily."
+
+    if release.get("isDraft") is not False:
+        raise ReleaseResolutionError(f"host release {tag!r} must be published")
+    if expected_kind == "stable":
+        if tag != stable_tag or release.get("isPrerelease") is not False:
+            raise ReleaseResolutionError(
+                f"host release {stable_tag} must be stable, not a prerelease"
+            )
+    elif expected_kind == "daily":
+        if (
+            not isinstance(tag, str)
+            or not tag.startswith(daily_prefix)
+            or release.get("isPrerelease") is not True
+        ):
+            raise ReleaseResolutionError(
+                f"daily host release {tag!r} must match {daily_prefix}* and be a prerelease"
+            )
+    else:
+        raise ReleaseResolutionError(f"unknown host release kind: {expected_kind}")
+
+    expected_asset = f"TypeWhisper-{tag}.zip"
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise ReleaseResolutionError(f"host release {tag} has no asset list")
+    matching_assets = [
+        asset
+        for asset in assets
+        if isinstance(asset, dict) and asset.get("name") == expected_asset
+    ]
+    if len(matching_assets) != 1:
+        raise ReleaseResolutionError(
+            f"host release {tag} must contain exactly one {expected_asset} asset"
+        )
+
+
+def resolve_host_release(
+    repository: str,
+    minimum_host_version: str,
+    *,
+    allow_prerelease_host: bool,
+) -> dict[str, Any]:
+    stable_tag = f"v{minimum_host_version}"
+    if exact_release_exists(repository, stable_tag):
+        release = load_release(repository, stable_tag)
+        validate_release(release, minimum_host_version, expected_kind="stable")
+        return release
+
+    if not allow_prerelease_host:
+        raise ReleaseResolutionError(
+            f"no published TypeWhisper release found for minHostVersion "
+            f"{minimum_host_version} ({stable_tag})"
+        )
+
+    daily_prefix = f"{stable_tag}-daily."
+    candidates = [
+        release
+        for release in list_releases(repository)
+        if release.get("isDraft") is False
+        and release.get("isPrerelease") is True
+        and isinstance(release.get("tagName"), str)
+        and release["tagName"].startswith(daily_prefix)
+        and isinstance(release.get("publishedAt"), str)
+    ]
+    if not candidates:
+        raise ReleaseResolutionError(
+            f"no published daily TypeWhisper release found for minHostVersion "
+            f"{minimum_host_version}"
+        )
+
+    selected = max(candidates, key=lambda release: release["publishedAt"])
+    release = load_release(repository, selected["tagName"])
+    validate_release(release, minimum_host_version, expected_kind="daily")
+    return release
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--min-host-version", required=True)
+    parser.add_argument("--allow-prerelease-host", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        release = resolve_host_release(
+            arguments.repository,
+            arguments.min_host_version,
+            allow_prerelease_host=arguments.allow_prerelease_host,
+        )
+    except ReleaseResolutionError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(release, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_resolve_plugin_host_release.py
+++ b/scripts/test_resolve_plugin_host_release.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import unittest
+from unittest.mock import patch
+
+from resolve_plugin_host_release import ReleaseResolutionError, resolve_host_release
+
+
+def gh_result(
+    *,
+    returncode: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["gh"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def release_json(tag: str, *, prerelease: bool) -> str:
+    return json.dumps(
+        {
+            "tagName": tag,
+            "isDraft": False,
+            "isPrerelease": prerelease,
+            "assets": [{"name": f"TypeWhisper-{tag}.zip", "digest": "sha256:test"}],
+        }
+    )
+
+
+class ResolvePluginHostReleaseTests(unittest.TestCase):
+    @patch("resolve_plugin_host_release.run_gh")
+    def test_prefers_exact_stable_release(self, mock_run_gh) -> None:
+        mock_run_gh.side_effect = [
+            gh_result(stdout="HTTP/2.0 200 OK\n"),
+            gh_result(stdout=release_json("v1.7.0", prerelease=False)),
+        ]
+
+        release = resolve_host_release(
+            "TypeWhisper/typewhisper-mac",
+            "1.7.0",
+            allow_prerelease_host=True,
+        )
+
+        self.assertEqual(release["tagName"], "v1.7.0")
+        self.assertEqual(mock_run_gh.call_count, 2)
+
+    @patch("resolve_plugin_host_release.run_gh")
+    def test_falls_back_to_latest_matching_daily_after_404(self, mock_run_gh) -> None:
+        releases = [
+            {
+                "tagName": "v1.7.0-daily.20260831",
+                "isDraft": False,
+                "isPrerelease": True,
+                "publishedAt": "2026-08-31T10:00:00Z",
+            },
+            {
+                "tagName": "v1.7.0-daily.20260901",
+                "isDraft": False,
+                "isPrerelease": True,
+                "publishedAt": "2026-09-01T10:00:00Z",
+            },
+            {
+                "tagName": "v1.6.0-daily.20260902",
+                "isDraft": False,
+                "isPrerelease": True,
+                "publishedAt": "2026-09-02T10:00:00Z",
+            },
+        ]
+        mock_run_gh.side_effect = [
+            gh_result(
+                returncode=1,
+                stdout="HTTP/2.0 404 Not Found\n",
+                stderr="gh: Not Found (HTTP 404)",
+            ),
+            gh_result(stdout=json.dumps(releases)),
+            gh_result(stdout=release_json("v1.7.0-daily.20260901", prerelease=True)),
+        ]
+
+        release = resolve_host_release(
+            "TypeWhisper/typewhisper-mac",
+            "1.7.0",
+            allow_prerelease_host=True,
+        )
+
+        self.assertEqual(release["tagName"], "v1.7.0-daily.20260901")
+
+    @patch("resolve_plugin_host_release.run_gh")
+    def test_propagates_non_404_lookup_failure(self, mock_run_gh) -> None:
+        mock_run_gh.return_value = gh_result(
+            returncode=1,
+            stdout="HTTP/2.0 503 Service Unavailable\n",
+            stderr="gh: service unavailable (HTTP 503)",
+        )
+
+        with self.assertRaisesRegex(ReleaseResolutionError, "without a 404"):
+            resolve_host_release(
+                "TypeWhisper/typewhisper-mac",
+                "1.7.0",
+                allow_prerelease_host=True,
+            )
+
+    @patch("resolve_plugin_host_release.run_gh")
+    def test_rejects_exact_tag_prerelease(self, mock_run_gh) -> None:
+        mock_run_gh.side_effect = [
+            gh_result(stdout="HTTP/2.0 200 OK\n"),
+            gh_result(stdout=release_json("v1.7.0", prerelease=True)),
+        ]
+
+        with self.assertRaisesRegex(ReleaseResolutionError, "must be stable"):
+            resolve_host_release(
+                "TypeWhisper/typewhisper-mac",
+                "1.7.0",
+                allow_prerelease_host=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an explicit, default-off workflow input for validating a plugin against the latest matching daily host release
- keep stable host validation as the default for manual and tag-triggered releases
- fall back only after an exact 404, while propagating authentication, rate-limit, API, and network failures
- require stable and daily tags to match the manifest minHostVersion and retain asset digest plus SDK ABI verification

This allows the Meta 1.0.0 plugin to be published ahead of the stable TypeWhisper 1.7.0 host while remaining installable only on compatible 1.7 builds.

## Test plan

- `python3 scripts/test_resolve_plugin_host_release.py`
- `actionlint -color .github/workflows/plugin-release.yml`
- `shellcheck scripts/pr-preflight.sh`
- resolve the live stable `v1.6.0` release and verify `TypeWhisper-v1.6.0.zip` is selected
- resolve the live prerelease fallback for `v1.7.0` and verify `TypeWhisper-v1.7.0-daily.20260901.zip` is selected
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional compatibility checks against prerelease host versions for manually triggered releases.
  - Enhanced SDK compatibility validation to select matching published daily host releases when enabled.
  - Added comprehensive validation for release status, tag format, and required assets.

- **Bug Fixes**
  - Tag-triggered releases now consistently reject prerelease hosts by default.
  - Improved handling of missing, invalid, or unavailable host-release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->