### PR TITLE
security: update Swift Crypto to 4.5.1

### DIFF
--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
-        "version" : "4.2.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {


### PR DESCRIPTION
## Summary

- update the root Xcode package resolution from swift-crypto 4.2.0 to 4.5.1
- align the app resolution with the Plugin SDK's existing fixed version
- remove the app dependency graph from the affected CVE-2026-28815 range without changing any other package pin

## Issue context

Swift Crypto versions 4.0.0 through 4.3.0 are affected by [GHSA-9m44-rr2w-ppp7 / CVE-2026-28815](https://github.com/apple/swift-crypto/security/advisories/GHSA-9m44-rr2w-ppp7). The root Xcode lockfile resolved 4.2.0, while the Plugin SDK already resolved 4.5.1.

Closes #1250

## Test plan

~~~bash
xcodebuild -resolvePackageDependencies -project TypeWhisper.xcodeproj -scheme TypeWhisper
xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
xcodebuild -project TypeWhisper.xcodeproj -scheme CohereLocalPlugin -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
swift test --package-path TypeWhisperPluginSDK
git diff --check origin/main...HEAD
~~~

Results:

- TypeWhisper build succeeded.
- CohereLocalPlugin built the HuggingFace-to-Crypto dependency chain with swift-crypto 4.5.1.
- Plugin SDK tests passed: 690 executed, 2 skipped, 0 failures.
