### PR TITLE
Fix plugin uninstall hang

### DIFF
--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -664,10 +664,10 @@ final class PluginManager: ObservableObject {
                 return
             }
 
+            PluginSettingsWindowManager.shared.closeWindow(for: manifest.id)
             if existing.isEnabled {
                 existing.instance.deactivate()
             }
-            existing.bundle.unload()
             loadedPlugins.remove(at: existingIndex)
             logger.info("Replacing plugin \(manifest.id) from \(existing.sourceURL.lastPathComponent) with \(url.lastPathComponent)")
         }
@@ -819,12 +819,12 @@ final class PluginManager: ObservableObject {
         } else {
             // If the deactivated plugin was selected as default engine, fall back to first available
             let disabledProviderIds = transcriptionProviderIds(exposedBy: loadedPlugins[index].instance)
+            PluginSettingsWindowManager.shared.closeWindow(for: pluginId)
             selectFallbackTranscriptionProviderIfNeeded(disabling: disabledProviderIds)
 
             let plugin = loadedPlugins[index]
             if plugin.isRuntimeLoaded {
                 plugin.instance.deactivate()
-                plugin.bundle.unload()
             }
 
             do {
@@ -854,8 +854,15 @@ final class PluginManager: ObservableObject {
     }
 
     func selectFallbackTranscriptionProviderIfNeeded(disabling disabledProviderIds: Set<String>) {
-        guard let fallbackProviderId = fallbackTranscriptionProviderId(disabling: disabledProviderIds) else { return }
-        ServiceContainer.shared.modelManagerService.selectProvider(fallbackProviderId)
+        guard !disabledProviderIds.isEmpty,
+              let selectedProvider = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine),
+              disabledProviderIds.contains(selectedProvider) else { return }
+
+        if let fallbackProviderId = fallbackTranscriptionProviderId(disabling: disabledProviderIds) {
+            ServiceContainer.shared.modelManagerService.selectProvider(fallbackProviderId)
+        } else {
+            ServiceContainer.shared.modelManagerService.clearProviderSelection()
+        }
     }
 
     func fallbackTranscriptionProviderId(disabling disabledProviderIds: Set<String>) -> String? {
@@ -913,17 +920,22 @@ final class PluginManager: ObservableObject {
 
     // MARK: - Dynamic Plugin Management
 
+    /// Removes a plugin from the active runtime registry without unmapping its executable code.
+    /// SwiftUI and AppKit may retain plugin-defined view metadata beyond the visible window's
+    /// lifetime, so calling `Bundle.unload()` while the app is running is not safe.
     func unloadPlugin(_ pluginId: String) {
         guard let index = loadedPlugins.firstIndex(where: { $0.manifest.id == pluginId }) else { return }
         let plugin = loadedPlugins[index]
+        let disabledProviderIds = transcriptionProviderIds(exposedBy: plugin.instance)
+
+        PluginSettingsWindowManager.shared.closeWindow(for: pluginId)
+        selectFallbackTranscriptionProviderIfNeeded(disabling: disabledProviderIds)
+
         if plugin.isEnabled && plugin.isRuntimeLoaded {
             plugin.instance.deactivate()
         }
-        if plugin.isRuntimeLoaded {
-            plugin.bundle.unload()
-        }
         loadedPlugins.remove(at: index)
-        logger.info("Unloaded plugin: \(pluginId)")
+        logger.info("Removed plugin from runtime registry: \(pluginId)")
     }
 
     func bundleURL(for pluginId: String) -> URL? {

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -187,6 +187,18 @@ final class PluginSettingsWindowManager {
         windows[pluginId]
     }
 
+    func closeWindow(for pluginId: String) {
+        guard let window = windows.removeValue(forKey: pluginId) else { return }
+
+        delegates.removeValue(forKey: pluginId)
+        window.delegate = nil
+        window.close()
+
+        // A closed NSWindow with isReleasedWhenClosed=false retains its hosting view.
+        // Tear down the plugin-owned SwiftUI graph before its runtime registration is removed.
+        window.contentView = nil
+    }
+
     func present(_ plugin: LoadedPlugin) {
         guard let settingsView = plugin.instance.settingsView else { return }
         let layout = plugin.instance as? any PluginSettingsWindowLayoutProviding

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import SwiftUI
 import TypeWhisperPluginSDK
+import XCTest
 @testable import TypeWhisper
 
 final class PluginRegistryServiceTests: XCTestCase {
@@ -580,21 +581,24 @@ final class PluginRegistryServiceTests: XCTestCase {
             version: "1.0.0"
         )
         let bundle = try XCTUnwrap(Bundle(url: bundleURL))
-        pluginManager.loadedPlugins = [
-            LoadedPlugin(
-                manifest: PluginManifest(
-                    id: pluginId,
-                    name: "Update Uninstall Plugin",
-                    version: "1.0.0",
-                    sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
-                    principalClass: "RuntimeUpdatePlugin"
-                ),
-                instance: MockRuntimeUpdatePlugin(),
-                bundle: bundle,
-                sourceURL: bundleURL,
-                isEnabled: false
+        let loadedPlugin = LoadedPlugin(
+            manifest: PluginManifest(
+                id: pluginId,
+                name: "Update Uninstall Plugin",
+                version: "1.0.0",
+                sdkCompatibilityVersion: PluginSDKCompatibility.currentVersion,
+                principalClass: "RuntimeUpdatePlugin"
             ),
-        ]
+            instance: MockRuntimeUpdatePlugin(),
+            bundle: bundle,
+            sourceURL: bundleURL,
+            isEnabled: false
+        )
+        pluginManager.loadedPlugins = [loadedPlugin]
+
+        PluginSettingsWindowManager.shared.present(loadedPlugin)
+        XCTAssertNotNil(PluginSettingsWindowManager.shared.managedWindow(for: pluginId))
+        defer { PluginSettingsWindowManager.shared.closeWindow(for: pluginId) }
 
         let service = PluginRegistryService(
             registryBaseURL: URL(string: "https://example.com")!,
@@ -618,6 +622,7 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertTrue(service.availableUpdatePlugins().isEmpty)
         XCTAssertTrue(pluginManager.loadedPlugins.isEmpty)
         XCTAssertFalse(FileManager.default.fileExists(atPath: bundleURL.path))
+        XCTAssertNil(PluginSettingsWindowManager.shared.managedWindow(for: pluginId))
 
         var installerWasCalled = false
         let result = await service.updateAllAvailablePlugins { _ in
@@ -1687,5 +1692,14 @@ final class PluginRegistryServiceTests: XCTestCase {
 
         func activate(host: any HostServices) {}
         func deactivate() {}
+
+        @MainActor
+        var settingsView: AnyView? {
+            AnyView(
+                Picker("Model", selection: .constant("muse-voice-transcribe-1.0")) {
+                    Text("Muse Voice Transcribe").tag("muse-voice-transcribe-1.0")
+                }
+            )
+        }
     }
 }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -9426,6 +9426,16 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let fallbackProviderId = PluginManager.shared.fallbackTranscriptionProviderId(disabling: disabledProviderIds)
 
         XCTAssertEqual(fallbackProviderId, fallbackEngine.providerId)
+
+        PluginManager.shared.unloadPlugin("com.typewhisper.mock.expanded-role")
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: selectedEngineKey), fallbackEngine.providerId)
+        XCTAssertEqual(PluginManager.shared.loadedPlugins.map(\.id), ["com.typewhisper.mock.transcription"])
+
+        PluginManager.shared.unloadPlugin("com.typewhisper.mock.transcription")
+
+        XCTAssertNil(UserDefaults.standard.string(forKey: selectedEngineKey))
+        XCTAssertTrue(PluginManager.shared.loadedPlugins.isEmpty)
     }
 
     @MainActor


### PR DESCRIPTION
## Summary

- close and tear down plugin settings windows before disabling, replacing, or uninstalling a plugin
- keep dynamically loaded plugin executable code mapped for the lifetime of the host process so retained SwiftUI/AppKit metadata cannot reference unloaded code
- fall back from an uninstalled transcription provider, or clear the selection when no fallback remains
- add regressions for uninstalling with an open Picker-based settings view and for provider fallback cleanup

## Context

A user running the September 2 daily build reported TypeWhisper becoming unresponsive while uninstalling the Meta/Muse plugin. The supplied hang report shows the main thread spending the sampling window in SwiftUI AttributeGraph and AppKit picker accessibility updates while the uninstall path could call `Bundle.unload()`.

This is a host lifecycle fix; the Meta plugin sources and manifest are unchanged.

## Test Plan

- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''` (29 tests, 0 failures)
- [x] `xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS' -only-testing:TypeWhisperTests/PluginRegistryServiceTests/testUninstallingPluginWithAvailableUpdateRefreshesCount -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testExpandedPluginFallbackIncludesAdditionalTranscriptionEngine CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''` (2 tests, 0 failures on final tree)
- [x] `git diff --check`
- [ ] Manually uninstall the released Meta plugin in a signed development build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plugin settings windows now close automatically when a plugin is replaced, disabled, or removed.
  * Disabling or removing a transcription plugin now selects an available configured fallback when possible.
  * The selected transcription engine is cleared when no compatible providers remain.
  * Plugin removal now reliably updates the active plugin list and prevents stale settings windows from remaining open.

* **Tests**
  * Added coverage for plugin settings window cleanup and transcription provider fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->