### PR TITLE
Bound cloud transcription HTTP error bodies

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -219,8 +219,14 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         case 200: break
         case 401: throw PluginTranscriptionError.invalidApiKey
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("Upload failed HTTP \(httpResponse.statusCode): \(body)")
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: data,
+                underlyingError: PluginTranscriptionError.apiError(
+                    "Upload failed HTTP \(httpResponse.statusCode): \(body)"
+                )
+            )
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -269,7 +275,7 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
         case 401: throw PluginTranscriptionError.invalidApiKey
         case 429: throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("Submit failed HTTP \(httpResponse.statusCode): \(body)")
         }
 

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/AssemblyAIPlugin.swift
@@ -229,6 +229,15 @@ final class AssemblyAIPlugin: NSObject, StructuredTranscriptionEnginePlugin, Dic
             )
         }
 
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: data,
+            response: httpResponse
+        ) {
+            throw PluginTranscriptionError.apiError(
+                "Invalid upload response: \(htmlPageSummary)"
+            )
+        }
+
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let uploadUrl = json["upload_url"] as? String else {
             throw PluginTranscriptionError.apiError("Invalid upload response")

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -408,7 +408,11 @@ final class CartesiaPlugin: NSObject,
             )
 
             let (data, response) = try await PluginHTTPClient.data(for: request)
-            try Self.validateHTTPResponse(data: data, response: response)
+            try Self.validateHTTPResponse(
+                data: data,
+                response: response,
+                preservesRawResponseForUploadRetry: true
+            )
             return try Self.parseTranscriptionResponse(
                 data,
                 fallbackLanguage: resolvedLanguage
@@ -709,7 +713,11 @@ extension CartesiaPlugin {
         return request
     }
 
-    static func validateHTTPResponse(data: Data, response: URLResponse) throws {
+    static func validateHTTPResponse(
+        data: Data,
+        response: URLResponse,
+        preservesRawResponseForUploadRetry: Bool = false
+    ) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PluginTranscriptionError.networkError("Invalid response")
         }
@@ -724,7 +732,15 @@ extension CartesiaPlugin {
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            throw PluginTranscriptionError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+            let error = PluginTranscriptionError.apiError(errorMessage(from: data, response: httpResponse))
+            if preservesRawResponseForUploadRetry {
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: httpResponse.statusCode,
+                    responseData: data,
+                    underlyingError: error
+                )
+            }
+            throw error
         }
     }
 
@@ -776,20 +792,18 @@ extension CartesiaPlugin {
         }
     }
 
-    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+    private static func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let message = json["message"] as? String {
-                return "HTTP \(statusCode): \(message)"
+                return "HTTP \(response.statusCode): \(message)"
             }
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String {
-                return "HTTP \(statusCode): \(message)"
+                return "HTTP \(response.statusCode): \(message)"
             }
         }
-        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
-            return "HTTP \(statusCode): \(body)"
-        }
-        return "HTTP \(statusCode)"
+        let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        return "HTTP \(response.statusCode): \(body)"
     }
 
     struct TranscriptionResponse: Decodable {

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/CartesiaPlugin.swift
@@ -724,6 +724,22 @@ extension CartesiaPlugin {
 
         switch httpResponse.statusCode {
         case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                let error = PluginTranscriptionError.apiError(
+                    "Failed to parse Cartesia response: \(htmlPageSummary)"
+                )
+                if preservesRawResponseForUploadRetry {
+                    throw PluginAudioUploadHTTPFailure(
+                        statusCode: httpResponse.statusCode,
+                        responseData: data,
+                        underlyingError: error
+                    )
+                }
+                throw error
+            }
             return
         case 401, 403:
             throw PluginTranscriptionError.invalidApiKey
@@ -795,11 +811,11 @@ extension CartesiaPlugin {
     private static func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let message = json["message"] as? String {
-                return "HTTP \(response.statusCode): \(message)"
+                return "HTTP \(response.statusCode): \(PluginHTTPErrorBodyFormatter.summary(from: message))"
             }
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String {
-                return "HTTP \(response.statusCode): \(message)"
+                return "HTTP \(response.statusCode): \(PluginHTTPErrorBodyFormatter.summary(from: message))"
             }
         }
         let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -172,7 +172,7 @@ final class CloudflareASRPlugin: NSObject, TranscriptionEnginePlugin, Dictionary
         case 413:
             throw PluginTranscriptionError.fileTooLarge
         default:
-            let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            let errorMessage = PluginHTTPErrorBodyFormatter.summary(from: responseData, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/CloudflareASRPlugin.swift
@@ -176,6 +176,15 @@ final class CloudflareASRPlugin: NSObject, TranscriptionEnginePlugin, Dictionary
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: responseData,
+            response: httpResponse
+        ) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Cloudflare response: \(htmlPageSummary)"
+            )
+        }
+
         return try Self.parseTranscriptionResponse(responseData)
     }
 

--- a/TypeWhisperPluginSDK/Plugins/CoherePlugin/CoherePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CoherePlugin/CoherePlugin.swift
@@ -120,7 +120,7 @@ final class CoherePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let errorBody = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            let errorBody = PluginHTTPErrorBodyFormatter.summary(from: responseData, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorBody)")
         }
 

--- a/TypeWhisperPluginSDK/Plugins/CoherePlugin/CoherePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CoherePlugin/CoherePlugin.swift
@@ -124,6 +124,15 @@ final class CoherePlugin: NSObject, TranscriptionEnginePlugin, DictionaryTermsCa
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorBody)")
         }
 
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: responseData,
+            response: httpResponse
+        ) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Cohere response: \(htmlPageSummary)"
+            )
+        }
+
         guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
               let text = json["text"] as? String else {
             throw PluginTranscriptionError.apiError("Failed to parse Cohere response")

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/DeepgramPlugin.swift
@@ -888,8 +888,14 @@ final class DeepgramPlugin: NSObject,
             case 401: throw PluginTranscriptionError.invalidApiKey
             case 429: throw PluginTranscriptionError.rateLimited
             default:
-                let body = String(data: data, encoding: .utf8) ?? ""
-                throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+                let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: httpResponse.statusCode,
+                    responseData: data,
+                    underlyingError: PluginTranscriptionError.apiError(
+                        "HTTP \(httpResponse.statusCode): \(body)"
+                    )
+                )
             }
 
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -424,6 +424,14 @@ final class ElevenLabsPlugin: NSObject, DictionaryTermHintTranscriptionEnginePlu
 
             switch httpResponse.statusCode {
             case 200:
+                if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                    from: data,
+                    response: httpResponse
+                ) {
+                    throw PluginTranscriptionError.apiError(
+                        "Invalid ElevenLabs response: \(htmlPageSummary)"
+                    )
+                }
                 return try Self.parseRESTResponse(data, fallbackLanguage: language)
             case 401:
                 throw PluginTranscriptionError.invalidApiKey

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/ElevenLabsPlugin.swift
@@ -432,8 +432,14 @@ final class ElevenLabsPlugin: NSObject, DictionaryTermHintTranscriptionEnginePlu
             case 429:
                 throw PluginTranscriptionError.rateLimited
             default:
-                let body = String(data: data, encoding: .utf8) ?? ""
-                throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+                let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: httpResponse.statusCode,
+                    responseData: data,
+                    underlyingError: PluginTranscriptionError.apiError(
+                        "HTTP \(httpResponse.statusCode): \(body)"
+                    )
+                )
             }
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -711,6 +711,22 @@ final class GeminiPlugin: NSObject,
 
         switch httpResponse.statusCode {
         case 200..<300:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                let error = PluginTranscriptionError.apiError(
+                    "Failed to parse Gemini response: \(htmlPageSummary)"
+                )
+                if preservesRawResponseForUploadRetry {
+                    throw PluginAudioUploadHTTPFailure(
+                        statusCode: httpResponse.statusCode,
+                        responseData: data,
+                        underlyingError: error
+                    )
+                }
+                throw error
+            }
             return
         case 401, 403:
             throw PluginTranscriptionError.invalidApiKey
@@ -737,7 +753,7 @@ final class GeminiPlugin: NSObject,
            let error = json["error"] as? [String: Any],
            let message = error["message"] as? String,
            !message.isEmpty {
-            return message
+            return PluginHTTPErrorBodyFormatter.summary(from: message)
         }
         return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
     }

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/GeminiPlugin.swift
@@ -506,7 +506,11 @@ final class GeminiPlugin: NSObject,
                     for: request,
                     resourceTimeout: Self.dedicatedTranscriptionRequestTimeout
                 )
-                try Self.validateTranscriptionResponse(data: data, response: response)
+                try Self.validateTranscriptionResponse(
+                    data: data,
+                    response: response,
+                    preservesRawResponseForUploadRetry: true
+                )
                 let text = try Self.parseDedicatedTranscriptionResponse(data)
                 await Self.deleteUploadedFile(uploadedFile, apiKey: apiKey)
                 return PluginTranscriptionResult(text: text, detectedLanguage: language)
@@ -523,7 +527,11 @@ final class GeminiPlugin: NSObject,
     ) async throws -> GeminiUploadedFile {
         let startRequest = try makeFileUploadStartRequest(uploadFile: uploadFile, apiKey: apiKey)
         let (startData, startResponse) = try await PluginHTTPClient.data(for: startRequest)
-        try validateTranscriptionResponse(data: startData, response: startResponse)
+        try validateTranscriptionResponse(
+            data: startData,
+            response: startResponse,
+            preservesRawResponseForUploadRetry: true
+        )
 
         guard let httpResponse = startResponse as? HTTPURLResponse,
               let uploadURLValue = httpResponse.value(forHTTPHeaderField: "x-goog-upload-url"),
@@ -539,7 +547,11 @@ final class GeminiPlugin: NSObject,
             for: uploadRequest,
             resourceTimeout: Self.dedicatedTranscriptionRequestTimeout
         )
-        try validateTranscriptionResponse(data: data, response: response)
+        try validateTranscriptionResponse(
+            data: data,
+            response: response,
+            preservesRawResponseForUploadRetry: true
+        )
 
         do {
             let decoded = try JSONDecoder().decode(GeminiFileUploadResponse.self, from: data)
@@ -688,7 +700,11 @@ final class GeminiPlugin: NSObject,
         _ = try? await PluginHTTPClient.data(for: request)
     }
 
-    static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
+    static func validateTranscriptionResponse(
+        data: Data,
+        response: URLResponse,
+        preservesRawResponseForUploadRetry: Bool = false
+    ) throws {
         guard let httpResponse = response as? HTTPURLResponse else {
             throw PluginTranscriptionError.networkError("Invalid Gemini response.")
         }
@@ -703,18 +719,27 @@ final class GeminiPlugin: NSObject,
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(transcriptionErrorMessage(from: data))")
+            let message = "HTTP \(httpResponse.statusCode): \(transcriptionErrorMessage(from: data, response: httpResponse))"
+            let error = PluginTranscriptionError.apiError(message)
+            if preservesRawResponseForUploadRetry {
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: httpResponse.statusCode,
+                    responseData: data,
+                    underlyingError: error
+                )
+            }
+            throw error
         }
     }
 
-    private static func transcriptionErrorMessage(from data: Data) -> String {
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let error = json["error"] as? [String: Any],
-              let message = error["message"] as? String,
-              !message.isEmpty else {
-            return "Gemini transcription request failed."
+    private static func transcriptionErrorMessage(from data: Data, response: HTTPURLResponse) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let error = json["error"] as? [String: Any],
+           let message = error["message"] as? String,
+           !message.isEmpty {
+            return message
         }
-        return message
+        return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
     }
 
     private static func resolvedTranscriptionModelId(

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -313,8 +313,14 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("Upload failed HTTP \(httpResponse.statusCode): \(body)")
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: data,
+                underlyingError: PluginTranscriptionError.apiError(
+                    "Upload failed HTTP \(httpResponse.statusCode): \(body)"
+                )
+            )
         }
     }
 
@@ -387,7 +393,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("Pre-recorded request failed HTTP \(httpResponse.statusCode): \(body)")
         }
     }
@@ -611,7 +617,7 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("Live session creation failed HTTP \(httpResponse.statusCode): \(body)")
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/GladiaPlugin.swift
@@ -300,6 +300,14 @@ final class GladiaPlugin: NSObject, TranscriptionEnginePlugin, LanguageHintTrans
 
         switch httpResponse.statusCode {
         case 200, 201:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Invalid upload response: \(htmlPageSummary)"
+                )
+            }
             guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let audioURL = json["audio_url"] as? String,
                   !audioURL.isEmpty else {

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
@@ -321,6 +321,15 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
             throw PluginTranscriptionError.apiError(message)
         }
 
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: data,
+            response: httpResponse
+        ) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Google OAuth response: \(htmlPageSummary)"
+            )
+        }
+
         let decoded = try JSONDecoder().decode(GoogleOAuthTokenResponse.self, from: data)
         await tokenCache.store(token: decoded.accessToken, expiresIn: decoded.expiresIn)
         return decoded.accessToken
@@ -440,6 +449,14 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
 
         switch httpResponse.statusCode {
         case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Failed to parse Google Cloud response: \(htmlPageSummary)"
+                )
+            }
             return try Self.parseRecognizeResponse(data)
         case 401:
             throw PluginTranscriptionError.apiError(
@@ -661,15 +678,15 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
     ) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let description = json["error_description"] as? String, !description.isEmpty {
-                return description
+                return PluginHTTPErrorBodyFormatter.summary(from: description)
             }
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String,
                !message.isEmpty {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
             if let error = json["error"] as? String, !error.isEmpty {
-                return error
+                return PluginHTTPErrorBodyFormatter.summary(from: error)
             }
         }
 

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/GoogleCloudSTTPlugin.swift
@@ -316,7 +316,7 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
         }
 
         guard httpResponse.statusCode == 200 else {
-            let message = Self.formattedGoogleErrorMessage(from: data, statusCode: httpResponse.statusCode)
+            let message = Self.formattedGoogleErrorMessage(from: data, response: httpResponse)
                 ?? "HTTP \(httpResponse.statusCode)"
             throw PluginTranscriptionError.apiError(message)
         }
@@ -449,7 +449,7 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
                 )
             )
         case 403:
-            let message = Self.formattedGoogleErrorMessage(from: data, statusCode: httpResponse.statusCode)
+            let message = Self.formattedGoogleErrorMessage(from: data, response: httpResponse)
                 ?? "Google Cloud denied access. Check IAM permissions and whether Speech-to-Text is enabled."
             throw PluginTranscriptionError.apiError(message)
         case 413:
@@ -457,7 +457,7 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let message = Self.formattedGoogleErrorMessage(from: data, statusCode: httpResponse.statusCode)
+            let message = Self.formattedGoogleErrorMessage(from: data, response: httpResponse)
                 ?? "HTTP \(httpResponse.statusCode)"
             throw PluginTranscriptionError.apiError(message)
         }
@@ -655,7 +655,10 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
         return Double(duration.dropLast())
     }
 
-    private static func extractGoogleErrorMessage(from data: Data) -> String? {
+    private static func extractGoogleErrorMessage(
+        from data: Data,
+        response: HTTPURLResponse
+    ) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let description = json["error_description"] as? String, !description.isEmpty {
                 return description
@@ -670,19 +673,18 @@ final class GoogleCloudSTTPlugin: NSObject, TranscriptionEnginePlugin, Dictionar
             }
         }
 
-        if let body = String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !body.isEmpty {
-            return body
-        }
-
-        return nil
+        guard !data.isEmpty else { return nil }
+        return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
     }
 
-    private static func formattedGoogleErrorMessage(from data: Data, statusCode: Int? = nil) -> String? {
-        guard let rawMessage = extractGoogleErrorMessage(from: data) else {
+    private static func formattedGoogleErrorMessage(
+        from data: Data,
+        response: HTTPURLResponse
+    ) -> String? {
+        guard let rawMessage = extractGoogleErrorMessage(from: data, response: response) else {
             return nil
         }
-        return formatGoogleErrorMessage(rawMessage, statusCode: statusCode)
+        return formatGoogleErrorMessage(rawMessage, statusCode: response.statusCode)
     }
 
     private static func formatGoogleErrorMessage(_ message: String, statusCode: Int? = nil) -> String {

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -268,7 +268,7 @@ struct MistralAPIClient {
         if httpResponse.statusCode == 200 {
             return try parseChatResponse(data)
         } else {
-            throw MistralAPIError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+            throw MistralAPIError.apiError(errorMessage(from: data, response: httpResponse))
         }
     }
     
@@ -355,7 +355,7 @@ struct MistralAPIClient {
                 ?? "en"
             return PluginTranscriptionResult(text: text.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines), detectedLanguage: detectedLanguage)
         } else {
-            throw MistralAPIError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+            throw MistralAPIError.apiError(errorMessage(from: data, response: httpResponse))
         }
     }
 
@@ -415,7 +415,7 @@ struct MistralAPIClient {
             // fall back to the requested language (or English).
             return PluginTranscriptionResult(text: text, detectedLanguage: language ?? "en")
         } else {
-            throw MistralAPIError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+            throw MistralAPIError.apiError(errorMessage(from: data, response: httpResponse))
         }
     }
 
@@ -438,15 +438,13 @@ struct MistralAPIClient {
         }
     }
     
-    private func errorMessage(from data: Data, statusCode: Int) -> String {
+    private func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let message = json["message"] as? String {
             return message
         }
-        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
-            return "HTTP \(statusCode): \(body)"
-        }
-        return "HTTP \(statusCode)"
+        let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        return "HTTP \(response.statusCode): \(body)"
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/MistralAIPlugin.swift
@@ -343,6 +343,14 @@ struct MistralAPIClient {
         }
 
         if httpResponse.statusCode == 200 {
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw MistralAPIError.apiError(
+                    "Failed to parse transcription response: \(htmlPageSummary)"
+                )
+            }
             guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                   let text = json["text"] as? String else {
                 throw MistralAPIError.apiError("Failed to parse transcription response")
@@ -410,6 +418,14 @@ struct MistralAPIClient {
         }
 
         if httpResponse.statusCode == 200 {
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw MistralAPIError.apiError(
+                    "Failed to parse chat transcription response: \(htmlPageSummary)"
+                )
+            }
             let text = try parseChatResponse(data)
             // Chat completions returns no structured detected-language field, so
             // fall back to the requested language (or English).
@@ -441,7 +457,7 @@ struct MistralAPIClient {
     private func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let message = json["message"] as? String {
-            return message
+            return PluginHTTPErrorBodyFormatter.summary(from: message)
         }
         let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
         return "HTTP \(response.statusCode): \(body)"

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/OpenAICompatiblePlugin.swift
@@ -1594,8 +1594,14 @@ final class OpenAICompatiblePlugin: NSObject,
         case 413:
             throw PluginTranscriptionError.fileTooLarge
         default:
-            let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"
-            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
+            let errorMessage = PluginHTTPErrorBodyFormatter.summary(from: responseData, response: httpResponse)
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: responseData,
+                underlyingError: PluginTranscriptionError.apiError(
+                    "HTTP \(httpResponse.statusCode): \(errorMessage)"
+                )
+            )
         }
 
         struct Segment: Decodable {

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -858,8 +858,13 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            throw PluginTranscriptionError.apiError(
-                Self.errorMessage(from: responseData, statusCode: httpResponse.statusCode)
+            let error = PluginTranscriptionError.apiError(
+                Self.errorMessage(from: responseData, response: httpResponse)
+            )
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: responseData,
+                underlyingError: error
             )
         }
 
@@ -881,17 +886,15 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
         }
     }
 
-    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+    private static func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
            let error = json["error"] as? [String: Any],
            let message = error["message"] as? String,
            !message.isEmpty {
-            return "HTTP \(statusCode): \(message)"
+            return "HTTP \(response.statusCode): \(message)"
         }
-        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
-            return "HTTP \(statusCode): \(body)"
-        }
-        return "HTTP \(statusCode)"
+        let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        return "HTTP \(response.statusCode): \(body)"
     }
 }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/OpenAIPlugin.swift
@@ -891,7 +891,7 @@ private struct OpenAIContextAwareFileTranscriptionClient: Sendable {
            let error = json["error"] as? [String: Any],
            let message = error["message"] as? String,
            !message.isEmpty {
-            return "HTTP \(response.statusCode): \(message)"
+            return "HTTP \(response.statusCode): \(PluginHTTPErrorBodyFormatter.summary(from: message))"
         }
         let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
         return "HTTP \(response.statusCode): \(body)"

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -218,6 +218,14 @@ final class OpenRouterPlugin: NSObject,
 
         switch httpResponse.statusCode {
         case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Failed to parse transcription response: \(htmlPageSummary)"
+                )
+            }
             return
         case 401:
             throw PluginTranscriptionError.invalidApiKey
@@ -267,10 +275,10 @@ final class OpenRouterPlugin: NSObject,
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
             if let message = json["message"] as? String {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
         }
         return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -226,7 +226,7 @@ final class OpenRouterPlugin: NSObject,
         case 413:
             throw PluginTranscriptionError.fileTooLarge
         default:
-            let errorMessage = Self.apiErrorMessage(from: data)
+            let errorMessage = Self.apiErrorMessage(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
     }
@@ -263,7 +263,7 @@ final class OpenRouterPlugin: NSObject,
         }
     }
 
-    private static func apiErrorMessage(from data: Data) -> String {
+    private static func apiErrorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let error = json["error"] as? [String: Any],
                let message = error["message"] as? String {
@@ -273,7 +273,7 @@ final class OpenRouterPlugin: NSObject,
                 return message
             }
         }
-        return String(data: data, encoding: .utf8) ?? "Unknown error"
+        return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
     }
 
     // MARK: - LLMProviderPlugin
@@ -400,7 +400,7 @@ final class OpenRouterPlugin: NSObject,
         case 429:
             throw PluginChatError.rateLimited
         default:
-            throw PluginChatError.apiError(Self.apiErrorMessage(from: data))
+            throw PluginChatError.apiError(Self.apiErrorMessage(from: data, response: httpResponse))
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -458,6 +458,40 @@ final class OpenRouterPluginTests: XCTestCase {
         }
     }
 
+    func testTranscriptionRejectsHTMLSuccessBody() {
+        let data = Data("<html><head><title>Proxy failure</title></head><body>secret</body></html>".utf8)
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
+            data: data,
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.contains("upstream returned an HTML error page"))
+            XCTAssertTrue(message.contains("Proxy failure"))
+            XCTAssertFalse(message.contains("secret"))
+        }
+    }
+
+    func testTranscriptionBoundsExtractedJSONErrorMessage() {
+        let providerMessage = String(repeating: "x", count: 700)
+        let data = Data("{\"error\":{\"message\":\"\(providerMessage)\"}}".utf8)
+
+        XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
+            data: data,
+            response: Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 500)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.hasSuffix("(truncated from 700 bytes)"))
+            XCTAssertLessThan(message.count, 580)
+        }
+    }
+
     private static func audio() -> AudioData {
         let samples = [Float](repeating: 0.1, count: 16_000)
         return AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1)

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
@@ -541,7 +541,7 @@ final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendab
         case 429: throw PluginTranscriptionError.rateLimited
         case 500: throw PluginTranscriptionError.apiError("Reson8 server error: \(Self.errorMessage(from: data))")
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
         }
 

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/Reson8Plugin.swift
@@ -534,15 +534,33 @@ final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendab
 
         switch httpResponse.statusCode {
         case 200: break
-        case 400: throw PluginTranscriptionError.apiError("Invalid request: \(Self.errorMessage(from: data))")
+        case 400:
+            throw PluginTranscriptionError.apiError(
+                "Invalid request: \(Self.errorMessage(from: data, response: httpResponse))"
+            )
         case 401: throw PluginTranscriptionError.invalidApiKey
-        case 404: throw PluginTranscriptionError.apiError("Custom model not found: \(Self.errorMessage(from: data))")
+        case 404:
+            throw PluginTranscriptionError.apiError(
+                "Custom model not found: \(Self.errorMessage(from: data, response: httpResponse))"
+            )
         case 413: throw PluginTranscriptionError.fileTooLarge
         case 429: throw PluginTranscriptionError.rateLimited
-        case 500: throw PluginTranscriptionError.apiError("Reson8 server error: \(Self.errorMessage(from: data))")
+        case 500:
+            throw PluginTranscriptionError.apiError(
+                "Reson8 server error: \(Self.errorMessage(from: data, response: httpResponse))"
+            )
         default:
             let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
+        }
+
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: data,
+            response: httpResponse
+        ) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Reson8 response: \(htmlPageSummary)"
+            )
         }
 
         let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -661,17 +679,30 @@ final class Reson8Plugin: NSObject, TranscriptionEnginePlugin, @unchecked Sendab
 
     // MARK: - JSON Error Body Helper
 
-    fileprivate static func errorMessage(from data: Data) -> String {
+    fileprivate static func errorMessage(
+        from data: Data,
+        response: HTTPURLResponse? = nil
+    ) -> String {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            if let response {
+                return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+            }
             return ""
         }
+        let message: String?
         if let code = json["code"] as? String,
            let message = json["message"] as? String {
-            return "\(code): \(message)"
+            return PluginHTTPErrorBodyFormatter.summary(from: "\(code): \(message)")
         }
-        if let message = json["message"] as? String { return message }
-        if let error = json["error"] as? String { return error }
-        if let detail = json["detail"] as? String { return detail }
+        message = (json["message"] as? String)
+            ?? (json["error"] as? String)
+            ?? (json["detail"] as? String)
+        if let message {
+            return PluginHTTPErrorBodyFormatter.summary(from: message)
+        }
+        if let response {
+            return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        }
         return ""
     }
 

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -702,12 +702,12 @@ extension SaluteSpeechPlugin {
             throw PluginTranscriptionError.rateLimited
         default:
             throw PluginTranscriptionError.apiError(
-                "Sber SaluteSpeech HTTP \(httpResponse.statusCode): \(responseBodyMessage(data: data))"
+                "Sber SaluteSpeech HTTP \(httpResponse.statusCode): \(responseBodyMessage(data: data, response: httpResponse))"
             )
         }
     }
 
-    static func responseBodyMessage(data: Data) -> String {
+    static func responseBodyMessage(data: Data, response: HTTPURLResponse? = nil) -> String {
         if let object = try? JSONSerialization.jsonObject(with: data) {
             if let message = firstStringValue(
                 in: object,
@@ -717,9 +717,10 @@ extension SaluteSpeechPlugin {
             }
         }
 
-        let body = String(data: data, encoding: .utf8)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return body?.nilIfEmpty ?? "Unknown error"
+        if let response {
+            return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        }
+        return PluginHTTPErrorBodyFormatter.summary(from: data, contentType: nil)
     }
 
     static func parseTokenResponse(_ data: Data) throws -> TokenResponse {

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/SaluteSpeechPlugin.swift
@@ -689,6 +689,16 @@ extension SaluteSpeechPlugin {
             throw PluginTranscriptionError.networkError("Invalid response")
         }
 
+        if successStatusCodes.contains(httpResponse.statusCode),
+           let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+               from: data,
+               response: httpResponse
+           ) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse Sber SaluteSpeech response: \(htmlPageSummary)"
+            )
+        }
+
         guard !successStatusCodes.contains(httpResponse.statusCode) else { return }
 
         switch httpResponse.statusCode {
@@ -713,7 +723,7 @@ extension SaluteSpeechPlugin {
                 in: object,
                 keys: ["message", "error_description", "error", "detail"]
             ) {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
         }
 

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/Tests/SaluteSpeechPluginTests.swift
@@ -531,6 +531,23 @@ final class SaluteSpeechPluginTests: XCTestCase {
         }
     }
 
+    func testSuccessfulHTMLResponseIsRejected() {
+        let data = Data("<html><head><title>Proxy failure</title></head><body>secret</body></html>".utf8)
+
+        XCTAssertThrowsError(try SaluteSpeechPlugin.validateHTTPResponse(
+            data: data,
+            response: Self.httpResponse(url: "https://smartspeech.sber.ru/rest/v1/speech:recognize", statusCode: 200)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.contains("upstream returned an HTML error page"))
+            XCTAssertTrue(message.contains("Proxy failure"))
+            XCTAssertFalse(message.contains("secret"))
+        }
+    }
+
     private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: URL(string: url)!,

--- a/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/SmallestAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/SmallestAIPlugin.swift
@@ -306,7 +306,7 @@ extension SmallestAIPlugin {
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? "Unknown error"
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/SmallestAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/SmallestAIPlugin.swift
@@ -298,6 +298,14 @@ extension SmallestAIPlugin {
 
         switch httpResponse.statusCode {
         case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Failed to parse Smallest Pulse response: \(htmlPageSummary)"
+                )
+            }
             return
         case 401, 403:
             throw PluginTranscriptionError.invalidApiKey

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -1687,8 +1687,14 @@ final class SonioxPlugin: NSObject,
         case 413: throw PluginTranscriptionError.fileTooLarge
         case 429: throw Self.rateLimitError(from: data)
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("Upload failed HTTP \(httpResponse.statusCode): \(body)")
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: data,
+                underlyingError: PluginTranscriptionError.apiError(
+                    "Upload failed HTTP \(httpResponse.statusCode): \(body)"
+                )
+            )
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
@@ -1725,7 +1731,7 @@ final class SonioxPlugin: NSObject,
         case 401: throw PluginTranscriptionError.invalidApiKey
         case 429: throw Self.rateLimitError(from: data)
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("Create transcription failed HTTP \(httpResponse.statusCode): \(body)")
         }
 
@@ -1888,7 +1894,7 @@ final class SonioxPlugin: NSObject,
         case 429:
             throw rateLimitError(from: data)
         default:
-            throw PluginTranscriptionError.apiError(errorMessage(from: data, statusCode: httpResponse.statusCode))
+            throw PluginTranscriptionError.apiError(errorMessage(from: data, response: httpResponse))
         }
     }
 
@@ -2244,7 +2250,7 @@ final class SonioxPlugin: NSObject,
         case 429:
             throw Self.rateLimitError(from: data)
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("Fetch transcript failed HTTP \(httpResponse.statusCode): \(body)")
         }
 
@@ -2340,14 +2346,12 @@ final class SonioxPlugin: NSObject,
         return .apiError(message)
     }
 
-    private static func errorMessage(from data: Data, statusCode: Int) -> String {
+    private static func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let message = providerErrorMessage(from: data) {
             return message
         }
-        if let body = String(data: data, encoding: .utf8), !body.isEmpty {
-            return "HTTP \(statusCode): \(body)"
-        }
-        return "HTTP \(statusCode)"
+        let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+        return "HTTP \(response.statusCode): \(body)"
     }
 
     // MARK: - Settings View

--- a/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SonioxPlugin/SonioxPlugin.swift
@@ -2320,14 +2320,14 @@ final class SonioxPlugin: NSObject,
     private static func providerErrorMessage(from data: Data) -> String? {
         if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             if let message = nonEmptyString(json["message"]) {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
             if let message = nonEmptyString(json["error_message"]) {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
             if let error = json["error"] as? [String: Any],
                let message = nonEmptyString(error["message"]) {
-                return message
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
             }
         }
         return nil
@@ -2348,7 +2348,7 @@ final class SonioxPlugin: NSObject,
 
     private static func errorMessage(from data: Data, response: HTTPURLResponse) -> String {
         if let message = providerErrorMessage(from: data) {
-            return message
+            return "HTTP \(response.statusCode): \(message)"
         }
         let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
         return "HTTP \(response.statusCode): \(body)"

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/SpeechmaticsPlugin.swift
@@ -299,8 +299,14 @@ final class SpeechmaticsPlugin: NSObject, TranscriptionEnginePlugin, DictionaryT
         case 401: throw PluginTranscriptionError.invalidApiKey
         case 429: throw PluginTranscriptionError.rateLimited
         default:
-            let responseBody = String(data: data, encoding: .utf8) ?? ""
-            throw PluginTranscriptionError.apiError("Submit failed HTTP \(httpResponse.statusCode): \(responseBody)")
+            let responseBody = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+            throw PluginAudioUploadHTTPFailure(
+                statusCode: httpResponse.statusCode,
+                responseData: data,
+                underlyingError: PluginTranscriptionError.apiError(
+                    "Submit failed HTTP \(httpResponse.statusCode): \(responseBody)"
+                )
+            )
         }
 
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
@@ -1110,7 +1110,7 @@ final class XAIPlugin: NSObject,
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let body = String(data: data, encoding: .utf8) ?? ""
+            let body = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(body)")
         }
     }

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/XAIPlugin.swift
@@ -1102,6 +1102,14 @@ final class XAIPlugin: NSObject,
 
         switch httpResponse.statusCode {
         case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Invalid xAI STT response: \(htmlPageSummary)"
+                )
+            }
             return try Self.parseSTTResponse(data, fallbackLanguage: language)
         case 401:
             throw PluginTranscriptionError.invalidApiKey

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -1119,9 +1119,12 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         _ data: Data,
         response: HTTPURLResponse
     ) throws -> PluginTranscriptionResult {
-        if PluginHTTPErrorBodyFormatter.isHTMLPage(data: data, response: response) {
+        if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+            from: data,
+            response: response
+        ) {
             throw PluginTranscriptionError.apiError(
-                "Failed to parse response: \(PluginHTTPErrorBodyFormatter.summary(from: data, response: response))"
+                "Failed to parse response: \(htmlPageSummary)"
             )
         }
 

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -311,6 +311,20 @@ public struct PluginAudioUploadFile: Sendable, Equatable {
     }
 }
 
+/// Preserves the raw HTTP response used to classify an upload retry while
+/// keeping the user-facing error bounded and provider-specific.
+public struct PluginAudioUploadHTTPFailure: Error, @unchecked Sendable {
+    public let statusCode: Int
+    public let responseData: Data
+    public let underlyingError: any Error
+
+    public init(statusCode: Int, responseData: Data, underlyingError: any Error) {
+        self.statusCode = statusCode
+        self.responseData = responseData
+        self.underlyingError = underlyingError
+    }
+}
+
 public enum PluginAudioUploadEncoder {
     public static let sampleRate = 16_000
     public static let minimumUploadDuration: TimeInterval = 1.0
@@ -373,17 +387,40 @@ public enum PluginAudioUploadEncoder {
         do {
             preferredUpload = try compressedM4AUpload(from: uploadAudio)
         } catch {
-            return try await operation(wavUpload(from: uploadAudio))
+            do {
+                return try await operation(wavUpload(from: uploadAudio))
+            } catch {
+                throw underlyingUploadError(error)
+            }
         }
 
         do {
             return try await operation(preferredUpload)
         } catch {
-            guard shouldRetryWithWavUpload(error: error) else {
-                throw error
+            let shouldRetry: Bool
+            if let failure = error as? PluginAudioUploadHTTPFailure {
+                shouldRetry = shouldRetryWithWavUpload(
+                    statusCode: failure.statusCode,
+                    responseData: failure.responseData
+                )
+            } else {
+                shouldRetry = shouldRetryWithWavUpload(error: error)
             }
-            return try await operation(wavUpload(from: uploadAudio))
+
+            guard shouldRetry else {
+                throw underlyingUploadError(error)
+            }
+
+            do {
+                return try await operation(wavUpload(from: uploadAudio))
+            } catch {
+                throw underlyingUploadError(error)
+            }
         }
+    }
+
+    private static func underlyingUploadError(_ error: any Error) -> any Error {
+        (error as? PluginAudioUploadHTTPFailure)?.underlyingError ?? error
     }
 
     public static func shouldRetryWithWavUpload(statusCode: Int, responseData: Data) -> Bool {
@@ -789,35 +826,37 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         responseFormat: String? = nil,
         apiVersion: String?
     ) async throws -> PluginTranscriptionResult {
+        let uploadAudio = normalizedAudioForUpload(audio)
+        let preferredUpload: PluginAudioUploadFile
         do {
-            return try await transcribeCompressedAudio(
-                audio: audio,
-                apiKey: apiKey,
-                modelName: modelName,
-                language: language,
-                translate: translate,
-                prompt: prompt,
-                requestTimeout: requestTimeout,
-                responseFormat: responseFormat,
-                apiVersion: apiVersion
-            )
+            preferredUpload = try PluginAudioUploadEncoder.compressedM4AUpload(from: uploadAudio)
         } catch {
-            guard PluginAudioUploadEncoder.shouldRetryWithWavUpload(error: error) else {
-                throw error
-            }
-
-            return try await transcribe(
-                audio: audio,
+            return try await performTranscribe(
+                audio: uploadAudio,
                 apiKey: apiKey,
                 modelName: modelName,
                 language: language,
                 translate: translate,
                 prompt: prompt,
-                requestTimeout: requestTimeout,
                 responseFormat: responseFormat,
+                requestTimeout: requestTimeout,
                 apiVersion: apiVersion
             )
         }
+
+        return try await performTranscribe(
+            audio: uploadAudio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: requestTimeout,
+            uploadFile: preferredUpload,
+            apiVersion: apiVersion,
+            allowsWavFallback: true
+        )
     }
 
     public func transcribeWithUploadFallback(
@@ -857,38 +896,19 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         uploadFile: PluginAudioUploadFile,
         apiVersion: String?
     ) async throws -> PluginTranscriptionResult {
-        do {
-            return try await performTranscribe(
-                audio: audio,
-                apiKey: apiKey,
-                modelName: modelName,
-                language: language,
-                translate: translate,
-                prompt: prompt,
-                responseFormat: responseFormat,
-                requestTimeout: requestTimeout,
-                uploadFile: uploadFile,
-                apiVersion: apiVersion
-            )
-        } catch {
-            guard uploadFile.format != "wav",
-                  PluginAudioUploadEncoder.shouldRetryWithWavUpload(error: error) else {
-                throw error
-            }
-
-            return try await performTranscribe(
-                audio: audio,
-                apiKey: apiKey,
-                modelName: modelName,
-                language: language,
-                translate: translate,
-                prompt: prompt,
-                responseFormat: responseFormat,
-                requestTimeout: requestTimeout,
-                uploadFile: PluginAudioUploadEncoder.wavUpload(from: normalizedAudioForUpload(audio)),
-                apiVersion: apiVersion
-            )
-        }
+        try await performTranscribe(
+            audio: audio,
+            apiKey: apiKey,
+            modelName: modelName,
+            language: language,
+            translate: translate,
+            prompt: prompt,
+            responseFormat: responseFormat,
+            requestTimeout: requestTimeout,
+            uploadFile: uploadFile,
+            apiVersion: apiVersion,
+            allowsWavFallback: true
+        )
     }
 
     public func transcribe(
@@ -952,7 +972,8 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         responseFormat: String?,
         requestTimeout: TimeInterval,
         uploadFile: PluginAudioUploadFile? = nil,
-        apiVersion: String? = nil
+        apiVersion: String? = nil,
+        allowsWavFallback: Bool = false
     ) async throws -> PluginTranscriptionResult {
         let path = translate ? "/v1/audio/translations" : "/v1/audio/transcriptions"
         guard let url = requestURL(path: path, apiVersion: apiVersion) else {
@@ -1003,6 +1024,26 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
             throw PluginTranscriptionError.networkError("Invalid response")
         }
 
+        if allowsWavFallback,
+           uploadFile.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: responseData
+           ) {
+            return try await performTranscribe(
+                audio: audio,
+                apiKey: apiKey,
+                modelName: modelName,
+                language: language,
+                translate: translate,
+                prompt: prompt,
+                responseFormat: responseFormat,
+                requestTimeout: requestTimeout,
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: normalizedAudioForUpload(audio)),
+                apiVersion: apiVersion
+            )
+        }
+
         switch httpResponse.statusCode {
         case 200:
             break
@@ -1013,11 +1054,14 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         case 413:
             throw PluginTranscriptionError.fileTooLarge
         default:
-            let errorMessage = String(data: responseData, encoding: .utf8) ?? "Unknown error"
+            let errorMessage = PluginHTTPErrorBodyFormatter.summary(
+                from: responseData,
+                response: httpResponse
+            )
             throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
         }
 
-        return try parseResponse(responseData)
+        return try parseResponse(responseData, response: httpResponse)
     }
 
     public func validateApiKey(_ apiKey: String) async -> Bool {
@@ -1071,7 +1115,16 @@ public struct PluginOpenAITranscriptionHelper: Sendable {
         let segments: [APISegment]?
     }
 
-    private func parseResponse(_ data: Data) throws -> PluginTranscriptionResult {
+    private func parseResponse(
+        _ data: Data,
+        response: HTTPURLResponse
+    ) throws -> PluginTranscriptionResult {
+        if PluginHTTPErrorBodyFormatter.isHTMLPage(data: data, response: response) {
+            throw PluginTranscriptionError.apiError(
+                "Failed to parse response: \(PluginHTTPErrorBodyFormatter.summary(from: data, response: response))"
+            )
+        }
+
         do {
             let response = try JSONDecoder().decode(APIResponse.self, from: data)
             let segments = (response.segments ?? []).map {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
@@ -85,8 +85,7 @@ public enum PluginHTTPErrorBodyFormatter {
         }
 
         let lowercasedHead = trimmedHead.lowercased()
-        return containsTagPrefix("<!doctype html", in: lowercasedHead)
-            || containsTagPrefix("<html", in: lowercasedHead)
+        return hasHTMLDocumentRoot(in: lowercasedHead)
     }
 
     private static func mimeType(from contentType: String?) -> String? {
@@ -97,16 +96,43 @@ public enum PluginHTTPErrorBodyFormatter {
             .lowercased()
     }
 
-    private static func containsTagPrefix(_ prefix: String, in text: String) -> Bool {
-        var searchStart = text.startIndex
-        while searchStart < text.endIndex,
-              let range = text.range(of: prefix, range: searchStart..<text.endIndex) {
-            if isTagBoundary(text[range.upperBound...].first) {
+    private static func hasHTMLDocumentRoot(in lowercasedHead: String) -> Bool {
+        var remainder = lowercasedHead[...]
+
+        while true {
+            remainder = remainder.drop(while: { $0.isWhitespace })
+
+            if hasTagPrefixAtStart("<html", in: remainder)
+                || hasTagPrefixAtStart("<!doctype html", in: remainder) {
                 return true
             }
-            searchStart = range.upperBound
+
+            if remainder.hasPrefix("<!--") {
+                guard let end = remainder.range(of: "-->")?.upperBound else { return false }
+                remainder = remainder[end...]
+                continue
+            }
+
+            if remainder.hasPrefix("<?") {
+                guard let end = remainder.range(of: "?>")?.upperBound else { return false }
+                remainder = remainder[end...]
+                continue
+            }
+
+            if remainder.hasPrefix("<!doctype") {
+                guard let end = remainder.firstIndex(of: ">") else { return false }
+                remainder = remainder[remainder.index(after: end)...]
+                continue
+            }
+
+            return false
         }
-        return false
+    }
+
+    private static func hasTagPrefixAtStart(_ prefix: String, in text: Substring) -> Bool {
+        guard text.hasPrefix(prefix) else { return false }
+        let boundaryIndex = text.index(text.startIndex, offsetBy: prefix.count)
+        return isTagBoundary(text[boundaryIndex...].first)
     }
 
     private static func htmlTitle(in head: String) -> String? {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// Produces bounded, human-readable summaries for HTTP error response bodies.
+public enum PluginHTTPErrorBodyFormatter {
+    static let maximumTextCharacters = 512
+    static let maximumTitleCharacters = 160
+    static let sniffByteLimit = 4_096
+
+    public static func summary(from data: Data, response: HTTPURLResponse) -> String {
+        summary(
+            from: data,
+            contentType: response.value(forHTTPHeaderField: "Content-Type")
+        )
+    }
+
+    public static func summary(from data: Data, contentType: String?) -> String {
+        guard !data.isEmpty else {
+            return "upstream returned an empty error body"
+        }
+
+        guard let head = decodedHead(from: data) else {
+            return "upstream returned non-UTF-8 error data (\(data.count) bytes)"
+        }
+
+        let trimmedHead = head.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let firstCharacter = trimmedHead.first else {
+            return "upstream returned an empty error body (\(data.count) bytes)"
+        }
+
+        if firstCharacter == "{" || firstCharacter == "[" {
+            return boundedTextSummary(trimmedHead, totalByteCount: data.count, headWasTruncated: data.count > sniffByteLimit)
+        }
+
+        if firstCharacter == "<", isHTMLPage(trimmedHead: trimmedHead, contentType: contentType) {
+            var message = "upstream returned an HTML error page (\(data.count) bytes)"
+            if let title = htmlTitle(in: trimmedHead) {
+                message += ": \(title)"
+            }
+            return message
+        }
+
+        return boundedTextSummary(trimmedHead, totalByteCount: data.count, headWasTruncated: data.count > sniffByteLimit)
+    }
+
+    static func isHTMLPage(data: Data, response: HTTPURLResponse) -> Bool {
+        guard let head = decodedHead(from: data) else { return false }
+        let trimmedHead = head.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedHead.first == "<" else { return false }
+        return isHTMLPage(
+            trimmedHead: trimmedHead,
+            contentType: response.value(forHTTPHeaderField: "Content-Type")
+        )
+    }
+
+    private static func decodedHead(from data: Data) -> String? {
+        var prefix = Data(data.prefix(sniffByteLimit))
+        for _ in 0...3 {
+            if let decoded = String(data: prefix, encoding: .utf8) {
+                return decoded
+            }
+            guard !prefix.isEmpty else { break }
+            prefix.removeLast()
+        }
+        return nil
+    }
+
+    private static func isHTMLPage(trimmedHead: String, contentType: String?) -> Bool {
+        if mimeType(from: contentType) == "text/html" {
+            return true
+        }
+
+        let lowercasedHead = trimmedHead.lowercased()
+        return containsTagPrefix("<!doctype html", in: lowercasedHead)
+            || containsTagPrefix("<html", in: lowercasedHead)
+    }
+
+    private static func mimeType(from contentType: String?) -> String? {
+        contentType?
+            .split(separator: ";", maxSplits: 1, omittingEmptySubsequences: true)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private static func containsTagPrefix(_ prefix: String, in text: String) -> Bool {
+        var searchStart = text.startIndex
+        while searchStart < text.endIndex,
+              let range = text.range(of: prefix, range: searchStart..<text.endIndex) {
+            if isTagBoundary(text[range.upperBound...].first) {
+                return true
+            }
+            searchStart = range.upperBound
+        }
+        return false
+    }
+
+    private static func htmlTitle(in head: String) -> String? {
+        guard let openingTag = tagRange(prefix: "<title", in: head),
+              let openingTagEnd = head[openingTag.upperBound...].firstIndex(of: ">") else {
+            return nil
+        }
+
+        let contentStart = head.index(after: openingTagEnd)
+        guard contentStart < head.endIndex,
+              let closingTag = tagRange(
+                prefix: "</title",
+                in: head,
+                range: contentStart..<head.endIndex
+              ) else {
+            return nil
+        }
+
+        let title = String(head[contentStart..<closingTag.lowerBound])
+        let normalizedTitle = normalizedSingleLine(strippingTags(from: title))
+        guard !normalizedTitle.isEmpty else { return nil }
+        return truncated(normalizedTitle, maximumCharacters: maximumTitleCharacters).text
+    }
+
+    private static func tagRange(
+        prefix: String,
+        in text: String,
+        range: Range<String.Index>? = nil
+    ) -> Range<String.Index>? {
+        let searchRange = range ?? text.startIndex..<text.endIndex
+        var searchStart = searchRange.lowerBound
+        while searchStart < searchRange.upperBound,
+              let candidate = text.range(
+                of: prefix,
+                options: .caseInsensitive,
+                range: searchStart..<searchRange.upperBound
+              ) {
+            if isTagBoundary(text[candidate.upperBound...].first) {
+                return candidate
+            }
+            searchStart = candidate.upperBound
+        }
+        return nil
+    }
+
+    private static func isTagBoundary(_ character: Character?) -> Bool {
+        guard let character else { return false }
+        return character == ">" || character.isWhitespace
+    }
+
+    private static func strippingTags(from text: String) -> String {
+        var result = ""
+        var isInsideTag = false
+        for character in text {
+            if character == "<" {
+                isInsideTag = true
+                continue
+            }
+            if character == ">", isInsideTag {
+                isInsideTag = false
+                continue
+            }
+            if !isInsideTag {
+                result.append(character)
+            }
+        }
+        return decodeCommonHTMLEntities(in: result)
+    }
+
+    private static func decodeCommonHTMLEntities(in text: String) -> String {
+        text
+            .replacingOccurrences(of: "&amp;", with: "&", options: .caseInsensitive)
+            .replacingOccurrences(of: "&lt;", with: "<", options: .caseInsensitive)
+            .replacingOccurrences(of: "&gt;", with: ">", options: .caseInsensitive)
+            .replacingOccurrences(of: "&quot;", with: "\"", options: .caseInsensitive)
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&apos;", with: "'", options: .caseInsensitive)
+    }
+
+    private static func boundedTextSummary(
+        _ text: String,
+        totalByteCount: Int,
+        headWasTruncated: Bool
+    ) -> String {
+        let normalizedText = normalizedSingleLine(text)
+        guard !normalizedText.isEmpty else {
+            return "upstream returned an empty error body (\(totalByteCount) bytes)"
+        }
+
+        let result = truncated(normalizedText, maximumCharacters: maximumTextCharacters)
+        if result.wasTruncated || headWasTruncated {
+            return "\(result.text)… (truncated from \(totalByteCount) bytes)"
+        }
+        return result.text
+    }
+
+    private static func normalizedSingleLine(_ text: String) -> String {
+        text
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+    }
+
+    private static func truncated(
+        _ text: String,
+        maximumCharacters: Int
+    ) -> (text: String, wasTruncated: Bool) {
+        guard text.count > maximumCharacters else { return (text, false) }
+        return (String(text.prefix(maximumCharacters)), true)
+    }
+}

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginHTTPErrorBodyFormatter.swift
@@ -13,6 +13,15 @@ public enum PluginHTTPErrorBodyFormatter {
         )
     }
 
+    public static func summary(from text: String) -> String {
+        summary(from: Data(text.utf8), contentType: "text/plain")
+    }
+
+    public static func htmlPageSummary(from data: Data, response: HTTPURLResponse) -> String? {
+        guard isHTMLPage(data: data, response: response) else { return nil }
+        return summary(from: data, response: response)
+    }
+
     public static func summary(from data: Data, contentType: String?) -> String {
         guard !data.isEmpty else {
             return "upstream returned an empty error body"
@@ -22,7 +31,7 @@ public enum PluginHTTPErrorBodyFormatter {
             return "upstream returned non-UTF-8 error data (\(data.count) bytes)"
         }
 
-        let trimmedHead = head.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedHead = normalizedHead(head)
         guard let firstCharacter = trimmedHead.first else {
             return "upstream returned an empty error body (\(data.count) bytes)"
         }
@@ -44,7 +53,7 @@ public enum PluginHTTPErrorBodyFormatter {
 
     static func isHTMLPage(data: Data, response: HTTPURLResponse) -> Bool {
         guard let head = decodedHead(from: data) else { return false }
-        let trimmedHead = head.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedHead = normalizedHead(head)
         guard trimmedHead.first == "<" else { return false }
         return isHTMLPage(
             trimmedHead: trimmedHead,
@@ -62,6 +71,12 @@ public enum PluginHTTPErrorBodyFormatter {
             prefix.removeLast()
         }
         return nil
+    }
+
+    private static func normalizedHead(_ head: String) -> String {
+        head.trimmingCharacters(
+            in: .whitespacesAndNewlines.union(CharacterSet(charactersIn: "\u{FEFF}"))
+        )
     }
 
     private static func isHTMLPage(trimmedHead: String, contentType: String?) -> Bool {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class HTTPErrorBodyFormatterTests: XCTestCase {
+    func testSummarizesHTMLPageWithTitleAndByteCount() throws {
+        let html = """
+            <!DOCTYPE html>
+            <html><head><title>example.com | 522: Connection timed out</title></head>
+            <body>IP address: 203.0.113.42; trace: secret-trace</body></html>
+            """
+        var data = Data(html.utf8)
+        data.append(Data(repeating: 0x20, count: 7_224 - data.count))
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html; charset=UTF-8")
+        )
+
+        XCTAssertEqual(
+            summary,
+            "upstream returned an HTML error page (7224 bytes): example.com | 522: Connection timed out"
+        )
+        XCTAssertFalse(summary.contains("203.0.113.42"))
+        XCTAssertFalse(summary.contains("secret-trace"))
+        XCTAssertFalse(summary.localizedCaseInsensitiveContains("doctype"))
+    }
+
+    func testSniffsHTMLWithoutContentTypeAndDecodesTitleEntities() throws {
+        let data = Data("  <HTML><head><TITLE class=\"error\">Origin &amp; CDN</TITLE></head></HTML>".utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: nil)
+        )
+
+        XCTAssertEqual(
+            summary,
+            "upstream returned an HTML error page (73 bytes): Origin & CDN"
+        )
+    }
+
+    func testMislabeledJSONIsKeptAndBounded() throws {
+        let data = Data("{\"error\":\"\(String(repeating: "x", count: 700))\"}".utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html")
+        )
+
+        XCTAssertTrue(summary.hasPrefix("{\"error\":\""))
+        XCTAssertTrue(summary.hasSuffix("(truncated from 712 bytes)"))
+        XCTAssertFalse(summary.contains("HTML error page"))
+        XCTAssertLessThan(summary.count, 560)
+    }
+
+    func testPlainTextServedAsHTMLRemainsPlainText() throws {
+        let data = Data("origin connection timed out".utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html")
+        )
+
+        XCTAssertEqual(summary, "origin connection timed out")
+    }
+
+    func testSimilarMimeAndTagNamesDoNotClassifyAsHTML() throws {
+        let data = Data("<html-widget><title-widget>plain diagnostic</title-widget></html-widget>".utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/htmlish")
+        )
+
+        XCTAssertFalse(summary.contains("HTML error page"))
+        XCTAssertTrue(summary.contains("plain diagnostic"))
+    }
+
+    func testTitleRequiresClosingTagBoundary() throws {
+        let data = Data(
+            "<html><head><title>Keep </title-widget> remaining</title></head></html>".utf8
+        )
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html")
+        )
+
+        XCTAssertTrue(summary.hasSuffix(": Keep remaining"))
+    }
+
+    func testExtractsUnicodeTitleWhenEarlierTextUsesMultibyteCharacters() throws {
+        let data = Data(
+            "<html><head><!-- Grüße --><title>Überlastet</title></head></html>".utf8
+        )
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html")
+        )
+
+        XCTAssertTrue(summary.hasSuffix(": Überlastet"))
+    }
+
+    func testMarkerBeyondSniffWindowDoesNotReclassifyBody() throws {
+        let data = Data(("<diagnostic>" + String(repeating: "x", count: 5_000) + "<html><title>Late</title>").utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: nil)
+        )
+
+        XCTAssertFalse(summary.contains("HTML error page"))
+        XCTAssertTrue(summary.hasSuffix("(truncated from \(data.count) bytes)"))
+    }
+
+    func testEmptyAndBinaryBodiesHaveBoundedFallbacks() throws {
+        XCTAssertEqual(
+            PluginHTTPErrorBodyFormatter.summary(
+                from: Data(),
+                response: try response(contentType: nil)
+            ),
+            "upstream returned an empty error body"
+        )
+        XCTAssertEqual(
+            PluginHTTPErrorBodyFormatter.summary(
+                from: Data([0xFF, 0xFE, 0xFD, 0xFC, 0xFB]),
+                response: try response(contentType: "application/octet-stream")
+            ),
+            "upstream returned non-UTF-8 error data (5 bytes)"
+        )
+    }
+
+    private func response(contentType: String?) throws -> HTTPURLResponse {
+        var headers: [String: String] = [:]
+        if let contentType {
+            headers["Content-Type"] = contentType
+        }
+        return try XCTUnwrap(
+            HTTPURLResponse(
+                url: URL(string: "https://example.test/error")!,
+                statusCode: 522,
+                httpVersion: nil,
+                headerFields: headers
+            )
+        )
+    }
+}

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
@@ -118,6 +118,35 @@ final class HTTPErrorBodyFormatterTests: XCTestCase {
         XCTAssertFalse(summary.contains("secret"))
     }
 
+    func testRecognizesHTMLAfterDeclarationAndComment() throws {
+        let data = Data(
+            "<?xml version=\"1.0\"?><!-- generated --><html><title>Proxy failure</title></html>".utf8
+        )
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "application/octet-stream")
+        )
+
+        XCTAssertTrue(summary.contains("upstream returned an HTML error page"))
+        XCTAssertTrue(summary.hasSuffix(": Proxy failure"))
+    }
+
+    func testNestedHTMLElementInXMLDoesNotClassifyAsHTMLPage() throws {
+        let data = Data(
+            "<?xml version=\"1.0\"?><response><html>embedded value</html></response>".utf8
+        )
+        let httpResponse = try response(contentType: "application/xml")
+
+        XCTAssertNil(
+            PluginHTTPErrorBodyFormatter.htmlPageSummary(from: data, response: httpResponse)
+        )
+        XCTAssertFalse(
+            PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+                .contains("HTML error page")
+        )
+    }
+
     func testBoundsExtractedProviderMessage() {
         let message = String(repeating: "x", count: 700)
 

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/HTTPErrorBodyFormatterTests.swift
@@ -103,6 +103,30 @@ final class HTTPErrorBodyFormatterTests: XCTestCase {
         XCTAssertTrue(summary.hasSuffix(": Überlastet"))
     }
 
+    func testRecognizesBOMPrefixedHTML() throws {
+        let data = Data("\u{FEFF}<html><head><title>Proxy failure</title></head><body>secret</body></html>".utf8)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(
+            from: data,
+            response: try response(contentType: "text/html")
+        )
+
+        XCTAssertEqual(
+            summary,
+            "upstream returned an HTML error page (\(data.count) bytes): Proxy failure"
+        )
+        XCTAssertFalse(summary.contains("secret"))
+    }
+
+    func testBoundsExtractedProviderMessage() {
+        let message = String(repeating: "x", count: 700)
+
+        let summary = PluginHTTPErrorBodyFormatter.summary(from: message)
+
+        XCTAssertTrue(summary.hasSuffix("(truncated from 700 bytes)"))
+        XCTAssertLessThan(summary.count, 560)
+    }
+
     func testMarkerBeyondSniffWindowDoesNotReclassifyBody() throws {
         let data = Data(("<diagnostic>" + String(repeating: "x", count: 5_000) + "<html><title>Late</title>").utf8)
 

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/OpenAITranscriptionHelperTests.swift
@@ -217,6 +217,66 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
         )
     }
 
+    func testGenericWavFallbackClassifiesRawHTTPBodyBeyondDisplayLimit() async throws {
+        let longError = Data(
+            #"{"error":""#
+                .appending(String(repeating: "x", count: 700))
+                .appending(" unsupported audio format\"}")
+                .utf8
+        )
+        let audio = AudioData(
+            samples: [Float](repeating: 0.1, count: 16_000),
+            wavData: PluginWavEncoder.encode([Float](repeating: 0.1, count: 16_000)),
+            duration: 1.0
+        )
+
+        let format = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(
+            from: audio
+        ) { uploadFile in
+            if uploadFile.format != "wav" {
+                let displayedBody = PluginHTTPErrorBodyFormatter.summary(
+                    from: longError,
+                    contentType: "application/json"
+                )
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: 400,
+                    responseData: longError,
+                    underlyingError: PluginTranscriptionError.apiError("HTTP 400: \(displayedBody)")
+                )
+            }
+            return uploadFile.format
+        }
+
+        XCTAssertEqual(format, "wav")
+    }
+
+    func testGenericWavFallbackUnwrapsNonRetryableHTTPFailure() async throws {
+        let audio = AudioData(
+            samples: [Float](repeating: 0.1, count: 16_000),
+            wavData: PluginWavEncoder.encode([Float](repeating: 0.1, count: 16_000)),
+            duration: 1.0
+        )
+        var attemptedFormats: [String] = []
+
+        do {
+            _ = try await PluginAudioUploadEncoder.withCompressedM4AUploadWavFallback(
+                from: audio
+            ) { uploadFile -> String in
+                attemptedFormats.append(uploadFile.format)
+                throw PluginAudioUploadHTTPFailure(
+                    statusCode: 522,
+                    responseData: Data("<html><title>Origin timeout</title></html>".utf8),
+                    underlyingError: PluginTranscriptionError.apiError("HTTP 522: bounded summary")
+                )
+            }
+            XCTFail("Expected HTTP failure")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(message, "HTTP 522: bounded summary")
+        }
+
+        XCTAssertEqual(attemptedFormats, ["m4a"])
+    }
+
     func testTranscribeCustomTimeoutAppliesToUploadRequest() async throws {
         let store = OpenAITranscriptionMockSessionStore()
         PluginHTTPClient.configureForTesting { _ in
@@ -434,6 +494,125 @@ final class OpenAITranscriptionHelperTests: XCTestCase {
 
         XCTAssertEqual(store.sessions.first?.requestedRequests.count, 1)
     }
+
+    func testTranscribeSummarizesHTMLHTTPErrorBody() async throws {
+        let html = """
+            <!DOCTYPE html>
+            <html><head><title>example.com | 522: Connection timed out</title></head>
+            <body>IP address: 203.0.113.42; trace: secret-trace</body></html>
+            """
+        var data = Data(html.utf8)
+        data.append(Data(repeating: 0x20, count: 7_224 - data.count))
+
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [
+                .response(data, 522, ["Content-Type": "text/html; charset=UTF-8"]),
+            ])
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        do {
+            _ = try await helper.transcribe(
+                audio: audio,
+                apiKey: "test-key",
+                modelName: "whisper-1",
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected HTTP error")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(
+                message,
+                "HTTP 522: upstream returned an HTML error page (7224 bytes): example.com | 522: Connection timed out"
+            )
+            XCTAssertFalse(message.contains("203.0.113.42"))
+            XCTAssertFalse(message.contains("secret-trace"))
+        }
+    }
+
+    func testSuccessfulStatusWithHTMLBodyReportsUpstreamPage() async throws {
+        let data = Data("<html><head><title>Proxy failure</title></head></html>".utf8)
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [
+                .response(data, 200, ["Content-Type": "text/html"]),
+            ])
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        do {
+            _ = try await helper.transcribe(
+                audio: audio,
+                apiKey: "test-key",
+                modelName: "whisper-1",
+                language: nil,
+                translate: false,
+                prompt: nil
+            )
+            XCTFail("Expected parse error")
+        } catch PluginTranscriptionError.apiError(let message) {
+            XCTAssertEqual(
+                message,
+                "Failed to parse response: upstream returned an HTML error page (\(data.count) bytes): Proxy failure"
+            )
+        }
+    }
+
+    func testWavFallbackUsesRawBodyBeyondDisplayedErrorLimit() async throws {
+        let longError = Data(
+            #"{"error":""#
+                .appending(String(repeating: "x", count: 700))
+                .appending(" unsupported audio format\"}")
+                .utf8
+        )
+        let store = OpenAITranscriptionMockSessionStore()
+        PluginHTTPClient.configureForTesting { _ in
+            store.makeSession(outcomes: [
+                .success(longError, 400),
+                .success(Data(#"{"text":"fallback ok"}"#.utf8), 200),
+            ])
+        }
+
+        let helper = PluginOpenAITranscriptionHelper(baseURL: "https://example.test", responseFormat: "json")
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        let audio = AudioData(
+            samples: samples,
+            wavData: PluginWavEncoder.encode(samples),
+            duration: 1.0
+        )
+
+        let result = try await helper.transcribeCompressedAudioWithWavFallback(
+            audio: audio,
+            apiKey: "test-key",
+            modelName: "whisper-1",
+            language: nil,
+            translate: false,
+            prompt: nil,
+            requestTimeout: 600
+        )
+
+        XCTAssertEqual(result.text, "fallback ok")
+        let requests = try XCTUnwrap(store.sessions.first?.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertTrue(String(decoding: try XCTUnwrap(requests[0].httpBody), as: UTF8.self).contains(#"filename="audio.m4a""#))
+        XCTAssertTrue(String(decoding: try XCTUnwrap(requests[1].httpBody), as: UTF8.self).contains(#"filename="audio.wav""#))
+    }
 }
 
 private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {
@@ -456,6 +635,7 @@ private final class OpenAITranscriptionMockSessionStore: @unchecked Sendable {
 private final class OpenAITranscriptionMockSession: PluginHTTPClientSession, @unchecked Sendable {
     enum Outcome {
         case success(Data, Int)
+        case response(Data, Int, [String: String])
         case failure(Error)
     }
 
@@ -483,6 +663,14 @@ private final class OpenAITranscriptionMockSession: PluginHTTPClientSession, @un
                 statusCode: statusCode,
                 httpVersion: nil,
                 headerFields: nil
+            )!
+            return (data, response)
+        case .response(let data, let statusCode, let headerFields):
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: headerFields
             )!
             return (data, response)
         case .failure(let error):


### PR DESCRIPTION
## Summary

- add a shared, bounded formatter for HTML, JSON, plain-text, empty, and binary HTTP error bodies
- apply it to the shared transcription helper and provider-specific REST transcription paths
- preserve raw response data for M4A-to-WAV retry classification while keeping displayed and persisted errors bounded
- identify HTML returned with HTTP 200 as an upstream page instead of surfacing a generic decoding error

## Issue context

Cloud transcription endpoints can return CDN or proxy error pages. Those bodies were interpolated verbatim into `PluginTranscriptionError.apiError`, exposing thousands of characters of markup—including potentially an IP address or trace identifier—in the UI and persisted error log.

This change turns those responses into a concise message containing the status, byte count, and HTML title when available. It also covers provider-specific REST implementations that do not use the shared helper.

## Plugin compatibility

No plugin versions, manifests, or releases are changed here. A future release of any plugin that imports the new SDK formatter or retry carrier must declare TypeWhisper 1.7 as its minimum host version.

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter "HTTPErrorBodyFormatterTests|OpenAITranscriptionHelperTests"`
- `swift test --package-path TypeWhisperPluginSDK`
- `./scripts/check_release_binary_instrumentation.sh --self-test`
- `./scripts/check_release_signing.sh --self-test`
- `./scripts/pr-preflight.sh origin/main` currently reaches the existing localization-completeness gate and reports 60 unrelated missing `zh-Hans` entries in AuthenticatedCLI and Meta; this PR changes no `.xcstrings` files. All subsequent preflight steps were run separately and passed.

Closes #1266

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Audio upload failures now preserve HTTP status codes, response data, and underlying error details for improved retry and fallback handling.
  * Transcription fallback handling is improved for WAV uploads and compressed-audio encoding failures.
  * HTTP errors now provide clearer, bounded summaries for JSON, text, HTML, empty, and binary responses.

* **Bug Fixes**
  * HTML error pages returned during successful requests are now identified and reported instead of being parsed as transcription data.
  * Provider-specific API messages are retained when available, with safer, sanitized diagnostics when they are not.
  * Oversized error responses are truncated to keep messages readable and manageable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->