### PR TITLE
Fix Microsoft AI plugin host compatibility

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/MicrosoftAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/MicrosoftAIPlugin.swift
@@ -282,9 +282,9 @@ struct MicrosoftAITranscriptionClient: Sendable {
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let summary = Self.errorSummary(from: data)
+            let errorText = Self.errorText(from: data)
             if httpResponse.statusCode == 400,
-               summary.localizedCaseInsensitiveContains("enhanced mode with model"),
+               errorText.localizedCaseInsensitiveContains("enhanced mode with model"),
                let region = MicrosoftAIEndpoint.unsupportedMAIRegion(from: endpoint) {
                 let template = String(
                     localized: "MAI Transcribe is not available in the Azure region %@. Use a Speech resource in one of these regions: %@.",
@@ -298,6 +298,7 @@ struct MicrosoftAITranscriptionClient: Sendable {
                     )
                 )
             }
+            let summary = Self.boundedErrorSummary(errorText)
             throw PluginTranscriptionError.apiError(
                 "Microsoft AI transcription failed (HTTP \(httpResponse.statusCode)): \(summary)"
             )
@@ -305,20 +306,27 @@ struct MicrosoftAITranscriptionClient: Sendable {
     }
 
     static func errorSummary(from data: Data) -> String {
-        if let response = try? JSONDecoder().decode(ErrorResponseBody.self, from: data),
-           let message = response.error?.message ?? response.message {
-            return normalizedErrorSummary(message)
-        }
-
-        return normalizedErrorSummary(String(decoding: data.prefix(4_096), as: UTF8.self))
+        boundedErrorSummary(errorText(from: data))
     }
 
-    private static func normalizedErrorSummary(_ value: String) -> String {
-        let summary = value
+    private static func errorText(from data: Data) -> String {
+        if let response = try? JSONDecoder().decode(ErrorResponseBody.self, from: data),
+           let message = response.error?.message ?? response.message {
+            return normalizedErrorText(message)
+        }
+
+        return normalizedErrorText(String(decoding: data.prefix(4_096), as: UTF8.self))
+    }
+
+    private static func normalizedErrorText(_ value: String) -> String {
+        let text = value
             .split(whereSeparator: { $0.isWhitespace })
             .joined(separator: " ")
-        guard !summary.isEmpty else { return "No response body." }
-        return String(summary.prefix(1_000))
+        return text.isEmpty ? "No response body." : text
+    }
+
+    private static func boundedErrorSummary(_ value: String) -> String {
+        String(value.prefix(1_000))
     }
 
     static func parseResponse(_ data: Data) throws -> PluginStructuredTranscriptionResult {

--- a/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/MicrosoftAIPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/MicrosoftAIPlugin.swift
@@ -119,6 +119,15 @@ struct MicrosoftAIModelCatalogResponse: Decodable, Sendable {
 }
 
 struct MicrosoftAITranscriptionClient: Sendable {
+    private struct ErrorResponseBody: Decodable {
+        struct ErrorDetail: Decodable {
+            let message: String?
+        }
+
+        let message: String?
+        let error: ErrorDetail?
+    }
+
     struct Definition: Encodable, Sendable {
         struct EnhancedMode: Encodable, Sendable {
             struct ModelOptions: Encodable, Sendable {
@@ -273,7 +282,7 @@ struct MicrosoftAITranscriptionClient: Sendable {
         case 429:
             throw PluginTranscriptionError.rateLimited
         default:
-            let summary = PluginHTTPErrorBodyFormatter.summary(from: data, response: httpResponse)
+            let summary = Self.errorSummary(from: data)
             if httpResponse.statusCode == 400,
                summary.localizedCaseInsensitiveContains("enhanced mode with model"),
                let region = MicrosoftAIEndpoint.unsupportedMAIRegion(from: endpoint) {
@@ -293,6 +302,23 @@ struct MicrosoftAITranscriptionClient: Sendable {
                 "Microsoft AI transcription failed (HTTP \(httpResponse.statusCode)): \(summary)"
             )
         }
+    }
+
+    static func errorSummary(from data: Data) -> String {
+        if let response = try? JSONDecoder().decode(ErrorResponseBody.self, from: data),
+           let message = response.error?.message ?? response.message {
+            return normalizedErrorSummary(message)
+        }
+
+        return normalizedErrorSummary(String(decoding: data.prefix(4_096), as: UTF8.self))
+    }
+
+    private static func normalizedErrorSummary(_ value: String) -> String {
+        let summary = value
+            .split(whereSeparator: { $0.isWhitespace })
+            .joined(separator: " ")
+        guard !summary.isEmpty else { return "No response body." }
+        return String(summary.prefix(1_000))
     }
 
     static func parseResponse(_ data: Data) throws -> PluginStructuredTranscriptionResult {

--- a/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/Tests/MicrosoftAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/Tests/MicrosoftAIPluginTests.swift
@@ -350,11 +350,17 @@ final class MicrosoftAIPluginTests: XCTestCase {
         )
         let plugin = MicrosoftAIPlugin()
         plugin.activate(host: host)
+        let unsupportedMessage = String(repeating: "x", count: 1_100)
+            + " Enhanced mode with model is currently not supported yet."
+        let responseData = try JSONEncoder().encode([
+            "code": "InvalidRequest",
+            "message": unsupportedMessage,
+        ])
 
         PluginHTTPClientTestHarness.configure { _ in
             PluginHTTPClientMockSession(outcomes: [
                 .success(
-                    Data(#"{"code":"InvalidRequest","message":"Enhanced mode with model is currently not supported yet."}"#.utf8),
+                    responseData,
                     Self.httpResponse(statusCode: 400)
                 ),
             ])

--- a/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/Tests/MicrosoftAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MicrosoftAIPlugin/Tests/MicrosoftAIPluginTests.swift
@@ -375,6 +375,31 @@ final class MicrosoftAIPluginTests: XCTestCase {
         }
     }
 
+    func testErrorSummaryHandlesAzureShapesAndBoundsFallbackText() {
+        XCTAssertEqual(
+            MicrosoftAITranscriptionClient.errorSummary(
+                from: Data(#"{"message":"  Root\nmessage  "}"#.utf8)
+            ),
+            "Root message"
+        )
+        XCTAssertEqual(
+            MicrosoftAITranscriptionClient.errorSummary(
+                from: Data(#"{"error":{"message":"Nested message"}}"#.utf8)
+            ),
+            "Nested message"
+        )
+        XCTAssertEqual(
+            MicrosoftAITranscriptionClient.errorSummary(from: Data()),
+            "No response body."
+        )
+        XCTAssertEqual(
+            MicrosoftAITranscriptionClient.errorSummary(
+                from: Data(String(repeating: "x", count: 5_000).utf8)
+            ).count,
+            1_000
+        )
+    }
+
     func testRequiresConfigurationAndRejectsTranslation() async throws {
         let unconfigured = MicrosoftAIPlugin()
         unconfigured.activate(host: try PluginTestHostServices())


### PR DESCRIPTION
## Context

The initial Microsoft AI plugin release run failed its SDK compatibility gate against the latest available TypeWhisper 1.7.0 daily host. The plugin referenced `PluginHTTPErrorBodyFormatter.summary(from:response:)`, which was added to the SDK after that host build and is therefore unavailable at the declared `minHostVersion`.

Failed release run: https://github.com/TypeWhisper/typewhisper-mac/actions/runs/33800904583

## Summary

- replace the newer SDK formatter call with a bounded plugin-local Azure error parser
- preserve actionable root-level and nested Azure error messages
- add regression coverage for supported error shapes, empty responses, and output bounds

## Test plan

- `swift test --package-path TypeWhisperPluginSDK --filter MicrosoftAIPluginTests`
- `xcodebuild -project TypeWhisper.xcodeproj -scheme MicrosoftAIPlugin -configuration Debug CODE_SIGNING_ALLOWED=NO build`
- rerun the official Microsoft AI plugin release workflow and verify the SDK compatibility gate against `v1.7.0-daily.20260903`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Azure transcription error messages by extracting useful details from nested and top-level responses.
  * Normalized whitespace and limited raw error summaries to 1,000 characters.
  * Preserved regional unsupported-model detection even when responses contain lengthy error details.
  * Added clearer fallback messaging when error responses are empty or incomplete.

* **Tests**
  * Added coverage for error-message extraction, formatting, empty responses, length limits, and regional error detection beyond the summary limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->