### PR TITLE
Improve audio encoding, text processing, and plugin discovery performance

### DIFF
--- a/TypeWhisper/Services/Cloud/WavEncoder.swift
+++ b/TypeWhisper/Services/Cloud/WavEncoder.swift
@@ -30,11 +30,16 @@ struct WavEncoder {
         data.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
         data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
 
-        // Convert Float samples to Int16
-        for sample in samples {
-            let clamped = max(-1.0, min(1.0, sample))
-            let int16Value = Int16(clamped * 32767)
-            data.append(contentsOf: withUnsafeBytes(of: int16Value.littleEndian) { Array($0) })
+        // Fill the PCM payload in one allocation instead of appending each sample.
+        data.count = 44 + Int(dataSize)
+        data.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
+            for (index, sample) in samples.enumerated() {
+                let clamped = max(-1.0, min(1.0, sample))
+                let value = UInt16(bitPattern: Int16(clamped * 32767))
+                // Explicit bytes avoid alignment assumptions and preserve little endian PCM.
+                bytes[44 + index * 2] = UInt8(truncatingIfNeeded: value)
+                bytes[45 + index * 2] = UInt8(truncatingIfNeeded: value >> 8)
+            }
         }
 
         return data

--- a/TypeWhisper/Services/PluginManager.swift
+++ b/TypeWhisper/Services/PluginManager.swift
@@ -541,9 +541,14 @@ final class PluginManager: ObservableObject {
     }
 
     func sortedPluginBundleURLs(_ urls: [URL], isBundledSource: Bool) -> [URL] {
-        urls.sorted { lhs, rhs in
-            let left = pluginBundleSortMetadata(for: lhs, isBundledSource: isBundledSource)
-            let right = pluginBundleSortMetadata(for: rhs, isBundledSource: isBundledSource)
+        // Read each manifest once per scan. Sorting must not repeatedly perform
+        // file IO and JSON decoding, and later scans must see changed settings.
+        let candidates = urls.map { url in
+            (url: url, metadata: pluginBundleSortMetadata(for: url, isBundledSource: isBundledSource))
+        }
+        return candidates.sorted { lhs, rhs in
+            let left = lhs.metadata
+            let right = rhs.metadata
 
             if left.isEnabled != right.isEnabled {
                 return left.isEnabled && !right.isEnabled
@@ -553,8 +558,8 @@ final class PluginManager: ObservableObject {
                 return left.sortName < right.sortName
             }
 
-            return lhs.path < rhs.path
-        }
+            return lhs.url.path < rhs.url.path
+        }.map(\.url)
     }
 
     private func pluginBundleSortMetadata(for url: URL, isBundledSource: Bool) -> (isEnabled: Bool, sortName: String) {

--- a/TypeWhisper/Services/SpeechPunctuationService.swift
+++ b/TypeWhisper/Services/SpeechPunctuationService.swift
@@ -8,6 +8,11 @@ enum PunctuationApplicationMode {
 @MainActor
 final class SpeechPunctuationService {
     private let rulesLoader: PunctuationRulesLoader
+    private struct CompiledRule {
+        let rule: PunctuationReplacementRule
+        let regex: NSRegularExpression
+    }
+    private var compiledRules: [String: [CompiledRule]] = [:]
 
     init(rulesLoader: PunctuationRulesLoader = PunctuationRulesLoader()) {
         self.rulesLoader = rulesLoader
@@ -19,6 +24,7 @@ final class SpeechPunctuationService {
         mode: PunctuationApplicationMode = .fullFallback
     ) -> String {
         guard !text.isEmpty,
+              let languageCode = PunctuationLanguageNormalizer.normalize(language),
               let ruleSet = rulesLoader.ruleSet(for: language) else {
             return text
         }
@@ -26,11 +32,25 @@ final class SpeechPunctuationService {
         var result = text
         var replacementApplied = false
 
-        for rule in ruleSet.rules.sorted(by: { $0.phrase.count > $1.phrase.count }) {
+        let rules: [CompiledRule]
+        if let cached = compiledRules[languageCode] {
+            rules = cached
+        } else {
+            rules = ruleSet.rules.sorted(by: { $0.phrase.count > $1.phrase.count }).compactMap { rule in
+                guard let regex = try? NSRegularExpression(
+                    pattern: wholePhrasePattern(for: rule.phrase),
+                    options: [.caseInsensitive]
+                ) else { return nil }
+                return CompiledRule(rule: rule, regex: regex)
+            }
+            compiledRules[languageCode] = rules
+        }
+
+        for compiled in rules {
             let updated = replaceWholePhrase(
-                rule.phrase,
-                with: rule.replacement,
-                category: rule.category,
+                compiled.regex,
+                with: compiled.rule.replacement,
+                category: compiled.rule.category,
                 in: result
             )
             if updated != result {
@@ -48,18 +68,11 @@ final class SpeechPunctuationService {
     }
 
     private func replaceWholePhrase(
-        _ phrase: String,
+        _ regex: NSRegularExpression,
         with replacement: String,
         category: PunctuationRuleCategory,
         in text: String
     ) -> String {
-        guard let regex = try? NSRegularExpression(
-            pattern: wholePhrasePattern(for: phrase, category: category),
-            options: [.caseInsensitive]
-        ) else {
-            return text
-        }
-
         let range = NSRange(text.startIndex..., in: text)
         let matches = regex.matches(in: text, options: [], range: range)
         guard !matches.isEmpty else {
@@ -89,7 +102,7 @@ final class SpeechPunctuationService {
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    private func wholePhrasePattern(for phrase: String, category: PunctuationRuleCategory) -> String {
+    private func wholePhrasePattern(for phrase: String) -> String {
         let escapedWords = phrase
             .split(whereSeparator: \.isWhitespace)
             .map { NSRegularExpression.escapedPattern(for: String($0)) }
@@ -106,6 +119,7 @@ final class SpeechPunctuationService {
 
         var result = ""
         var index = text.startIndex
+        var nextNonWhitespaceIndex = text.startIndex
 
         while index < text.endIndex {
             let character = text[index]
@@ -113,7 +127,15 @@ final class SpeechPunctuationService {
             if character.isWhitespace {
                 let nextIndex = text.index(after: index)
                 let nextCharacter = nextIndex < text.endIndex ? text[nextIndex] : nil
-                let followingNonWhitespace = nextNonWhitespaceCharacter(in: text, after: index)
+                // Scan each whitespace run once, even when preserving the existing
+                // per-character spacing rules for punctuation and mixed scripts.
+                if nextNonWhitespaceIndex <= index {
+                    nextNonWhitespaceIndex = index
+                    while nextNonWhitespaceIndex < text.endIndex && text[nextNonWhitespaceIndex].isWhitespace {
+                        nextNonWhitespaceIndex = text.index(after: nextNonWhitespaceIndex)
+                    }
+                }
+                let followingNonWhitespace = nextNonWhitespaceIndex < text.endIndex ? text[nextNonWhitespaceIndex] : nil
 
                 if let previous = result.last,
                    behavior(for: previous, opening: openingTokens, closing: closingTokens, inline: inlineTokens) == .opening {

--- a/TypeWhisper/Services/TextDiffService.swift
+++ b/TypeWhisper/Services/TextDiffService.swift
@@ -22,28 +22,50 @@ final class TextDiffService {
         if origWords.isEmpty { return procWords.map { .added($0) } }
         if procWords.isEmpty { return origWords.map { .removed($0) } }
 
-        let m = origWords.count, n = procWords.count
+        // Backtracking always consumes an equal suffix first. Excluding it from
+        // the table preserves the original tie-breaking, including repeated words.
+        // An equal prefix cannot be trimmed with that same guarantee.
+        var m = origWords.count, n = procWords.count
+        while m > 0 && n > 0 && origWords[m - 1] == procWords[n - 1] {
+            m -= 1
+            n -= 1
+        }
 
-        // LCS dynamic programming
-        var dp = Array(repeating: Array(repeating: 0, count: n + 1), count: m + 1)
-        for i in 1...m {
-            for j in 1...n {
-                if origWords[i - 1] == procWords[j - 1] {
-                    dp[i][j] = dp[i - 1][j - 1] + 1
-                } else {
-                    dp[i][j] = max(dp[i - 1][j], dp[i][j - 1])
+        // Keep only the current LCS row and one byte per backtracking direction,
+        // rather than an Int for every cell in a nested copy-on-write array.
+        var row = Array(repeating: 0, count: n + 1)
+        var directions = Array(repeating: UInt8(0), count: m * n)
+        if m > 0 && n > 0 {
+            for i in 1...m {
+                var diagonal = 0
+                let rowOffset = (i - 1) * n
+                for j in 1...n {
+                    let above = row[j]
+                    if origWords[i - 1] == procWords[j - 1] {
+                        row[j] = diagonal + 1
+                    } else if row[j - 1] >= above {
+                        row[j] = row[j - 1]
+                        directions[rowOffset + j - 1] = 1 // added (left wins ties)
+                    } else {
+                        directions[rowOffset + j - 1] = 2 // removed
+                    }
+                    diagonal = above
                 }
             }
         }
 
         // Backtrack to produce segments
         var segments: [DiffSegment] = []
+        segments.reserveCapacity(origWords.count + procWords.count)
+        for word in origWords[m...].reversed() {
+            segments.append(.unchanged(word))
+        }
         var i = m, j = n
         while i > 0 || j > 0 {
-            if i > 0 && j > 0 && origWords[i - 1] == procWords[j - 1] {
+            if i > 0 && j > 0 && directions[(i - 1) * n + j - 1] == 0 {
                 segments.append(.unchanged(origWords[i - 1]))
                 i -= 1; j -= 1
-            } else if j > 0 && (i == 0 || dp[i][j - 1] >= dp[i - 1][j]) {
+            } else if j > 0 && (i == 0 || directions[(i - 1) * n + j - 1] == 1) {
                 segments.append(.added(procWords[j - 1]))
                 j -= 1
             } else {

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift
@@ -287,10 +287,16 @@ public struct PluginWavEncoder {
         data.append(contentsOf: [0x64, 0x61, 0x74, 0x61]) // "data"
         data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
 
-        for sample in samples {
-            let clamped = max(-1.0, min(1.0, sample))
-            let int16Value = Int16(clamped * 32767)
-            data.append(contentsOf: withUnsafeBytes(of: int16Value.littleEndian) { Array($0) })
+        // Fill the PCM payload in one allocation instead of appending each sample.
+        data.count = 44 + Int(dataSize)
+        data.withUnsafeMutableBytes { (bytes: UnsafeMutableRawBufferPointer) in
+            for (index, sample) in samples.enumerated() {
+                let clamped = max(-1.0, min(1.0, sample))
+                let value = UInt16(bitPattern: Int16(clamped * 32767))
+                // Explicit bytes avoid alignment assumptions and preserve little endian PCM.
+                bytes[44 + index * 2] = UInt8(truncatingIfNeeded: value)
+                bytes[45 + index * 2] = UInt8(truncatingIfNeeded: value >> 8)
+            }
         }
 
         return data

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/ProtocolContractTests.swift
@@ -732,6 +732,21 @@ final class ProtocolContractTests: XCTestCase {
         XCTAssertEqual(String(data: wav.prefix(4), encoding: .utf8), "RIFF")
     }
 
+    func testWavEncoderPreservesSignedPCMClippingAndLittleEndianHeader() {
+        let wav = PluginWavEncoder.encode([-2, -1, -0.5, 0, 0.5, 1, 2])
+        XCTAssertEqual(wav, Data([
+            0x52, 0x49, 0x46, 0x46, 50, 0, 0, 0, 0x57, 0x41, 0x56, 0x45,
+            0x66, 0x6d, 0x74, 0x20, 16, 0, 0, 0, 1, 0, 1, 0,
+            0x80, 0x3e, 0, 0, 0, 0x7d, 0, 0, 2, 0, 16, 0,
+            0x64, 0x61, 0x74, 0x61, 14, 0, 0, 0,
+            1, 0x80, 1, 0x80, 1, 0xc0, 0, 0, 0xff, 0x3f, 0xff, 0x7f, 0xff, 0x7f,
+        ]))
+        XCTAssertEqual(PluginWavEncoder.encode([]).count, 44)
+        let alternateRate = PluginWavEncoder.encode([0], sampleRate: 48_000)
+        XCTAssertEqual(Array(alternateRate[24..<28]), [0x80, 0xbb, 0, 0])
+        XCTAssertEqual(Array(alternateRate[28..<32]), [0, 0x77, 1, 0])
+    }
+
     func testDictionaryTermsCapabilityProtocolIsOptional() {
         let legacyPlugin = MockTranscriptionPlugin()
         let capabilityPlugin = MockDictionaryTermsPlugin()

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -2083,6 +2083,16 @@ final class PluginManagerLoadOrderTests: XCTestCase {
             sorted.map(\.lastPathComponent),
             ["Gemma4Plugin.bundle", "ParakeetPlugin.bundle", "VoxtralPlugin.bundle"]
         )
+
+        // Metadata is a per-sort snapshot, not a persistent cache of enablement.
+        defaults.set(true, forKey: voxtralKey)
+        defaults.set(false, forKey: gemmaKey)
+        defaults.set(false, forKey: parakeetKey)
+        XCTAssertEqual(
+            manager.sortedPluginBundleURLs([enabledGemma, disabledVoxtral, enabledParakeet], isBundledSource: false)
+                .map(\.lastPathComponent),
+            ["VoxtralPlugin.bundle", "Gemma4Plugin.bundle", "ParakeetPlugin.bundle"]
+        )
     }
 
     func testScanAndLoadPluginsRegistersDisabledBundleWithoutLoadingRuntime() throws {

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -3,6 +3,27 @@ import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class SpeechPunctuationServiceTests: XCTestCase {
+    @MainActor
+    func testRepeatedNormalizationKeepsLanguageRulesAndAliasesSeparate() {
+        let service = SpeechPunctuationService(rulesLoader: makeRulesLoader())
+        for _ in 0..<3 {
+            XCTAssertEqual(service.normalize(text: "ciao virgola mondo", language: "it-IT"), "ciao, mondo")
+            XCTAssertEqual(service.normalize(text: "メモ 鍵かっこ開く 重要 鍵かっこ閉じる", language: "ja_JP"), "メモ「重要」")
+            XCTAssertEqual(service.normalize(text: "ciao virgola mondo", language: "it"), "ciao, mondo")
+            XCTAssertEqual(service.normalize(text: "unchanged", language: "unknown"), "unchanged")
+        }
+    }
+
+    @MainActor
+    func testLongWhitespaceRunsPreserveMixedScriptSpacing() {
+        let service = SpeechPunctuationService(rulesLoader: makeRulesLoader())
+        let spaces = String(repeating: " \t\n", count: 1000)
+        XCTAssertEqual(service.normalize(text: "ciao\(spaces)mondo", language: "it"), "ciao mondo")
+        XCTAssertEqual(service.normalize(text: "ciao\(spaces)mondo", language: "it", mode: .selectiveFallback), "ciao\(spaces)mondo")
+        XCTAssertEqual(service.normalize(text: "メモ（\(spaces)重要\(spaces)）", language: "ja"), "メモ（重要）")
+        XCTAssertEqual(service.normalize(text: "確認？\(spaces)next", language: "ja"), "確認？ next")
+    }
+
     private func makeRulesLoader() -> PunctuationRulesLoader {
         PunctuationRulesLoader { languageCode in
             switch languageCode {

--- a/TypeWhisperTests/TextDiffServiceTests.swift
+++ b/TypeWhisperTests/TextDiffServiceTests.swift
@@ -2,6 +2,31 @@ import XCTest
 @testable import TypeWhisper
 
 final class TextDiffServiceTests: XCTestCase {
+    func testWordDiffPreservesRepeatedWordTieBreaking() {
+        let service = TextDiffService()
+        XCTAssertEqual(service.computeWordDiff(original: "a b", processed: "b a"), [
+            .removed("a"), .unchanged("b"), .added("a"),
+        ])
+        XCTAssertEqual(service.computeWordDiff(original: "a a", processed: "a"), [
+            .removed("a"), .unchanged("a"),
+        ])
+        XCTAssertEqual(service.computeWordDiff(original: "a", processed: "a a"), [
+            .added("a"), .unchanged("a"),
+        ])
+    }
+
+    func testWordDiffHandlesEmptyInputsUnicodeAndAnUnchangedSuffix() {
+        let service = TextDiffService()
+        XCTAssertEqual(service.computeWordDiff(original: "", processed: ""), [])
+        XCTAssertEqual(service.computeWordDiff(original: "", processed: "🌍 世界"), [.added("🌍"), .added("世界")])
+        XCTAssertEqual(service.computeWordDiff(original: "🌍", processed: ""), [.removed("🌍")])
+        XCTAssertEqual(service.computeWordDiff(original: "old\t🌍\n世界", processed: "new 🌍 世界"), [
+            .removed("old"), .added("new"), .unchanged("🌍"), .unchanged("世界"),
+        ])
+        let text = Array(repeating: "word", count: 10_000).joined(separator: " ")
+        XCTAssertEqual(service.computeWordDiff(original: text, processed: text), Array(repeating: .unchanged("word"), count: 10_000))
+    }
+
     func testExtractCorrectionsFindsLocalizedWordReplacement() {
         let service = TextDiffService()
 

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -37,6 +37,19 @@ private final class APIFakeAudioInputDeviceDefaultController: AudioInputDeviceDe
     }
 }
 
+final class WavEncoderParityTests: XCTestCase {
+    func testAppAndPluginEncodersProduceIdenticalPCMAtSupportedRates() {
+        for rate in [8_000, 16_000, 44_100, 48_000] {
+            for samples: [Float] in [[], [0], [-2, -1, -0.5, 0, 0.5, 1, 2],
+                                    (0..<16_001).map { Float($0 % 201 - 100) / 90 }] {
+                let appData = WavEncoder.encode(samples, sampleRate: rate)
+                XCTAssertEqual(appData, PluginWavEncoder.encode(samples, sampleRate: rate))
+                XCTAssertEqual(appData.count, 44 + samples.count * 2)
+            }
+        }
+    }
+}
+
 final class SecureInputDiagnosticsProviderTests: XCTestCase {
     func testSnapshotPrefersOnConsoleIORegistryOwner() {
         let consoleUsers: NSArray = [

--- a/scripts/performance/Benchmark.swift
+++ b/scripts/performance/Benchmark.swift
@@ -1,0 +1,199 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+@main
+struct PerformanceBenchmark {
+    @MainActor
+    static func main() throws {
+        let name = CommandLine.arguments[1]
+        let directory = URL(fileURLWithPath: CommandLine.arguments[2])
+        let loader = PunctuationRulesLoader { language in
+            try? Data(contentsOf: directory.appendingPathComponent("\(language).json"))
+        }
+        let punctuation = SpeechPunctuationService(rulesLoader: loader)
+        let diff = TextDiffService()
+
+        if name == "verify" {
+            var digest = SHA256()
+            var checks = 0
+            // Repeated words exercise the existing LCS tie-breaking policy.
+            var sequences = [""]
+            var level = [""]
+            for _ in 0..<4 {
+                level = level.flatMap { prefix in ["a", "b", "🌍"].map { prefix.isEmpty ? $0 : prefix + " " + $0 } }
+                sequences.append(contentsOf: level)
+            }
+            for original in sequences {
+                for processed in sequences {
+                    let result = diff.computeWordDiff(original: original, processed: processed)
+                    let left = result.compactMap { segment -> String? in
+                        switch segment { case .unchanged(let word), .removed(let word): word; case .added: nil }
+                    }.joined(separator: " ")
+                    let right = result.compactMap { segment -> String? in
+                        switch segment { case .unchanged(let word), .added(let word): word; case .removed: nil }
+                    }.joined(separator: " ")
+                    precondition(left == original && right == processed)
+                    digest.update(data: serialize(result))
+                    checks += 1
+                }
+            }
+            for language in ["de", "en", "it", "ja"] {
+                let rules = loader.ruleSet(for: language)!
+                for scenario in rules.verificationScenarios {
+                    precondition(punctuation.normalize(text: scenario.spoken, language: language) == scenario.expected)
+                    checks += 1
+                }
+                for rule in rules.rules {
+                    for padding in [" ", "  ", "\t", "\n", "\r\n", "\u{00a0}", String(repeating: " ", count: 50)] {
+                        for body in [rule.phrase, rule.phrase.uppercased(), "word\(rule.phrase)word",
+                                     "🌍\(padding)\(rule.phrase)\(padding)世界", "(\(padding)\(rule.phrase)\(padding))",
+                                     "\(rule.replacement)\(padding)\(rule.phrase)", "\(rule.phrase)\(padding)\(rule.replacement)",
+                                     "\(rule.phrase)\(padding)\(rule.phrase)"] {
+                            for mode in [PunctuationApplicationMode.fullFallback, .selectiveFallback] {
+                                let result = punctuation.normalize(text: body, language: language, mode: mode)
+                                digest.update(data: Data(result.utf8))
+                                digest.update(data: Data([0]))
+                                checks += 1
+                            }
+                        }
+                    }
+                }
+                // Aliases must share semantics; alternating languages must not reuse stale rules.
+                precondition(punctuation.normalize(text: rules.rules[0].phrase, language: language + "-XX") ==
+                             punctuation.normalize(text: rules.rules[0].phrase, language: language))
+            }
+            for rate in [8_000, 16_000, 44_100, 48_000] {
+                for samples: [Float] in [[], [0], [-2, -1, -0.5, 0, 0.5, 1, 2, .infinity, -.infinity],
+                                        (0..<10001).map { Float($0 % 199 - 99) / 87 }] {
+                    let data = WavEncoder.encode(samples, sampleRate: rate)
+                    precondition(data == PluginWavEncoder.encode(samples, sampleRate: rate))
+                    precondition(data.count == 44 + samples.count * 2)
+                    for (index, sample) in samples.enumerated() {
+                        let expected = UInt16(bitPattern: Int16(max(-1, min(1, sample)) * 32767))
+                        precondition(data[44 + index * 2] == UInt8(truncatingIfNeeded: expected))
+                        precondition(data[45 + index * 2] == UInt8(truncatingIfNeeded: expected >> 8))
+                    }
+                    digest.update(data: data)
+                    checks += 1
+                }
+            }
+            emit(["case": name, "checks": checks, "digest": hex(digest.finalize())])
+            return
+        }
+
+        let operation: () -> Data
+        let iterations: Int
+        if name == "plugin-sort-64" {
+            let manager = PluginSortingFixture()
+            let root = directory.appendingPathComponent("plugins")
+            var urls: [URL] = []
+            for index in 0..<64 {
+                let shuffled = (index * 37) % 64
+                let url = root.appendingPathComponent(String(format: "%03d.bundle", shuffled))
+                let resources = url.appendingPathComponent("Contents/Resources")
+                try FileManager.default.createDirectory(at: resources, withIntermediateDirectories: true)
+                let id = "benchmark.performance.\(shuffled)"
+                UserDefaults.standard.register(defaults: ["plugin.\(id).enabled": shuffled % 3 == 0])
+                if shuffled % 8 != 0 {
+                    let manifest = PluginManifest(id: id, name: id, version: "1.0.0", principalClass: "Plugin")
+                    try JSONEncoder().encode(manifest).write(to: resources.appendingPathComponent("manifest.json"))
+                }
+                urls.append(url)
+            }
+            // Exercise malformed/missing manifests, both default enabled states,
+            // ordering ties, and repeated URLs without loading plugin code.
+            urls.append(urls[0])
+            operation = {
+                var output = ""
+                for bundled in [false, true] {
+                    output += manager.sortedPluginBundleURLs(urls, isBundledSource: bundled)
+                        .map(\.lastPathComponent).joined(separator: "\n")
+                }
+                return Data(output.utf8)
+            }
+            iterations = 5
+        } else if name.hasPrefix("wav-") {
+            let seconds = name.hasSuffix("600s") ? 600 : name.hasSuffix("60s") ? 60 : 10
+            let samples = (0..<(16_000 * seconds)).map { Float($0 % 201 - 100) / 90 }
+            operation = name.hasPrefix("wav-app") ? { WavEncoder.encode(samples) } : { PluginWavEncoder.encode(samples) }
+            iterations = 1
+        } else if name.hasPrefix("diff-") {
+            let words = (0..<2000).map { "word\($0 % 97)" }
+            let original = words.joined(separator: " ")
+            var edited = words
+            switch name {
+            case "diff-middle-edit": edited[1000] = "corrected"
+            case "diff-last-edit": edited[1999] = "corrected"
+            case "diff-rewrite": edited = (0..<2000).map { "replacement\($0 % 101)" }
+            default: break
+            }
+            let processed = edited.joined(separator: " ")
+            operation = { serialize(diff.computeWordDiff(original: original, processed: processed)) }
+            iterations = 1
+        } else {
+            let text: String
+            switch name {
+            case "punctuation-long": text = String(repeating: "Hallo Komma Welt Punkt Das ist ein Test Fragezeichen ", count: 100)
+            case "punctuation-spaces": text = "Hallo" + String(repeating: " ", count: 4000) + "Welt"
+            default: text = "Hallo Komma Welt Punkt Das ist ein Test Fragezeichen"
+            }
+            if name == "punctuation-cold" {
+                operation = {
+                    let freshLoader = PunctuationRulesLoader { language in
+                        try? Data(contentsOf: directory.appendingPathComponent("\(language).json"))
+                    }
+                    return Data(SpeechPunctuationService(rulesLoader: freshLoader).normalize(text: text, language: "de").utf8)
+                }
+            } else {
+                operation = { Data(punctuation.normalize(text: text, language: "de").utf8) }
+            }
+            iterations = name == "punctuation-short" ? 100 : name == "punctuation-cold" ? 20 : 1
+        }
+
+        // Input creation, compilation and output hashing are outside timed regions.
+        // Each case runs in a fresh process; RSS includes inputs and runtime overhead.
+        let expected = autoreleasepool(invoking: operation)
+        precondition(autoreleasepool(invoking: operation) == expected)
+        var timings: [Double] = []
+        var checksum = 0
+        for _ in 0..<9 {
+            let start = DispatchTime.now().uptimeNanoseconds
+            for _ in 0..<iterations {
+                checksum &+= autoreleasepool { consume(operation()) }
+            }
+            timings.append(Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000 / Double(iterations))
+        }
+        var usage = rusage()
+        getrusage(RUSAGE_SELF, &usage)
+        emit(["case": name, "median_ms": timings.sorted()[4], "samples_ms": timings,
+              "iterations_per_sample": iterations, "peak_rss_bytes": usage.ru_maxrss,
+              "digest": hex(SHA256.hash(data: expected)), "checksum": checksum])
+    }
+
+    @inline(never)
+    static func consume(_ data: Data) -> Int {
+        data.count &+ Int(data.first ?? 0) &+ Int(data.last ?? 0)
+    }
+
+    static func serialize(_ segments: [DiffSegment]) -> Data {
+        var result = Data()
+        for segment in segments {
+            switch segment {
+            case .unchanged(let text): result.append(contentsOf: ("=\(text)\u{0}").utf8)
+            case .removed(let text): result.append(contentsOf: ("-\(text)\u{0}").utf8)
+            case .added(let text): result.append(contentsOf: ("+\(text)\u{0}").utf8)
+            }
+        }
+        return result
+    }
+
+    static func hex<D: Sequence>(_ digest: D) -> String where D.Element == UInt8 {
+        digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func emit(_ object: [String: Any]) {
+        let data = try! JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        print(String(decoding: data, as: UTF8.self))
+    }
+}

--- a/scripts/performance/run.py
+++ b/scripts/performance/run.py
@@ -25,6 +25,20 @@ CASES = ["wav-app-10s", "wav-app-60s", "wav-sdk-60s", "wav-sdk-600s",
          "plugin-sort-64"]
 
 
+def compare_reports(baseline, report):
+    """Reject incompatible or changed outputs, including under python -O."""
+    harness = "scripts/performance/Benchmark.swift"
+    if baseline.get("source_sha256", {}).get(harness) != report["source_sha256"][harness]:
+        raise SystemExit("Benchmark harness hash changed or is missing; rerun baseline")
+    previous = {row["case"]: row for row in baseline.get("results", [])}
+    for row in report["results"]:
+        name = row["case"]
+        if name not in previous:
+            raise SystemExit(f"Baseline is missing benchmark case: {name}")
+        if row["digest"] != previous[name].get("digest"):
+            raise SystemExit(f"Output digest changed or is missing for benchmark case: {name}")
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--ref", help="Read production sources from this git ref")
@@ -97,10 +111,7 @@ def main():
     args.output.write_text(json.dumps(report, indent=2) + "\n")
     if args.compare:
         baseline = json.loads(args.compare.read_text())
-        assert baseline["source_sha256"]["scripts/performance/Benchmark.swift"] == hashes["scripts/performance/Benchmark.swift"], "Harness changed; rerun baseline"
-        previous = {row["case"]: row for row in baseline["results"]}
-        for row in results:
-            assert row["digest"] == previous[row["case"]]["digest"], f"Output changed: {row['case']}"
+        compare_reports(baseline, report)
         print("All output digests match the baseline.")
 
 

--- a/scripts/performance/run.py
+++ b/scripts/performance/run.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Benchmark actual production Swift sources, optionally from an immutable git ref."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import platform
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+SOURCES = [
+    "TypeWhisper/Services/Cloud/WavEncoder.swift",
+    "TypeWhisper/Services/TextDiffService.swift",
+    "TypeWhisper/Services/SpeechPunctuationService.swift",
+    "TypeWhisper/Services/PunctuationRulesLoader.swift",
+    "TypeWhisper/Models/PunctuationRules.swift",
+    "TypeWhisper/Models/DictationPunctuationProfile.swift",
+    "TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/PluginManifest.swift",
+]
+SDK_SOURCE = "TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/HostServices.swift"
+CASES = ["wav-app-10s", "wav-app-60s", "wav-sdk-60s", "wav-sdk-600s",
+         "diff-identical", "diff-middle-edit", "diff-last-edit", "diff-rewrite",
+         "punctuation-short", "punctuation-long", "punctuation-spaces", "punctuation-cold",
+         "plugin-sort-64"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref", help="Read production sources from this git ref")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--compare", type=Path, help="Require identical output digests")
+    args = parser.parse_args()
+
+    def read(relative):
+        if args.ref:
+            return subprocess.check_output(["git", "show", f"{args.ref}:{relative}"], cwd=ROOT)
+        return (ROOT / relative).read_bytes()
+
+    hashes = {}
+    with tempfile.TemporaryDirectory(prefix="typewhisper-performance-") as directory:
+        scratch = Path(directory)
+        paths = []
+        for relative in SOURCES:
+            data = read(relative)
+            hashes[relative] = hashlib.sha256(data).hexdigest()
+            target = scratch / Path(relative).name
+            target.write_bytes(data)
+            paths.append(str(target))
+        # Compile the complete SDK encoder verbatim, without pulling in unrelated
+        # model runtimes. Fail loudly if its declaration boundaries change.
+        sdk = read(SDK_SOURCE)
+        hashes[SDK_SOURCE] = hashlib.sha256(sdk).hexdigest()
+        encoder = sdk.decode().split("public struct PluginWavEncoder {", 1)[1].split(
+            "\npublic struct PluginAudioUploadFile:", 1)[0]
+        target = scratch / "PluginWavEncoder.swift"
+        target.write_text("import Foundation\npublic struct PluginWavEncoder {" + encoder)
+        paths.append(str(target))
+        relative = "TypeWhisper/Services/PluginManager.swift"
+        manager = read(relative)
+        hashes[relative] = hashlib.sha256(manager).hexdigest()
+        methods = manager.decode().split("    func sortedPluginBundleURLs(", 1)[1].split(
+            "\n    func loadPlugin(", 1)[0]
+        target = scratch / "PluginSortingFixture.swift"
+        target.write_text("import Foundation\nfinal class PluginSortingFixture {\n    func sortedPluginBundleURLs(" + methods + "\n}\n")
+        paths.append(str(target))
+        resources = scratch / "rules"
+        resources.mkdir()
+        for language in ["de", "en", "it", "ja"]:
+            relative = f"TypeWhisper/Resources/PunctuationRules/{language}.json"
+            data = read(relative)
+            hashes[relative] = hashlib.sha256(data).hexdigest()
+            (resources / f"{language}.json").write_bytes(data)
+        harness = ROOT / "scripts/performance/Benchmark.swift"
+        hashes["scripts/performance/Benchmark.swift"] = hashlib.sha256(harness.read_bytes()).hexdigest()
+        binary = scratch / "benchmark"
+        command = ["xcrun", "swiftc", "-O", "-whole-module-optimization", "-swift-version", "6",
+                   *paths, str(harness), "-o", str(binary)]
+        subprocess.run(command, check=True, cwd=ROOT)
+        results = []
+        for case in ["verify", *CASES]:
+            result = subprocess.check_output([str(binary), case, str(resources)], text=True)
+            row = json.loads(result)
+            results.append(row)
+            print(json.dumps(row), flush=True)
+        report = {
+            "revision": subprocess.check_output(["git", "rev-parse", args.ref or "HEAD"], cwd=ROOT, text=True).strip(),
+            "source": args.ref or "working-tree",
+            "machine": platform.platform(),
+            "cpu": subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip(),
+            "compiler": subprocess.check_output(["xcrun", "swiftc", "--version"], text=True, stderr=subprocess.STDOUT).strip(),
+            "flags": "-O -whole-module-optimization -swift-version 6",
+            "source_sha256": hashes,
+            "results": results,
+        }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2) + "\n")
+    if args.compare:
+        baseline = json.loads(args.compare.read_text())
+        assert baseline["source_sha256"]["scripts/performance/Benchmark.swift"] == hashes["scripts/performance/Benchmark.swift"], "Harness changed; rerun baseline"
+        previous = {row["case"]: row for row in baseline["results"]}
+        for row in results:
+            assert row["digest"] == previous[row["case"]]["digest"], f"Output changed: {row['case']}"
+        print("All output digests match the baseline.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/performance/test_run.py
+++ b/scripts/performance/test_run.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Run normally and with python -O to verify comparison checks stay enabled."""
+import copy
+import unittest
+
+from run import compare_reports
+
+
+class ComparisonTests(unittest.TestCase):
+    def setUp(self):
+        self.report = {
+            "source_sha256": {"scripts/performance/Benchmark.swift": "harness"},
+            "results": [{"case": "wav-app-10s", "digest": "output"}],
+        }
+        self.baseline = copy.deepcopy(self.report)
+
+    def test_matching_reports_pass(self):
+        compare_reports(self.baseline, self.report)
+
+    def test_changed_harness_fails(self):
+        self.baseline["source_sha256"]["scripts/performance/Benchmark.swift"] = "old-harness"
+        with self.assertRaisesRegex(SystemExit, "harness hash changed"):
+            compare_reports(self.baseline, self.report)
+
+    def test_missing_harness_fails(self):
+        self.baseline.pop("source_sha256")
+        with self.assertRaisesRegex(SystemExit, "harness hash changed or is missing"):
+            compare_reports(self.baseline, self.report)
+
+    def test_missing_case_fails(self):
+        self.baseline["results"] = []
+        with self.assertRaisesRegex(SystemExit, "missing benchmark case: wav-app-10s"):
+            compare_reports(self.baseline, self.report)
+
+    def test_changed_output_fails(self):
+        self.baseline["results"][0]["digest"] = "old-output"
+        with self.assertRaisesRegex(SystemExit, "Output digest changed.*wav-app-10s"):
+            compare_reports(self.baseline, self.report)
+
+    def test_missing_output_digest_fails(self):
+        self.baseline["results"][0].pop("digest")
+        with self.assertRaisesRegex(SystemExit, "Output digest changed or is missing.*wav-app-10s"):
+            compare_reports(self.baseline, self.report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Long recordings, text comparison, punctuation processing and plugin discovery perform avoidable allocations or repeated work. This change fills WAV payloads directly in the app and SDK, stores word-diff backtracking directions in bytes with a single score row, caches compiled punctuation rules by language, scans whitespace runs once, and reads plugin sort metadata once per candidate.

PCM bytes, repeated-word diff alignment, punctuation output and plugin ordering are preserved. Regression tests and a standalone benchmark compile the production implementations. No public SDK API changes. Audit documents, inventories and local result files are excluded from the PR.

## Related issues

- Related to #1236: reduces local WAV encoding and text-processing overhead. Incremental/concurrent workflow LLM processing remains separate work; this PR does not implement or close that request.
- Related to #1269: another identified per-dictation cost, but incremental usage-statistics persistence is outside this change and remains open.
- Follows the performance investigation in #1268, which was already resolved by #1272. This PR preserves the bounded-history architecture and addresses different CPU/allocation hot spots.

No open issue found in the issue review is fully resolved by these specific changes, so no automatic-closing reference is included.

## Before / after

Median milliseconds on an Apple M1 Pro with Apple Swift 6.3.3, `-O -whole-module-optimization -swift-version 6`. Baseline: `70d7c83ed28d5763263811819b2a4a8d1446719c`. Each workload uses two warmups and nine measured samples; short operations are batched. Before and after ran sequentially with identical inputs and harnesses, before integration-test builds started.

| Workload | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| App WAV encoder, 10 seconds of audio | 9.946 ms | 0.156 ms | 63.67× |
| App WAV encoder, 60 seconds | 59.891 ms | 0.926 ms | 64.65× |
| SDK WAV encoder, 60 seconds | 59.805 ms | 0.930 ms | 64.28× |
| SDK WAV encoder, 10 minutes | 618.179 ms | 9.403 ms | 65.74× |
| Word diff, 2,000 identical words | 21.226 ms | 2.036 ms | 10.43× |
| Word diff, 2,000 words, one middle replacement | 21.323 ms | 5.468 ms | 3.90× |
| Word diff, 2,000 words, one final replacement | 21.234 ms | 15.941 ms | 1.33× |
| Word diff, complete 2,000-word rewrite | 22.894 ms | 16.878 ms | 1.36× |
| Punctuation, short German text, warm service | 3.928 ms | 0.0195 ms | 201.21× |
| Punctuation, 100 repetitions of the short text | 5.260 ms | 1.303 ms | 4.04× |
| Punctuation, 4,000-space stress case | 341.160 ms | 2.315 ms | 147.37× |
| Punctuation, newly created service and loader | 3.781 ms | 3.763 ms | 1.00× |
| Plugin ordering, 64 bundles, external + bundled sort | 67.651 ms | 3.787 ms | 17.86× |

Word-diff process peak RSS fell from 38.69 to 8.02 MiB for the middle edit, and from 39.16 to 11.30 MiB for the complete rewrite. Worst-case diff complexity remains quadratic. Cold-service punctuation performance is essentially unchanged.

These are function benchmarks, not whole-app launch or transcription latency measurements. WAV inputs are synthetic mono 16 kHz samples. Diff timing includes identical segment serialization. Plugin timing uses the exact production sorting methods with temporary local fixtures and a warm filesystem cache, including a duplicate URL and missing manifests; it excludes bundle/model loading. RSS includes the benchmark runtime, inputs and retained expected output.

## Test plan

- [x] 19,045 benchmark verification cases and all 13 workload output digests match the baseline, including exhaustive short repeated-word/Unicode diffs, punctuation variants and WAV bytes at four sample rates.
- [x] Review fix: six benchmark-comparison tests pass both normally and under `python -O`; the full benchmark also passes under `-O` with matching baseline outputs.
- [x] Full app suite: 1,718 tests, 0 failures, `TEST SUCCEEDED`.
- [x] Full SDK/plugin suite: 739 tests, 3 optional live-CLI tests skipped, 0 failures.
- [x] First-party Xcode warning check, release signing/instrumentation self-tests, Python script tests and `git diff --check` passed.
- [ ] `scripts/pr-preflight.sh origin/main`: blocked by 60 missing `zh-Hans` translations in the Authenticated CLI and Meta plugin catalogs. Running the localization checker on a snapshot of `origin/main` produces exactly the same failure/output; this PR changes no string catalogs. Checks after that early exit were run separately.

Reproduce the before/after comparison from the PR checkout:

```sh
python3 scripts/performance/run.py --ref 70d7c83ed28d5763263811819b2a4a8d1446719c --output /tmp/typewhisper-before.json
python3 scripts/performance/run.py --output /tmp/typewhisper-after.json --compare /tmp/typewhisper-before.json
```

Integration verification (the app run used an existing local Swift package cache):

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO \
  -derivedDataPath /tmp/typewhisper-performance-app-tests \
  -clonedSourcePackagesDirPath "$PACKAGE_CACHE" \
  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
swift test --package-path TypeWhisperPluginSDK
python3 scripts/performance/test_run.py
python3 -O scripts/performance/test_run.py
bash scripts/pr-preflight.sh origin/main
bash scripts/check_release_binary_instrumentation.sh --self-test
bash scripts/check_release_signing.sh --self-test
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-performance-app-tests.log
git diff --check
```

Set `PACKAGE_CACHE` to an existing local Swift package cache, or omit that optional flag. The warning check uses the captured Xcode build/test log. No manual UI/device performance claim is made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved efficiency when encoding audio, scanning plugins, normalizing punctuation, and calculating text differences.
  * Reduced processing overhead for repeated language-specific punctuation normalization and large text comparisons.

* **Reliability**
  * Improved consistency of WAV audio output across supported sample rates and app/plugin workflows.
  * Enhanced handling of multilingual punctuation, whitespace, Unicode text, and repeated-word comparisons.

* **Testing**
  * Expanded coverage for audio encoding, plugin ordering, punctuation normalization, and text differences.
  * Added performance benchmark validation for key processing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

