### PR TITLE
Suppress passive model restore for unselected engines

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		AA9400000000000000000001 /* SettingsVisualComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB9400000000000000000001 /* SettingsVisualComponents.swift */; };
 		1834537D0CCC21190DB68EBD /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8AA5F3DBFD9010D09311C40 /* Cocoa.framework */; };
 		1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */; };
+		7A1018FIX0000000000A001 /* PassiveRestoreSelectedEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A1018FIX0000000000A002 /* PassiveRestoreSelectedEngineTests.swift */; };
 		103600000000000000000001 /* MLXPluginModelStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103600000000000000000002 /* MLXPluginModelStorageTests.swift */; };
 		1F7A2C3D4E5B60718293A4C5 /* PromptWizardComposerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C5 /* PromptWizardComposerTests.swift */; };
 		1F7A2C3D4E5B60718293A4C6 /* PromptWizardInferenceServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A7B3C4D5E6F708192A3B4C6 /* PromptWizardInferenceServiceTests.swift */; };
@@ -1081,6 +1082,7 @@
 		BB00000000000000000246 /* AccessibilityAnnouncementService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityAnnouncementService.swift; sourceTree = "<group>"; };
 		BB00000000000000000247 /* SpeechFeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechFeedbackService.swift; sourceTree = "<group>"; };
 		BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PluginManifestValidationTests.swift; sourceTree = "<group>"; };
+		7A1018FIX0000000000A002 /* PassiveRestoreSelectedEngineTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PassiveRestoreSelectedEngineTests.swift; sourceTree = "<group>"; };
 		103600000000000000000002 /* MLXPluginModelStorageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MLXPluginModelStorageTests.swift; sourceTree = "<group>"; };
 		BE6B6611B899F649B097A726 /* SnippetServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SnippetServiceTests.swift; sourceTree = "<group>"; };
 		B2D4F6A8C0E2143F9B7D5C1A /* PromptActionTemperaturePersistenceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptActionTemperaturePersistenceTests.swift; sourceTree = "<group>"; };
@@ -2808,6 +2810,7 @@
 				C50700000000000000000002 /* MemoryServiceTests.swift */,
 				A1F000000000000000000101 /* PostUpdatePromptCoordinatorTests.swift */,
 				BDF548E65340A17A3A16590B /* PluginManifestValidationTests.swift */,
+				7A1018FIX0000000000A002 /* PassiveRestoreSelectedEngineTests.swift */,
 				103600000000000000000002 /* MLXPluginModelStorageTests.swift */,
 				91B4D7E2C5A809F1632E4B7D /* PluginRegistryServiceTests.swift */,
 				545000000000000000000001 /* SetupWizardRecommendationAvailabilityTests.swift */,
@@ -4634,6 +4637,7 @@
 				C23000000000000000000004 /* Gemma4SettingsView.swift in Sources */,
 				C42900000000000000000003 /* LiveTranscriptPlugin.swift in Sources */,
 				1E6EDB8B0D1573A05A610078 /* PluginManifestValidationTests.swift in Sources */,
+				7A1018FIX0000000000A001 /* PassiveRestoreSelectedEngineTests.swift in Sources */,
 				103600000000000000000001 /* MLXPluginModelStorageTests.swift in Sources */,
 				F18A00000000000000000006 /* FillerWordsPlugin.swift in Sources */,
 				91B4D7E2C5A809F1632E4B7C /* PluginRegistryServiceTests.swift in Sources */,

--- a/TypeWhisper/Services/HostServicesImpl.swift
+++ b/TypeWhisper/Services/HostServicesImpl.swift
@@ -30,6 +30,23 @@ private enum PassiveLoadedModelRestoreContext {
 final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @unchecked Sendable {
     let pluginId: String
     let pluginDataDirectory: URL
+    /// Whether this plugin backs the engine the user actually has selected,
+    /// evaluated AT CALL TIME rather than captured once.
+    ///
+    /// *** IT MUST BE DYNAMIC. *** `ModelManagerService.selectProvider` writes
+    /// `selectedEngine` at any moment and notifies no existing host, and at startup
+    /// `restoreProviderSelection()` runs AFTER `scanAndLoadPlugins()` -- three lines
+    /// apart in ServiceContainer -- so a value captured during activation can be
+    /// stale before the app has finished launching. Several plugins also consult
+    /// their host again later from their settings views. A snapshot would suppress
+    /// restore for an engine selected afterwards, and permit it for one deselected
+    /// since.
+    ///
+    /// Defaults to `{ true }`, the pre-existing behaviour, so any host built without
+    /// this knowledge behaves exactly as before.
+    private let backsSelectedEngine: @Sendable () -> Bool
+
+    var backsSelectedTranscriptionEngine: Bool { backsSelectedEngine() }
     let eventBus: EventBusProtocol
     private let ruleNamesProvider: @MainActor () -> [String]
     private let workflowProvider: @MainActor () -> [PluginWorkflowInfo]
@@ -38,9 +55,11 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
         pluginId: String,
         eventBus: EventBusProtocol,
         ruleNamesProvider: @escaping @MainActor () -> [String],
-        workflowProvider: @escaping @MainActor () -> [PluginWorkflowInfo] = { [] }
+        workflowProvider: @escaping @MainActor () -> [PluginWorkflowInfo] = { [] },
+        backsSelectedTranscriptionEngine: @escaping @Sendable () -> Bool = { true }
     ) {
         self.pluginId = pluginId
+        self.backsSelectedEngine = backsSelectedTranscriptionEngine
         self.eventBus = eventBus
         self.ruleNamesProvider = ruleNamesProvider
         self.workflowProvider = workflowProvider
@@ -100,8 +119,21 @@ final class HostServicesImpl: HostServices, HostModelLifecyclePolicyProviding, @
 
     // MARK: - Model Lifecycle Policy
 
+    /// Passive restore is permitted only when the auto-unload policy allows it AND
+    /// this plugin backs the selected engine.
+    ///
+    /// *** THIS IS THE LIVE PATH, AND THAT IS THE WHOLE POINT. *** Each local-model
+    /// plugin spawns its own restore from this property, e.g. Qwen3Plugin.activate:
+    /// `if shouldRestoreLoadedModelsPassively { Task { await restoreLoadedModel() } }`.
+    /// An earlier fix for the same issue instead tightened
+    /// `PluginManager.shouldSuppressPassiveLoadedModelRestore`, which feeds a guard
+    /// whose last term is `!shouldRestoreLoadedModelsPassively` -- so it could only
+    /// fire when the policy was NOT "Never", while the plugins only restore when it
+    /// IS. Mutually exclusive, and therefore inert. Its tests passed because they
+    /// asserted a predicate's return value rather than that a model fails to load.
     var shouldRestoreLoadedModelsPassively: Bool {
         ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively()
+            && backsSelectedTranscriptionEngine
     }
 
     func performPluginActivation(

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -801,10 +801,14 @@ final class PluginManager: ObservableObject {
     /// `@unchecked Sendable` and plugins read the property from arbitrary
     /// contexts, so the closure must capture no actor-isolated state.
     ///
-    /// Two cases deliberately keep the previous behaviour, so the change stays
-    /// narrow: a plugin exposing no transcription engines has no engine-backing
-    /// model to restore, and an unrecorded selection is not evidence that this
-    /// plugin is unselected.
+    /// One case deliberately keeps the previous behaviour: a plugin exposing no
+    /// transcription engines has no engine-backing model to restore.
+    ///
+    /// An ABSENT selection now suppresses rather than permits. An earlier revision
+    /// permitted it, reasoning that an unrecorded selection is not evidence a plugin
+    /// is unselected. That is true in isolation and wrong here, because the absent
+    /// case is exactly the startup window in which a restore gets spawned that no
+    /// later selection can cancel.
     /// `nonisolated` deliberately: this manager is `@MainActor`, but the returned
     /// predicate is read by plugins from arbitrary contexts, so the builder must
     /// touch no actor-isolated state. The compiler enforces that here, which is why
@@ -813,11 +817,24 @@ final class PluginManager: ObservableObject {
         forEnginesExposedBy exposed: Set<String>,
         defaults: @autoclosure @escaping @Sendable () -> UserDefaults = .standard
     ) -> @Sendable () -> Bool {
-        { 
+        {
+            // A plugin exposing no transcription engines has no engine-backing model
+            // to restore, so it keeps its previous behaviour entirely.
             guard !exposed.isEmpty else { return true }
+            // NO SELECTION RECORDED => SUPPRESS, not permit.
+            //
+            // Passive restore exists to reload the model for the engine you use. If
+            // no engine is selected there is no such engine, so nothing should be
+            // restored on its behalf.
+            //
+            // This also closes the startup window. `restoreProviderSelection()` runs
+            // AFTER `scanAndLoadPlugins()` and WRITES a selection when the saved one
+            // is missing or no longer usable, and a selection written then cannot
+            // cancel a restore task that activation has already spawned. Permitting
+            // during that window is what let an unselected engine's model load.
             guard let selected = defaults().string(forKey: UserDefaultsKeys.selectedEngine),
                   !selected.isEmpty
-            else { return true }
+            else { return false }
             return exposed.contains(selected)
         }
     }

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -805,7 +805,11 @@ final class PluginManager: ObservableObject {
     /// narrow: a plugin exposing no transcription engines has no engine-backing
     /// model to restore, and an unrecorded selection is not evidence that this
     /// plugin is unselected.
-    static func selectionMatcher(
+    /// `nonisolated` deliberately: this manager is `@MainActor`, but the returned
+    /// predicate is read by plugins from arbitrary contexts, so the builder must
+    /// touch no actor-isolated state. The compiler enforces that here, which is why
+    /// the closure captures a plain `Set` rather than the manager or the plugin.
+    nonisolated static func selectionMatcher(
         forEnginesExposedBy exposed: Set<String>,
         defaults: @autoclosure @escaping @Sendable () -> UserDefaults = .standard
     ) -> @Sendable () -> Bool {

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -778,12 +778,50 @@ final class PluginManager: ObservableObject {
             pluginId: plugin.manifest.id,
             eventBus: EventBus.shared,
             ruleNamesProvider: ruleNamesProvider,
-            workflowProvider: workflowProvider
+            workflowProvider: workflowProvider,
+            backsSelectedTranscriptionEngine: Self.selectionMatcher(
+                forEnginesExposedBy: transcriptionProviderIds(exposedBy: plugin.instance)
+            )
         )
         host.performPluginActivation(suppressPassiveLoadedModelRestore: shouldSuppressPassiveLoadedModelRestore(for: plugin)) {
             plugin.instance.activate(host: host)
         }
         logger.info("Activated plugin: \(plugin.manifest.id)")
+    }
+
+    /// Builds the predicate a host uses to decide whether it backs the selected
+    /// engine. Re-reads `selectedEngine` on EVERY call.
+    ///
+    /// *** WHY A CLOSURE OVER A CAPTURED SET, AND NOT A CAPTURED Bool. ***
+    /// `selectProvider` writes `selectedEngine` at any time and notifies no
+    /// existing host, and at startup `restoreProviderSelection()` runs AFTER
+    /// `scanAndLoadPlugins()`, so a Bool decided during activation can be stale
+    /// before launch finishes. The exposed ids ARE captured, because they are a
+    /// plain value: this manager is `@MainActor` while `HostServicesImpl` is
+    /// `@unchecked Sendable` and plugins read the property from arbitrary
+    /// contexts, so the closure must capture no actor-isolated state.
+    ///
+    /// Two cases deliberately keep the previous behaviour, so the change stays
+    /// narrow: a plugin exposing no transcription engines has no engine-backing
+    /// model to restore, and an unrecorded selection is not evidence that this
+    /// plugin is unselected.
+    static func selectionMatcher(
+        forEnginesExposedBy exposed: Set<String>,
+        defaults: @autoclosure @escaping @Sendable () -> UserDefaults = .standard
+    ) -> @Sendable () -> Bool {
+        { 
+            guard !exposed.isEmpty else { return true }
+            guard let selected = defaults().string(forKey: UserDefaultsKeys.selectedEngine),
+                  !selected.isEmpty
+            else { return true }
+            return exposed.contains(selected)
+        }
+    }
+
+    func backsSelectedTranscriptionEngine(_ plugin: LoadedPlugin) -> Bool {
+        Self.selectionMatcher(
+            forEnginesExposedBy: transcriptionProviderIds(exposedBy: plugin.instance)
+        )()
     }
 
     func shouldSuppressPassiveLoadedModelRestore(for plugin: LoadedPlugin) -> Bool {

--- a/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
+++ b/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
@@ -183,14 +183,15 @@ final class PassiveRestoreSelectedEngineTests: XCTestCase {
         XCTAssertFalse(manager.backsSelectedTranscriptionEngine(plugin),
                        "a different selected engine must not back")
 
-        // No selection recorded: conservative, keep the previous behaviour.
+        // No selection recorded: SUPPRESS. Nothing is selected, so no engine's
+        // model should be restored on its behalf.
         _ = selectEngine(nil)
-        XCTAssertTrue(manager.backsSelectedTranscriptionEngine(plugin),
-                      "an absent selection is not evidence that this plugin is unselected")
+        XCTAssertFalse(manager.backsSelectedTranscriptionEngine(plugin),
+                       "an absent selection must suppress, not permit")
 
         _ = selectEngine("")
-        XCTAssertTrue(manager.backsSelectedTranscriptionEngine(plugin),
-                      "an empty selection is treated the same as absent")
+        XCTAssertFalse(manager.backsSelectedTranscriptionEngine(plugin),
+                       "an empty selection is treated the same as absent")
 
         restoreEngine(saved)
     }
@@ -281,12 +282,18 @@ extension PassiveRestoreSelectedEngineTests {
     /// The startup ordering specifically: activation happens BEFORE
     /// restoreProviderSelection(), so a host is built while the selection is absent
     /// and must honour the selection that arrives afterwards.
+    ///
+    /// ⚠️ The FIRST assertion is the one a cross-family reviewer corrected. It used to
+    /// assert `true` here, on the reasoning that an unrecorded selection is not
+    /// evidence a plugin is unselected. But this is precisely the window in which
+    /// activation SPAWNS a restore task, and no later selection can cancel a task
+    /// that already exists, so permitting here defeated the whole fix.
     func testSelectionRestoredAfterActivationIsHonoured() {
         var host: HostServicesImpl?
         withSelection(nil) {
             host = liveHost(exposing: ["qwen3"])
-            XCTAssertTrue(host!.shouldRestoreLoadedModelsPassively,
-                          "no selection recorded yet: conservative, previous behaviour")
+            XCTAssertFalse(host!.shouldRestoreLoadedModelsPassively,
+                           "the unhydrated window must SUPPRESS: a task spawned here is uncancellable")
         }
         withSelection("groq") {
             XCTAssertFalse(host!.shouldRestoreLoadedModelsPassively,
@@ -314,5 +321,58 @@ extension PassiveRestoreSelectedEngineTests {
         withSelection("groq") {
             XCTAssertFalse(host.shouldRestoreLoadedModelsPassively)
         }
+    }
+}
+
+// MARK: - The startup window, asserted on the RESTORE, not the predicate
+//
+// Requested by an automated reviewer on PR #1270, and the request was fair: every
+// other test here asserts what the PREDICATE returns. None asserted that no restore
+// TASK was spawned, which is the thing that actually cannot be undone. A predicate
+// that flips after the task exists fixes nothing.
+
+extension PassiveRestoreSelectedEngineTests {
+
+    /// Activate while the selection is unhydrated, THEN hydrate a different one, and
+    /// assert no restore was spawned at activation time.
+    ///
+    /// This models the real startup order: ServiceContainer runs
+    /// scanAndLoadPlugins() (which activates) and only then
+    /// restoreProviderSelection(), which WRITES a selection when the saved one is
+    /// missing or unusable.
+    func testNoRestoreIsSpawnedWhenActivatingBeforeSelectionIsHydrated() {
+        let host = liveHost(exposing: ["qwen3"])
+        let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+
+        // Activation happens here, with no selection yet recorded.
+        withSelection(nil) {
+            plugin.activate(host: host)
+        }
+        XCTAssertFalse(
+            plugin.didSpawnRestore,
+            "activation during the unhydrated window must not spawn a restore"
+        )
+
+        // restoreProviderSelection() now writes a DIFFERENT engine. The already-made
+        // decision cannot be revisited, which is exactly why it had to be correct.
+        withSelection("groq") {
+            XCTAssertFalse(plugin.didSpawnRestore,
+                           "and nothing may retroactively appear")
+            XCTAssertFalse(host.shouldRestoreLoadedModelsPassively,
+                           "the host now also reports the hydrated selection correctly")
+        }
+    }
+
+    /// The positive half: hydrated to THIS engine before activation, a restore is
+    /// spawned. Without this, the test above cannot be told apart from a stub that
+    /// never restores.
+    func testRestoreIsSpawnedWhenTheSelectionIsAlreadyHydratedToThisEngine() {
+        let host = liveHost(exposing: ["qwen3"])
+        let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+        withSelection("qwen3") {
+            plugin.activate(host: host)
+        }
+        XCTAssertTrue(plugin.didSpawnRestore,
+                      "the selected engine must still restore at launch")
     }
 }

--- a/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
+++ b/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
@@ -1,0 +1,318 @@
+import XCTest
+import SwiftUI
+@testable import TypeWhisper
+@testable import TypeWhisperPluginSDK
+
+/// Passive startup restore must not load a model for an engine the user has not
+/// selected (#1018).
+///
+/// *** THESE TESTS ASSERT THAT A RESTORE IS NOT SPAWNED, NOT THAT A PREDICATE
+/// RETURNS FALSE. *** An earlier fix for this issue shipped with six passing tests
+/// over a no-op, because every one of them asserted a predicate's return value.
+/// The stub below mirrors the real shape used by the local-model plugins, e.g.
+/// Qwen3Plugin.activate:
+///
+///     if shouldRestoreLoadedModelsPassively {
+///         Task { await restoreLoadedModel(allowDownloads: false) }
+///     }
+///
+/// so `didSpawnRestore` is the observable this issue is actually about.
+final class PassiveRestoreSelectedEngineTests: XCTestCase {
+
+    /// A local-model transcription plugin, reduced to the one behaviour under test.
+    final class RestoreRecordingPlugin: TranscriptionEnginePlugin, @unchecked Sendable {
+        static let pluginId = "stub.local.engine"
+        static let pluginName = "Stub Local Engine"
+
+        private let engineId: String
+        private(set) var didSpawnRestore = false
+
+        init() { self.engineId = "qwen3" }
+        init(engineId: String) { self.engineId = engineId }
+
+        var providerId: String { engineId }
+        var providerDisplayName: String { "Stub" }
+        var isConfigured: Bool { true }
+        var transcriptionModels: [PluginModelInfo] { [] }
+        var selectedModelId: String? { nil }
+        func selectModel(_ modelId: String) {}
+        var supportsTranslation: Bool { false }
+        var supportsStreaming: Bool { false }
+        var supportedLanguages: [String] { [] }
+
+        func activate(host: HostServices) {
+            // The exact shape every shipped local-model plugin uses.
+            if let policyHost = host as? HostModelLifecyclePolicyProviding,
+               policyHost.shouldRestoreLoadedModelsPassively {
+                didSpawnRestore = true
+            }
+        }
+
+        func deactivate() {}
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool,
+                        prompt: String?) async throws -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "")
+        }
+
+        func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?,
+                        onProgress: @Sendable @escaping (String) -> Bool) async throws
+            -> PluginTranscriptionResult {
+            PluginTranscriptionResult(text: "")
+        }
+    }
+
+    private func host(backsSelected: Bool) -> HostServicesImpl {
+        // A constant predicate, for the cases that are not about selection CHANGING.
+        HostServicesImpl(
+            pluginId: "stub.local.engine",
+            eventBus: EventBus.shared,
+            ruleNamesProvider: { [] },
+            workflowProvider: { [] },
+            backsSelectedTranscriptionEngine: { backsSelected }
+        )
+    }
+
+    private var savedPolicy: Any?
+
+    override func setUp() {
+        super.setUp()
+        savedPolicy = UserDefaults.standard.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        // 0 is the UI's "Never", the only policy under which passive restore runs
+        // at all. Every assertion below is therefore made in the ONE configuration
+        // where a restore is actually possible; anywhere else they would pass
+        // vacuously.
+        UserDefaults.standard.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+    }
+
+    override func tearDown() {
+        if let savedPolicy {
+            UserDefaults.standard.set(savedPolicy, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        }
+        super.tearDown()
+    }
+
+    /// THE POSITIVE CONTROL, and it is not optional. Without it, the suppression
+    /// test below cannot be distinguished from a stub that never restores at all.
+    func testPluginBackingTheSelectedEngineDoesSpawnARestore() {
+        XCTAssertTrue(
+            ModelAutoUnloadPolicy.shouldRestoreLoadedModelsPassively(),
+            "precondition: the policy must permit restore, or this proves nothing"
+        )
+        let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+        plugin.activate(host: host(backsSelected: true))
+        XCTAssertTrue(plugin.didSpawnRestore, "the selected engine must still restore")
+    }
+
+    /// The defect: a model loaded for an engine the user never selected.
+    func testPluginNotBackingTheSelectedEngineDoesNotSpawnARestore() {
+        let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+        plugin.activate(host: host(backsSelected: false))
+        XCTAssertFalse(
+            plugin.didSpawnRestore,
+            "an unselected engine must not restore its model at launch"
+        )
+    }
+
+    /// The policy still wins. With auto-unload NOT "Never", nothing restores
+    /// passively regardless of selection, which is pre-existing behaviour.
+    func testAPolicyOtherThanNeverStillSuppressesEveryone() {
+        UserDefaults.standard.set(300, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+        plugin.activate(host: host(backsSelected: true))
+        XCTAssertFalse(plugin.didSpawnRestore)
+    }
+
+    /// The gate itself, at the host level.
+    func testHostGateCombinesPolicyAndSelection() {
+        XCTAssertTrue(host(backsSelected: true).shouldRestoreLoadedModelsPassively)
+        XCTAssertFalse(host(backsSelected: false).shouldRestoreLoadedModelsPassively)
+    }
+
+    // MARK: - The PluginManager computation, end to end
+    //
+    // A cross-family review noted, correctly, that every test above INJECTS
+    // `backsSelected` and so never exercises the provider-id computation that
+    // decides it. That is the half where the manifest-id-versus-provider-id
+    // mistake would live, so it gets its own coverage rather than static tracing.
+
+    private func selectEngine(_ providerId: String?) -> Any? {
+        let saved = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedEngine)
+        if let providerId {
+            UserDefaults.standard.set(providerId, forKey: UserDefaultsKeys.selectedEngine)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedEngine)
+        }
+        return saved
+    }
+
+    private func restoreEngine(_ saved: Any?) {
+        if let saved {
+            UserDefaults.standard.set(saved, forKey: UserDefaultsKeys.selectedEngine)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedEngine)
+        }
+    }
+
+    @MainActor
+    func testManagerComputesBackingFromProviderIdNotManifestId() {
+        let manager = PluginManager()
+        // The manifest id and the providerId differ ON PURPOSE. `selectedEngine`
+        // stores a providerId, so a comparison against the manifest id would
+        // silently suppress a legitimately selected engine.
+        let plugin = LoadedPlugin(
+            manifest: PluginManifest(
+                id: "com.example.some-manifest-id",
+                name: "Stub Local Engine",
+                version: "1.0.0",
+                principalClass: "RestoreRecordingPlugin"
+            ),
+            instance: RestoreRecordingPlugin(engineId: "qwen3"),
+            bundle: Bundle.main,
+            sourceURL: URL(fileURLWithPath: "/tmp/stub"),
+            isEnabled: true
+        )
+
+        let saved = selectEngine("qwen3")
+        XCTAssertTrue(manager.backsSelectedTranscriptionEngine(plugin),
+                      "the SELECTED engine must back, matched by providerId")
+
+        _ = selectEngine("groq")
+        XCTAssertFalse(manager.backsSelectedTranscriptionEngine(plugin),
+                       "a different selected engine must not back")
+
+        // No selection recorded: conservative, keep the previous behaviour.
+        _ = selectEngine(nil)
+        XCTAssertTrue(manager.backsSelectedTranscriptionEngine(plugin),
+                      "an absent selection is not evidence that this plugin is unselected")
+
+        _ = selectEngine("")
+        XCTAssertTrue(manager.backsSelectedTranscriptionEngine(plugin),
+                      "an empty selection is treated the same as absent")
+
+        restoreEngine(saved)
+    }
+
+    /// A host constructed without the new argument keeps the old behaviour, so no
+    /// existing call site changes meaning.
+    func testDefaultConstructionPreservesPreviousBehaviour() {
+        let legacy = HostServicesImpl(
+            pluginId: "stub.local.engine",
+            eventBus: EventBus.shared,
+            ruleNamesProvider: { [] }
+        )
+        XCTAssertTrue(legacy.backsSelectedTranscriptionEngine)
+        XCTAssertTrue(legacy.shouldRestoreLoadedModelsPassively)
+    }
+}
+
+// MARK: - The selection is read LIVE, not captured
+//
+// Requested by the maintainer on PR #1270, and the finding was right: the first
+// version captured the answer once at host construction. `selectProvider` writes
+// `selectedEngine` at any time and notifies no existing host, and at startup
+// `restoreProviderSelection()` runs AFTER `scanAndLoadPlugins()` (three lines apart
+// in ServiceContainer), so a captured value can be stale before launch finishes.
+
+extension PassiveRestoreSelectedEngineTests {
+
+    private func liveHost(exposing exposed: Set<String>) -> HostServicesImpl {
+        HostServicesImpl(
+            pluginId: "stub.local.engine",
+            eventBus: EventBus.shared,
+            ruleNamesProvider: { [] },
+            workflowProvider: { [] },
+            backsSelectedTranscriptionEngine: PluginManager.selectionMatcher(
+                forEnginesExposedBy: exposed
+            )
+        )
+    }
+
+    private func withSelection(_ providerId: String?, _ body: () -> Void) {
+        let saved = UserDefaults.standard.object(forKey: UserDefaultsKeys.selectedEngine)
+        defer {
+            if let saved {
+                UserDefaults.standard.set(saved, forKey: UserDefaultsKeys.selectedEngine)
+            } else {
+                UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedEngine)
+            }
+        }
+        if let providerId {
+            UserDefaults.standard.set(providerId, forKey: UserDefaultsKeys.selectedEngine)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.selectedEngine)
+        }
+        body()
+    }
+
+    /// THE REGRESSION THE MAINTAINER ASKED FOR: change the selection AFTER the host
+    /// exists, then check the restore path. ONE host object throughout, because the
+    /// defect was that a new host is not created when the selection changes.
+    func testSelectionChangeAfterHostCreationIsHonoured() {
+        let host = liveHost(exposing: ["qwen3"])
+
+        withSelection("qwen3") {
+            XCTAssertTrue(host.shouldRestoreLoadedModelsPassively,
+                          "selected at this moment: must restore")
+            let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+            plugin.activate(host: host)
+            XCTAssertTrue(plugin.didSpawnRestore)
+        }
+
+        // The user switches engines. The SAME host must now answer differently.
+        withSelection("groq") {
+            XCTAssertFalse(host.shouldRestoreLoadedModelsPassively,
+                           "deselected since: must NOT restore")
+            let plugin = RestoreRecordingPlugin(engineId: "qwen3")
+            plugin.activate(host: host)
+            XCTAssertFalse(plugin.didSpawnRestore,
+                           "a host created while selected must stop restoring once deselected")
+        }
+
+        // ...and back again, so this cannot pass by latching to false.
+        withSelection("qwen3") {
+            XCTAssertTrue(host.shouldRestoreLoadedModelsPassively,
+                          "re-selected: must restore again")
+        }
+    }
+
+    /// The startup ordering specifically: activation happens BEFORE
+    /// restoreProviderSelection(), so a host is built while the selection is absent
+    /// and must honour the selection that arrives afterwards.
+    func testSelectionRestoredAfterActivationIsHonoured() {
+        var host: HostServicesImpl?
+        withSelection(nil) {
+            host = liveHost(exposing: ["qwen3"])
+            XCTAssertTrue(host!.shouldRestoreLoadedModelsPassively,
+                          "no selection recorded yet: conservative, previous behaviour")
+        }
+        withSelection("groq") {
+            XCTAssertFalse(host!.shouldRestoreLoadedModelsPassively,
+                           "the selection restored after activation must be honoured")
+        }
+    }
+
+    /// A plugin exposing no transcription engines is unaffected by any selection.
+    func testNonTranscriptionPluginIsUnaffectedBySelection() {
+        let host = liveHost(exposing: [])
+        for engine in ["groq", "qwen3", ""] {
+            withSelection(engine.isEmpty ? nil : engine) {
+                XCTAssertTrue(host.shouldRestoreLoadedModelsPassively,
+                              "no exposed engines: selection is irrelevant")
+            }
+        }
+    }
+
+    /// A plugin exposing SEVERAL engines backs the selection if any of them matches.
+    func testMultiEnginePluginMatchesAnyExposedEngine() {
+        let host = liveHost(exposing: ["qwen3", "qwen3-flash"])
+        withSelection("qwen3-flash") {
+            XCTAssertTrue(host.shouldRestoreLoadedModelsPassively)
+        }
+        withSelection("groq") {
+            XCTAssertFalse(host.shouldRestoreLoadedModelsPassively)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1018. Under the "Never" auto-unload policy, an enabled local ASR plugin restores its persisted model at launch even when the selected engine is a cloud provider, pinning gigabytes of unified memory for an engine that will not run in the session.

Passive restore is now permitted only when the auto-unload policy allows it **and** the plugin backs the selected engine.

**Where the gate goes, and why it matters.** Each local-model plugin spawns its own restore from `HostServices`, for example `Qwen3Plugin.activate`:

```swift
if shouldRestoreLoadedModelsPassively {
    Task { await restoreLoadedModel(allowDownloads: false) }
}
```

`HostServicesImpl` is constructed per plugin, so it can carry whether that plugin backs the selection; `PluginManager` computes it from the existing `transcriptionProviderIds(exposedBy:)` helper against `UserDefaultsKeys.selectedEngine`.

I want to flag this explicitly, because it is the interesting part of the change: an obvious-looking alternative is to tighten `PluginManager.shouldSuppressPassiveLoadedModelRestore`. That does not work. It feeds a guard whose final `AND` term is `!shouldRestoreLoadedModelsPassively`, so it can only fire when the policy is **not** "Never", while the plugins only restore when it **is**. The two conditions are mutually exclusive, so a fix there is inert while looking entirely reasonable.

**Deliberately narrow.** Two cases keep their existing behaviour: a plugin exposing no transcription engines has no engine-backing model to restore, which is why Gemma4 as an LLM provider is unaffected; and an unrecorded selection is not evidence that a plugin is unselected. The new initializer argument defaults to `true`, so no existing call site changes meaning. The comparison is against `providerId` rather than the manifest id, since `selectedEngine` stores a `providerId`, and plugins exposing several engines via `AdditionalTranscriptionEnginesProviding` are covered by the same helper.

**Coverage.** All eight shipped local-model plugins consult the gated property, so it is the single choke point for passive restore: CohereLocal `:117`, Gemma4 `:332`, Granite `:41`, Parakeet `:100`, Qwen3 `:57`, SpeechAnalyzer `:35`, Voxtral `:57`, WhisperKit `:60`. The gate runs before the restore task is created, so the `selectedModel` and lone-downloaded-model fallbacks inside `restoreLoadedModel` are never reached for an unselected engine, while explicit on-demand restore still reaches them.

## Test Plan

- [x] Ran `scripts/pr-preflight.sh` (see the note below: it stops early on a pre-existing failure, so the later steps were run individually)
- [x] Built, via `xcodebuild` in a clean macOS 26.4 / Xcode 26.5 VM
- [ ] **Tested the changed functionality manually** — NOT done, and I should not have ticked this earlier. Verification here is automated only: unit tests plus a mutation check. I have not launched the app and watched a model fail to restore.
- [x] No regressions in existing features, to the extent the suites cover it: full Plugin SDK suite green, app-tests green

`PassiveRestoreSelectedEngineTests`: 6 tests, 0 failures, under Xcode 26.5 on macOS 26.4.

The tests assert that **a restore is not spawned**, not that a predicate returns false. The stub mirrors the real plugin shape and records whether it would have created the restore task, and a positive control asserts the selected engine still restores, so suppression cannot be confused with a stub that never restores at all. One test drives the `PluginManager` computation end to end with a plugin whose manifest id and `providerId` deliberately differ, which is where a provider-id mixup would otherwise hide.

Mutation-checked rather than assumed: removing the new `&& backsSelectedTranscriptionEngine` term fails the defect assertion and the negative host-gate assertion, while the three control tests keep passing. That is the intended shape.

**One note on the preflight.** `scripts/pr-preflight.sh` fails at `check_localization_completeness.py` with "60 strings are missing complete zh-Hans localizations" in `AuthenticatedCLIPlugin` and `MetaPlugin`. That failure reproduces identically on unmodified `main`, and this change touches no `.xcstrings` files. Because the script runs under `set -e`, that stop also prevented the two release self-tests and the Plugin SDK tests from running, so I ran those directly: both self-tests pass, and the SDK suite is 698 tests, 0 failures, 3 skipped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Passive model restoration now runs only for plugins backing the selected transcription engine and meeting the auto-unload policy.
  - Prevented restoration when the engine selection is missing or empty, including during startup before selection data is available.
  - Restoration responds to live selection changes while preserving behavior for plugins without exposed engines and legacy hosts.

- **Tests**
  - Added coverage for selected-engine matching, multiple engines, selection hydration, auto-unload behavior, live changes, and backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
