### PR TITLE
Paginate history loading and add endless scrolling

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -352,7 +352,7 @@ final class ServiceContainer: ObservableObject {
         hotkeyService.setup()
         dictationViewModel.registerInitialTriggerHotkeys()
         usageStatisticsService.backfillFromHistoryIfNeeded {
-            historyService.allRecords()
+            try historyService.allRecordsThrowing()
         }
         let retentionDays = UserDefaults.standard.integer(forKey: UserDefaultsKeys.historyRetentionDays)
         if retentionDays > 0 { historyService.purgeOldRecords(retentionDays: retentionDays) }

--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -351,7 +351,9 @@ final class ServiceContainer: ObservableObject {
 
         hotkeyService.setup()
         dictationViewModel.registerInitialTriggerHotkeys()
-        usageStatisticsService.backfillFromHistoryIfNeeded(historyService.records)
+        usageStatisticsService.backfillFromHistoryIfNeeded {
+            historyService.allRecords()
+        }
         let retentionDays = UserDefaults.standard.integer(forKey: UserDefaultsKeys.historyRetentionDays)
         if retentionDays > 0 { historyService.purgeOldRecords(retentionDays: retentionDays) }
 

--- a/TypeWhisper/Services/ErrorLogService.swift
+++ b/TypeWhisper/Services/ErrorLogService.swift
@@ -670,7 +670,7 @@ final class ErrorLogService: ObservableObject {
             ),
             lastIndicatorFullscreenSuppression: IndicatorFullscreenSuppressionPolicy.lastSuppressionDiagnostics(),
             counts: .init(
-                historyRecords: container.historyService.records.count,
+                historyRecords: container.historyService.recordCount(),
                 profiles: container.profileService.profiles.count,
                 enabledProfiles: container.profileService.profiles.filter(\.isEnabled).count,
                 dictionaryTerms: container.dictionaryService.termsCount,

--- a/TypeWhisper/Services/HTTPServer/APIHandlers.swift
+++ b/TypeWhisper/Services/HTTPServer/APIHandlers.swift
@@ -821,23 +821,17 @@ final class APIHandlers: @unchecked Sendable {
     // MARK: - GET /v1/history
 
     private func handleGetHistory(_ request: HTTPRequest) async -> HTTPResponse {
-        let query = request.queryParams["q"]
-        let limit = min(Int(request.queryParams["limit"] ?? "") ?? 50, 200)
+        let searchText = request.queryParams["q"] ?? ""
+        let limit = max(min(Int(request.queryParams["limit"] ?? "") ?? 50, 200), 0)
         let offset = max(Int(request.queryParams["offset"] ?? "") ?? 0, 0)
 
         let historyService = self.historyService
         return await MainActor.run {
-            let allRecords: [TranscriptionRecord]
-            if let query, !query.isEmpty {
-                allRecords = historyService.searchRecords(query: query)
-            } else {
-                allRecords = historyService.records
-            }
-
-            let total = allRecords.count
-            let sliceEnd = min(offset + limit, total)
-            let sliceStart = min(offset, total)
-            let page = Array(allRecords[sliceStart..<sliceEnd])
+            let page = historyService.fetchPage(
+                query: HistoryQuery(searchText: searchText),
+                offset: offset,
+                limit: limit
+            )
 
             struct HistoryEntry: Encodable {
                 let id: String
@@ -861,7 +855,7 @@ final class APIHandlers: @unchecked Sendable {
                 let offset: Int
             }
 
-            let entries = page.map { record in
+            let entries = page.records.map { record in
                 HistoryEntry(
                     id: record.id.uuidString,
                     text: record.finalText,
@@ -878,7 +872,12 @@ final class APIHandlers: @unchecked Sendable {
                 )
             }
 
-            return .json(HistoryResponse(entries: entries, total: total, limit: limit, offset: offset))
+            return .json(HistoryResponse(
+                entries: entries,
+                total: page.totalCount,
+                limit: limit,
+                offset: page.offset
+            ))
         }
     }
 
@@ -892,11 +891,9 @@ final class APIHandlers: @unchecked Sendable {
 
         let historyService = self.historyService
         return await MainActor.run {
-            guard let record = historyService.records.first(where: { $0.id == uuid }) else {
+            guard historyService.deleteRecord(withID: uuid) else {
                 return .error(status: 404, message: "History entry not found")
             }
-
-            historyService.deleteRecord(record)
             return .json(["deleted": true])
         }
     }

--- a/TypeWhisper/Services/HistoryService.swift
+++ b/TypeWhisper/Services/HistoryService.swift
@@ -6,9 +6,65 @@ import os.log
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "TypeWhisper", category: "HistoryService")
 
+struct HistoryPage {
+    let records: [TranscriptionRecord]
+    let totalCount: Int
+    let offset: Int
+
+    var hasMore: Bool { offset + records.count < totalCount }
+}
+
+struct HistoryQuery {
+    enum Collection {
+        case all
+        case inbox
+        case withAudio
+        case failed
+    }
+
+    enum SortOrder {
+        case newest
+        case oldest
+        case duration
+        case appName
+    }
+
+    var searchText = ""
+    var appBundleIdentifier: String?
+    var cutoffDate: Date?
+    var collection: Collection = .all
+    var originDeviceID: String?
+    var includeLegacyCurrentMacRecords = false
+    var source: RecordingSource?
+    var sortOrder: SortOrder = .newest
+}
+
+struct HistoryAppFacet: Hashable {
+    let bundleID: String
+    let name: String
+    let count: Int
+}
+
+struct HistoryDeviceFacet: Hashable {
+    let deviceID: String
+    let platform: String
+    let source: RecordingSource
+    let count: Int
+}
+
+struct HistoryFacets {
+    let totalCount: Int
+    let inboxCount: Int
+    let audioCount: Int
+    let failedCount: Int
+    let apps: [HistoryAppFacet]
+    let devices: [HistoryDeviceFacet]
+}
+
 @MainActor
 final class HistoryService: ObservableObject {
     static let pluginSyncActionID = "com.typewhisper.history.transcription-updated"
+    static let recentRecordsLimit = 20
 
     private struct PluginSyncPayload: Codable {
         let id: UUID
@@ -24,7 +80,10 @@ final class HistoryService: ObservableObject {
         let pipelineSteps: [String]
     }
 
-    @Published var records: [TranscriptionRecord] = []
+    /// A deliberately bounded cache for surfaces that only need recent history.
+    /// Consumers requiring completeness must use `fetchPage`, `record(withID:)`,
+    /// `recordCount`, or `allRecords` instead.
+    @Published private(set) var recentRecords: [TranscriptionRecord] = []
 
     private let modelContainer: ModelContainer
     private let modelContext: ModelContext
@@ -32,8 +91,6 @@ final class HistoryService: ObservableObject {
     private let historySyncPreferences: HistorySyncPreferences?
 
     private(set) var totalRecords: Int = 0
-    private(set) var totalWords: Int = 0
-    private(set) var totalDuration: Double = 0
 
     private let audioDirectory: URL
 
@@ -64,7 +121,8 @@ final class HistoryService: ObservableObject {
             fatalError("Failed to initialize history store: \(error)")
         }
 
-        fetchRecords()
+        migrateWordsCountIfNeeded()
+        refreshRecentRecords()
     }
 
     @discardableResult
@@ -132,7 +190,7 @@ final class HistoryService: ObservableObject {
             && audioFileName != nil
         modelContext.insert(record)
         save()
-        fetchRecords()
+        refreshRecentRecords()
         return true
     }
 
@@ -150,7 +208,7 @@ final class HistoryService: ObservableObject {
         record.wordsCount = finalText.split(separator: " ").count
         record.contentUpdatedAt = Date()
         save()
-        fetchRecords()
+        refreshRecentRecords()
         let payload = PluginSyncPayload(
             id: record.id,
             rawText: record.rawText,
@@ -187,7 +245,7 @@ final class HistoryService: ObservableObject {
         deleteAudioFile(for: record)
         modelContext.delete(record)
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func deleteRecords(_ records: [TranscriptionRecord]) {
@@ -197,7 +255,7 @@ final class HistoryService: ObservableObject {
             modelContext.delete(record)
         }
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func clearAll() {
@@ -209,24 +267,218 @@ final class HistoryService: ObservableObject {
                 modelContext.delete(record)
             }
             save()
-            fetchRecords()
+            refreshRecentRecords()
         } catch {
             logger.error("Failed to clear records: \(error.localizedDescription)")
         }
     }
 
     func searchRecords(query: String) -> [TranscriptionRecord] {
-        guard !query.isEmpty else { return records }
-        let lowered = query.lowercased()
-        return records.filter {
-            $0.finalText.lowercased().contains(lowered) ||
-            ($0.appName?.lowercased().contains(lowered) ?? false)
+        fetchPage(
+            query: HistoryQuery(searchText: query),
+            offset: 0,
+            limit: Int.max
+        ).records
+    }
+
+    func fetchPage(
+        query: HistoryQuery = HistoryQuery(),
+        offset: Int,
+        limit: Int
+    ) -> HistoryPage {
+        var descriptor = fetchDescriptor(for: query)
+        let requestedOffset = max(offset, 0)
+        let requestedLimit = max(limit, 0)
+
+        // Device identity combines persisted fields, and free-text search spans computed
+        // values. Enumerate these queries in batches so only the requested page is retained.
+        if requiresPostFiltering(query) {
+            var records: [TranscriptionRecord] = []
+            var totalCount = 0
+            do {
+                try modelContext.enumerate(descriptor, batchSize: 500) { record in
+                    guard matchesPostFilters(record, query: query) else { return }
+                    if totalCount >= requestedOffset, records.count < requestedLimit {
+                        records.append(record)
+                    }
+                    totalCount += 1
+                }
+                return HistoryPage(
+                    records: records,
+                    totalCount: totalCount,
+                    offset: requestedOffset
+                )
+            } catch {
+                logger.error("Failed to enumerate filtered history: \(error.localizedDescription)")
+                return HistoryPage(records: [], totalCount: 0, offset: requestedOffset)
+            }
         }
+
+        let totalCount: Int
+        do {
+            totalCount = try modelContext.fetchCount(descriptor)
+        } catch {
+            logger.error("Failed to count history records: \(error.localizedDescription)")
+            return HistoryPage(records: [], totalCount: 0, offset: max(offset, 0))
+        }
+
+        let boundedOffset = min(requestedOffset, totalCount)
+        descriptor.fetchOffset = boundedOffset
+        if limit != Int.max {
+            descriptor.fetchLimit = requestedLimit
+        }
+
+        do {
+            return HistoryPage(
+                records: try modelContext.fetch(descriptor),
+                totalCount: totalCount,
+                offset: requestedOffset
+            )
+        } catch {
+            logger.error("Failed to fetch history page: \(error.localizedDescription)")
+            return HistoryPage(records: [], totalCount: totalCount, offset: requestedOffset)
+        }
+    }
+
+    func recordCount(query: HistoryQuery = HistoryQuery()) -> Int {
+        if requiresPostFiltering(query) {
+            var count = 0
+            do {
+                try modelContext.enumerate(fetchDescriptor(for: query), batchSize: 500) { record in
+                    if matchesPostFilters(record, query: query) { count += 1 }
+                }
+                return count
+            } catch {
+                logger.error("Failed to count filtered history records: \(error.localizedDescription)")
+                return 0
+            }
+        }
+        do {
+            return try modelContext.fetchCount(fetchDescriptor(for: query))
+        } catch {
+            logger.error("Failed to count history records: \(error.localizedDescription)")
+            return 0
+        }
+    }
+
+    func facets(currentDeviceID: String?) -> HistoryFacets {
+        struct AppAccumulator {
+            var name: String
+            var count: Int
+        }
+        struct DeviceKey: Hashable {
+            let deviceID: String
+            let platform: String
+            let source: RecordingSource
+        }
+
+        var totalCount = 0
+        var inboxCount = 0
+        var audioCount = 0
+        var failedCount = 0
+        var apps: [String: AppAccumulator] = [:]
+        var devices: [DeviceKey: Int] = [:]
+        let context = ModelContext(modelContainer)
+        var descriptor = FetchDescriptor<TranscriptionRecord>()
+        descriptor.propertiesToFetch = [
+            \TranscriptionRecord.appName,
+            \TranscriptionRecord.appBundleIdentifier,
+            \TranscriptionRecord.originDeviceID,
+            \TranscriptionRecord.originPlatformRaw,
+            \TranscriptionRecord.sourceRaw,
+            \TranscriptionRecord.inboxStateRaw,
+            \TranscriptionRecord.processingStateRaw,
+            \TranscriptionRecord.audioFileName,
+            \TranscriptionRecord.remoteAudioRelativePath,
+        ]
+
+        do {
+            try context.enumerate(descriptor, batchSize: 500) { record in
+                totalCount += 1
+                if record.isOpenInInbox { inboxCount += 1 }
+                if record.audioFileName != nil || record.hasRemoteAudio { audioCount += 1 }
+                if record.processingState == .failed { failedCount += 1 }
+
+                if let bundleID = record.appBundleIdentifier,
+                   let name = record.appName,
+                   !bundleID.isEmpty,
+                   !name.isEmpty {
+                    var value = apps[bundleID] ?? AppAccumulator(name: name, count: 0)
+                    value.name = name
+                    value.count += 1
+                    apps[bundleID] = value
+                }
+
+                let platform = record.originPlatformRaw
+                let trimmedID = record.originDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+                let normalizedPlatform = platform.lowercased()
+                let deviceID: String
+                if !trimmedID.isEmpty {
+                    deviceID = trimmedID
+                } else if normalizedPlatform.contains("mac"), let currentDeviceID {
+                    deviceID = currentDeviceID
+                } else {
+                    deviceID = "platform:\(normalizedPlatform.isEmpty ? "unknown" : normalizedPlatform)"
+                }
+                devices[DeviceKey(deviceID: deviceID, platform: platform, source: record.source), default: 0] += 1
+            }
+        } catch {
+            logger.error("Failed to build history facets: \(error.localizedDescription)")
+        }
+
+        return HistoryFacets(
+            totalCount: totalCount,
+            inboxCount: inboxCount,
+            audioCount: audioCount,
+            failedCount: failedCount,
+            apps: apps.map {
+                HistoryAppFacet(bundleID: $0.key, name: $0.value.name, count: $0.value.count)
+            },
+            devices: devices.map {
+                HistoryDeviceFacet(
+                    deviceID: $0.key.deviceID,
+                    platform: $0.key.platform,
+                    source: $0.key.source,
+                    count: $0.value
+                )
+            }
+        )
+    }
+
+    func allRecords(query: HistoryQuery = HistoryQuery()) -> [TranscriptionRecord] {
+        do {
+            let records = try modelContext.fetch(fetchDescriptor(for: query))
+            guard requiresPostFiltering(query) else { return records }
+            return records.filter { matchesPostFilters($0, query: query) }
+        } catch {
+            logger.error("Failed to fetch complete history: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    func record(withID id: UUID) -> TranscriptionRecord? {
+        var descriptor = FetchDescriptor<TranscriptionRecord>(
+            predicate: #Predicate { $0.id == id }
+        )
+        descriptor.fetchLimit = 1
+        do {
+            return try modelContext.fetch(descriptor).first
+        } catch {
+            logger.error("Failed to fetch history record by ID: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    @discardableResult
+    func deleteRecord(withID id: UUID) -> Bool {
+        guard let record = record(withID: id) else { return false }
+        deleteRecord(record)
+        return true
     }
 
     func uniqueDomains(limit: Int = 50) -> [String] {
         var counts: [String: Int] = [:]
-        for record in records {
+        for record in allRecords() {
             guard let domain = record.appDomain else { continue }
             let cleaned = domain.hasPrefix("www.") ? String(domain.dropFirst(4)) : domain
             guard !cleaned.isEmpty else { continue }
@@ -237,7 +489,16 @@ final class HistoryService: ObservableObject {
 
     func purgeOldRecords(retentionDays: Int = 90) {
         let cutoff = Calendar.current.date(byAdding: .day, value: -retentionDays, to: Date()) ?? Date()
-        let old = records.filter { $0.timestamp < cutoff }
+        let descriptor = FetchDescriptor<TranscriptionRecord>(
+            predicate: #Predicate { $0.timestamp < cutoff }
+        )
+        let old: [TranscriptionRecord]
+        do {
+            old = try modelContext.fetch(descriptor)
+        } catch {
+            logger.error("Failed to fetch records for retention: \(error.localizedDescription)")
+            return
+        }
         guard !old.isEmpty else { return }
         historySyncPreferences?.recordRetentionPrunes(old.map(\.id))
         for record in old {
@@ -245,7 +506,7 @@ final class HistoryService: ObservableObject {
             modelContext.delete(record)
         }
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func completeInbox(_ record: TranscriptionRecord) {
@@ -254,7 +515,7 @@ final class HistoryService: ObservableObject {
         record.inboxCompletedAt = Date()
         record.inboxUpdatedAt = Date()
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func reopenInbox(_ record: TranscriptionRecord) {
@@ -263,12 +524,12 @@ final class HistoryService: ObservableObject {
         record.inboxCompletedAt = nil
         record.inboxUpdatedAt = Date()
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func userDataSyncHistoryRecords() -> [UserDataSyncHistoryRecord] {
         guard historySyncPreferences?.isEnabled == true else { return [] }
-        return records.compactMap { record in
+        return allRecords().compactMap { record in
             guard historySyncPreferences?.isSuppressed(record.id) != true,
                   historySyncPreferences?.explicitDeletions[
                     record.id.uuidString.lowercased()
@@ -394,7 +655,7 @@ final class HistoryService: ObservableObject {
                 record.audioUpdatedAt = audio.updatedAt
                 record.historySyncAudioEligible = false
             case .deleteHistory(let recordID):
-                if let record = records.first(where: { $0.id == recordID }) {
+                if let record = record(withID: recordID) {
                     deleteAudioFile(for: record)
                     modelContext.delete(record)
                 }
@@ -406,11 +667,11 @@ final class HistoryService: ObservableObject {
             }
         }
         try modelContext.save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func installSynchronizedAudio(recordID: UUID, sourceURL: URL) throws {
-        guard let record = records.first(where: { $0.id == recordID }) else { return }
+        guard let record = record(withID: recordID) else { return }
         let fileName = "\(recordID.uuidString.lowercased()).wav"
         let destination = audioDirectory.appendingPathComponent(fileName)
         let temporary = audioDirectory.appendingPathComponent(".\(UUID().uuidString).partial")
@@ -427,7 +688,7 @@ final class HistoryService: ObservableObject {
         }
         record.audioFileName = fileName
         try modelContext.save()
-        fetchRecords()
+        refreshRecentRecords()
     }
 
     func synchronizedAudioDescriptor(
@@ -453,7 +714,7 @@ final class HistoryService: ObservableObject {
     }
 
     private func remoteRecord(for id: UUID, timestamp: Date) -> TranscriptionRecord {
-        if let existing = records.first(where: { $0.id == id }) { return existing }
+        if let existing = record(withID: id) { return existing }
         let record = TranscriptionRecord(
             id: id,
             timestamp: timestamp,
@@ -466,7 +727,6 @@ final class HistoryService: ObservableObject {
         record.processingState = .importing
         record.historySyncAudioEligible = false
         modelContext.insert(record)
-        records.insert(record, at: 0)
         return record
     }
 
@@ -474,22 +734,32 @@ final class HistoryService: ObservableObject {
         value.timeIntervalSince1970 > 0 ? value : fallback
     }
 
-    private func fetchRecords() {
-        let descriptor = FetchDescriptor<TranscriptionRecord>(
+    private func refreshRecentRecords() {
+        var descriptor = FetchDescriptor<TranscriptionRecord>(
             sortBy: [SortDescriptor(\.timestamp, order: .reverse)]
         )
+        descriptor.fetchLimit = Self.recentRecordsLimit
         do {
-            records = try modelContext.fetch(descriptor)
+            recentRecords = try modelContext.fetch(descriptor)
         } catch {
-            records = []
+            recentRecords = []
         }
-        migrateWordsCountIfNeeded()
-        updateAggregates()
+        totalRecords = recordCount()
     }
 
     private func migrateWordsCountIfNeeded() {
+        let descriptor = FetchDescriptor<TranscriptionRecord>(
+            predicate: #Predicate { $0.wordsCount == 0 && !$0.finalText.isEmpty }
+        )
+        let candidates: [TranscriptionRecord]
+        do {
+            candidates = try modelContext.fetch(descriptor)
+        } catch {
+            logger.error("Failed to fetch history word-count migration candidates: \(error.localizedDescription)")
+            return
+        }
         var needsSave = false
-        for record in records where record.wordsCount == 0 && !record.finalText.isEmpty {
+        for record in candidates {
             record.wordsCount = record.finalText.split(separator: " ").count
             needsSave = true
         }
@@ -498,10 +768,95 @@ final class HistoryService: ObservableObject {
         }
     }
 
-    private func updateAggregates() {
-        totalRecords = records.count
-        totalWords = records.reduce(0) { $0 + $1.wordsCount }
-        totalDuration = records.reduce(0) { $0 + $1.durationSeconds }
+    private func fetchDescriptor(for query: HistoryQuery) -> FetchDescriptor<TranscriptionRecord> {
+        let openInboxState = CaptureInboxState.open.rawValue
+        let failedProcessingState = RecordingProcessingState.failed.rawValue
+
+        // Keep the common mailbox-only path inside SQLite. The remaining optional filters
+        // are applied during bounded enumeration to avoid one prohibitively large predicate.
+        let predicate: Predicate<TranscriptionRecord>?
+        switch query.collection {
+        case .all:
+            predicate = nil
+        case .inbox:
+            predicate = #Predicate { $0.inboxStateRaw == openInboxState }
+        case .withAudio:
+            predicate = #Predicate { $0.audioFileName != nil || $0.remoteAudioRelativePath != nil }
+        case .failed:
+            predicate = #Predicate { $0.processingStateRaw == failedProcessingState }
+        }
+
+        let sortBy: [SortDescriptor<TranscriptionRecord>]
+        switch query.sortOrder {
+        case .newest:
+            sortBy = [
+                SortDescriptor(\.timestamp, order: .reverse),
+                SortDescriptor(\.id, order: .forward),
+            ]
+        case .oldest:
+            sortBy = [
+                SortDescriptor(\.timestamp, order: .forward),
+                SortDescriptor(\.id, order: .forward),
+            ]
+        case .duration:
+            sortBy = [
+                SortDescriptor(\.durationSeconds, order: .reverse),
+                SortDescriptor(\.timestamp, order: .reverse),
+                SortDescriptor(\.id, order: .forward),
+            ]
+        case .appName:
+            sortBy = [
+                SortDescriptor(\.appName, order: .forward),
+                SortDescriptor(\.timestamp, order: .reverse),
+                SortDescriptor(\.id, order: .forward),
+            ]
+        }
+        return FetchDescriptor(predicate: predicate, sortBy: sortBy)
+    }
+
+    private func requiresPostFiltering(_ query: HistoryQuery) -> Bool {
+        !query.searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || query.originDeviceID != nil
+            || query.appBundleIdentifier != nil
+            || query.cutoffDate != nil
+            || query.source != nil
+    }
+
+    private func matchesPostFilters(_ record: TranscriptionRecord, query: HistoryQuery) -> Bool {
+        if let appBundleIdentifier = query.appBundleIdentifier,
+           record.appBundleIdentifier != appBundleIdentifier {
+            return false
+        }
+        if let cutoffDate = query.cutoffDate, record.timestamp < cutoffDate { return false }
+        if let source = query.source, record.source != source { return false }
+        if let originDeviceID = query.originDeviceID,
+           !matchesDevice(record, deviceID: originDeviceID, includeLegacyMac: query.includeLegacyCurrentMacRecords) {
+            return false
+        }
+
+        let searchText = query.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !searchText.isEmpty else { return true }
+        let lowered = searchText.lowercased()
+        return record.rawText.lowercased().contains(lowered)
+            || record.finalText.lowercased().contains(lowered)
+            || (record.renderedDocument?.lowercased().contains(lowered) ?? false)
+            || (record.appName?.lowercased().contains(lowered) ?? false)
+            || (record.appDomain?.lowercased().contains(lowered) ?? false)
+            || record.source.displayName.lowercased().contains(lowered)
+    }
+
+    private func matchesDevice(
+        _ record: TranscriptionRecord,
+        deviceID: String,
+        includeLegacyMac: Bool
+    ) -> Bool {
+        let storedID = record.originDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+        if storedID == deviceID { return true }
+        guard storedID.isEmpty else { return false }
+
+        let normalizedPlatform = record.originPlatformRaw.lowercased()
+        if includeLegacyMac, normalizedPlatform.contains("mac") { return true }
+        return deviceID == "platform:\(normalizedPlatform.isEmpty ? "unknown" : normalizedPlatform)"
     }
 
     private func deleteAudioFile(for record: TranscriptionRecord) {
@@ -608,7 +963,7 @@ final class HistoryService: ObservableObject {
         }
 
         save()
-        fetchRecords()
+        refreshRecentRecords()
     }
     #endif
 }

--- a/TypeWhisper/Services/HistoryService.swift
+++ b/TypeWhisper/Services/HistoryService.swift
@@ -340,21 +340,20 @@ final class HistoryService: ObservableObject {
         }
     }
 
-    func recordCount(query: HistoryQuery = HistoryQuery()) -> Int {
+    func recordCountThrowing(query: HistoryQuery = HistoryQuery()) throws -> Int {
         if requiresPostFiltering(query) {
             var count = 0
-            do {
-                try modelContext.enumerate(fetchDescriptor(for: query), batchSize: 500) { record in
-                    if matchesPostFilters(record, query: query) { count += 1 }
-                }
-                return count
-            } catch {
-                logger.error("Failed to count filtered history records: \(error.localizedDescription)")
-                return 0
+            try modelContext.enumerate(fetchDescriptor(for: query), batchSize: 500) { record in
+                if matchesPostFilters(record, query: query) { count += 1 }
             }
+            return count
         }
+        return try modelContext.fetchCount(fetchDescriptor(for: query))
+    }
+
+    func recordCount(query: HistoryQuery = HistoryQuery()) -> Int {
         do {
-            return try modelContext.fetchCount(fetchDescriptor(for: query))
+            return try recordCountThrowing(query: query)
         } catch {
             logger.error("Failed to count history records: \(error.localizedDescription)")
             return 0
@@ -445,11 +444,15 @@ final class HistoryService: ObservableObject {
         )
     }
 
+    func allRecordsThrowing(query: HistoryQuery = HistoryQuery()) throws -> [TranscriptionRecord] {
+        let records = try modelContext.fetch(fetchDescriptor(for: query))
+        guard requiresPostFiltering(query) else { return records }
+        return records.filter { matchesPostFilters($0, query: query) }
+    }
+
     func allRecords(query: HistoryQuery = HistoryQuery()) -> [TranscriptionRecord] {
         do {
-            let records = try modelContext.fetch(fetchDescriptor(for: query))
-            guard requiresPostFiltering(query) else { return records }
-            return records.filter { matchesPostFilters($0, query: query) }
+            return try allRecordsThrowing(query: query)
         } catch {
             logger.error("Failed to fetch complete history: \(error.localizedDescription)")
             return []
@@ -477,12 +480,21 @@ final class HistoryService: ObservableObject {
     }
 
     func uniqueDomains(limit: Int = 50) -> [String] {
+        guard limit > 0 else { return [] }
         var counts: [String: Int] = [:]
-        for record in allRecords() {
-            guard let domain = record.appDomain else { continue }
-            let cleaned = domain.hasPrefix("www.") ? String(domain.dropFirst(4)) : domain
-            guard !cleaned.isEmpty else { continue }
-            counts[cleaned, default: 0] += 1
+        let context = ModelContext(modelContainer)
+        var descriptor = FetchDescriptor<TranscriptionRecord>()
+        descriptor.propertiesToFetch = [\TranscriptionRecord.appURL]
+        do {
+            try context.enumerate(descriptor, batchSize: 500) { record in
+                guard let domain = record.appDomain else { return }
+                let cleaned = domain.hasPrefix("www.") ? String(domain.dropFirst(4)) : domain
+                guard !cleaned.isEmpty else { return }
+                counts[cleaned, default: 0] += 1
+            }
+        } catch {
+            logger.error("Failed to enumerate history domains: \(error.localizedDescription)")
+            return []
         }
         return counts.sorted { $0.value > $1.value }.prefix(limit).map(\.key)
     }
@@ -740,11 +752,13 @@ final class HistoryService: ObservableObject {
         )
         descriptor.fetchLimit = Self.recentRecordsLimit
         do {
-            recentRecords = try modelContext.fetch(descriptor)
+            let refreshedTotalRecords = try recordCountThrowing()
+            let refreshedRecentRecords = try modelContext.fetch(descriptor)
+            totalRecords = refreshedTotalRecords
+            recentRecords = refreshedRecentRecords
         } catch {
-            recentRecords = []
+            logger.error("Failed to refresh recent history: \(error.localizedDescription)")
         }
-        totalRecords = recordCount()
     }
 
     private func migrateWordsCountIfNeeded() {

--- a/TypeWhisper/Services/ScreenshotFixtureSeeder.swift
+++ b/TypeWhisper/Services/ScreenshotFixtureSeeder.swift
@@ -31,7 +31,7 @@ extension ServiceContainer {
         }
 
         seedScreenshotHistory(content.history, languageCode: language.rawValue)
-        usageStatisticsService.replaceWithHistoryRecords(historyService.records)
+        usageStatisticsService.replaceWithHistoryRecords(historyService.allRecords())
 
         dictionaryService.addEntries(
             content.terms.map {
@@ -126,7 +126,7 @@ extension ServiceContainer {
                 audioSamples: includesAudio ? Array(repeating: Float.zero, count: 1_600) : nil
             )
 
-            guard let record = historyService.records.first(where: { $0.id == recordID }) else {
+            guard let record = historyService.record(withID: recordID) else {
                 continue
             }
             record.source = source
@@ -149,7 +149,7 @@ extension ServiceContainer {
         }
 
         if AppConstants.screenshotState == "history",
-           let selectedRecord = historyService.records.first(where: { $0.processingState == .ready }) {
+           let selectedRecord = historyService.allRecords().first(where: { $0.processingState == .ready }) {
             historyViewModel.requestRecordSelection([selectedRecord.id])
         }
     }

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -522,7 +522,7 @@ enum SettingsBackupExporter {
                 )
             }
 
-        let history = historyService.records.map { record in
+        let history = historyService.allRecords().map { record in
             HistoryEntryDTO(
                 timestamp: record.timestamp,
                 rawText: record.rawText,
@@ -770,7 +770,7 @@ enum SettingsBackupExporter {
             ? Calendar.current.date(byAdding: .day, value: -retentionDays, to: Date())
             : nil
 
-        let beforeHistoryCount = historyService.records.count
+        let beforeHistoryCount = historyService.recordCount()
         for (index, entry) in backup.history.enumerated() {
             if let retentionCutoff, entry.timestamp < retentionCutoff {
                 result.historySkippedByRetention += 1
@@ -816,7 +816,7 @@ enum SettingsBackupExporter {
                 await Task.yield()
             }
         }
-        result.historyImported = historyService.records.count - beforeHistoryCount
+        result.historyImported = historyService.recordCount() - beforeHistoryCount
 
         if let updateChannel = backup.updateChannel,
            AppConstants.ReleaseChannel(rawValue: updateChannel) != nil {

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -426,7 +426,7 @@ enum SettingsBackupExporter {
         pluginManager: PluginManager,
         historyService: HistoryService,
         userDefaults: UserDefaults = .standard
-    ) -> SettingsBackup {
+    ) throws -> SettingsBackup {
         let workflows = workflowService.workflows.map { workflow in
             WorkflowDTO(
                 name: workflow.name,
@@ -522,7 +522,7 @@ enum SettingsBackupExporter {
                 )
             }
 
-        let history = historyService.allRecords().map { record in
+        let history = try historyService.allRecordsThrowing().map { record in
             HistoryEntryDTO(
                 timestamp: record.timestamp,
                 rawText: record.rawText,
@@ -770,7 +770,6 @@ enum SettingsBackupExporter {
             ? Calendar.current.date(byAdding: .day, value: -retentionDays, to: Date())
             : nil
 
-        let beforeHistoryCount = historyService.recordCount()
         for (index, entry) in backup.history.enumerated() {
             if let retentionCutoff, entry.timestamp < retentionCutoff {
                 result.historySkippedByRetention += 1
@@ -798,6 +797,7 @@ enum SettingsBackupExporter {
             // counting those anyway would inflate Statistics beyond what's
             // visible in History.
             if inserted {
+                result.historyImported += 1
                 usageStatisticsService.recordTranscription(
                     timestamp: entry.timestamp,
                     wordsCount: entry.finalText.split(separator: " ").count,
@@ -816,8 +816,6 @@ enum SettingsBackupExporter {
                 await Task.yield()
             }
         }
-        result.historyImported = historyService.recordCount() - beforeHistoryCount
-
         if let updateChannel = backup.updateChannel,
            AppConstants.ReleaseChannel(rawValue: updateChannel) != nil {
             userDefaults.set(updateChannel, forKey: UserDefaultsKeys.updateChannel)
@@ -949,7 +947,7 @@ final class SettingsBackupAutomationService {
     }
 
     func exportData() throws -> Data {
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: workflowService,
             dictionaryService: dictionaryService,
             snippetService: snippetService,

--- a/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
+++ b/TypeWhisper/Services/Sync/CloudFolderSyncSettingsView.swift
@@ -1116,7 +1116,7 @@ final class CloudFolderSyncController: ObservableObject {
               let historyService else {
             return []
         }
-        let pending = historyService.records.compactMap { record -> (UUID, UserDataSyncHistoryAudioV1)? in
+        let pending = historyService.allRecords().compactMap { record -> (UUID, UserDataSyncHistoryAudioV1)? in
             guard historyService.audioFileURL(for: record) == nil,
                   let descriptor = historyService.synchronizedAudioDescriptor(for: record),
                   historySyncPreferences.shouldReceiveSynchronizedAudio(

--- a/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
+++ b/TypeWhisper/Services/Sync/TypeWhisperUserDataSyncStore.swift
@@ -39,7 +39,7 @@ final class TypeWhisperUserDataSyncStore: UserDataSyncStore, @unchecked Sendable
             }
             .store(in: &cancellables)
 
-        historyService?.$records
+        historyService?.$recentRecords
             .dropFirst()
             .sink { [weak self] _ in
                 self?.notifyLocalChange()

--- a/TypeWhisper/Services/UsageStatisticsService.swift
+++ b/TypeWhisper/Services/UsageStatisticsService.swift
@@ -196,6 +196,13 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
         }
     }
 
+    /// Defers loading History until a migration actually needs it. Normal launches with
+    /// completed aggregate migrations therefore never materialize the complete history.
+    func backfillFromHistoryIfNeeded(recordsProvider: () -> [TranscriptionRecord]) {
+        if historyBackfillCompleted, detailBackfillCompleted { return }
+        backfillFromHistoryIfNeeded(recordsProvider())
+    }
+
     /// Backfills only the app/model/hour breakdowns from history for installations that already
     /// completed the totals-only backfill before these fields existed. Does not touch totals.
     private func backfillDetailBreakdownsFromHistoryIfNeeded(_ records: [TranscriptionRecord]) {

--- a/TypeWhisper/Services/UsageStatisticsService.swift
+++ b/TypeWhisper/Services/UsageStatisticsService.swift
@@ -198,9 +198,13 @@ final class UsageStatisticsService: ObservableObject, UsageStatisticsRecording {
 
     /// Defers loading History until a migration actually needs it. Normal launches with
     /// completed aggregate migrations therefore never materialize the complete history.
-    func backfillFromHistoryIfNeeded(recordsProvider: () -> [TranscriptionRecord]) {
+    func backfillFromHistoryIfNeeded(recordsProvider: () throws -> [TranscriptionRecord]) {
         if historyBackfillCompleted, detailBackfillCompleted { return }
-        backfillFromHistoryIfNeeded(recordsProvider())
+        do {
+            backfillFromHistoryIfNeeded(try recordsProvider())
+        } catch {
+            usageStatisticsLogger.error("Failed to load history for usage statistics backfill: \(error.localizedDescription)")
+        }
     }
 
     /// Backfills only the app/model/hour breakdowns from history for installations that already

--- a/TypeWhisper/Services/WidgetDataService.swift
+++ b/TypeWhisper/Services/WidgetDataService.swift
@@ -12,7 +12,7 @@ final class WidgetDataService {
         self.historyService = historyService
         self.usageStatisticsService = usageStatisticsService
 
-        cancellable = Publishers.CombineLatest(historyService.$records, usageStatisticsService.$days)
+        cancellable = Publishers.CombineLatest(historyService.$recentRecords, usageStatisticsService.$days)
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
             .sink { [weak self] records, _ in
                 self?.updateWidgetData(records: records, now: Date())

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -830,7 +830,7 @@ final class DictationViewModel: ObservableObject {
         if let session = dictationSessions[id] {
             return session
         }
-        if let record = historyService.records.first(where: { $0.id == id }) {
+        if let record = historyService.record(withID: id) {
             return DictationSessionSnapshot(
                 id: id,
                 status: .completed,
@@ -2928,11 +2928,11 @@ final class DictationViewModel: ObservableObject {
     // MARK: - Workflow Palette
 
     var canCopyLastTranscription: Bool {
-        recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+        recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) != nil
     }
 
     func copyLastTranscriptionToClipboard() {
-        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) else { return }
+        guard let entry = recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) else { return }
         let text = entry.finalText.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
 

--- a/TypeWhisper/ViewModels/HistoryViewModel.swift
+++ b/TypeWhisper/ViewModels/HistoryViewModel.swift
@@ -167,6 +167,8 @@ private enum PendingHistoryTransition: Equatable {
 
 @MainActor
 final class HistoryViewModel: ObservableObject {
+    private static let pageSize = 100
+
     nonisolated(unsafe) static var _shared: HistoryViewModel?
     static var shared: HistoryViewModel {
         guard let instance = _shared else {
@@ -199,6 +201,10 @@ final class HistoryViewModel: ObservableObject {
     @Published private(set) var deviceSections: [HistoryDeviceSection] = []
     @Published private(set) var visibleRecordCount = 0
     @Published private(set) var visibleWordCount = 0
+    @Published private(set) var totalMatchingRecordCount = 0
+    @Published private(set) var hasMoreRecords = false
+    @Published private(set) var isLoadingMore = false
+    @Published private(set) var queryID = UUID()
     @Published private(set) var pendingDeletionIDs: Set<UUID> = []
 
     let audioPlaybackService = AudioPlaybackService()
@@ -215,6 +221,11 @@ final class HistoryViewModel: ObservableObject {
     private var didInitializeDeviceExpansion = false
     private var closeWindowHandler: (() -> Void)?
     private var cancellables = Set<AnyCancellable>()
+    private var isActive = false
+    private var facetDevices: [HistoryDeviceFacet] = []
+    @Published private(set) var inboxCount = 0
+    @Published private(set) var audioCount = 0
+    @Published private(set) var failedCount = 0
 
     init(
         historyService: HistoryService,
@@ -227,7 +238,12 @@ final class HistoryViewModel: ObservableObject {
         self.dictionaryService = dictionaryService
         self.syncController = syncController
         currentDeviceID = syncController?.historySyncPreferences?.deviceID
-        records = historyService.records
+        records = historyService.recentRecords
+        totalMatchingRecordCount = historyService.totalRecords
+        hasMoreRecords = records.count < totalMatchingRecordCount
+        inboxCount = records.count(where: \.isOpenInInbox)
+        audioCount = records.count(where: Self.hasAudio)
+        failedCount = records.count { $0.processingState == .failed }
         devices = syncController?.devices ?? []
         availableApps = Self.computeAvailableApps(records)
         deviceSections = Self.computeDeviceSections(
@@ -267,13 +283,6 @@ final class HistoryViewModel: ObservableObject {
 
     var showsUnsavedChangesPrompt: Bool { pendingTransition != nil }
 
-    var totalRecords: Int { historyService.totalRecords }
-    var totalWords: Int { historyService.totalWords }
-    var totalDuration: Double { historyService.totalDuration }
-    var inboxCount: Int { records.count(where: \.isOpenInInbox) }
-    var audioCount: Int { records.count(where: Self.hasAudio) }
-    var failedCount: Int { records.count { $0.processingState == .failed } }
-
     var navigationTitle: String {
         switch navigationSelection {
         case .smartMailbox(let scope): scope.displayName
@@ -285,18 +294,9 @@ final class HistoryViewModel: ObservableObject {
     }
 
     var navigationSummary: String {
-        let entries = String.localizedStringWithFormat(
+        String.localizedStringWithFormat(
             String(localized: "%lld entries"),
-            Int64(visibleRecordCount)
-        )
-        let words = String.localizedStringWithFormat(
-            String(localized: "%lld words"),
-            Int64(visibleWordCount)
-        )
-        return String.localizedStringWithFormat(
-            String(localized: "%@, %@"),
-            entries,
-            words
+            Int64(totalMatchingRecordCount)
         )
     }
 
@@ -313,10 +313,42 @@ final class HistoryViewModel: ObservableObject {
     func count(for scope: HistoryCollectionScope) -> Int {
         switch scope {
         case .inbox: inboxCount
-        case .all: records.count
+        case .all: historyService.totalRecords
         case .withAudio: audioCount
         case .failed: failedCount
         }
+    }
+
+    func activate() {
+        guard !isActive else { return }
+        isActive = true
+        reloadCurrentQuery()
+        refreshFacets()
+    }
+
+    func deactivate() {
+        isActive = false
+        records = historyService.recentRecords
+        totalMatchingRecordCount = historyService.totalRecords
+        hasMoreRecords = records.count < totalMatchingRecordCount
+        recomputeVisibleRecords()
+    }
+
+    func loadMoreRecords() {
+        guard isActive, hasMoreRecords, !isLoadingMore else { return }
+        isLoadingMore = true
+        defer { isLoadingMore = false }
+
+        let page = historyService.fetchPage(
+            query: currentQuery,
+            offset: records.count,
+            limit: Self.pageSize
+        )
+        let existingIDs = Set(records.map(\.id))
+        records.append(contentsOf: page.records.filter { !existingIDs.contains($0.id) })
+        totalMatchingRecordCount = page.totalCount
+        hasMoreRecords = page.hasMore
+        recomputeVisibleRecords()
     }
 
     func toggleDeviceExpansion(_ id: String) {
@@ -361,7 +393,7 @@ final class HistoryViewModel: ObservableObject {
     func requestSortOrder(_ order: HistorySortOrder) {
         guard order != selectedSortOrder else { return }
         selectedSortOrder = order
-        recomputeVisibleRecords()
+        reloadCurrentQuery()
     }
 
     func requestClearAllFilters() {
@@ -405,7 +437,7 @@ final class HistoryViewModel: ObservableObject {
         selectedAppFilter = nil
         selectedTimeRange = .all
         searchQuery = ""
-        recomputeVisibleRecords()
+        reloadCurrentQuery()
     }
 
     func selectRecord(_ record: TranscriptionRecord?) {
@@ -585,10 +617,43 @@ final class HistoryViewModel: ObservableObject {
         devices: [CloudFolderSyncDeviceRecord],
         currentDeviceID: String?
     ) -> [HistoryDeviceSection] {
+        struct Key: Hashable {
+            let deviceID: String
+            let platform: String
+            let source: RecordingSource
+        }
+        var counts: [Key: Int] = [:]
+        for record in records {
+            let key = Key(
+                deviceID: deviceIdentity(for: record, currentDeviceID: currentDeviceID),
+                platform: record.originPlatformRaw,
+                source: record.source
+            )
+            counts[key, default: 0] += 1
+        }
+        return computeDeviceSections(
+            facets: counts.map {
+                HistoryDeviceFacet(
+                    deviceID: $0.key.deviceID,
+                    platform: $0.key.platform,
+                    source: $0.key.source,
+                    count: $0.value
+                )
+            },
+            devices: devices,
+            currentDeviceID: currentDeviceID
+        )
+    }
+
+    static func computeDeviceSections(
+        facets: [HistoryDeviceFacet],
+        devices: [CloudFolderSyncDeviceRecord],
+        currentDeviceID: String?
+    ) -> [HistoryDeviceSection] {
         struct Accumulator {
             var metadata: CloudFolderSyncDeviceRecord?
             var platform: String
-            var records: [TranscriptionRecord]
+            var sourceCounts: [RecordingSource: Int]
         }
 
         var grouped: [String: Accumulator] = [:]
@@ -605,29 +670,28 @@ final class HistoryViewModel: ObservableObject {
             grouped[id] = Accumulator(
                 metadata: device,
                 platform: device.platform,
-                records: previous?.records ?? []
+                sourceCounts: previous?.sourceCounts ?? [:]
             )
         }
 
-        for record in records {
-            let id = deviceIdentity(for: record, currentDeviceID: currentDeviceID)
-            var accumulator = grouped[id] ?? Accumulator(
+        for facet in facets {
+            var accumulator = grouped[facet.deviceID] ?? Accumulator(
                 metadata: nil,
-                platform: record.originPlatformRaw,
-                records: []
+                platform: facet.platform,
+                sourceCounts: [:]
             )
-            accumulator.records.append(record)
+            accumulator.sourceCounts[facet.source, default: 0] += facet.count
             if accumulator.platform.isEmpty {
-                accumulator.platform = record.originPlatformRaw
+                accumulator.platform = facet.platform
             }
-            grouped[id] = accumulator
+            grouped[facet.deviceID] = accumulator
         }
 
         if let currentDeviceID, grouped[currentDeviceID] == nil {
             grouped[currentDeviceID] = Accumulator(
                 metadata: nil,
                 platform: "macOS",
-                records: []
+                sourceCounts: [:]
             )
         }
 
@@ -636,9 +700,8 @@ final class HistoryViewModel: ObservableObject {
         ]
         return grouped.map { id, accumulator in
             let isCurrent = id == currentDeviceID
-            let counts = Dictionary(grouping: accumulator.records, by: \.source).mapValues(\.count)
             let sources = sourceOrder.compactMap { source -> HistoryDeviceSourceSection? in
-                guard let count = counts[source], count > 0 else { return nil }
+                guard let count = accumulator.sourceCounts[source], count > 0 else { return nil }
                 return HistoryDeviceSourceSection(
                     source: source,
                     title: sourceTitle(source),
@@ -656,7 +719,7 @@ final class HistoryViewModel: ObservableObject {
                 platform: accumulator.platform,
                 systemImage: deviceSystemImage(platform: accumulator.platform),
                 isCurrent: isCurrent,
-                count: accumulator.records.count,
+                count: accumulator.sourceCounts.values.reduce(0, +),
                 sources: sources
             )
         }
@@ -666,19 +729,91 @@ final class HistoryViewModel: ObservableObject {
         }
     }
 
+    private var currentQuery: HistoryQuery {
+        let sortOrder: HistoryQuery.SortOrder = switch selectedSortOrder {
+        case .newest: .newest
+        case .oldest: .oldest
+        case .duration: .duration
+        case .appName: .appName
+        }
+        var query = HistoryQuery(
+            searchText: searchQuery,
+            appBundleIdentifier: selectedAppFilter,
+            cutoffDate: selectedTimeRange.cutoffDate,
+            collection: .all,
+            sortOrder: sortOrder
+        )
+
+        switch navigationSelection {
+        case .smartMailbox(let scope):
+            query.collection = switch scope {
+            case .inbox: .inbox
+            case .all: .all
+            case .withAudio: .withAudio
+            case .failed: .failed
+            }
+        case .device(let deviceID):
+            query.originDeviceID = deviceID
+            query.includeLegacyCurrentMacRecords = deviceID == currentDeviceID
+        case .deviceSource(let deviceID, let source):
+            query.originDeviceID = deviceID
+            query.includeLegacyCurrentMacRecords = deviceID == currentDeviceID
+            query.source = source
+        }
+        return query
+    }
+
+    private func reloadCurrentQuery() {
+        guard !isDirty else { return }
+        let page = historyService.fetchPage(
+            query: currentQuery,
+            offset: 0,
+            limit: isActive ? Self.pageSize : HistoryService.recentRecordsLimit
+        )
+        records = page.records
+        totalMatchingRecordCount = page.totalCount
+        hasMoreRecords = page.hasMore
+        queryID = UUID()
+        recomputeVisibleRecords()
+    }
+
+    private func refreshFacets() {
+        guard isActive else { return }
+        let facets = historyService.facets(currentDeviceID: currentDeviceID)
+        inboxCount = facets.inboxCount
+        audioCount = facets.audioCount
+        failedCount = facets.failedCount
+        availableApps = facets.apps
+            .sorted {
+                if $0.count != $1.count { return $0.count > $1.count }
+                return $0.name.localizedStandardCompare($1.name) == .orderedAscending
+            }
+            .map { AppEntry(bundleId: $0.bundleID, name: $0.name) }
+        facetDevices = facets.devices
+        recomputeDeviceSections(facets: facetDevices, devices: devices)
+    }
+
     private func setupBindings() {
-        historyService.$records
+        historyService.$recentRecords
             .dropFirst()
-            .sink { [weak self] records in self?.records = records }
+            .sink { [weak self] recentRecords in
+                guard let self else { return }
+                if self.isActive {
+                    self.reloadCurrentQuery()
+                    self.refreshFacets()
+                } else {
+                    self.records = recentRecords
+                    self.totalMatchingRecordCount = self.historyService.totalRecords
+                    self.hasMoreRecords = recentRecords.count < self.totalMatchingRecordCount
+                    self.recomputeVisibleRecords()
+                }
+            }
             .store(in: &cancellables)
 
-        let deferredTriggers: [AnyPublisher<Void, Never>] = [
-            $searchQuery.dropFirst().map { _ in () }.eraseToAnyPublisher(),
-            $records.dropFirst().map { _ in () }.eraseToAnyPublisher(),
-        ]
-        Publishers.MergeMany(deferredTriggers)
+        $searchQuery
+            .dropFirst()
             .debounce(for: .milliseconds(120), scheduler: DispatchQueue.main)
-            .sink { [weak self] in self?.recomputeVisibleRecords() }
+            .sink { [weak self] _ in self?.reloadCurrentQuery() }
             .store(in: &cancellables)
 
         $collapsedGroups
@@ -692,32 +827,21 @@ final class HistoryViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
-        $records
-            .map(Self.computeAvailableApps)
-            .assign(to: &$availableApps)
-
-        $records
-            .sink { [weak self] records in
-                guard let self else { return }
-                self.recomputeDeviceSections(records: records, devices: self.devices)
-            }
-            .store(in: &cancellables)
-
         syncController?.$devices
             .sink { [weak self] devices in
                 guard let self else { return }
                 self.devices = devices
-                self.recomputeDeviceSections(records: self.records, devices: devices)
+                self.recomputeDeviceSections(facets: self.facetDevices, devices: devices)
             }
             .store(in: &cancellables)
     }
 
     private func recomputeDeviceSections(
-        records: [TranscriptionRecord],
+        facets: [HistoryDeviceFacet],
         devices: [CloudFolderSyncDeviceRecord]
     ) {
         deviceSections = Self.computeDeviceSections(
-            records: records,
+            facets: facets,
             devices: devices,
             currentDeviceID: currentDeviceID
         )
@@ -735,38 +859,17 @@ final class HistoryViewModel: ObservableObject {
     }
 
     private func recomputeVisibleRecords() {
-        var scoped = records
-        switch navigationSelection {
-        case .smartMailbox(let scope):
-            scoped = Self.applyCollectionScope(scope, to: scoped)
-        case .device(let id):
-            scoped = scoped.filter {
-                Self.deviceIdentity(for: $0, currentDeviceID: currentDeviceID) == id
-            }
-        case .deviceSource(let id, let source):
-            scoped = scoped.filter {
-                Self.deviceIdentity(for: $0, currentDeviceID: currentDeviceID) == id
-                    && $0.source == source
-            }
-        }
-        let filtered = Self.applyCommonFilters(
-            to: scoped,
-            query: searchQuery,
-            appFilter: selectedAppFilter,
-            timeRange: selectedTimeRange,
-            sortOrder: selectedSortOrder
-        )
-        let sections = Self.computeSections(filtered)
+        let sections = Self.computeSections(records)
         if !isDirty {
             syncSelection(withVisibleRecordIDs: Self.visibleRecordIDs(
                 sections: sections,
                 collapsedGroups: collapsedGroups
             ))
         }
-        filteredRecords = filtered
+        filteredRecords = records
         groupedSections = sections
-        visibleRecordCount = filtered.count
-        visibleWordCount = filtered.reduce(0) { $0 + $1.wordsCount }
+        visibleRecordCount = records.count
+        visibleWordCount = records.reduce(0) { $0 + $1.wordsCount }
     }
 
     private func prepare(_ transition: PendingHistoryTransition) {
@@ -792,13 +895,13 @@ final class HistoryViewModel: ObservableObject {
             selectedRecordIDs = selection
         case .navigation(let selection):
             navigationSelection = selection
-            recomputeVisibleRecords()
+            reloadCurrentQuery()
         case .appFilter(let bundleID):
             selectedAppFilter = bundleID
-            recomputeVisibleRecords()
+            reloadCurrentQuery()
         case .timeRange(let range):
             selectedTimeRange = range
-            recomputeVisibleRecords()
+            reloadCurrentQuery()
         case .clearFilters:
             clearAllFilters()
         case .deletion(let ids):

--- a/TypeWhisper/ViewModels/HistoryViewModel.swift
+++ b/TypeWhisper/ViewModels/HistoryViewModel.swift
@@ -322,7 +322,7 @@ final class HistoryViewModel: ObservableObject {
     func activate() {
         guard !isActive else { return }
         isActive = true
-        reloadCurrentQuery()
+        reloadCurrentQuery(resetListIdentity: false)
         refreshFacets()
     }
 
@@ -763,17 +763,28 @@ final class HistoryViewModel: ObservableObject {
         return query
     }
 
-    private func reloadCurrentQuery() {
+    private func reloadCurrentQuery(
+        preservingLoadedRecords: Bool = false,
+        resetListIdentity: Bool = true
+    ) {
         guard !isDirty else { return }
+        let limit: Int
+        if isActive {
+            limit = preservingLoadedRecords ? max(records.count, Self.pageSize) : Self.pageSize
+        } else {
+            limit = HistoryService.recentRecordsLimit
+        }
         let page = historyService.fetchPage(
             query: currentQuery,
             offset: 0,
-            limit: isActive ? Self.pageSize : HistoryService.recentRecordsLimit
+            limit: limit
         )
         records = page.records
         totalMatchingRecordCount = page.totalCount
         hasMoreRecords = page.hasMore
-        queryID = UUID()
+        if resetListIdentity {
+            queryID = UUID()
+        }
         recomputeVisibleRecords()
     }
 
@@ -799,7 +810,10 @@ final class HistoryViewModel: ObservableObject {
             .sink { [weak self] recentRecords in
                 guard let self else { return }
                 if self.isActive {
-                    self.reloadCurrentQuery()
+                    self.reloadCurrentQuery(
+                        preservingLoadedRecords: true,
+                        resetListIdentity: false
+                    )
                     self.refreshFacets()
                 } else {
                     self.records = recentRecords

--- a/TypeWhisper/ViewModels/HomeViewModel.swift
+++ b/TypeWhisper/ViewModels/HomeViewModel.swift
@@ -34,7 +34,7 @@ final class HomeViewModel: ObservableObject {
     }
 
     private func setupBindings() {
-        historyService.$records
+        historyService.$recentRecords
             .dropFirst()
             .sink { [weak self] _ in self?.scheduleRefresh() }
             .store(in: &cancellables)
@@ -55,9 +55,9 @@ final class HomeViewModel: ObservableObject {
     }
 
     func refresh() {
-        let allRecords = historyService.records
-        hasAnyTranscriptions = usageStatisticsService.hasAnyStatistics || !allRecords.isEmpty
-        recentTranscriptions = Array(allRecords.prefix(3))
+        let recentRecords = historyService.recentRecords
+        hasAnyTranscriptions = usageStatisticsService.hasAnyStatistics || !recentRecords.isEmpty
+        recentTranscriptions = Array(recentRecords.prefix(3))
     }
 
     func completeSetupWizard() {

--- a/TypeWhisper/ViewModels/PromptPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/PromptPaletteHandler.swift
@@ -85,7 +85,7 @@ final class PromptPaletteHandler {
         guard currentState == .idle else { return }
 
         let workflows = workflowService.workflows.filter { $0.isEnabled && $0.isManuallyRunnable }
-        let recentEntries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.records)
+        let recentEntries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.recentRecords)
         guard !workflows.isEmpty || !recentEntries.isEmpty else { return }
 
         if workflows.isEmpty {

--- a/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
+++ b/TypeWhisper/ViewModels/RecentTranscriptionPaletteHandler.swift
@@ -36,7 +36,7 @@ final class RecentTranscriptionPaletteHandler {
 
         guard currentState == .idle else { return }
 
-        let entries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.records)
+        let entries = recentTranscriptionStore.mergedEntries(historyRecords: historyService.recentRecords)
         guard !entries.isEmpty else {
             onShowNotchFeedback?(
                 String(localized: "No recent transcriptions"),

--- a/TypeWhisper/Views/AdvancedSettingsView.swift
+++ b/TypeWhisper/Views/AdvancedSettingsView.swift
@@ -619,16 +619,21 @@ struct AdvancedSettingsView: View {
     /// right away.
     private func beginExport() {
         let container = ServiceContainer.shared
-        let backup = SettingsBackupExporter.buildBackup(
-            workflowService: container.workflowService,
-            dictionaryService: container.dictionaryService,
-            snippetService: container.snippetService,
-            profileService: container.profileService,
-            promptActionService: container.promptActionService,
-            pluginManager: container.pluginManager,
-            historyService: container.historyService
-        )
-        exportBackupDraft = ExportBackupDraft(backup: backup)
+        do {
+            let backup = try SettingsBackupExporter.buildBackup(
+                workflowService: container.workflowService,
+                dictionaryService: container.dictionaryService,
+                snippetService: container.snippetService,
+                profileService: container.profileService,
+                promptActionService: container.promptActionService,
+                pluginManager: container.pluginManager,
+                historyService: container.historyService
+            )
+            exportBackupDraft = ExportBackupDraft(backup: backup)
+        } catch {
+            backupErrorMessage = error.localizedDescription
+            showBackupError = true
+        }
     }
 
     private func performBackupExport(_ backup: SettingsBackupExporter.SettingsBackup, categories: Set<SettingsBackupExporter.Category>) {

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -200,7 +200,7 @@ struct HistoryView: View {
                                         .tag(record.id)
                                         .contextMenu { recordContextMenu(for: record) }
                                         .onAppear {
-                                            guard record.id == viewModel.records.last?.id else { return }
+                                            guard record.id == lastVisibleRecordID else { return }
                                             viewModel.loadMoreRecords()
                                         }
                                 }
@@ -222,6 +222,12 @@ struct HistoryView: View {
         }
         .navigationTitle(viewModel.navigationTitle)
         .navigationSubtitle(viewModel.navigationSummary)
+    }
+
+    private var lastVisibleRecordID: UUID? {
+        viewModel.groupedSections
+            .last { !viewModel.collapsedGroups.contains($0.group) }?
+            .records.last?.id
     }
 
     @ViewBuilder

--- a/TypeWhisper/Views/HistoryView.swift
+++ b/TypeWhisper/Views/HistoryView.swift
@@ -61,6 +61,8 @@ struct HistoryView: View {
             viewModel.consumePendingDeletion()
         }
         .frame(minWidth: 900, minHeight: 560)
+        .onAppear { viewModel.activate() }
+        .onDisappear { viewModel.deactivate() }
     }
 
     private var unsavedChangesBinding: Binding<Bool> {
@@ -197,6 +199,10 @@ struct HistoryView: View {
                                     HistoryRecordRow(record: record)
                                         .tag(record.id)
                                         .contextMenu { recordContextMenu(for: record) }
+                                        .onAppear {
+                                            guard record.id == viewModel.records.last?.id else { return }
+                                            viewModel.loadMoreRecords()
+                                        }
                                 }
                             }
                         } header: {
@@ -211,7 +217,7 @@ struct HistoryView: View {
                     }
                 }
                 .listStyle(.inset)
-                .id(viewModel.navigationSelection)
+                .id(viewModel.queryID)
             }
         }
         .navigationTitle(viewModel.navigationTitle)

--- a/TypeWhisper/Views/HomeSettingsView.swift
+++ b/TypeWhisper/Views/HomeSettingsView.swift
@@ -46,7 +46,7 @@ struct HomeSettingsView: View {
                             Button("Seed Demo Data") {
                                 let historyService = ServiceContainer.shared.historyService
                                 historyService.seedDemoData()
-                                ServiceContainer.shared.usageStatisticsService.replaceWithHistoryRecords(historyService.records)
+                                ServiceContainer.shared.usageStatisticsService.replaceWithHistoryRecords(historyService.allRecords())
                             }
                             .buttonStyle(.plain)
                             .foregroundStyle(.orange)

--- a/TypeWhisper/Views/MenuBarView.swift
+++ b/TypeWhisper/Views/MenuBarView.swift
@@ -33,7 +33,7 @@ private final class MenuBarState: ObservableObject {
 
         // Set initial values immediately
         self.isModelReady = modelManager.isModelReady
-        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) != nil
         self.hasRecentTranscriptions = hasRecentTranscriptions
         self.canCopyLastTranscription = hasRecentTranscriptions
         self.hasLastTranscribedText = dictation.lastTranscribedText != nil
@@ -78,7 +78,7 @@ private final class MenuBarState: ObservableObject {
             }
             .store(in: &cancellables)
 
-        historyService.$records
+        historyService.$recentRecords
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.refreshCopyAvailability()
@@ -185,7 +185,7 @@ private final class MenuBarState: ObservableObject {
     private func refreshCopyAvailability() {
         let historyService = ServiceContainer.shared.historyService
         let recentTranscriptionStore = ServiceContainer.shared.recentTranscriptionStore
-        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.records) != nil
+        let hasRecentTranscriptions = recentTranscriptionStore.latestEntry(historyRecords: historyService.recentRecords) != nil
         self.hasRecentTranscriptions = hasRecentTranscriptions
         canCopyLastTranscription = hasRecentTranscriptions
     }

--- a/TypeWhisperTests/CloudFolderSyncTests.swift
+++ b/TypeWhisperTests/CloudFolderSyncTests.swift
@@ -1977,7 +1977,7 @@ final class CloudFolderSyncTests: XCTestCase {
         let diagnostics = await controller.installPendingSynchronizedAudio(in: folder)
 
         XCTAssertTrue(diagnostics.isEmpty)
-        let record = try XCTUnwrap(historyService.records.first { $0.id == recordID })
+        let record = try XCTUnwrap(historyService.recentRecords.first { $0.id == recordID })
         let installedURL = try XCTUnwrap(historyService.audioFileURL(for: record))
         XCTAssertEqual(try Data(contentsOf: installedURL), try Data(contentsOf: sourceURL))
     }
@@ -2045,7 +2045,7 @@ final class CloudFolderSyncTests: XCTestCase {
         let diagnostics = await controller.installPendingSynchronizedAudio(in: folder)
 
         XCTAssertTrue(diagnostics.isEmpty)
-        let record = try XCTUnwrap(historyService.records.first { $0.id == recordID })
+        let record = try XCTUnwrap(historyService.recentRecords.first { $0.id == recordID })
         XCTAssertNil(historyService.audioFileURL(for: record))
     }
 

--- a/TypeWhisperTests/FileTranscriptionViewModelTests.swift
+++ b/TypeWhisperTests/FileTranscriptionViewModelTests.swift
@@ -889,7 +889,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         XCTAssertEqual(capturedTask, .translate)
         XCTAssertEqual(capturedEngineOverrideId, "parakeet")
         XCTAssertEqual(capturedModelOverrideId, "parakeet-large")
-        let historyRecord = try XCTUnwrap(historyService.records.first)
+        let historyRecord = try XCTUnwrap(historyService.recentRecords.first)
         XCTAssertEqual(historyRecord.rawText, "Recovered dictation")
         XCTAssertEqual(historyRecord.finalText, "Recovered dictation")
         XCTAssertEqual(historyRecord.language, "de")
@@ -933,7 +933,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         viewModel.transcribe()
         try await waitForRecoveryToSave(viewModel, historyService: historyService)
 
-        let historyRecord = try XCTUnwrap(historyService.records.first)
+        let historyRecord = try XCTUnwrap(historyService.recentRecords.first)
         XCTAssertNil(historyService.audioFileURL(for: historyRecord))
         XCTAssertFalse(FileManager.default.fileExists(atPath: recoveryURL.path))
         XCTAssertTrue(viewModel.recoveries.isEmpty)
@@ -1204,7 +1204,7 @@ final class FileTranscriptionViewModelTests: XCTestCase {
         historyService: HistoryService
     ) async throws {
         for _ in 0..<50 {
-            if viewModel.lastSavedHistoryRecordID != nil, !historyService.records.isEmpty {
+            if viewModel.lastSavedHistoryRecordID != nil, !historyService.recentRecords.isEmpty {
                 return
             }
             try await Task.sleep(for: .milliseconds(20))

--- a/TypeWhisperTests/HistoryServiceTests.swift
+++ b/TypeWhisperTests/HistoryServiceTests.swift
@@ -750,6 +750,22 @@ final class HistoryServiceTests: XCTestCase {
         XCTAssertEqual(viewModel.records.count, 125)
         XCTAssertFalse(viewModel.hasMoreRecords)
 
+        let queryID = viewModel.queryID
+        historyService.addRecord(
+            timestamp: baseDate.addingTimeInterval(126),
+            rawText: "New record",
+            finalText: "New record",
+            appName: "Notes",
+            appBundleIdentifier: "com.apple.Notes",
+            durationSeconds: 1,
+            language: "en",
+            engineUsed: "test"
+        )
+        XCTAssertEqual(viewModel.records.count, 125)
+        XCTAssertEqual(viewModel.totalMatchingRecordCount, 126)
+        XCTAssertTrue(viewModel.hasMoreRecords)
+        XCTAssertEqual(viewModel.queryID, queryID)
+
         viewModel.deactivate()
         XCTAssertEqual(viewModel.records.count, HistoryService.recentRecordsLimit)
     }

--- a/TypeWhisperTests/HistoryServiceTests.swift
+++ b/TypeWhisperTests/HistoryServiceTests.swift
@@ -59,7 +59,7 @@ final class HistoryServiceTests: XCTestCase {
             )),
         ])
 
-        let record = try XCTUnwrap(service.records.first)
+        let record = try XCTUnwrap(service.recentRecords.first)
         XCTAssertEqual(record.source, .appleWatch)
         XCTAssertEqual(record.inboxState, .open)
         XCTAssertEqual(record.inboxCompletionPolicyRaw, "afterAction")
@@ -113,7 +113,7 @@ final class HistoryServiceTests: XCTestCase {
         XCTAssertTrue(preferences.isSuppressed(retentionID))
         XCTAssertNil(preferences.explicitDeletions[retentionID.uuidString.lowercased()])
 
-        service.deleteRecord(try XCTUnwrap(service.records.first { $0.id == explicitID }))
+        service.deleteRecord(try XCTUnwrap(service.recentRecords.first { $0.id == explicitID }))
         XCTAssertNotNil(preferences.explicitDeletions[explicitID.uuidString.lowercased()])
     }
 
@@ -193,7 +193,7 @@ final class HistoryServiceTests: XCTestCase {
             language: "en",
             engineUsed: "test"
         )
-        let record = try XCTUnwrap(historyService.records.first)
+        let record = try XCTUnwrap(historyService.recentRecords.first)
         record.inboxState = .open
         record.inboxCompletionPolicyRaw = UserDataSyncHistoryCompletionPolicy.onOpen.rawValue
 
@@ -234,7 +234,7 @@ final class HistoryServiceTests: XCTestCase {
             engineUsed: "test"
         )
         let inboxRecord = try XCTUnwrap(
-            historyService.records.first { $0.finalText == "Inbox note" }
+            historyService.recentRecords.first { $0.finalText == "Inbox note" }
         )
         inboxRecord.inboxState = .open
 
@@ -358,13 +358,13 @@ final class HistoryServiceTests: XCTestCase {
 
         XCTAssertEqual(viewModel.selectedRecordIDs, [firstID])
         XCTAssertTrue(viewModel.showsUnsavedChangesPrompt)
-        XCTAssertEqual(historyService.records.first { $0.id == firstID }?.finalText, "First")
+        XCTAssertEqual(historyService.recentRecords.first { $0.id == firstID }?.finalText, "First")
 
         viewModel.discardAndContinue()
 
         XCTAssertEqual(viewModel.selectedRecordIDs, [secondID])
         XCTAssertFalse(viewModel.showsUnsavedChangesPrompt)
-        XCTAssertEqual(historyService.records.first { $0.id == firstID }?.finalText, "First")
+        XCTAssertEqual(historyService.recentRecords.first { $0.id == firstID }?.finalText, "First")
     }
 
     @MainActor
@@ -394,12 +394,12 @@ final class HistoryServiceTests: XCTestCase {
             dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory)
         )
         viewModel.requestRecordSelection([selectedID])
-        let contextRecord = try XCTUnwrap(historyService.records.first { $0.id == contextID })
+        let contextRecord = try XCTUnwrap(historyService.recentRecords.first { $0.id == contextID })
 
         viewModel.deleteRecords([contextRecord])
 
         XCTAssertEqual(viewModel.selectedRecordIDs, [selectedID])
-        XCTAssertEqual(historyService.records.map(\.id), [selectedID])
+        XCTAssertEqual(historyService.recentRecords.map(\.id), [selectedID])
     }
 
     @MainActor
@@ -428,7 +428,7 @@ final class HistoryServiceTests: XCTestCase {
             pipelineSteps: ["Cleanup"]
         )
 
-        let record = try XCTUnwrap(service.records.first)
+        let record = try XCTUnwrap(service.recentRecords.first)
         record.renderedDocument = "Rendered document"
         record.synchronizedStructuredDocument = UserDataSyncHistoryStructuredDocumentV1(
             kind: "note",
@@ -488,25 +488,269 @@ final class HistoryServiceTests: XCTestCase {
             engineUsed: "parakeet"
         )
 
-        XCTAssertEqual(service.records.count, 2)
+        XCTAssertEqual(service.recentRecords.count, 2)
         XCTAssertEqual(service.searchRecords(query: "planning").count, 1)
         XCTAssertEqual(service.uniqueDomains(), ["github.com"])
-        XCTAssertNotNil(service.audioFileURL(for: service.records.first { $0.audioFileName != nil }!))
+        XCTAssertNotNil(service.audioFileURL(for: service.recentRecords.first { $0.audioFileName != nil }!))
 
-        let staleRecord = try XCTUnwrap(service.records.first(where: { $0.finalText == "Older note" }))
+        let staleRecord = try XCTUnwrap(service.recentRecords.first(where: { $0.finalText == "Older note" }))
         staleRecord.timestamp = Calendar.current.date(byAdding: .day, value: -120, to: Date())!
         service.updateRecord(staleRecord, finalText: staleRecord.finalText)
-        usageStatisticsService.backfillFromHistoryIfNeeded(service.records)
+        usageStatisticsService.backfillFromHistoryIfNeeded(service.recentRecords)
 
         service.purgeOldRecords(retentionDays: 30)
 
-        XCTAssertEqual(service.records.count, 1)
+        XCTAssertEqual(service.recentRecords.count, 1)
         XCTAssertEqual(service.totalRecords, 1)
-        XCTAssertEqual(service.totalWords, 3)
+        XCTAssertEqual(service.allRecords().reduce(0) { $0 + $1.wordsCount }, 3)
 
         let allTimeUsage = usageStatisticsService.summary(from: nil)
         XCTAssertEqual(allTimeUsage.transcriptionCount, 2)
         XCTAssertEqual(allTimeUsage.words, 5)
         XCTAssertEqual(allTimeUsage.appCount, 2)
+    }
+
+    @MainActor
+    func testRecentCacheIsBoundedWhilePagesCoverCompleteHistory() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "HistoryPagination"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = HistoryService(appSupportDirectory: appSupportDirectory)
+        let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+        var oldestID: UUID?
+
+        for index in 0..<125 {
+            let id = UUID()
+            if index == 0 { oldestID = id }
+            service.addRecord(
+                id: id,
+                timestamp: baseDate.addingTimeInterval(Double(index)),
+                rawText: "Record \(index)",
+                finalText: "Record \(index)",
+                appName: "Notes",
+                appBundleIdentifier: "com.apple.Notes",
+                durationSeconds: Double(index),
+                language: "en",
+                engineUsed: "test"
+            )
+        }
+
+        XCTAssertEqual(service.recentRecords.count, HistoryService.recentRecordsLimit)
+        XCTAssertEqual(service.recentRecords.first?.finalText, "Record 124")
+        XCTAssertEqual(service.totalRecords, 125)
+
+        let firstPage = service.fetchPage(offset: 0, limit: 100)
+        let secondPage = service.fetchPage(offset: 100, limit: 100)
+        let allIDs = firstPage.records.map(\.id) + secondPage.records.map(\.id)
+
+        XCTAssertEqual(firstPage.totalCount, 125)
+        XCTAssertTrue(firstPage.hasMore)
+        XCTAssertEqual(firstPage.records.count, 100)
+        XCTAssertEqual(secondPage.records.count, 25)
+        XCTAssertFalse(secondPage.hasMore)
+        XCTAssertEqual(Set(allIDs).count, 125)
+        XCTAssertEqual(service.record(withID: try XCTUnwrap(oldestID))?.finalText, "Record 0")
+    }
+
+    @MainActor
+    func testUserDataSyncIncludesRecordsBeyondRecentCache() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "HistorySyncComplete"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let suiteName = "HistorySyncComplete-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let preferences = HistorySyncPreferences(defaults: defaults)
+        preferences.isEnabled = true
+        let service = HistoryService(
+            appSupportDirectory: appSupportDirectory,
+            historySyncPreferences: preferences
+        )
+
+        for index in 0..<25 {
+            service.addRecord(
+                rawText: "Sync \(index)",
+                finalText: "Sync \(index)",
+                appName: nil,
+                appBundleIdentifier: nil,
+                durationSeconds: 1,
+                language: "en",
+                engineUsed: "test"
+            )
+        }
+
+        XCTAssertEqual(service.recentRecords.count, HistoryService.recentRecordsLimit)
+        XCTAssertEqual(service.userDataSyncHistoryRecords().count, 25)
+    }
+
+    @MainActor
+    func testSearchAndRetentionIncludeRecordsOutsideRecentCache() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "HistoryCompleteQueries"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = HistoryService(appSupportDirectory: appSupportDirectory)
+        let now = Date()
+        let targetID = UUID()
+
+        service.addRecord(
+            id: targetID,
+            timestamp: Calendar.current.date(byAdding: .day, value: -120, to: now)!,
+            rawText: "Needle outside recent cache",
+            finalText: "Needle outside recent cache",
+            appName: "Safari",
+            appBundleIdentifier: "com.apple.Safari",
+            durationSeconds: 2,
+            language: "en",
+            engineUsed: "test"
+        )
+        for index in 0..<30 {
+            service.addRecord(
+                timestamp: now.addingTimeInterval(Double(index)),
+                rawText: "Recent \(index)",
+                finalText: "Recent \(index)",
+                appName: "Notes",
+                appBundleIdentifier: "com.apple.Notes",
+                durationSeconds: 1,
+                language: "en",
+                engineUsed: "test"
+            )
+        }
+
+        XCTAssertFalse(service.recentRecords.contains { $0.id == targetID })
+        let searchPage = service.fetchPage(
+            query: HistoryQuery(searchText: "needle"),
+            offset: 0,
+            limit: 100
+        )
+        XCTAssertEqual(searchPage.records.map(\.id), [targetID])
+
+        service.purgeOldRecords(retentionDays: 30)
+
+        XCTAssertNil(service.record(withID: targetID))
+        XCTAssertEqual(service.recordCount(), 30)
+    }
+
+    @MainActor
+    func testPagedQueryCombinesAppTimeDeviceAndSourceFilters() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "HistoryCombinedQuery"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let service = HistoryService(appSupportDirectory: appSupportDirectory)
+        let now = Date()
+
+        func addRecord(
+            text: String,
+            timestamp: Date,
+            appBundleIdentifier: String,
+            deviceID: String,
+            source: RecordingSource
+        ) throws -> UUID {
+            let id = UUID()
+            service.addRecord(
+                id: id,
+                timestamp: timestamp,
+                rawText: text,
+                finalText: text,
+                appName: "Test App",
+                appBundleIdentifier: appBundleIdentifier,
+                durationSeconds: 1,
+                language: "en",
+                engineUsed: "test"
+            )
+            let record = try XCTUnwrap(service.record(withID: id))
+            record.originDeviceID = deviceID
+            record.originPlatformRaw = "iOS"
+            record.source = source
+            service.updateRecord(record, finalText: text)
+            return id
+        }
+
+        let targetID = try addRecord(
+            text: "Target",
+            timestamp: now,
+            appBundleIdentifier: "com.apple.Notes",
+            deviceID: "phone-1",
+            source: .keyboard
+        )
+        _ = try addRecord(
+            text: "Wrong source",
+            timestamp: now,
+            appBundleIdentifier: "com.apple.Notes",
+            deviceID: "phone-1",
+            source: .appleWatch
+        )
+        _ = try addRecord(
+            text: "Wrong app",
+            timestamp: now,
+            appBundleIdentifier: "com.apple.TextEdit",
+            deviceID: "phone-1",
+            source: .keyboard
+        )
+        _ = try addRecord(
+            text: "Too old",
+            timestamp: Calendar.current.date(byAdding: .day, value: -120, to: now)!,
+            appBundleIdentifier: "com.apple.Notes",
+            deviceID: "phone-1",
+            source: .keyboard
+        )
+
+        let page = service.fetchPage(
+            query: HistoryQuery(
+                appBundleIdentifier: "com.apple.Notes",
+                cutoffDate: Calendar.current.date(byAdding: .day, value: -30, to: now),
+                originDeviceID: "phone-1",
+                source: .keyboard
+            ),
+            offset: 0,
+            limit: 100
+        )
+
+        XCTAssertEqual(page.records.map(\.id), [targetID])
+        XCTAssertEqual(page.totalCount, 1)
+        XCTAssertFalse(page.hasMore)
+    }
+
+    @MainActor
+    func testHistoryViewModelLoadsAdditionalPagesAndReleasesThemWhenInactive() throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory(
+            prefix: "HistoryViewPagination"
+        )
+        defer { TestSupport.remove(appSupportDirectory) }
+        let historyService = HistoryService(appSupportDirectory: appSupportDirectory)
+        let baseDate = Date(timeIntervalSince1970: 1_800_000_000)
+        for index in 0..<125 {
+            historyService.addRecord(
+                timestamp: baseDate.addingTimeInterval(Double(index)),
+                rawText: "Paged \(index)",
+                finalText: "Paged \(index)",
+                appName: "Notes",
+                appBundleIdentifier: "com.apple.Notes",
+                durationSeconds: 1,
+                language: "en",
+                engineUsed: "test"
+            )
+        }
+        let viewModel = HistoryViewModel(
+            historyService: historyService,
+            textDiffService: TextDiffService(),
+            dictionaryService: DictionaryService(appSupportDirectory: appSupportDirectory)
+        )
+
+        XCTAssertEqual(viewModel.records.count, HistoryService.recentRecordsLimit)
+        viewModel.activate()
+        XCTAssertEqual(viewModel.records.count, 100)
+        XCTAssertEqual(viewModel.totalMatchingRecordCount, 125)
+        XCTAssertTrue(viewModel.hasMoreRecords)
+
+        viewModel.loadMoreRecords()
+        XCTAssertEqual(viewModel.records.count, 125)
+        XCTAssertFalse(viewModel.hasMoreRecords)
+
+        viewModel.deactivate()
+        XCTAssertEqual(viewModel.records.count, HistoryService.recentRecordsLimit)
     }
 }

--- a/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionPaletteHandlerTests.swift
@@ -85,7 +85,7 @@ final class RecentTranscriptionPaletteHandlerTests: XCTestCase {
             language: "en",
             engineUsed: "mock"
         )
-        let historyRecord = try XCTUnwrap(historyService.records.first)
+        let historyRecord = try XCTUnwrap(historyService.recentRecords.first)
         historyRecord.timestamp = Date().addingTimeInterval(-10)
         historyService.updateRecord(historyRecord, finalText: historyRecord.finalText)
 

--- a/TypeWhisperTests/RecentTranscriptionStoreTests.swift
+++ b/TypeWhisperTests/RecentTranscriptionStoreTests.swift
@@ -33,11 +33,11 @@ final class RecentTranscriptionStoreTests: XCTestCase {
             engineUsed: "mock"
         )
 
-        let newerHistory = try XCTUnwrap(historyService.records.first(where: { $0.id == duplicatedID }))
+        let newerHistory = try XCTUnwrap(historyService.recentRecords.first(where: { $0.id == duplicatedID }))
         newerHistory.timestamp = now.addingTimeInterval(-60)
         historyService.updateRecord(newerHistory, finalText: newerHistory.finalText)
 
-        let olderHistory = try XCTUnwrap(historyService.records.first(where: { $0.id != duplicatedID }))
+        let olderHistory = try XCTUnwrap(historyService.recentRecords.first(where: { $0.id != duplicatedID }))
         olderHistory.timestamp = now.addingTimeInterval(-180)
         historyService.updateRecord(olderHistory, finalText: olderHistory.finalText)
 
@@ -56,7 +56,7 @@ final class RecentTranscriptionStoreTests: XCTestCase {
             appBundleIdentifier: "com.apple.mail"
         )
 
-        let merged = store.mergedEntries(historyRecords: historyService.records)
+        let merged = store.mergedEntries(historyRecords: historyService.recentRecords)
 
         XCTAssertEqual(merged.map(\.finalText), ["Session newest", "History newer", "History oldest"])
         XCTAssertEqual(merged.count, 3)
@@ -101,7 +101,7 @@ final class RecentTranscriptionStoreTests: XCTestCase {
             language: "en",
             engineUsed: "mock"
         )
-        let historyRecord = try XCTUnwrap(historyService.records.first)
+        let historyRecord = try XCTUnwrap(historyService.recentRecords.first)
         historyRecord.timestamp = now.addingTimeInterval(-120)
         historyService.updateRecord(historyRecord, finalText: historyRecord.finalText)
 
@@ -113,8 +113,8 @@ final class RecentTranscriptionStoreTests: XCTestCase {
             appBundleIdentifier: "com.apple.mail"
         )
 
-        let mergedFirst = try XCTUnwrap(store.mergedEntries(historyRecords: historyService.records).first)
-        let latest = try XCTUnwrap(store.latestEntry(historyRecords: historyService.records))
+        let mergedFirst = try XCTUnwrap(store.mergedEntries(historyRecords: historyService.recentRecords).first)
+        let latest = try XCTUnwrap(store.latestEntry(historyRecords: historyService.recentRecords))
 
         XCTAssertEqual(latest, mergedFirst)
     }

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -427,7 +427,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         )
 
         XCTAssertEqual(result.historyImported, 1)
-        let importedRecord = try XCTUnwrap(destination.historyService.records.first)
+        let importedRecord = try XCTUnwrap(destination.historyService.recentRecords.first)
         XCTAssertEqual(importedRecord.finalText, "Hello, world.")
         XCTAssertEqual(importedRecord.timestamp.timeIntervalSince1970, originalTimestamp.timeIntervalSince1970, accuracy: 0.001)
         XCTAssertNil(importedRecord.audioFileName)
@@ -674,7 +674,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         )
 
         XCTAssertEqual(result.historyImported, 0)
-        XCTAssertTrue(destination.historyService.records.isEmpty)
+        XCTAssertTrue(destination.historyService.recentRecords.isEmpty)
         XCTAssertFalse(destination.usageStatisticsService.hasAnyStatistics)
     }
 
@@ -723,7 +723,7 @@ final class SettingsBackupExporterTests: XCTestCase {
 
         XCTAssertEqual(result.historyImported, 1)
         XCTAssertEqual(result.historySkippedByRetention, 1)
-        XCTAssertEqual(destination.historyService.records.first?.finalText, "recent")
+        XCTAssertEqual(destination.historyService.recentRecords.first?.finalText, "recent")
     }
 
     func testProfileImportAppendsRatherThanReusingSourcePriority() async throws {

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -79,7 +79,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         fixture.promptActionService.addPreset(PromptAction.presets[0])
         fixture.promptActionService.addAction(name: "Custom", prompt: "Do the thing")
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: fixture.workflowService,
             dictionaryService: fixture.dictionaryService,
             snippetService: fixture.snippetService,
@@ -103,7 +103,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             makeLoadedPlugin(id: "com.typewhisper.community", name: "Community", version: "2.1.0", isEnabled: false, bundled: false),
         ]
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: fixture.workflowService,
             dictionaryService: fixture.dictionaryService,
             snippetService: fixture.snippetService,
@@ -134,7 +134,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.dictionaryService.addEntry(type: .correction, original: "teh", replacement: "the")
         source.snippetService.addSnippet(trigger: ";sig", replacement: "Best, Alex")
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -183,7 +183,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             promptActionId: action.id.uuidString
         )
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -227,7 +227,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         let hotkey = UnifiedHotkey(keyCode: 8, modifierFlags: 0x100, isFn: false)
         source.userDefaults.set(try JSONEncoder().encode([hotkey]), forKey: UserDefaultsKeys.toggleHotkeys)
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -295,7 +295,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             makeLoadedPlugin(id: "com.typewhisper.gone", name: "Gone Plugin", version: "1.0.0", isEnabled: true, bundled: false),
         ]
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -340,7 +340,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             makeLoadedPlugin(id: "com.typewhisper.already", name: "Already Installed", version: "1.0.0", isEnabled: true, bundled: false),
         ]
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -393,7 +393,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             pipelineSteps: ["dictionary", "formatting"]
         )
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -456,7 +456,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         // Deliberately excluded: engine/model selections must not be exported.
         source.userDefaults.set("com.typewhisper.some-engine", forKey: UserDefaultsKeys.fileTranscriptionEngine)
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -531,7 +531,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             ]
         )
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -554,7 +554,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.userDefaults.set(AppConstants.ReleaseChannel.daily.rawValue, forKey: UserDefaultsKeys.updateChannel)
         source.userDefaults.set("de", forKey: UserDefaultsKeys.selectedLanguage)
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -587,7 +587,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         source.snippetService.addSnippet(trigger: ";sig", replacement: "Best, Alex")
         source.userDefaults.set(AppConstants.ReleaseChannel.daily.rawValue, forKey: UserDefaultsKeys.updateChannel)
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -731,7 +731,7 @@ final class SettingsBackupExporterTests: XCTestCase {
         defer { teardown(source) }
         source.profileService.addProfile(name: "Slack", bundleIdentifiers: ["com.tinyspeck.slackmacgap"], priority: 0)
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,
@@ -786,7 +786,7 @@ final class SettingsBackupExporterTests: XCTestCase {
             promptActionId: action.id.uuidString
         )
 
-        let backup = SettingsBackupExporter.buildBackup(
+        let backup = try SettingsBackupExporter.buildBackup(
             workflowService: source.workflowService,
             dictionaryService: source.dictionaryService,
             snippetService: source.snippetService,

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -1873,6 +1873,17 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 language: "en",
                 engineUsed: "parakeet"
             )
+            for index in 1..<25 {
+                context.historyService.addRecord(
+                    rawText: "History entry \(index)",
+                    finalText: "History entry \(index)",
+                    appName: "Notes",
+                    appBundleIdentifier: "com.apple.Notes",
+                    durationSeconds: 1,
+                    language: "en",
+                    engineUsed: "parakeet"
+                )
+            }
             context.profileService.addProfile(
                 name: "Legacy Docs",
                 urlPatterns: ["docs.github.com"],
@@ -1899,6 +1910,24 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         let history = try Self.jsonObject(
             await router.route(HTTPRequest(method: "GET", path: "/v1/history", queryParams: [:], headers: [:], body: Data()))
         )
+        let historyPage = try Self.jsonObject(
+            await router.route(HTTPRequest(
+                method: "GET",
+                path: "/v1/history",
+                queryParams: ["limit": "5", "offset": "20"],
+                headers: [:],
+                body: Data()
+            ))
+        )
+        let historySearch = try Self.jsonObject(
+            await router.route(HTTPRequest(
+                method: "GET",
+                path: "/v1/history",
+                queryParams: ["q": "Sprint planning"],
+                headers: [:],
+                body: Data()
+            ))
+        )
         let rules = try Self.jsonObject(
             await router.route(HTTPRequest(method: "GET", path: "/v1/rules", queryParams: [:], headers: [:], body: Data()))
         )
@@ -1909,7 +1938,13 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(status["status"] as? String, "no_model")
         XCTAssertEqual(status["api_version"] as? String, "1.2")
         XCTAssertEqual(status["supports_workflow_dictation"] as? Bool, true)
-        XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual((history["entries"] as? [[String: Any]])?.count, 25)
+        XCTAssertEqual(history["total"] as? Int, 25)
+        XCTAssertEqual((historyPage["entries"] as? [[String: Any]])?.count, 5)
+        XCTAssertEqual(historyPage["total"] as? Int, 25)
+        XCTAssertEqual(historyPage["offset"] as? Int, 20)
+        XCTAssertEqual((historySearch["entries"] as? [[String: Any]])?.count, 1)
+        XCTAssertEqual(historySearch["total"] as? Int, 1)
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["name"] as? String, "Docs")
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_mode"] as? String, "multiple")
         XCTAssertEqual((rules["rules"] as? [[String: Any]])?.first?["language_hints"] as? [String], ["de", "en"])
@@ -3955,7 +3990,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(transcription["app_bundle_id"] as? String, "com.apple.Notes")
         XCTAssertEqual(transcription["words_count"] as? Int, 1)
 
-        let recordID = await MainActor.run { apiContext.historyService.records.first?.id.uuidString }
+        let recordID = await MainActor.run { apiContext.historyService.recentRecords.first?.id.uuidString }
         XCTAssertEqual(recordID, startID)
         XCTAssertEqual(workflowPlugin.restoredModelId, "beta")
         XCTAssertEqual(workflowPlugin.transcribedModelId, "beta")
@@ -4622,7 +4657,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(otherValue, "Other")
         XCTAssertEqual(activationCount, 1)
         XCTAssertEqual(focusCount, 1)
-        XCTAssertEqual(context.historyService.records.first?.appBundleIdentifier, "com.apple.Notes")
+        XCTAssertEqual(context.historyService.recentRecords.first?.appBundleIdentifier, "com.apple.Notes")
     }
 
     @MainActor
@@ -4743,7 +4778,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(activationCount, 1)
         XCTAssertEqual(observationBeginCount, 1)
         XCTAssertEqual(
-            context.historyService.records.first?.appBundleIdentifier,
+            context.historyService.recentRecords.first?.appBundleIdentifier,
             "com.microsoft.VSCode"
         )
     }
@@ -6606,9 +6641,9 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(session.status, .completed)
         XCTAssertEqual(pasteboard.string(forType: .string), "transcribed")
         XCTAssertEqual(session.transcription?.text, "transcribed")
-        XCTAssertEqual(context.historyService.records.first?.finalText, "transcribed")
+        XCTAssertEqual(context.historyService.recentRecords.first?.finalText, "transcribed")
         XCTAssertEqual(
-            context.recentTranscriptionStore.latestEntry(historyRecords: context.historyService.records)?.finalText,
+            context.recentTranscriptionStore.latestEntry(historyRecords: context.historyService.recentRecords)?.finalText,
             "transcribed"
         )
     }
@@ -6856,7 +6891,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(session.status, .completed)
         XCTAssertEqual(pasteboard.string(forType: .string), " strong ")
         XCTAssertEqual(session.transcription?.text, "Strong.")
-        XCTAssertEqual(context.historyService.records.first?.finalText, "Strong.")
+        XCTAssertEqual(context.historyService.recentRecords.first?.finalText, "Strong.")
     }
 
     @MainActor

--- a/TypeWhisperTests/UsageStatisticsServiceTests.swift
+++ b/TypeWhisperTests/UsageStatisticsServiceTests.swift
@@ -55,8 +55,8 @@ final class UsageStatisticsServiceTests: XCTestCase {
         )
 
         let service = UsageStatisticsService(appSupportDirectory: directory)
-        service.backfillFromHistoryIfNeeded(historyService.records)
-        service.backfillFromHistoryIfNeeded(historyService.records)
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
 
         var summary = service.summary(from: nil)
         XCTAssertEqual(summary.transcriptionCount, 2)
@@ -64,7 +64,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
         XCTAssertEqual(summary.appCount, 2)
 
         service.clearUsageStatistics()
-        service.backfillFromHistoryIfNeeded(historyService.records)
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
 
         summary = service.summary(from: nil)
         XCTAssertEqual(summary.transcriptionCount, 0)
@@ -94,7 +94,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
             engineUsed: "parakeet",
             modelUsed: "parakeet-fast"
         )
-        let recordHour = calendar.component(.hour, from: historyService.records[0].timestamp)
+        let recordHour = calendar.component(.hour, from: historyService.recentRecords[0].timestamp)
 
         do {
             // Simulate a pre-existing installation: totals already backfilled from history
@@ -118,7 +118,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
         }
 
         let service = UsageStatisticsService(appSupportDirectory: directory, calendar: calendar)
-        service.backfillFromHistoryIfNeeded(historyService.records)
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
 
         let summary = service.summary(from: today)
         XCTAssertEqual(summary.transcriptionCount, 1, "Totals must not be double-counted by the detail backfill")
@@ -130,7 +130,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
         XCTAssertEqual(snapshot.hourCounts[recordHour], 1)
 
         // Running it again must stay idempotent.
-        service.backfillFromHistoryIfNeeded(historyService.records)
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
         let secondSnapshot = try XCTUnwrap(service.dailyWordCounts(days: 1).first)
         XCTAssertEqual(secondSnapshot.appCounts, [UsageStatisticsKeys.appKey(bundleIdentifier: "com.example.editor", appName: "Editor"): 1])
     }
@@ -187,7 +187,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
             historyService: historyService,
             usageStatisticsService: usageStatisticsService
         )
-        let widgetData = widgetDataService.buildWidgetData(records: historyService.records, now: now)
+        let widgetData = widgetDataService.buildWidgetData(records: historyService.recentRecords, now: now)
 
         XCTAssertEqual(widgetData.stats.wordsToday, 120)
         XCTAssertEqual(widgetData.stats.wordsThisWeek, 120)
@@ -284,7 +284,7 @@ final class UsageStatisticsServiceTests: XCTestCase {
         let viewModel = StatisticsViewModel(usageStatisticsService: usageStatisticsService)
         viewModel.refresh()
 
-        XCTAssertTrue(historyService.records.isEmpty)
+        XCTAssertTrue(historyService.recentRecords.isEmpty)
         XCTAssertTrue(viewModel.hasAnyData)
         XCTAssertEqual(viewModel.totalTranscriptions, 1)
         XCTAssertEqual(viewModel.totalDaysActive, 1)

--- a/TypeWhisperTests/UsageStatisticsServiceTests.swift
+++ b/TypeWhisperTests/UsageStatisticsServiceTests.swift
@@ -71,6 +71,33 @@ final class UsageStatisticsServiceTests: XCTestCase {
         XCTAssertEqual(summary.words, 0)
     }
 
+    @MainActor
+    func testHistoryBackfillProviderFailureDoesNotMarkMigrationComplete() throws {
+        enum TestError: Error { case historyUnavailable }
+
+        let directory = try TestSupport.makeTemporaryDirectory(prefix: "UsageStatisticsProvider")
+        defer { TestSupport.remove(directory) }
+
+        let historyService = HistoryService(appSupportDirectory: directory)
+        historyService.addRecord(
+            rawText: "Alpha beta gamma",
+            finalText: "Alpha beta gamma",
+            appName: "Editor",
+            appBundleIdentifier: "com.example.editor",
+            durationSeconds: 30,
+            language: "en",
+            engineUsed: "parakeet"
+        )
+        let service = UsageStatisticsService(appSupportDirectory: directory)
+
+        service.backfillFromHistoryIfNeeded(recordsProvider: {
+            throw TestError.historyUnavailable
+        })
+        service.backfillFromHistoryIfNeeded(historyService.recentRecords)
+
+        XCTAssertEqual(service.summary(from: nil).transcriptionCount, 1)
+    }
+
     /// Installations that already completed the totals-only backfill (before app/model/hour
     /// breakdowns existed) must have those breakdowns filled in from history on next launch,
     /// without re-adding to the already-migrated totals.


### PR DESCRIPTION
## Context

Issue #1268 identified that History eagerly loaded and retained the complete transcription archive, causing unnecessary launch latency and memory growth for large databases. Usage-statistics aggregation is intentionally tracked separately in #1269.

Closes #1268

## What changed

- keep only a bounded 20-record recent-history cache for lightweight consumers
- fetch History in 100-record pages and append pages with endless scrolling
- paginate filtered and searched results while preserving the existing filter semantics
- calculate sidebar facets in batches without retaining the entire archive
- move full-history consumers to explicit store-backed queries so backup, sync, retention, statistics backfill, and the local API remain complete
- cover pagination, large-history lookup, filters, retention, sync, API behavior, and view-model cache release

## Test plan

- [x] `xcodebuild build -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- [x] `xcodebuild build-for-testing -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
- [x] 15 `HistoryServiceTests` passed through the direct `xctest` fallback
- [x] 32 adjacent backup, statistics, recent-history, sync, and HTTP API tests passed through the direct `xctest` fallback
- [x] After review fixes, repeated `build-for-testing` and ran 39 affected tests: 15 History, 16 backup, and 8 usage-statistics tests

The standard local `xcodebuild test` runner stalled before test execution while materializing workers. The already-built test bundle was therefore run directly; all selected tests passed.
