### PR TITLE
Stop bundling Authenticated Provider CLIs

### DIFF
--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -365,7 +365,6 @@
 		E1A000000000000000000003 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000024 /* Assets.xcassets */; };
 		E1A000000000000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = E1A000000000000000000025 /* InfoPlist.xcstrings */; };
 		5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = BB00000000000000000159 /* SpeechAnalyzerPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		AC1100000000000000000060 /* AuthenticatedCLIPlugin.bundle in Embed Built-In Plugins */ = {isa = PBXBuildFile; fileRef = AC1100000000000000000018 /* AuthenticatedCLIPlugin.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		AA00000000000000000199 /* VoxtralPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000191 /* VoxtralPlugin.swift */; };
 		AA00000000000000000200 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000192 /* manifest.json */; };
 		AA00000000000000000201 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = BB00000000000000000193 /* Localizable.xcstrings */; };
@@ -609,13 +608,6 @@
 			remoteGlobalIDString = DD00000000000000000012;
 			remoteInfo = SpeechAnalyzerPlugin;
 		};
-		AC1100000000000000000061 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = EE00000000000000000001 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = AC1100000000000000000030;
-			remoteInfo = AuthenticatedCLIPlugin;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -671,7 +663,6 @@
 			dstSubfolderSpec = 13;
 			files = (
 				5E7A00000000000000000001 /* SpeechAnalyzerPlugin.bundle in Embed Built-In Plugins */,
-				AC1100000000000000000060 /* AuthenticatedCLIPlugin.bundle in Embed Built-In Plugins */,
 			);
 			name = "Embed Built-In Plugins";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2890,7 +2881,6 @@
 				GG00000000000000000009 /* PBXTargetDependency */,
 				E1A000000000000000000060 /* PBXTargetDependency */,
 				5E7A00000000000000000004 /* PBXTargetDependency */,
-				AC1100000000000000000062 /* PBXTargetDependency */,
 				1C1000000000000000000045 /* PBXTargetDependency */,
 			);
 			name = TypeWhisper;
@@ -5356,11 +5346,6 @@
 			isa = PBXTargetDependency;
 			target = DD00000000000000000012 /* SpeechAnalyzerPlugin */;
 			targetProxy = 5E7A00000000000000000003 /* PBXContainerItemProxy */;
-		};
-		AC1100000000000000000062 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = AC1100000000000000000030 /* AuthenticatedCLIPlugin */;
-			targetProxy = AC1100000000000000000061 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 


### PR DESCRIPTION
## Context

Authenticated Provider CLIs is an opt-in Marketplace plugin. PR #1262 also embedded its bundle in every TypeWhisper app build, which made it appear under My Plugins before an explicit download and prevented users from uninstalling it.

The plugin already has a published Marketplace release and registry entry. This change only removes its automatic delivery with the host app.

## Changes

- remove `AuthenticatedCLIPlugin.bundle` from the host app’s `Embed Built-In Plugins` phase
- remove the host app target dependency on `AuthenticatedCLIPlugin`
- keep the standalone plugin target and Marketplace distribution unchanged

## Test plan

- `xcodebuild -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -derivedDataPath /tmp/typewhisper-auth-cli-unbundle CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build`
- `test -d /tmp/typewhisper-auth-cli-unbundle/Build/Products/Debug/TypeWhisper.app/Contents/PlugIns/SpeechAnalyzerPlugin.bundle && test ! -e /tmp/typewhisper-auth-cli-unbundle/Build/Products/Debug/TypeWhisper.app/Contents/PlugIns/AuthenticatedCLIPlugin.bundle`
- built and launched the signed development app from this branch; verified Authenticated Provider CLIs is labeled Marketplace and offers Uninstall when separately installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build Changes**
  * Removed the built-in authenticated CLI plugin from the application bundle.
  * The plugin is no longer included as a build target dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->