### PR TITLE
Bundle authenticated CLI provider with the macOS app

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -365,6 +365,7 @@
 		E1A000000000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000024 /* Assets.xcassets */; };
 		E1A000000000000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000025 /* InfoPlist.xcstrings */; };
 		5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		AC1100000000000000000060 /* AuthenticatedCLIPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = AC1100000000000000000018 /* AuthenticatedCLIPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA00000000000000000199 /* VoxtralPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000191 /* VoxtralPlugin.swift */; };
 		AA00000000000000000200 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000192 /* manifest.json */; };
 		AA00000000000000000201 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000193 /* Localizable.xcstrings */; };
@@ -603,6 +604,13 @@
 			remoteGlobalIDString = DD00000000000000000012;
 			remoteInfo = SpeechAnalyzerPlugin;
 		};
+		AC1100000000000000000061 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = EE00000000000000000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = AC1100000000000000000030;
+			remoteInfo = AuthenticatedCLIPlugin;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -658,6 +666,7 @@
 			dstSubfolderSpec = 13;
 			files = (
 				5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */,
+				AC1100000000000000000060 /* AuthenticatedCLIPlugin.bundle in Embed Built-In Plugins */,
 			);
 			name = "Embed Built-In Plugins";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2849,6 +2858,7 @@
 				GG00000000000000000009 /* PBXTargetDependency */,
 				E1A000000000000000000060 /* PBXTargetDependency */,
 				5E7A00000000000000000004 /* PBXTargetDependency */,
+				AC1100000000000000000062 /* PBXTargetDependency */,
 				1C1000000000000000000045 /* PBXTargetDependency */,
 			);
 			name = TypeWhisper;
@@ -5275,6 +5285,11 @@
 			isa = PBXTargetDependency;
 			target = DD00000000000000000012 /* SpeechAnalyzerPlugin */;
 			targetProxy = 5E7A00000000000000000003 /* PBXContainerItemProxy */;
+		};
+		AC1100000000000000000062 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = AC1100000000000000000030 /* AuthenticatedCLIPlugin */;
+			targetProxy = AC1100000000000000000061 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/AuthenticatedCLIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/AuthenticatedCLIPlugin.swift
@@ -620,15 +620,23 @@ final class AuthenticatedCLIPlugin: NSObject,
 
     static func effortDisplayName(_ id: String) -> String {
         switch id.lowercased() {
-        case "minimal": String(localized: "Minimal", bundle: .module)
-        case "low": String(localized: "Low", bundle: .module)
-        case "medium": String(localized: "Medium", bundle: .module)
-        case "high": String(localized: "High", bundle: .module)
-        case "xhigh": String(localized: "XHigh", bundle: .module)
-        case "max": String(localized: "Max", bundle: .module)
-        case "ultracode": String(localized: "Ultracode", bundle: .module)
+        case "minimal": String(localized: "Minimal", bundle: localizationBundle)
+        case "low": String(localized: "Low", bundle: localizationBundle)
+        case "medium": String(localized: "Medium", bundle: localizationBundle)
+        case "high": String(localized: "High", bundle: localizationBundle)
+        case "xhigh": String(localized: "XHigh", bundle: localizationBundle)
+        case "max": String(localized: "Max", bundle: localizationBundle)
+        case "ultracode": String(localized: "Ultracode", bundle: localizationBundle)
         default: id.capitalized
         }
+    }
+
+    private static var localizationBundle: Bundle {
+#if SWIFT_PACKAGE
+        .module
+#else
+        Bundle(for: AuthenticatedCLIPlugin.self)
+#endif
     }
 
     private static var screenshotStatuses: [CLIProviderKind: CLIProviderStatus] {


### PR DESCRIPTION
## Context

PR #1151 added the Authenticated Provider CLIs implementation, but the `TypeWhisper` app target did not build or embed `AuthenticatedCLIPlugin.bundle`. As a result, released app bundles could not discover the provider as a built-in plugin.

## Summary

- add `AuthenticatedCLIPlugin` as an explicit dependency of the macOS app target
- embed and sign the plugin bundle in `TypeWhisper.app/Contents/PlugIns`
- resolve localized effort names from the correct resource bundle in both Xcode and Swift Package builds

The plugin remains a separate bundle internally, but it is delivered automatically with every app build.

## Test plan

```bash
AUTHCLI_DERIVED_DATA="$(mktemp -d /tmp/typewhisper-authcli-build.XXXXXX)"
xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath "$AUTHCLI_DERIVED_DATA" CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO ONLY_ACTIVE_ARCH=YES build

test -x "$AUTHCLI_DERIVED_DATA/Build/Products/Debug/TypeWhisper.app/Contents/PlugIns/AuthenticatedCLIPlugin.bundle/Contents/MacOS/AuthenticatedCLIPlugin"
test -f "$AUTHCLI_DERIVED_DATA/Build/Products/Debug/TypeWhisper.app/Contents/PlugIns/AuthenticatedCLIPlugin.bundle/Contents/Resources/manifest.json"

swift test --package-path TypeWhisperPluginSDK --filter AuthenticatedCLIPluginTests
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the Authenticated CLI plugin to the TypeWhisper app, making its functionality available in app builds.

- **Improvements**
  - Updated effort labels to use the correct localized resources across supported build environments, improving consistency for users viewing translated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->