### PR TITLE
Fix first Cohere model download

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -212,15 +212,21 @@ struct CohereLocalModelAssets: Sendable {
                 }
             }
         }
-        defer { samplingTask.cancel() }
-
-        _ = try await client.downloadFile(
-            at: fileName,
-            from: repositoryId,
-            to: destination,
-            revision: revision,
-            progress: progress
-        )
+        do {
+            _ = try await client.downloadFile(
+                at: fileName,
+                from: repositoryId,
+                to: destination,
+                revision: revision,
+                progress: progress
+            )
+        } catch {
+            samplingTask.cancel()
+            await samplingTask.value
+            throw error
+        }
+        samplingTask.cancel()
+        await samplingTask.value
         progressHandler(progressOffset + progressScale)
     }
 

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereGGUFAssets.swift
@@ -110,57 +110,55 @@ struct CohereLocalModelAssets: Sendable {
 
         let session = URLSession(configuration: .default)
         defer { session.invalidateAndCancel() }
-        let client = HubClient(
-            session: session,
-            host: HubClient.defaultHost,
-            userAgent: "TypeWhisper-CohereLocal/0.1.0",
-            bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(bearerToken),
-            cache: nil
-        )
-
-        if !isNonEmptyFile(modelFileURL) {
-            guard let repositoryId = Repo.ID(rawValue: Self.modelRepositoryId) else {
-                throw CohereLocalPluginError.invalidRepositoryIdentifier
-            }
-            _ = try await client.downloadSnapshot(
-                of: repositoryId,
-                to: rootDirectory,
-                revision: Self.modelRevision,
-                matching: [model.fileName],
-                maxConcurrentDownloads: 1,
-                progressHandler: { @MainActor progress in
-                    progressHandler(progress.fractionCompleted * 0.98)
-                }
-            )
-        }
-        try verifyOrDiscard(
+        if !isVerifiedFile(
             modelFileURL,
             expectedSize: model.fileSize,
             expectedSHA256: model.sha256
-        )
+        ) {
+            try await Self.downloadHubFile(
+                session: session,
+                repositoryId: Self.modelRepositoryId,
+                revision: Self.modelRevision,
+                fileName: model.fileName,
+                destination: modelFileURL,
+                bearerToken: bearerToken,
+                progressScale: 0.98,
+                progressHandler: progressHandler
+            )
+            try verifyOrDiscard(
+                modelFileURL,
+                expectedSize: model.fileSize,
+                expectedSHA256: model.sha256
+            )
+        }
         progressHandler(0.98)
 
-        if !isNonEmptyFile(vadModelURL) {
-            guard let repositoryId = Repo.ID(rawValue: Self.vadRepositoryId) else {
-                throw CohereLocalPluginError.invalidRepositoryIdentifier
-            }
+        if !isVerifiedFile(
+            vadModelURL,
+            expectedSize: Self.vadSize,
+            expectedSHA256: Self.vadSHA256
+        ) {
             try FileManager.default.createDirectory(
                 at: auxiliaryDirectory,
                 withIntermediateDirectories: true
             )
-            _ = try await client.downloadSnapshot(
-                of: repositoryId,
-                to: auxiliaryDirectory,
+            try await Self.downloadHubFile(
+                session: session,
+                repositoryId: Self.vadRepositoryId,
                 revision: Self.vadRevision,
-                matching: [Self.vadFileName],
-                maxConcurrentDownloads: 1
+                fileName: Self.vadFileName,
+                destination: vadModelURL,
+                bearerToken: bearerToken,
+                progressScale: 0.01,
+                progressOffset: 0.98,
+                progressHandler: progressHandler
+            )
+            try verifyOrDiscard(
+                vadModelURL,
+                expectedSize: Self.vadSize,
+                expectedSHA256: Self.vadSHA256
             )
         }
-        try verifyOrDiscard(
-            vadModelURL,
-            expectedSize: Self.vadSize,
-            expectedSHA256: Self.vadSHA256
-        )
         progressHandler(0.99)
 
         if !isRuntimeInstalled {
@@ -171,6 +169,59 @@ struct CohereLocalModelAssets: Sendable {
         guard isInstalled else {
             throw CohereLocalPluginError.incompleteModelDownload
         }
+    }
+
+    static func downloadHubFile(
+        session: URLSession,
+        host: URL = HubClient.defaultHost,
+        repositoryId: String,
+        revision: String,
+        fileName: String,
+        destination: URL,
+        bearerToken: String? = nil,
+        progressScale: Double = 1,
+        progressOffset: Double = 0,
+        progressHandler: @Sendable @escaping (Double) -> Void
+    ) async throws {
+        // swift-huggingface 0.9.0's snapshot API throws after a successful
+        // destination-only download when caching is disabled. Cohere needs one
+        // file per repository, so the single-file API avoids that false error.
+        guard let repositoryId = Repo.ID(rawValue: repositoryId) else {
+            throw CohereLocalPluginError.invalidRepositoryIdentifier
+        }
+
+        let client = HubClient(
+            session: session,
+            host: host,
+            userAgent: "TypeWhisper-CohereLocal/0.1.0",
+            bearerToken: PluginHuggingFaceTokenHelper.normalizedToken(bearerToken),
+            cache: nil
+        )
+        let progress = Progress(totalUnitCount: 1)
+        let samplingTask = Task {
+            while !Task.isCancelled {
+                let fraction = progress.fractionCompleted
+                let normalizedFraction = fraction.isFinite
+                    ? min(max(fraction, 0), 1)
+                    : 0
+                progressHandler(progressOffset + normalizedFraction * progressScale)
+                do {
+                    try await Task.sleep(for: .milliseconds(100))
+                } catch {
+                    return
+                }
+            }
+        }
+        defer { samplingTask.cancel() }
+
+        _ = try await client.downloadFile(
+            at: fileName,
+            from: repositoryId,
+            to: destination,
+            revision: revision,
+            progress: progress
+        )
+        progressHandler(progressOffset + progressScale)
     }
 
     func deleteModelFiles(allModels: [CohereLocalModelDefinition]) throws {
@@ -304,6 +355,25 @@ struct CohereLocalModelAssets: Sendable {
         } catch {
             try? FileManager.default.removeItem(at: file)
             throw error
+        }
+    }
+
+    private func isVerifiedFile(
+        _ file: URL,
+        expectedSize: Int64,
+        expectedSHA256: String
+    ) -> Bool {
+        guard isNonEmptyFile(file) else { return false }
+        do {
+            try verify(
+                file,
+                expectedSize: expectedSize,
+                expectedSHA256: expectedSHA256
+            )
+            return true
+        } catch {
+            try? FileManager.default.removeItem(at: file)
+            return false
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -40,11 +40,13 @@ private final class CohereDownloadURLProtocol: URLProtocol, @unchecked Sendable 
     static let payload = Data("first-download".utf8)
     static let requestRecorder = CohereDownloadRequestRecorder()
 
+    // swiftlint:disable static_over_final_class
     override class func canInit(with _: URLRequest) -> Bool { true }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest {
         request
     }
+    // swiftlint:enable static_over_final_class
 
     override func startLoading() {
         Self.requestRecorder.record(request)

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -6,6 +6,66 @@ import XCTest
 
 @testable import CohereLocalPlugin
 
+private final class CohereDownloadRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [URLRequest] = []
+
+    func reset() {
+        lock.withLock { requests = [] }
+    }
+
+    func record(_ request: URLRequest) {
+        lock.withLock { requests.append(request) }
+    }
+
+    var recordedRequests: [URLRequest] {
+        lock.withLock { requests }
+    }
+}
+
+private final class CohereDownloadProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [Double] = []
+
+    func record(_ value: Double) {
+        lock.withLock { values.append(value) }
+    }
+
+    var lastValue: Double? {
+        lock.withLock { values.last }
+    }
+}
+
+private final class CohereDownloadURLProtocol: URLProtocol, @unchecked Sendable {
+    static let payload = Data("first-download".utf8)
+    static let requestRecorder = CohereDownloadRequestRecorder()
+
+    override class func canInit(with _: URLRequest) -> Bool { true }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestRecorder.record(request)
+        guard let url = request.url,
+              let response = HTTPURLResponse(
+                  url: url,
+                  statusCode: 200,
+                  httpVersion: "HTTP/1.1",
+                  headerFields: ["Content-Length": String(Self.payload.count)]
+              ) else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.payload)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 final class CohereLocalPluginTests: XCTestCase {
     private actor RequestRecorder {
         private var request: URLRequest?
@@ -165,6 +225,58 @@ final class CohereLocalPluginTests: XCTestCase {
         ) { error in
             XCTAssertEqual((error as? URLError)?.code, .notConnectedToInternet)
         }
+    }
+
+    func testHubFileDownloadSucceedsOnFirstAttemptWithoutSnapshotCache() async throws {
+        CohereDownloadURLProtocol.requestRecorder.reset()
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [CohereDownloadURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer { session.invalidateAndCancel() }
+
+        let temporaryDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cohere-first-download-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let destination = temporaryDirectory.appendingPathComponent("model.gguf")
+        let progressRecorder = CohereDownloadProgressRecorder()
+
+        try await CohereLocalModelAssets.downloadHubFile(
+            session: session,
+            host: try XCTUnwrap(URL(string: "https://cohere-download.test")),
+            repositoryId: "owner/model",
+            revision: "0123456789012345678901234567890123456789",
+            fileName: "model.gguf",
+            destination: destination,
+            bearerToken: "  hf_first_download  ",
+            progressScale: 0.98
+        ) { progress in
+            progressRecorder.record(progress)
+        }
+
+        XCTAssertEqual(try Data(contentsOf: destination), CohereDownloadURLProtocol.payload)
+        let request = try XCTUnwrap(
+            CohereDownloadURLProtocol.requestRecorder.recordedRequests.first
+        )
+        XCTAssertEqual(
+            request.url?.absoluteString,
+            "https://cohere-download.test/owner/model/resolve/0123456789012345678901234567890123456789/model.gguf"
+        )
+        XCTAssertEqual(request.httpMethod, "GET")
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "Authorization"),
+            "Bearer hf_first_download"
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(progressRecorder.lastValue),
+            0.98,
+            accuracy: 0.000_001
+        )
     }
 
     func testSelectingAnotherModelStopsServerThatIsStillStarting() async throws {

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.cohere-transcribe",
     "name": "Cohere Transcribe (Local)",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -146,14 +146,14 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 
-    func testCohereLocalPlugin10RequiresCompatibleHost16() throws {
+    func testCohereLocalPlugin101RequiresCompatibleHost16() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent(
             "TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json"
         )
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
-        XCTAssertEqual(manifest.version, "1.0.0")
+        XCTAssertEqual(manifest.version, "1.0.1")
         XCTAssertEqual(manifest.minHostVersion, "1.6.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])


### PR DESCRIPTION
## Summary

- download the Cohere model and VAD with the Hugging Face single-file API
- avoid the false cache error emitted by the snapshot API after a successful destination-only download
- discard invalid partial assets and redownload them during the same attempt
- preserve download progress reporting and add a first-attempt regression test

## Root cause

With caching disabled, `swift-huggingface` 0.9.0 writes a snapshot to the explicit destination and then incorrectly throws `snapshotRequiresCacheOrDestination`. The plugin surfaced that error even though the model file was already present, so selecting another model and returning made the original model appear to recover.

## Test plan

- `swift build --package-path TypeWhisperPluginSDK --target CohereLocalPlugin`
- `swift test --package-path TypeWhisperPluginSDK --filter CohereLocalPluginTests`
- `swift test --package-path TypeWhisperPluginSDK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cohere model and VAD asset downloads now validate cached files before reuse.
  * Invalid or incomplete files are removed and downloaded again.
  * Download progress reporting is more accurate and consistent.
  * Authentication and destination-only downloads are handled more reliably.

* **Tests**
  * Added coverage for download requests, authentication, payloads, and progress reporting.

* **Maintenance**
  * Updated the Cohere Local Plugin version to 1.0.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->