### PR TITLE
Require TypeWhisper 1.7 for authenticated CLI plugin

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.authenticated-cli",
     "name": "Authenticated Provider CLIs",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
## Context

The authenticated CLI plugin release failed its SDK compatibility gate because the plugin imports LLMEffortControllableProvider and PluginLLMEffortInfo, while the manifest declared TypeWhisper 1.6.0. Those symbols are exported by the published TypeWhisper 1.7 daily host for both arm64 and x86_64.

This updates only the plugin manifest to declare the actual minimum compatible host version and unblocks the independent v1.0.0 plugin release.

## Test plan

- python3 -m json.tool TypeWhisperPluginSDK/Plugins/AuthenticatedCLIPlugin/manifest.json
- PYTHONPATH=scripts python3 -m unittest scripts/test_resolve_plugin_host_release.py
- swift test --package-path TypeWhisperPluginSDK --filter AuthenticatedCLIPluginTests
- xcodebuild -project TypeWhisper.xcodeproj -target AuthenticatedCLIPlugin -configuration Release SYMROOT=/tmp/authcli-abi-build CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=2D8ALY3LCL MACOSX_DEPLOYMENT_TARGET=14.0 MARKETING_VERSION=1.0.0 ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO
- python3 scripts/check_plugin_sdk_symbol_compatibility.py --plugin-binary <plugin-binary> --build-sdk <build-sdk> --host-sdk <TypeWhisper-v1.7.0-daily.20260902-sdk> --min-host-version 1.7.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Compatibility**
  - Updated the minimum supported host version to **1.7.0**.
  - Please upgrade the host application before installing or using this plugin version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->