### PR TITLE
Surface saved recovery actions after failed dictations

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -18676,6 +18676,28 @@
         }
       }
     },
+    "Open Recovery" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wiederherstellung öffnen"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "音声入力の復元を開く"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开听写恢复"
+          }
+        }
+      }
+    },
     "Open Setup Wizard" : {
       "localizations" : {
         "ja" : {
@@ -29203,6 +29225,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "专用同步文件夹已删除。本地数据已保留。"
+          }
+        }
+      }
+    },
+    "The recording was saved to Dictation Recovery." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Die Aufnahme wurde in der Diktat-Wiederherstellung gespeichert."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "録音は「音声入力の復元」に保存されました。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "录音已保存到“听写恢复”。"
           }
         }
       }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -2501,9 +2501,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     func preserveActiveRecoveryRecording() -> URL? {
-        let url = recoveryAudioStore.preserveActiveRecording()
+        preserveActiveRecoveryRecordingResult().latestRecoveryURL
+    }
+
+    func preserveActiveRecoveryRecordingResult() -> DictationRecoveryPreservationResult {
+        let result = recoveryAudioStore.preserveActiveRecordingResult()
         publishRecoverableRecordingURLs(recoveryAudioStore.recoveryURLs)
-        return url
+        return result
     }
 
     func discardActiveRecoveryRecording() {

--- a/TypeWhisper/Services/DictationRecoveryAudioStore.swift
+++ b/TypeWhisper/Services/DictationRecoveryAudioStore.swift
@@ -30,6 +30,11 @@ enum DictationRecoveryRetentionPolicy: Int, CaseIterable, Sendable {
     }
 }
 
+struct DictationRecoveryPreservationResult: Equatable, Sendable {
+    let latestRecoveryURL: URL?
+    let newlyPreservedURL: URL?
+}
+
 /// Persists the active dictation as a temporary 16 kHz mono PCM WAV so the
 /// audio can be recovered if transcription fails after recording has stopped.
 final class DictationRecoveryAudioStore: @unchecked Sendable {
@@ -147,6 +152,10 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
 
     @discardableResult
     func preserveActiveRecording() -> URL? {
+        preserveActiveRecordingResult().latestRecoveryURL
+    }
+
+    func preserveActiveRecordingResult() -> DictationRecoveryPreservationResult {
         queue.sync {
             guard retentionPolicy.keepsRecoveryFiles else {
                 closeActiveHandle()
@@ -154,11 +163,17 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
                 hasActiveRecording = false
                 removeItemIfExists(at: activeFileURL)
                 removeStoredRecoveries()
-                return nil
+                return DictationRecoveryPreservationResult(
+                    latestRecoveryURL: nil,
+                    newlyPreservedURL: nil
+                )
             }
 
             guard hasActiveRecording else {
-                return storedRecoveryURLs().first
+                return DictationRecoveryPreservationResult(
+                    latestRecoveryURL: storedRecoveryURLs().first,
+                    newlyPreservedURL: nil
+                )
             }
 
             closeActiveHandle()
@@ -167,7 +182,10 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
             guard activeSampleCount > 0 else {
                 activeSampleCount = 0
                 removeItemIfExists(at: activeFileURL)
-                return storedRecoveryURLs().first
+                return DictationRecoveryPreservationResult(
+                    latestRecoveryURL: storedRecoveryURLs().first,
+                    newlyPreservedURL: nil
+                )
             }
 
             finalizeActiveWavHeader(sampleCount: activeSampleCount)
@@ -176,11 +194,18 @@ final class DictationRecoveryAudioStore: @unchecked Sendable {
             do {
                 try fileManager.moveItem(at: activeFileURL, to: recoveryURL)
                 activeSampleCount = 0
-                return canonicalFileURL(recoveryURL)
+                let canonicalRecoveryURL = canonicalFileURL(recoveryURL)
+                return DictationRecoveryPreservationResult(
+                    latestRecoveryURL: canonicalRecoveryURL,
+                    newlyPreservedURL: canonicalRecoveryURL
+                )
             } catch {
                 activeSampleCount = 0
                 removeItemIfExists(at: activeFileURL)
-                return storedRecoveryURLs().first
+                return DictationRecoveryPreservationResult(
+                    latestRecoveryURL: storedRecoveryURLs().first,
+                    newlyPreservedURL: nil
+                )
             }
         }
     }

--- a/TypeWhisper/Services/IndicatorCoordinator.swift
+++ b/TypeWhisper/Services/IndicatorCoordinator.swift
@@ -200,7 +200,7 @@ struct IndicatorPresentationData {
     let actionFeedbackMessage: String?
     let actionFeedbackIcon: String?
     let actionFeedbackIsError: Bool
-    let actionFeedbackUndoTitle: String?
+    let actionFeedbackActionTitle: String?
     let actionFeedbackRemainingFraction: Double?
     let actionFeedbackIsPaused: Bool
     let externalStreamingDisplayCount: Int
@@ -245,7 +245,7 @@ struct IndicatorPresentationData {
                 actionFeedbackMessage: dictation.actionFeedbackMessage,
                 actionFeedbackIcon: dictation.actionFeedbackIcon,
                 actionFeedbackIsError: dictation.actionFeedbackIsError,
-                actionFeedbackUndoTitle: dictation.actionFeedbackUndoTitle,
+                actionFeedbackActionTitle: dictation.actionFeedbackActionTitle,
                 actionFeedbackRemainingFraction: presentation.state == .inserting
                     && dictation.actionFeedbackMessage != nil
                     ? dictation.actionFeedbackRemainingFraction
@@ -268,7 +268,7 @@ struct IndicatorPresentationData {
                 actionFeedbackMessage: nil,
                 actionFeedbackIcon: nil,
                 actionFeedbackIsError: false,
-                actionFeedbackUndoTitle: nil,
+                actionFeedbackActionTitle: nil,
                 actionFeedbackRemainingFraction: nil,
                 actionFeedbackIsPaused: false,
                 externalStreamingDisplayCount: dictation.externalStreamingDisplayCount

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -174,6 +174,20 @@ final class DictationViewModel: ObservableObject {
         case processing
     }
 
+    private enum ActionFeedbackAction {
+        case undoLearnedCorrections([LearnedDictionaryCorrection])
+        case openDictationRecovery
+
+        var title: String {
+            switch self {
+            case .undoLearnedCorrections:
+                String(localized: "Undo")
+            case .openDictationRecovery:
+                String(localized: "Open Recovery")
+            }
+        }
+    }
+
     private struct PendingHotkeyDictationStart {
         let forcedWorkflowId: UUID?
         let requestUptimeNanoseconds: UInt64
@@ -262,12 +276,13 @@ final class DictationViewModel: ObservableObject {
     @Published var actionFeedbackMessage: String?
     @Published var actionFeedbackIcon: String?
     @Published var actionFeedbackIsError: Bool = false
-    @Published var actionFeedbackUndoTitle: String?
+    @Published private(set) var actionFeedbackActionTitle: String?
     @Published private(set) var actionFeedbackRemainingFraction: Double = 0
     @Published private(set) var actionFeedbackIsPaused = false
     @Published var activeAppIcon: NSImage?
     private var actionDisplayDuration: TimeInterval = 3.5
     private let indicatorFeedbackLifetime = IndicatorFeedbackLifetime()
+    private var actionFeedbackAction: ActionFeedbackAction?
 
     @Published var indicatorStyle: IndicatorStyle {
         didSet { Self.persistIndicatorStyle(indicatorStyle) }
@@ -339,7 +354,6 @@ final class DictationViewModel: ObservableObject {
     private var stopFinalizationTask: Task<Void, Never>?
     private var targetAppCorrectionLearningTask: Task<Void, Never>?
     private var targetAppAccessibilityObservationLease: TargetAppAccessibilityObservationLease?
-    private var pendingLearnedCorrections: [LearnedDictionaryCorrection] = []
     private var errorResetTask: Task<Void, Never>?
     private var insertingResetTask: Task<Void, Never>?
     private var pendingHotkeyStartTask: Task<Void, Never>?
@@ -1235,7 +1249,7 @@ final class DictationViewModel: ObservableObject {
         transcriptionTask?.cancel()
         transcriptionTask = nil
         cancelTargetAppCorrectionLearning()
-        clearPendingUndoActionFeedback()
+        clearActionFeedbackAction()
         insertingResetTask?.cancel()
         insertingResetTask = nil
         indicatorFeedbackLifetime.cancel()
@@ -1905,15 +1919,17 @@ final class DictationViewModel: ObservableObject {
                 guard !text.isEmpty else {
                     handleLiveFieldTranscriptionFailure(stablePreviewText: previewText)
                     logger.info("Transcription returned empty text (duration: \(String(format: "%.2f", result.duration))s, engine: \(result.engineUsed))")
-                    audioRecordingService.preserveActiveRecoveryRecording()
+                    let recoveryPreservation = audioRecordingService
+                        .preserveActiveRecoveryRecordingResult()
                     let errorMessage = String(localized: "No speech recognized")
                     if let sessionID {
                         failDictationSession(id: sessionID, error: errorMessage)
                     }
-                    showNotchFeedback(
+                    showRecoveryAwareFeedback(
                         message: errorMessage,
                         icon: "text.magnifyingglass",
-                        duration: 2.0
+                        duration: 2.0,
+                        recoveryPreservation: recoveryPreservation
                     )
                     soundService.play(.error, enabled: soundFeedbackEnabled)
                     return
@@ -2236,7 +2252,8 @@ final class DictationViewModel: ObservableObject {
             } catch {
                 guard !Task.isCancelled else { return }
                 handleLiveFieldTranscriptionFailure(stablePreviewText: previewText)
-                audioRecordingService.preserveActiveRecoveryRecording()
+                let recoveryPreservation = audioRecordingService
+                    .preserveActiveRecoveryRecordingResult()
                 EventBus.shared.emit(.transcriptionFailed(TranscriptionFailedPayload(
                     error: error.localizedDescription,
                     appName: capturedActiveApp?.name,
@@ -2246,7 +2263,11 @@ final class DictationViewModel: ObservableObject {
                     failDictationSession(id: sessionID, error: error.localizedDescription)
                 }
                 accessibilityAnnouncementService.announceError(error.localizedDescription)
-                showError(error.localizedDescription, category: "transcription")
+                showError(
+                    error.localizedDescription,
+                    category: "transcription",
+                    recoveryPreservation: recoveryPreservation
+                )
                 clearActiveRuleState()
                 capturedActiveApp = nil
                 activeAppIcon = nil
@@ -2448,7 +2469,7 @@ final class DictationViewModel: ObservableObject {
         actionFeedbackMessage = nil
         actionFeedbackIcon = nil
         actionFeedbackIsError = false
-        clearPendingUndoActionFeedback()
+        clearActionFeedbackAction()
         actionDisplayDuration = 3.5
 
         guard pendingHotkeyDictationStart != nil else { return }
@@ -3089,15 +3110,14 @@ final class DictationViewModel: ObservableObject {
         targetAppAccessibilityObservationLease = nil
     }
 
-    private func clearPendingUndoActionFeedback() {
-        actionFeedbackUndoTitle = nil
-        pendingLearnedCorrections = []
+    private func clearActionFeedbackAction() {
+        actionFeedbackActionTitle = nil
+        actionFeedbackAction = nil
     }
 
     private func showLearnedCorrectionsFeedback(_ learned: [LearnedDictionaryCorrection]) {
         guard !learned.isEmpty else { return }
 
-        pendingLearnedCorrections = learned
         let message: String
         if learned.count == 1, let correction = learned.first {
             message = String.localizedStringWithFormat(
@@ -3116,19 +3136,24 @@ final class DictationViewModel: ObservableObject {
             message: message,
             icon: "wand.and.sparkles",
             duration: 12.0,
-            undoTitle: String(localized: "Undo")
+            action: .undoLearnedCorrections(learned)
         )
     }
 
-    func undoActionFeedback() {
-        guard !pendingLearnedCorrections.isEmpty else { return }
-        dictionaryService.undoLearnedCorrections(pendingLearnedCorrections)
-        pendingLearnedCorrections = []
-        showNotchFeedback(
-            message: String(localized: "Correction learning undone"),
-            icon: "arrow.uturn.backward.circle.fill",
-            duration: 2.5
-        )
+    func performActionFeedbackAction(openRecoverySettingsWindow: Bool = true) {
+        guard let actionFeedbackAction else { return }
+
+        switch actionFeedbackAction {
+        case .undoLearnedCorrections(let learnedCorrections):
+            dictionaryService.undoLearnedCorrections(learnedCorrections)
+            showNotchFeedback(
+                message: String(localized: "Correction learning undone"),
+                icon: "arrow.uturn.backward.circle.fill",
+                duration: 2.5
+            )
+        case .openDictationRecovery:
+            recoverLastRecording(openSettingsWindow: openRecoverySettingsWindow)
+        }
     }
 
     private func showNotchFeedback(
@@ -3137,16 +3162,14 @@ final class DictationViewModel: ObservableObject {
         duration: TimeInterval = 2.5,
         isError: Bool = false,
         errorCategory: String = "general",
-        undoTitle: String? = nil
+        action: ActionFeedbackAction? = nil
     ) {
         actionFeedbackMessage = message
         actionFeedbackIcon = icon
         actionFeedbackIsError = isError
-        if undoTitle == nil {
-            clearPendingUndoActionFeedback()
-        } else {
-            actionFeedbackUndoTitle = undoTitle
-        }
+        clearActionFeedbackAction()
+        actionFeedbackAction = action
+        actionFeedbackActionTitle = action?.title
         actionDisplayDuration = duration
         state = .inserting
 
@@ -3195,9 +3218,60 @@ final class DictationViewModel: ObservableObject {
         externalStreamingDisplayCount += active ? 1 : -1
     }
 
-    private func showError(_ message: String, category: String = "general") {
+    private func showRecoveryAwareFeedback(
+        message: String,
+        icon: String,
+        duration: TimeInterval,
+        isError: Bool = false,
+        errorCategory: String = "general",
+        recoveryPreservation: DictationRecoveryPreservationResult
+    ) {
+        guard recoveryPreservation.newlyPreservedURL != nil else {
+            showNotchFeedback(
+                message: message,
+                icon: icon,
+                duration: duration,
+                isError: isError,
+                errorCategory: errorCategory
+            )
+            return
+        }
+
+        let recoveryMessage = String(localized: "The recording was saved to Dictation Recovery.")
+        showNotchFeedback(
+            message: "\(message)\n\(recoveryMessage)",
+            icon: icon,
+            duration: 12.0,
+            isError: isError,
+            errorCategory: errorCategory,
+            action: .openDictationRecovery
+        )
+    }
+
+    private func showError(
+        _ message: String,
+        category: String = "general",
+        recoveryPreservation: DictationRecoveryPreservationResult? = nil
+    ) {
         soundService.play(.error, enabled: soundFeedbackEnabled)
-        showNotchFeedback(message: message, icon: "xmark.circle.fill", duration: 3.0, isError: true, errorCategory: category)
+        if let recoveryPreservation {
+            showRecoveryAwareFeedback(
+                message: message,
+                icon: "xmark.circle.fill",
+                duration: 3.0,
+                isError: true,
+                errorCategory: category,
+                recoveryPreservation: recoveryPreservation
+            )
+        } else {
+            showNotchFeedback(
+                message: message,
+                icon: "xmark.circle.fill",
+                duration: 3.0,
+                isError: true,
+                errorCategory: category
+            )
+        }
     }
 
     private func startRecordingTimer() {

--- a/TypeWhisper/Views/MinimalIndicatorView.swift
+++ b/TypeWhisper/Views/MinimalIndicatorView.swift
@@ -135,7 +135,7 @@ struct MinimalIndicatorView: View {
             }
             .accessibilityElement(
                 children: countdownPresentation != nil
-                    || presentation.actionFeedbackUndoTitle != nil ? .contain : .combine
+                    || presentation.actionFeedbackActionTitle != nil ? .contain : .combine
             )
             .accessibilityLabel(accessibilityLabel)
         }
@@ -195,9 +195,9 @@ struct MinimalIndicatorView: View {
                     text: message,
                     icon: presentation.actionFeedbackIcon ?? (presentation.actionFeedbackIsError ? "xmark.circle.fill" : "checkmark.circle.fill"),
                     iconColor: presentation.actionFeedbackIsError ? .red : .green,
-                    actionTitle: presentation.actionFeedbackUndoTitle,
-                    onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
-                        viewModel.undoActionFeedback()
+                    actionTitle: presentation.actionFeedbackActionTitle,
+                    onAction: presentation.actionFeedbackActionTitle == nil ? nil : {
+                        viewModel.performActionFeedbackAction()
                     }
                 )
                 .padding(.horizontal, 14)

--- a/TypeWhisper/Views/NotchIndicatorView.swift
+++ b/TypeWhisper/Views/NotchIndicatorView.swift
@@ -226,7 +226,7 @@ struct NotchIndicatorView: View {
         .animation(.easeInOut(duration: 1.0), value: dotPulse)
         .accessibilityElement(
             children: countdownPresentation != nil
-                || presentation.actionFeedbackUndoTitle != nil ? .contain : .combine
+                || presentation.actionFeedbackActionTitle != nil ? .contain : .combine
         )
         .accessibilityLabel(notchAccessibilityLabel)
     }
@@ -313,9 +313,9 @@ struct NotchIndicatorView: View {
                 isError: presentation.actionFeedbackIsError,
                 iconColor: nil,
                 contentPadding: contentPadding,
-                actionTitle: presentation.actionFeedbackUndoTitle,
-                onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
-                    viewModel.undoActionFeedback()
+                actionTitle: presentation.actionFeedbackActionTitle,
+                onAction: presentation.actionFeedbackActionTitle == nil ? nil : {
+                    viewModel.performActionFeedbackAction()
                 },
                 remainingFraction: presentation.actionFeedbackRemainingFraction
             )

--- a/TypeWhisper/Views/OverlayIndicatorView.swift
+++ b/TypeWhisper/Views/OverlayIndicatorView.swift
@@ -205,7 +205,7 @@ struct OverlayIndicatorView: View {
         .animation(.easeInOut(duration: 1.0), value: dotPulse)
         .accessibilityElement(
             children: countdownPresentation != nil
-                || presentation.actionFeedbackUndoTitle != nil ? .contain : .combine
+                || presentation.actionFeedbackActionTitle != nil ? .contain : .combine
         )
         .accessibilityLabel(accessibilityLabel)
     }
@@ -276,9 +276,9 @@ struct OverlayIndicatorView: View {
                     isError: presentation.actionFeedbackIsError,
                     iconColor: nil,
                     contentPadding: contentPadding,
-                    actionTitle: presentation.actionFeedbackUndoTitle,
-                    onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
-                        viewModel.undoActionFeedback()
+                    actionTitle: presentation.actionFeedbackActionTitle,
+                    onAction: presentation.actionFeedbackActionTitle == nil ? nil : {
+                        viewModel.performActionFeedbackAction()
                     },
                     remainingFraction: presentation.actionFeedbackRemainingFraction
                 )
@@ -295,9 +295,9 @@ struct OverlayIndicatorView: View {
                     isError: presentation.actionFeedbackIsError,
                     iconColor: nil,
                     contentPadding: contentPadding,
-                    actionTitle: presentation.actionFeedbackUndoTitle,
-                    onAction: presentation.actionFeedbackUndoTitle == nil ? nil : {
-                        viewModel.undoActionFeedback()
+                    actionTitle: presentation.actionFeedbackActionTitle,
+                    onAction: presentation.actionFeedbackActionTitle == nil ? nil : {
+                        viewModel.performActionFeedbackAction()
                     },
                     remainingFraction: presentation.actionFeedbackRemainingFraction
                 )

--- a/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
+++ b/TypeWhisperTests/DictationRecoveryAudioStoreTests.swift
@@ -62,6 +62,29 @@ final class DictationRecoveryAudioStoreTests: XCTestCase {
         XCTAssertTrue(try fileNames(in: directory).contains(existingRecovery.lastPathComponent))
     }
 
+    func testPreservationResultOnlyMarksANewlyCreatedRecovery() throws {
+        let directory = makeTemporaryDirectory()
+        let store = DictationRecoveryAudioStore(directory: directory)
+
+        store.startNewRecording()
+        store.append([0.1])
+        let firstResult = store.preserveActiveRecordingResult()
+        let existingRecovery = try XCTUnwrap(firstResult.newlyPreservedURL)
+
+        XCTAssertEqual(firstResult.latestRecoveryURL, existingRecovery)
+
+        let noActiveRecordingResult = store.preserveActiveRecordingResult()
+
+        XCTAssertEqual(noActiveRecordingResult.latestRecoveryURL, existingRecovery)
+        XCTAssertNil(noActiveRecordingResult.newlyPreservedURL)
+
+        store.startNewRecording()
+        let emptyRecordingResult = store.preserveActiveRecordingResult()
+
+        XCTAssertEqual(emptyRecordingResult.latestRecoveryURL, existingRecovery)
+        XCTAssertNil(emptyRecordingResult.newlyPreservedURL)
+    }
+
     func testDiscardActiveKeepsStoredRecoveriesAndDiscardRecoveryDeletesSelectedFile() throws {
         let directory = makeTemporaryDirectory()
         let store = DictationRecoveryAudioStore(directory: directory)

--- a/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
+++ b/TypeWhisperTests/DictationViewModelIndicatorSettingsTests.swift
@@ -1070,7 +1070,7 @@ final class IndicatorPresentationStateTests: XCTestCase {
             actionFeedbackMessage: nil,
             actionFeedbackIcon: nil,
             actionFeedbackIsError: false,
-            actionFeedbackUndoTitle: nil,
+            actionFeedbackActionTitle: nil,
             actionFeedbackRemainingFraction: nil,
             actionFeedbackIsPaused: false,
             externalStreamingDisplayCount: 0
@@ -1095,7 +1095,7 @@ final class IndicatorPresentationStateTests: XCTestCase {
             actionFeedbackMessage: "Saved",
             actionFeedbackIcon: "checkmark.circle.fill",
             actionFeedbackIsError: false,
-            actionFeedbackUndoTitle: "Undo",
+            actionFeedbackActionTitle: "Undo",
             actionFeedbackRemainingFraction: remainingFraction,
             actionFeedbackIsPaused: isPaused,
             externalStreamingDisplayCount: 0

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -785,6 +785,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         nonisolated(unsafe) private static var _lastPrompt: String?
         nonisolated(unsafe) private static var _lastLanguageSelection = PluginLanguageSelection()
         nonisolated(unsafe) private static var _responseText = "transcribed"
+        nonisolated(unsafe) private static var _failureMessage: String?
         nonisolated(unsafe) private static var _transcribeCallCount = 0
 
         static var lastPrompt: String? {
@@ -804,6 +805,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 _lastPrompt = nil
                 _lastLanguageSelection = PluginLanguageSelection()
                 _responseText = "transcribed"
+                _failureMessage = nil
                 _transcribeCallCount = 0
             }
         }
@@ -811,6 +813,12 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         static func setResponseText(_ text: String) {
             promptLock.withLock {
                 _responseText = text
+            }
+        }
+
+        static func setFailureMessage(_ message: String) {
+            promptLock.withLock {
+                _failureMessage = message
             }
         }
 
@@ -831,12 +839,16 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         var supportedLanguages: [String] { languages }
 
         func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
-            Self.promptLock.withLock {
+            let result = Self.promptLock.withLock {
                 Self._lastPrompt = prompt
                 Self._lastLanguageSelection = PluginLanguageSelection(requestedLanguage: language)
                 Self._transcribeCallCount += 1
+                return (text: Self._responseText, failureMessage: Self._failureMessage)
             }
-            return PluginTranscriptionResult(text: Self.promptLock.withLock { Self._responseText }, detectedLanguage: language)
+            if let failureMessage = result.failureMessage {
+                throw PluginTranscriptionError.apiError(failureMessage)
+            }
+            return PluginTranscriptionResult(text: result.text, detectedLanguage: language)
         }
 
         func transcribe(
@@ -845,13 +857,17 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             translate: Bool,
             prompt: String?
         ) async throws -> PluginTranscriptionResult {
-            Self.promptLock.withLock {
+            let result = Self.promptLock.withLock {
                 Self._lastPrompt = prompt
                 Self._lastLanguageSelection = languageSelection
                 Self._transcribeCallCount += 1
+                return (text: Self._responseText, failureMessage: Self._failureMessage)
+            }
+            if let failureMessage = result.failureMessage {
+                throw PluginTranscriptionError.apiError(failureMessage)
             }
             return PluginTranscriptionResult(
-                text: Self.promptLock.withLock { Self._responseText },
+                text: result.text,
                 detectedLanguage: languageSelection.requestedLanguage ?? languageSelection.languageHints.first
             )
         }
@@ -8303,6 +8319,179 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         XCTAssertEqual(context.dictationViewModel.state, .inserting)
         XCTAssertTrue(context.ttsProvider.recordedRequests.isEmpty)
+    }
+
+    @MainActor
+    func testFailedTranscriptionSurfacesNewRecoveryAndOpenAction() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let recoveryStore = DictationRecoveryAudioStore(
+            directory: appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true),
+            retentionPolicy: .never
+        )
+        let previousSettingsNavigationCoordinator = SettingsNavigationCoordinator.shared
+        let navigationCoordinator = SettingsNavigationCoordinator()
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            SettingsNavigationCoordinator.shared = previousSettingsNavigationCoordinator
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        SettingsNavigationCoordinator.shared = navigationCoordinator
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setFailureMessage("Expected test failure")
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioRecordingRecoveryAudioStore: recoveryStore
+        )
+        let context = try XCTUnwrap(dictationContext)
+        let samples = Array(repeating: Float(0.25), count: Int(AudioRecordingService.targetSampleRate))
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in samples }
+        context.textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        context.textInsertionService.selectedTextOverride = { nil }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        recoveryStore.append(samples)
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .failed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let expectedFailure = PluginTranscriptionError.apiError("Expected test failure").localizedDescription
+        let recoveryMessage = try TestSupport.localizedCatalogValueForCurrentLocale(
+            for: "The recording was saved to Dictation Recovery."
+        )
+        let openRecoveryTitle = try TestSupport.localizedCatalogValueForCurrentLocale(for: "Open Recovery")
+        let session = try XCTUnwrap(context.dictationViewModel.apiDictationSession(id: sessionID))
+        XCTAssertEqual(session.status, .failed)
+        XCTAssertEqual(session.error, expectedFailure)
+        XCTAssertEqual(recoveryStore.recoveryURLs.count, 1)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            "\(expectedFailure)\n\(recoveryMessage)"
+        )
+        XCTAssertEqual(context.dictationViewModel.actionFeedbackActionTitle, openRecoveryTitle)
+        XCTAssertTrue(context.dictationViewModel.actionFeedbackIsError)
+
+        context.dictationViewModel.performActionFeedbackAction(openRecoverySettingsWindow: false)
+
+        XCTAssertEqual(navigationCoordinator.request?.tab, .dictationRecovery)
+    }
+
+    @MainActor
+    func testEmptyTranscriptionSurfacesNewRecoveryAndOpenAction() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let recoveryStore = DictationRecoveryAudioStore(
+            directory: appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true),
+            retentionPolicy: .never
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setResponseText("")
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioRecordingRecoveryAudioStore: recoveryStore
+        )
+        let context = try XCTUnwrap(dictationContext)
+        let samples = Array(repeating: Float(0.25), count: Int(AudioRecordingService.targetSampleRate))
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in samples }
+        context.textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        context.textInsertionService.selectedTextOverride = { nil }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        recoveryStore.append(samples)
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .failed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let noSpeechMessage = try TestSupport.localizedCatalogValueForCurrentLocale(for: "No speech recognized")
+        let recoveryMessage = try TestSupport.localizedCatalogValueForCurrentLocale(
+            for: "The recording was saved to Dictation Recovery."
+        )
+        let openRecoveryTitle = try TestSupport.localizedCatalogValueForCurrentLocale(for: "Open Recovery")
+        let session = try XCTUnwrap(context.dictationViewModel.apiDictationSession(id: sessionID))
+        XCTAssertEqual(session.status, .failed)
+        XCTAssertEqual(session.error, noSpeechMessage)
+        XCTAssertEqual(recoveryStore.recoveryURLs.count, 1)
+        XCTAssertEqual(
+            context.dictationViewModel.actionFeedbackMessage,
+            "\(noSpeechMessage)\n\(recoveryMessage)"
+        )
+        XCTAssertEqual(context.dictationViewModel.actionFeedbackActionTitle, openRecoveryTitle)
+        XCTAssertFalse(context.dictationViewModel.actionFeedbackIsError)
+    }
+
+    @MainActor
+    func testFailedTranscriptionWithoutNewRecoveryKeepsOriginalFeedback() async throws {
+        let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
+        let recoveryStore = DictationRecoveryAudioStore(
+            directory: appSupportDirectory.appendingPathComponent("dictation-recovery", isDirectory: true),
+            retentionPolicy: .immediately
+        )
+        var dictationContext: DictationContext?
+        defer {
+            dictationContext = nil
+            MockTranscriptionPlugin.reset()
+            TestSupport.remove(appSupportDirectory)
+        }
+
+        MockTranscriptionPlugin.reset()
+        MockTranscriptionPlugin.setFailureMessage("Expected test failure")
+        dictationContext = Self.makeDictationContext(
+            appSupportDirectory: appSupportDirectory,
+            audioRecordingRecoveryAudioStore: recoveryStore
+        )
+        let context = try XCTUnwrap(dictationContext)
+        let samples = Array(repeating: Float(0.25), count: Int(AudioRecordingService.targetSampleRate))
+        context.audioRecordingService.hasMicrophonePermissionOverride = true
+        context.audioRecordingService.inputAvailabilityOverride = { _ in true }
+        context.audioRecordingService.startRecordingOverride = {}
+        context.audioRecordingService.stopRecordingOverride = { _ in samples }
+        context.textInsertionService.captureActiveAppOverride = { ("Notes", "com.apple.Notes", nil) }
+        context.textInsertionService.selectedTextOverride = { nil }
+
+        let sessionID = context.dictationViewModel.apiStartRecording()
+        await context.dictationViewModel.testingWaitForRecordingStart()
+        recoveryStore.append(samples)
+        _ = context.dictationViewModel.apiStopRecording()
+
+        for _ in 0..<80 {
+            if context.dictationViewModel.apiDictationSession(id: sessionID)?.status == .failed {
+                break
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        let expectedFailure = PluginTranscriptionError.apiError("Expected test failure").localizedDescription
+        XCTAssertEqual(context.dictationViewModel.apiDictationSession(id: sessionID)?.status, .failed)
+        XCTAssertTrue(recoveryStore.recoveryURLs.isEmpty)
+        XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, expectedFailure)
+        XCTAssertNil(context.dictationViewModel.actionFeedbackActionTitle)
+        XCTAssertTrue(context.dictationViewModel.actionFeedbackIsError)
     }
 
     @MainActor


### PR DESCRIPTION
## Issue context

Failed dictations already preserve their audio in Dictation Recovery, but the failure indicator only shows the original transcription error. Users therefore have no indication that the recording was saved and no direct route to recover it.

Closes #1267

## Changes

- distinguish a newly preserved recovery from a previously existing latest recovery
- append a recovery notice and expose an Open Recovery action after provider failures and empty transcription results
- carry generic indicator actions through the notch, overlay, and minimal indicator styles while preserving dictionary-learning undo behavior
- keep the original feedback when no new recovery was created
- add German, Japanese, and Simplified Chinese localizations

## Test plan

- [x] Run the full macOS test suite:

      xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination "platform=macOS,arch=arm64" -parallel-testing-enabled NO CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

- [x] Verify 1,707 tests pass with zero failures.
- [x] Launch an Apple Development-signed dev build, force a configured cloud transcription failure, and verify the indicator mentions the saved recording and Open Recovery navigates to Settings > Recovery.
- [x] Set recovery retention to Immediately and verify the original error remains without a recovery action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Dictation Recovery actions to transcription error and empty-result feedback, allowing users to open saved recovery recordings.
  - Improved recovery handling to distinguish newly saved recordings while retaining access to the latest recovery recording.
  - Added German, Japanese, and Simplified Chinese translations for recovery-related messages.

- **Improvements**
  - Updated feedback controls across indicators to use clearer, context-sensitive action labels and behavior.
  - Improved accessibility handling for available feedback actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->