### PR TITLE
Restore local models after fallback engine selection

### DIFF
--- a/TypeWhisper/App/ServiceContainer.swift
+++ b/TypeWhisper/App/ServiceContainer.swift
@@ -369,7 +369,8 @@ final class ServiceContainer: ObservableObject {
         }
         pluginManager.scanAndLoadPlugins()
 
-        // Re-restore provider selection now that plugins are loaded
+        // Activation hydrates credentials and custom profiles before selection can settle.
+        // Reconciliation also requests passive restore from the final selected engine.
         modelManagerService.restoreProviderSelection()
         audioRecorderViewModel.reconcileSelectionWithAvailablePlugins()
         watchFolderViewModel.reconcileSelectionWithAvailablePlugins()

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -536,8 +536,8 @@ final class ModelManagerService: ObservableObject {
         let identity = ObjectIdentifier(plugin.instance)
         guard passiveRestoreSelection?.providerId != providerId
                 || passiveRestoreSelection?.instance != identity else { return }
-        passiveRestoreSelection = (providerId, identity)
         guard canUseForTranscription(engine) else { return }
+        passiveRestoreSelection = (providerId, identity)
         (plugin.instance as? any PassiveModelRestoreProviding)?.requestPassiveModelRestore()
     }
 

--- a/TypeWhisper/Services/ModelManagerService.swift
+++ b/TypeWhisper/Services/ModelManagerService.swift
@@ -193,6 +193,7 @@ final class ModelManagerService: ObservableObject {
     private var pluginRestoreBusyWaitAttempts = 5_700
     private var pluginConfiguredPollInterval: Duration = .milliseconds(100)
 
+    private var passiveRestoreSelection: (providerId: String, instance: ObjectIdentifier)?
     private let providerKey = UserDefaultsKeys.selectedEngine
     private let modelKey = UserDefaultsKeys.selectedModelId
 
@@ -277,11 +278,13 @@ final class ModelManagerService: ObservableObject {
     func selectProvider(_ providerId: String) {
         selectedProviderId = providerId
         UserDefaults.standard.set(providerId, forKey: providerKey)
+        reconcilePassiveModelRestore()
     }
 
     func clearProviderSelection() {
         selectedProviderId = nil
         UserDefaults.standard.removeObject(forKey: providerKey)
+        passiveRestoreSelection = nil
     }
 
     func selectModel(_ providerId: String, modelId: String) {
@@ -500,6 +503,7 @@ final class ModelManagerService: ObservableObject {
     /// Re-validate provider selection after plugins have been loaded.
     /// If the selected plugin is missing, fall back to the first available engine.
     func restoreProviderSelection() {
+        defer { reconcilePassiveModelRestore() }
         if let providerId = selectedProviderId,
            let engine = PluginManager.shared.transcriptionEngine(for: providerId),
            canUseForTranscription(engine) {
@@ -513,6 +517,28 @@ final class ModelManagerService: ObservableObject {
         } else {
             clearProviderSelection()
         }
+    }
+
+    /// Activation hydrates auth and profiles before selection can be reconciled.
+    /// Notify the selected runtime afterwards, including in-session fallback and reloads.
+    /// Readiness notifications for the same selection must not retry a failed restore.
+    private func reconcilePassiveModelRestore() {
+        guard let providerId = selectedProviderId,
+              let manager = PluginManager.shared,
+              let engine = manager.transcriptionEngine(for: providerId),
+              let plugin = manager.loadedPlugins.first(where: {
+                  $0.isEnabled && $0.isRuntimeLoaded
+                      && manager.transcriptionProviderIds(exposedBy: $0.instance).contains(providerId)
+              }) else {
+            passiveRestoreSelection = nil
+            return
+        }
+        let identity = ObjectIdentifier(plugin.instance)
+        guard passiveRestoreSelection?.providerId != providerId
+                || passiveRestoreSelection?.instance != identity else { return }
+        passiveRestoreSelection = (providerId, identity)
+        guard canUseForTranscription(engine) else { return }
+        (plugin.instance as? any PassiveModelRestoreProviding)?.requestPassiveModelRestore()
     }
 
     // MARK: - Transcription

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -17,7 +17,7 @@ enum CohereLocalNetworkAccessPolicy {
 // MARK: - Plugin Entry Point
 
 @objc(CohereLocalPlugin)
-final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, PluginSettingsWindowLayoutProviding, @unchecked Sendable {
+final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, PluginSettingsWindowLayoutProviding, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.cohere-transcribe"
     static let pluginName = "Cohere Transcribe (Local)"
     static let providerIdentifier = "cohere-transcribe"
@@ -102,6 +102,16 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
 
     private let state = OSAllocatedUnfairLock(initialState: State())
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -128,13 +138,12 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             host.setUserDefault(selectedModelId, forKey: "selectedModel")
         }
         if shouldRestore {
-            Task { [weak self] in
-                await self?.restoreLoadedModel(allowDownloads: false)
-            }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         let servers = state.withLock { state -> (Runtime?, CrispAsrServer?) in
             let runtime = state.runtime
             let startingServer = state.startingServer
@@ -318,7 +327,21 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
 
     // MARK: - Model Management
 
-    func loadModel(allowDownloads: Bool = true) async {
+    func loadModel(allowDownloads: Bool = true, passively: Bool = false, restoredModelId: String? = nil) async {
+        try? await modelLoadGate.withLock { [self] in
+            let host = state.withLock { $0.host }
+            guard let host else { return }
+            if passively {
+                guard host.shouldRestoreLoadedModelsPassively, !isConfigured else { return }
+            }
+            if let restoredModelId {
+                state.withLock { $0.selectedModelId = restoredModelId }
+            }
+            await performModelLoad(allowDownloads: allowDownloads && !passively)
+        }
+    }
+
+    private func performModelLoad(allowDownloads: Bool) async {
         guard let context = beginModelLoad() else { return }
         let assets = CohereLocalModelAssets(
             pluginDataDirectory: context.host.pluginDataDirectory,
@@ -400,15 +423,15 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
         }
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = false) async {
+    func restoreLoadedModel(allowDownloads: Bool = false, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
         let host = state.withLock { $0.host }
         let persistedModelId = host?.userDefault(forKey: "loadedModel") as? String
         guard host != nil,
               let loadedModelId = Self.model(for: persistedModelId)?.id else {
             return
         }
-        state.withLock { $0.selectedModelId = loadedModelId }
-        await loadModel(allowDownloads: allowDownloads)
+        await loadModel(allowDownloads: allowDownloads, passively: passively, restoredModelId: loadedModelId)
     }
 
     func unloadModel(clearPersistence: Bool = true) {

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/CohereLocalPlugin.swift
@@ -334,6 +334,12 @@ final class CohereLocalPlugin: NSObject, TranscriptionEnginePlugin, Transcriptio
             if passively {
                 guard host.shouldRestoreLoadedModelsPassively, !isConfigured else { return }
             }
+            if !allowDownloads || passively {
+                guard let model = Self.model(for: restoredModelId ?? selectedModelId),
+                      CohereLocalModelAssets(
+                        pluginDataDirectory: host.pluginDataDirectory, model: model
+                      ).isInstalled else { return }
+            }
             if let restoredModelId {
                 state.withLock { $0.selectedModelId = restoredModelId }
             }

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/Tests/CohereLocalPluginTests.swift
@@ -470,6 +470,25 @@ final class CohereLocalPluginTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: fastAssets.runtimeExecutableURL.path))
     }
 
+    func testPassiveRestoreWithMissingAssetsPreservesSelectionAndState() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["loadedModel": CohereLocalPlugin.fastModel.id,
+                       "selectedModel": CohereLocalPlugin.compactModel.id],
+            shouldRestoreLoadedModelsPassively: false
+        )
+        let plugin = CohereLocalPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+        host.shouldRestoreLoadedModelsPassively = true
+
+        await plugin.restoreLoadedModel(passively: true)
+
+        XCTAssertEqual(plugin.modelState, .notLoaded)
+        XCTAssertEqual(plugin.selectedModelId, CohereLocalPlugin.compactModel.id)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, CohereLocalPlugin.fastModel.id)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+    }
+
     func testPassiveRestorePolicyIsDeclaredForExternalPlugin() throws {
         let plugin = CohereLocalPlugin()
         let lifecycleAwarePlugin: any HostModelLifecyclePolicyAwarePlugin = plugin

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/GranitePlugin.swift
@@ -9,7 +9,7 @@ import MLXAudioSTT
 // MARK: - Plugin Entry Point
 
 @objc(GranitePlugin)
-final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.granite"
     static let pluginName = "Granite Speech"
 
@@ -27,6 +27,16 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     )
     private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -39,11 +49,12 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
-            Task { await restoreLoadedModel(allowDownloads: false) }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
@@ -195,7 +206,18 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     // MARK: - Model Management
 
-    fileprivate func loadModel(_ modelDef: GraniteModelDef) async throws {
+    fileprivate func loadModel(_ modelDef: GraniteModelDef, passively: Bool = false) async throws {
+        try await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+            }
+            guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+            try await performModelLoad(modelDef, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(_ modelDef: GraniteModelDef, allowDownloads: Bool) async throws {
         modelState = .loading
         do {
             let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models")
@@ -206,6 +228,10 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                guard allowDownloads else {
+                    modelState = .notLoaded
+                    return
+                }
                 removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
@@ -241,6 +267,8 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             }
             let loaded = try await GraniteSpeechModel.fromModelDirectory(modelDirectory)
 
+            try Task.checkCancellation()
+            guard host != nil else { return }
             model = loaded
             loadedModelId = modelDef.id
             _selectedModelId = modelDef.id
@@ -248,6 +276,11 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             host?.setUserDefault(modelDef.id, forKey: "loadedModel")
             modelState = .ready(modelDef.id)
             host?.notifyCapabilitiesChanged()
+        } catch is CancellationError {
+            if host != nil {
+                modelState = loadedModelId.map { .ready($0) } ?? .notLoaded
+            }
+            throw CancellationError()
         } catch {
             modelState = .error("\(error)")
             throw error
@@ -288,13 +321,17 @@ final class GranitePlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         )
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
+    func restoreLoadedModel(allowDownloads: Bool = true, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        }
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
               let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
             return
         }
         guard allowDownloads || hasDownloadedModel(modelDef) else { return }
-        try? await loadModel(modelDef)
+        try? await loadModel(modelDef, passively: passively)
     }
 
     private func hasDownloadedModel(_ modelDef: GraniteModelDef) -> Bool {
@@ -580,7 +617,7 @@ private struct GraniteSettingsView: View {
         .task {
             if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
-                await plugin.restoreLoadedModel(allowDownloads: false)
+                await plugin.restoreLoadedModel(allowDownloads: false, passively: true)
                 isPolling = false
                 modelState = plugin.modelState
             }

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/ParakeetPlugin.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreML
 import OSLog
 import SwiftUI
 import FluidAudio
@@ -39,7 +40,7 @@ private actor AsyncTranscriptionGate {
 // MARK: - Plugin Entry Point
 
 @objc(ParakeetPlugin)
-final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscriptionEnginePlugin, DictionaryTermsCapabilityProviding, TranscriptPreviewFallbackPolicyProviding, PluginSettingsActivityReporting, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.parakeet"
     static let pluginName = "Parakeet"
     static let vocabularyAssetFileName = "parakeet_vocab.json"
@@ -73,6 +74,16 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
     var lastConfiguredPrompt: String?
     var lastBoostingTermCount: Int = 0
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self, self.restoresModelOnActivate else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -98,11 +109,12 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
             }
         }
         if restoresModelOnActivate, host.shouldRestoreLoadedModelsPassively {
-            Task { await restoreLoadedModel(allowDownloads: false) }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         clearVocabularyBoostingState(resetModelState: true)
         asrManager = nil
         loadedAsrModels = nil
@@ -598,41 +610,101 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
 
     // MARK: - Model Management
 
-    fileprivate func loadModel() async {
+    fileprivate func loadModel(version: ParakeetVersion? = nil, passively: Bool = false) async {
+        let version = version ?? selectedVersion
+        try? await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                let vocabularyURL = Self.vocabularyAssetDirectory(for: version)
+                    .appendingPathComponent(Self.vocabularyAssetFileName)
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured,
+                      isModelDownloaded(version: version),
+                      Self.vocabularyAssetExists(at: vocabularyURL) else { return }
+            }
+            guard !(isConfigured && loadedModelId == version.modelDef.id) else { return }
+            await performModelLoad(version: version, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(version: ParakeetVersion, allowDownloads: Bool) async {
         modelState = .downloading
         downloadProgress = 0.1
 
         do {
             applyHuggingFaceTokenToEnvironment()
-            try await ensureVocabularyAsset(for: selectedVersion)
-            let models = try await AsrModels.downloadAndLoad(version: selectedVersion.asrModelVersion)
+            if allowDownloads {
+                try await ensureVocabularyAsset(for: version)
+            }
+            let models: AsrModels
+            if allowDownloads {
+                models = try await AsrModels.downloadAndLoad(version: version.asrModelVersion)
+            } else {
+                models = try Self.loadInstalledModels(version: version)
+            }
             downloadProgress = 0.7
 
             let manager = AsrManager(config: .default)
             try await manager.loadModels(models)
             downloadProgress = 1.0
 
+            try Task.checkCancellation()
+            guard host != nil else { return }
+            selectedVersion = version
             asrManager = manager
             loadedAsrModels = models
-            loadedModelId = selectedVersion.modelDef.id
-            _selectedModelId = selectedVersion.modelDef.id
+            loadedModelId = version.modelDef.id
+            _selectedModelId = version.modelDef.id
             modelState = .ready
 
-            host?.setUserDefault(selectedVersion.modelDef.id, forKey: "selectedModel")
-            host?.setUserDefault(selectedVersion.modelDef.id, forKey: "loadedModel")
-            host?.setUserDefault(selectedVersion.rawValue, forKey: "selectedVersion")
+            host?.setUserDefault(version.modelDef.id, forKey: "selectedModel")
+            host?.setUserDefault(version.modelDef.id, forKey: "loadedModel")
+            host?.setUserDefault(version.rawValue, forKey: "selectedVersion")
             host?.notifyCapabilitiesChanged()
 
-            if vocabularyBoostingEnabled {
+            // Optional vocabulary preparation remains on the explicit/first-use path;
+            // FluidAudio's CTC loader may repair its cache by downloading assets.
+            if vocabularyBoostingEnabled, allowDownloads {
                 let cacheDir = CtcModels.defaultCacheDirectory(for: .ctc110m)
                 if CtcModels.modelsExist(at: cacheDir) {
                     await downloadCtcModel()
                 }
             }
+        } catch is CancellationError {
+            if host != nil { modelState = isConfigured ? .ready : .notLoaded }
+            return
         } catch {
             modelState = .error(error.localizedDescription)
             downloadProgress = 0
         }
+    }
+
+    /// FluidAudio's high-level loaders can delete and re-download a corrupt cache,
+    /// even when every file exists. Passive restore must use local Core ML loading.
+    static func loadInstalledModels(version: ParakeetVersion, directory: URL? = nil) throws -> AsrModels {
+        let directory = directory ?? AsrModels.defaultCacheDirectory(for: version.asrModelVersion)
+        let vocabularyURL = directory.appendingPathComponent(ModelNames.ASR.vocabularyFile)
+        let tokens = try JSONDecoder().decode([String: String].self, from: Data(contentsOf: vocabularyURL))
+        var vocabulary: [Int: String] = [:]
+        for (key, token) in tokens {
+            if let id = Int(key) { vocabulary[id] = token }
+        }
+        guard !vocabulary.isEmpty else {
+            throw AsrModelsError.loadingFailed("Installed vocabulary is empty")
+        }
+        let configuration = AsrModels.defaultConfiguration()
+        let preprocessorConfiguration = MLModelConfiguration()
+        preprocessorConfiguration.computeUnits = .cpuOnly
+        preprocessorConfiguration.allowLowPrecisionAccumulationOnGPU = true
+        let jointFile = version == .v3 ? ModelNames.ASR.jointV3File : ModelNames.ASR.jointFile
+        return try AsrModels(
+            encoder: MLModel(contentsOf: directory.appendingPathComponent(ModelNames.ASR.encoderFile), configuration: configuration),
+            preprocessor: MLModel(contentsOf: directory.appendingPathComponent(ModelNames.ASR.preprocessorFile), configuration: preprocessorConfiguration),
+            decoder: MLModel(contentsOf: directory.appendingPathComponent(ModelNames.ASR.decoderFile), configuration: configuration),
+            joint: MLModel(contentsOf: directory.appendingPathComponent(jointFile), configuration: configuration),
+            configuration: configuration,
+            vocabulary: vocabulary,
+            version: version.asrModelVersion
+        )
     }
 
     static func vocabularyAssetURL(for version: ParakeetVersion) -> URL {
@@ -775,20 +847,15 @@ final class ParakeetPlugin: NSObject, DictionaryTermHintSourceProgressTranscript
         host?.notifyCapabilitiesChanged()
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
-        guard let savedModelId = host?.userDefault(forKey: "loadedModel") as? String else {
-            return
+    func restoreLoadedModel(allowDownloads: Bool = true, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
         }
-        if _selectedModelId == nil {
-            _selectedModelId = savedModelId
-            host?.setUserDefault(savedModelId, forKey: "selectedModel")
-        }
-        // Infer version from persisted model ID for backwards compatibility
-        if let version = ParakeetVersion.from(modelId: savedModelId) {
-            selectedVersion = version
-        }
-        guard allowDownloads || isModelDownloaded(version: selectedVersion) else { return }
-        await loadModel()
+        guard let savedModelId = host?.userDefault(forKey: "loadedModel") as? String else { return }
+        let version = ParakeetVersion.from(modelId: savedModelId) ?? selectedVersion
+        guard allowDownloads || isModelDownloaded(version: version) else { return }
+        await loadModel(version: version, passively: passively)
     }
 
     fileprivate func isModelDownloaded(version: ParakeetVersion) -> Bool {

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/Tests/ParakeetPluginTests.swift
@@ -66,6 +66,22 @@ final class ParakeetPluginTests: XCTestCase {
         return directory
     }
 
+    func testPassiveLocalLoaderPreservesCorruptCacheAndDoesNotRepairIt() throws {
+        let directory = try makeTemporaryDirectory()
+        let vocabulary = directory.appendingPathComponent(ParakeetPlugin.vocabularyAssetFileName)
+        try Data(#"{"0":"test"}"#.utf8).write(to: vocabulary)
+        let corruptModel = directory.appendingPathComponent("Encoder.mlmodelc")
+        try FileManager.default.createDirectory(at: corruptModel, withIntermediateDirectories: true)
+        let marker = corruptModel.appendingPathComponent("keep-me")
+        try Data("incomplete model".utf8).write(to: marker)
+
+        for version in ParakeetVersion.allCases {
+            XCTAssertThrowsError(try ParakeetPlugin.loadInstalledModels(version: version, directory: directory))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: marker.path))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: vocabulary.path))
+        }
+    }
+
     func testVocabularyAssetURLsMapToVersionRepositories() {
         XCTAssertEqual(
             ParakeetPlugin.vocabularyAssetURL(for: .v2).absoluteString,

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/Qwen3Plugin.swift
@@ -8,7 +8,7 @@ import MLXAudioSTT
 // MARK: - Plugin Entry Point
 
 @objc(Qwen3Plugin)
-final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, @unchecked Sendable {
+final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PluginRuntimeMemoryDiagnosticsReporting, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.qwen3"
     static let pluginName = "Qwen3 ASR"
 
@@ -44,6 +44,16 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
     )
     private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -55,11 +65,12 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
-            Task { await restoreLoadedModel(allowDownloads: false) }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
@@ -237,7 +248,18 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
 
     // MARK: - Model Management
 
-    fileprivate func loadModel(_ modelDef: Qwen3ModelDef) async throws {
+    fileprivate func loadModel(_ modelDef: Qwen3ModelDef, passively: Bool = false) async throws {
+        try await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+            }
+            guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+            try await performModelLoad(modelDef, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(_ modelDef: Qwen3ModelDef, allowDownloads: Bool) async throws {
         modelState = .loading
         do {
             let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models")
@@ -248,6 +270,10 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                guard allowDownloads else {
+                    modelState = .notLoaded
+                    return
+                }
                 removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
@@ -283,6 +309,8 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             }
             let loaded = try await Qwen3ASRModel.fromModelDirectory(modelDirectory)
 
+            try Task.checkCancellation()
+            guard host != nil else { return }
             model = loaded
             loadedModelId = modelDef.id
             _selectedModelId = modelDef.id
@@ -290,6 +318,11 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
             host?.setUserDefault(modelDef.id, forKey: "loadedModel")
             modelState = .ready(modelDef.id)
             host?.notifyCapabilitiesChanged()
+        } catch is CancellationError {
+            if host != nil {
+                modelState = loadedModelId.map { .ready($0) } ?? .notLoaded
+            }
+            throw CancellationError()
         } catch {
             modelState = .error("\(error)")
             throw error
@@ -330,11 +363,16 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
         )
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = false) async {
-        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil)
+    func restoreLoadedModel(allowDownloads: Bool = false, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        }
+        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil, passively: passively)
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = false, preferredModelId: String?) async {
+    func restoreLoadedModel(allowDownloads: Bool = false, preferredModelId: String?, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
         for modelId in restoreCandidateModelIds(
             preferredModelId: preferredModelId,
             allowDownloads: allowDownloads
@@ -343,7 +381,7 @@ final class Qwen3Plugin: NSObject, TranscriptionEnginePlugin, TranscriptionModel
                 continue
             }
             do {
-                try await loadModel(modelDef)
+                try await loadModel(modelDef, passively: passively)
                 return
             } catch {
                 continue
@@ -1151,7 +1189,7 @@ private struct Qwen3SettingsView: View {
             // Auto-restore previously loaded model
             if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
-                await plugin.restoreLoadedModel(allowDownloads: false)
+                await plugin.restoreLoadedModel(allowDownloads: false, passively: true)
                 isPolling = false
                 modelState = plugin.modelState
             }

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/SpeechAnalyzerPlugin.swift
@@ -9,7 +9,7 @@ import os
 
 @available(macOS 26, *)
 @objc(SpeechAnalyzerPlugin)
-final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, @unchecked Sendable {
+final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.speechanalyzer"
     static let pluginName = "Apple Speech"
     private static let logger = Logger(subsystem: "com.typewhisper.speechanalyzer", category: "Plugin")
@@ -23,6 +23,16 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
     fileprivate var cachedModels: [SpeechModelDef] = []
     private var releaseTask: Task<Void, Never>?
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -33,12 +43,13 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
             await populateModels()
             host.notifyCapabilitiesChanged()
             if host.shouldRestoreLoadedModelsPassively {
-                await restoreLoadedModel(allowDownloads: false)
+                requestPassiveModelRestore()
             }
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         if let locale = currentLocale {
             releaseTask = Task { await AssetInventory.release(reservedLocale: locale) }
         }
@@ -261,7 +272,18 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
         }.sorted { $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending }
     }
 
-    fileprivate func loadModel(_ modelDef: SpeechModelDef) async {
+    fileprivate func loadModel(_ modelDef: SpeechModelDef, passively: Bool = false) async {
+        try? await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+            }
+            guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+            await performModelLoad(modelDef, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(_ modelDef: SpeechModelDef, allowDownloads: Bool) async {
         modelState = .downloading
         downloadProgress = 0.1
 
@@ -275,6 +297,10 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
 
             // Download assets if needed
             if let downloader = try await AssetInventory.assetInstallationRequest(supporting: [transcriber]) {
+                guard allowDownloads else {
+                    modelState = .notLoaded
+                    return
+                }
                 let downloadProgressObj = downloader.progress
                 let progressTask = Task.detached { [downloadProgressObj] in
                     while !downloadProgressObj.isFinished && !Task.isCancelled {
@@ -283,13 +309,17 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
                         try? await Task.sleep(for: .milliseconds(250))
                     }
                 }
+                defer { progressTask.cancel() }
                 try await downloader.downloadAndInstall()
-                progressTask.cancel()
             }
 
             downloadProgress = 0.9
             try await AssetInventory.reserve(locale: modelDef.locale)
 
+            guard !Task.isCancelled, host != nil else {
+                await AssetInventory.release(reservedLocale: modelDef.locale)
+                return
+            }
             currentLocale = modelDef.locale
             loadedModelId = modelDef.id
             downloadProgress = 1.0
@@ -298,6 +328,7 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
             host?.setUserDefault(modelDef.id, forKey: "loadedModel")
             host?.notifyCapabilitiesChanged()
         } catch {
+            guard !Task.isCancelled, host != nil else { return }
             modelState = .error(error.localizedDescription)
             downloadProgress = 0
         }
@@ -343,7 +374,11 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
         host?.notifyCapabilitiesChanged()
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
+    func restoreLoadedModel(allowDownloads: Bool = true, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        }
         if cachedModels.isEmpty {
             await populateModels()
             host?.notifyCapabilitiesChanged()
@@ -357,7 +392,7 @@ final class SpeechAnalyzerPlugin: NSObject, LiveTranscriptionCapablePlugin, Tran
             let hasInstalledAssets = await self.hasInstalledAssets(for: modelDef)
             guard hasInstalledAssets else { return }
         }
-        await loadModel(modelDef)
+        await loadModel(modelDef, passively: passively)
     }
 
     func prepareModelForTranscription(languageCode: String?) async {

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/VoxtralPlugin.swift
@@ -9,7 +9,7 @@ import MLXAudioSTT
 // MARK: - Plugin Entry Point
 
 @objc(VoxtralPlugin)
-final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, @unchecked Sendable {
+final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.voxtral"
     static let pluginName = "Voxtral"
 
@@ -43,6 +43,16 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
     )
     private static let modelDownloadPatterns = ["*.safetensors", "*.json", "*.txt", "*.wav"]
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -55,11 +65,12 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         cleanupRedundantModelCopies()
 
         if shouldRestoreLoadedModelsPassively {
-            Task { await restoreLoadedModel(allowDownloads: false) }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         model = nil
         loadedModelId = nil
         modelState = .notLoaded
@@ -203,7 +214,18 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
     // MARK: - Model Management
 
-    fileprivate func loadModel(_ modelDef: VoxtralModelDef) async throws {
+    fileprivate func loadModel(_ modelDef: VoxtralModelDef, passively: Bool = false) async throws {
+        try await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+            }
+            guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+            try await performModelLoad(modelDef, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(_ modelDef: VoxtralModelDef, allowDownloads: Bool) async throws {
         modelState = .loading
         do {
             let modelsDir = host?.pluginDataDirectory.appendingPathComponent("models")
@@ -214,6 +236,10 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             if let existing = usableModelDirectory(for: modelDef, modelsDirectory: modelsDir) {
                 modelDirectory = existing
             } else {
+                guard allowDownloads else {
+                    modelState = .notLoaded
+                    return
+                }
                 removeIncompleteModelIfNeeded(modelDef, modelsDirectory: modelsDir)
                 guard let repoID = Repo.ID(rawValue: modelDef.repoId) else {
                     throw NSError(
@@ -248,6 +274,8 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
 
             let loaded = try VoxtralRealtimeModel.fromDirectory(modelDirectory)
 
+            try Task.checkCancellation()
+            guard host != nil else { return }
             model = loaded
             loadedModelId = modelDef.id
             _selectedModelId = modelDef.id
@@ -255,6 +283,11 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
             host?.setUserDefault(modelDef.id, forKey: "loadedModel")
             modelState = .ready(modelDef.id)
             host?.notifyCapabilitiesChanged()
+        } catch is CancellationError {
+            if host != nil {
+                modelState = loadedModelId.map { .ready($0) } ?? .notLoaded
+            }
+            throw CancellationError()
         } catch {
             modelState = .error("\(error)")
             throw error
@@ -296,13 +329,17 @@ final class VoxtralPlugin: NSObject, TranscriptionEnginePlugin, TranscriptionMod
         )
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
+    func restoreLoadedModel(allowDownloads: Bool = true, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        }
         guard let savedId = host?.userDefault(forKey: "loadedModel") as? String,
               let modelDef = Self.availableModels.first(where: { $0.id == savedId }) else {
             return
         }
         guard allowDownloads || hasDownloadedModel(modelDef) else { return }
-        try? await loadModel(modelDef)
+        try? await loadModel(modelDef, passively: passively)
     }
 
     private func hasDownloadedModel(_ modelDef: VoxtralModelDef) -> Bool {
@@ -605,7 +642,7 @@ private struct VoxtralSettingsView: View {
         .task {
             if case .notLoaded = plugin.modelState, plugin.shouldRestoreLoadedModelsPassively {
                 isPolling = true
-                await plugin.restoreLoadedModel(allowDownloads: false)
+                await plugin.restoreLoadedModel(allowDownloads: false, passively: true)
                 isPolling = false
                 modelState = plugin.modelState
             }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/Tests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/Tests/WhisperKitPluginLifecycleTests.swift
@@ -144,6 +144,57 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         #endif
     }
 
+    func testReconciliationRetriesActivationTimeDenialWithoutDownloadingMissingModel() async throws {
+        let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"],
+                                shouldRestoreLoadedModelsPassively: false)
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        host.shouldRestoreLoadedModelsPassively = true
+        plugin.requestPassiveModelRestore()
+        #if DEBUG
+        await waitForRestoreLoadedModelInvocationCount(plugin, toBecome: 1)
+        #endif
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertNil(plugin.loadingModelIdForTesting)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, "openai_whisper-tiny")
+        plugin.deactivate()
+    }
+
+    func testQueuedPassiveRestoreRechecksSelectionBeforeStarting() async throws {
+        let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"],
+                                shouldRestoreLoadedModelsPassively: false)
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        host.shouldRestoreLoadedModelsPassively = true
+        plugin.requestPassiveModelRestore()
+        host.shouldRestoreLoadedModelsPassively = false
+        // The controller starts on MainActor after this synchronous selection change.
+        try await Task.sleep(for: .milliseconds(50))
+        #if DEBUG
+        XCTAssertEqual(plugin.restoreLoadedModelInvocationCountForTesting, 0)
+        #endif
+        XCTAssertNil(plugin.loadingModelIdForTesting)
+        plugin.deactivate()
+    }
+
+    func testDeactivationCancelsQueuedPassiveRestore() async throws {
+        let host = try makeHost(defaults: ["loadedModel": "openai_whisper-tiny"])
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        plugin.requestPassiveModelRestore()
+        plugin.deactivate()
+        try await Task.sleep(for: .milliseconds(50))
+        #if DEBUG
+        XCTAssertEqual(plugin.restoreLoadedModelInvocationCountForTesting, 0)
+        #endif
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+    }
+
     func testRestoreWhileSameModelLoadingDoesNotStartAnotherLoad() async throws {
         let modelId = "openai_whisper-large-v3_turbo"
         let host = try makeHost(

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/Tests/WhisperKitPluginLifecycleTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/Tests/WhisperKitPluginLifecycleTests.swift
@@ -584,6 +584,27 @@ final class WhisperKitPluginLifecycleTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(host.capabilitiesChangedCount, 1)
     }
 
+    func testFailedPassiveRestorePreservesPersistedModelWithoutReportingAnError() async throws {
+        let modelId = "openai_whisper-tiny"
+        let host = try makeHost(defaults: ["loadedModel": modelId],
+                                shouldRestoreLoadedModelsPassively: false)
+        defer { TestSupport.remove(host.pluginDataDirectory) }
+        let directory = try makeUsableWhisperModelDirectory(host: host, modelId: modelId)
+        // The files pass the presence check but contain invalid Core ML data.
+        let plugin = WhisperKitPlugin()
+        plugin.activate(host: host)
+        defer { plugin.deactivate() }
+        host.shouldRestoreLoadedModelsPassively = true
+
+        await plugin.restoreLoadedModel(allowDownloads: false, passively: true)
+
+        XCTAssertEqual(host.userDefault(forKey: "loadedModel") as? String, modelId)
+        XCTAssertEqual(plugin.settingsModelState, .notLoaded)
+        XCTAssertNil(plugin.loadingModelIdForTesting)
+        XCTAssertEqual(host.capabilitiesChangedCount, 0)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: directory.path))
+    }
+
     private func makeUsableWhisperModelDirectory(
         host: MockHostServices,
         modelId: String

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -17,7 +17,7 @@ enum WhisperKitNetworkAccessPolicy {
 // MARK: - Plugin Entry Point
 
 @objc(WhisperKitPlugin)
-final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, @unchecked Sendable {
+final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin, TranscriptionModelCatalogProviding, DictionaryTermsCapabilityProviding, DictionaryTermsBudgetProviding, PluginSettingsActivityReporting, PluginDownloadedModelManaging, HostModelLifecyclePolicyAwarePlugin, PassiveModelRestoreProviding, @unchecked Sendable {
     static let pluginId = "com.typewhisper.whisperkit"
     static let pluginName = "WhisperKit"
     private static let maxConditioningPromptChars = 500
@@ -42,6 +42,16 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
     private(set) var restoreLoadedModelInvocationCountForTesting = 0
     #endif
 
+    private let passiveRestoreController = PluginPassiveModelRestoreController()
+    private let modelLoadGate = PluginLocalInferenceGate()
+
+    func requestPassiveModelRestore() {
+        passiveRestoreController.request { [weak self] in
+            guard let self else { return }
+            await self.restoreLoadedModel(allowDownloads: false, passively: true)
+        }
+    }
+
     required override init() {
         super.init()
     }
@@ -58,11 +68,12 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             }
         }
         if shouldRestoreLoadedModelsPassively {
-            Task { await restoreLoadedModel(allowDownloads: false) }
+            requestPassiveModelRestore()
         }
     }
 
     func deactivate() {
+        passiveRestoreController.cancel()
         invalidateModelLoad()
         releaseWhisperKitResources()
         whisperKit = nil
@@ -540,7 +551,18 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         return modelStorageRoots[0].appendingPathComponent(modelDef.id)
     }
 
-    fileprivate func loadModel(_ modelDef: WhisperModelDef) async {
+    fileprivate func loadModel(_ modelDef: WhisperModelDef, passively: Bool = false) async {
+        try? await modelLoadGate.withLock { [self] in
+            guard host != nil else { return }
+            if passively {
+                guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+            }
+            guard !(isConfigured && loadedModelId == modelDef.id) else { return }
+            await performModelLoad(modelDef, allowDownloads: !passively)
+        }
+    }
+
+    private func performModelLoad(_ modelDef: WhisperModelDef, allowDownloads: Bool) async {
         beginModelUse()
         defer { endModelUse() }
 
@@ -560,6 +582,11 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
                 downloadProgress = 0.80
                 modelFolder = modelPath
             } else {
+                guard allowDownloads else {
+                    clearLoadingModelIfCurrent(modelDef.id, generation: loadGeneration)
+                    modelState = .notLoaded
+                    return
+                }
                 removeIncompleteModelIfNeeded(at: modelPath)
                 modelState = .downloading
                 downloadProgress = 0.05
@@ -579,7 +606,9 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
                 }
             }
             guard isCurrentModelLoad(loadGeneration) else { return }
-            try await repairDownloadedModelIfNeeded(at: modelFolder, variant: modelDef.id)
+            if allowDownloads {
+                try await repairDownloadedModelIfNeeded(at: modelFolder, variant: modelDef.id)
+            }
             guard isCurrentModelLoad(loadGeneration) else { return }
 
             // Load
@@ -752,11 +781,16 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
         }
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true) async {
-        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil)
+    func restoreLoadedModel(allowDownloads: Bool = true, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
+        if passively {
+            guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        }
+        await restoreLoadedModel(allowDownloads: allowDownloads, preferredModelId: nil, passively: passively)
     }
 
-    func restoreLoadedModel(allowDownloads: Bool = true, preferredModelId: String?) async {
+    func restoreLoadedModel(allowDownloads: Bool = true, preferredModelId: String?, passively: Bool = false) async {
+        guard !Task.isCancelled else { return }
         #if DEBUG
         restoreLoadedModelInvocationCountForTesting += 1
         #endif
@@ -765,7 +799,7 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             allowDownloads: allowDownloads,
             preferredModelId: preferredModelId
         ) else { return }
-        await loadModel(modelDef)
+        await loadModel(modelDef, passively: passively)
     }
 
     private func modelDefinitionForRestore(
@@ -1352,7 +1386,7 @@ private struct WhisperKitSettingsView: View {
                 modelState = .loading(phase: "loading")
                 isPolling = true
                 Task {
-                    await plugin.restoreLoadedModel(allowDownloads: false)
+                    await plugin.restoreLoadedModel(allowDownloads: false, passively: true)
                     syncViewStateFromPlugin()
                 }
             }

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/WhisperKitPlugin.swift
@@ -680,8 +680,12 @@ final class WhisperKitPlugin: NSObject, SourceProgressTranscriptionEnginePlugin,
             whisperKit = nil
             loadedModelId = nil
             clearLoadingModelIfCurrent(modelDef.id, generation: loadGeneration)
-            modelState = .error(error.localizedDescription)
             downloadProgress = 0
+            guard allowDownloads else {
+                modelState = .notLoaded
+                return
+            }
+            modelState = .error(error.localizedDescription)
             host?.setUserDefault(nil, forKey: "loadedModel")
             host?.notifyCapabilitiesChanged()
         }

--- a/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
+++ b/TypeWhisperPluginSDK/Sources/TypeWhisperPluginSDK/TypeWhisperPlugin.swift
@@ -94,6 +94,66 @@ public extension PluginUserInterfaceProviding {
 
 public protocol HostModelLifecyclePolicyAwarePlugin: TypeWhisperPlugin {}
 
+/// Optional notification after the host reconciles its selected transcription engine.
+/// Implementations must re-check the live host policy, restore only installed assets,
+/// and coalesce this request with activation, settings and first-use model loads.
+/// The host may call this more than once; a request must not retry failed loads forever.
+public protocol PassiveModelRestoreProviding: HostModelLifecyclePolicyAwarePlugin {
+    func requestPassiveModelRestore()
+}
+
+/// Coalesces passive requests from activation and host selection reconciliation.
+/// Own one controller per plugin instance and cancel it on deactivation.
+public final class PluginPassiveModelRestoreController: @unchecked Sendable {
+    private let lock = NSLock()
+    private var task: Task<Void, Never>?
+    private var pendingRestore: (@Sendable () async -> Void)?
+    private var generation = 0
+
+    public init() {}
+
+    public func request(_ restore: @escaping @Sendable () async -> Void) {
+        lock.withLock {
+            // Keep the newest request even when an older gate read is finishing.
+            // Dropping it could miss a rapid away-and-back selection change.
+            pendingRestore = restore
+            guard task == nil else { return }
+            generation += 1
+            let currentGeneration = generation
+            // Start after the current main-actor selection/model update has finished.
+            // Correctness still comes from explicit reconciliation and the live gate.
+            task = Task { @MainActor [weak self] in
+                while !Task.isCancelled,
+                      let next = self?.takePending(currentGeneration) {
+                    await next()
+                }
+            }
+        }
+    }
+
+    public func cancel() {
+        lock.withLock {
+            generation += 1
+            task?.cancel()
+            task = nil
+            pendingRestore = nil
+        }
+    }
+
+    private func takePending(_ currentGeneration: Int) -> (@Sendable () async -> Void)? {
+        lock.withLock {
+            guard generation == currentGeneration else { return nil }
+            guard let next = pendingRestore else {
+                task = nil
+                return nil
+            }
+            pendingRestore = nil
+            return next
+        }
+    }
+}
+
+
 // MARK: - Shared Settings Activity
 
 public struct PluginSettingsActivity: Sendable, Equatable {

--- a/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PassiveModelRestoreControllerTests.swift
+++ b/TypeWhisperPluginSDK/Tests/TypeWhisperPluginSDKTests/PassiveModelRestoreControllerTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import TypeWhisperPluginSDK
+
+final class PassiveModelRestoreControllerTests: XCTestCase {
+    func testConcurrentRequestsCoalesceWhileRestoreIsInFlight() async {
+        let controller = PluginPassiveModelRestoreController()
+        let started = expectation(description: "restore started once")
+        started.assertForOverFulfill = true
+        let release = AsyncRestoreBarrier()
+        controller.request {
+            started.fulfill()
+            await release.wait()
+        }
+        await fulfillment(of: [started], timeout: 2)
+        let pending = expectation(description: "pending requests coalesced")
+        pending.assertForOverFulfill = true
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<32 {
+                group.addTask {
+                    controller.request { pending.fulfill() }
+                }
+            }
+        }
+        await release.open()
+        await fulfillment(of: [pending], timeout: 2)
+        controller.cancel()
+    }
+
+    func testCancelDoesNotLetOldCompletionClearNewRequest() async {
+        let controller = PluginPassiveModelRestoreController()
+        let oldStarted = expectation(description: "old restore started")
+        let oldCompleted = expectation(description: "old restore completed")
+        let oldRelease = AsyncRestoreBarrier()
+        controller.request {
+            oldStarted.fulfill()
+            await oldRelease.wait()
+            XCTAssertTrue(Task.isCancelled)
+            oldCompleted.fulfill()
+        }
+        await fulfillment(of: [oldStarted], timeout: 2)
+        controller.cancel()
+        let newStarted = expectation(description: "new restore started")
+        let newRelease = AsyncRestoreBarrier()
+        controller.request {
+            newStarted.fulfill()
+            await newRelease.wait()
+        }
+        await fulfillment(of: [newStarted], timeout: 2)
+        await oldRelease.open()
+        await fulfillment(of: [oldCompleted], timeout: 2)
+        // Give the old task's completion a chance to run before another request.
+        for _ in 0..<10 { await Task.yield() }
+        let pending = expectation(description: "request after new restore")
+        let state = RestoreTestState()
+        controller.request {
+            let isAllowed = await state.isAllowed
+            XCTAssertFalse(isAllowed, "Old completion cleared the new restore")
+            pending.fulfill()
+        }
+        for _ in 0..<10 { await Task.yield() }
+        await state.deselect()
+        await newRelease.open()
+        await fulfillment(of: [pending], timeout: 2)
+        controller.cancel()
+    }
+
+    func testSerializedLoadRechecksLivePolicyAfterWaiting() async throws {
+        let gate = PluginLocalInferenceGate()
+        let state = RestoreTestState()
+        let busy = expectation(description: "explicit load in flight")
+        let release = AsyncRestoreBarrier()
+        let explicit = Task {
+            try await gate.withLock {
+                busy.fulfill()
+                await release.wait()
+            }
+        }
+        await fulfillment(of: [busy], timeout: 2)
+        let passive = Task {
+            try await gate.withLock {
+                guard await state.isAllowed else { return }
+                await state.recordLoad()
+            }
+        }
+        await state.deselect()
+        await release.open()
+        try await explicit.value
+        try await passive.value
+        let loads = await state.loads
+        XCTAssertEqual(loads, 0)
+    }
+}
+
+private actor AsyncRestoreBarrier {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        guard !isOpen else { return }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+    func open() {
+        isOpen = true
+        let pending = waiters
+        waiters.removeAll()
+        pending.forEach { $0.resume() }
+    }
+}
+
+private actor RestoreTestState {
+    var isAllowed = true
+    var loads = 0
+    func deselect() { isAllowed = false }
+    func recordLoad() { loads += 1 }
+}

--- a/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
+++ b/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
@@ -508,6 +508,7 @@ final class PassiveRestoreReconciliationTests: XCTestCase {
         XCTAssertFalse(manager.loadedPlugins[0].isEnabled)
         XCTAssertFalse(manager.loadedPlugins[0].isRuntimeLoaded)
 
+        defaults.set(savedPolicy, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
         manager.loadedPlugins = savedPlugins
         await drainMainQueue()
         if let savedSelection { modelManager.selectProvider(savedSelection) }

--- a/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
+++ b/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
@@ -376,3 +376,233 @@ extension PassiveRestoreSelectedEngineTests {
                       "the selected engine must still restore at launch")
     }
 }
+
+// MARK: - Reconciliation after activation (#1279)
+
+@MainActor
+final class PassiveRestoreReconciliationTests: XCTestCase {
+    private func withManager(
+        selected: String?,
+        _ test: (PluginManager, ModelManagerService) async throws -> Void
+    ) async throws {
+        let defaults = UserDefaults.standard
+        let savedSelection = defaults.object(forKey: UserDefaultsKeys.selectedEngine)
+        let savedPolicy = defaults.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let savedManager = PluginManager.shared
+        let savedBus = EventBus.shared
+        let directory = try TestSupport.makeTemporaryDirectory()
+        defer {
+            PluginManager.shared = savedManager
+            EventBus.shared = savedBus
+            defaults.set(savedSelection, forKey: UserDefaultsKeys.selectedEngine)
+            defaults.set(savedPolicy, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            TestSupport.remove(directory)
+        }
+        defaults.set(selected, forKey: UserDefaultsKeys.selectedEngine)
+        defaults.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        EventBus.shared = EventBus()
+        let manager = PluginManager(appSupportDirectory: directory)
+        PluginManager.shared = manager
+        let modelManager = ModelManagerService()
+        try await test(manager, modelManager)
+    }
+
+    private func install(_ plugin: ReconciledRestorePlugin, in manager: PluginManager) {
+        let host = HostServicesImpl(
+            pluginId: plugin.providerId,
+            eventBus: EventBus.shared,
+            ruleNamesProvider: { [] },
+            backsSelectedTranscriptionEngine: PluginManager.selectionMatcher(
+                forEnginesExposedBy: [plugin.providerId]
+            )
+        )
+        plugin.activate(host: host)
+        manager.loadedPlugins.append(LoadedPlugin(
+            manifest: PluginManifest(id: plugin.providerId, name: plugin.providerId,
+                                     version: "1.0.0", principalClass: "ReconciledRestorePlugin"),
+            instance: plugin,
+            bundle: Bundle.main,
+            sourceURL: manager.pluginsDirectory.appendingPathComponent(plugin.providerId),
+            isEnabled: true
+        ))
+    }
+
+    func testMissingStartupSelectionRestoresFallbackAfterActivationDeclined() async throws {
+        try await withManager(selected: "missing") { manager, modelManager in
+            let fallback = ReconciledRestorePlugin(id: "local")
+            install(fallback, in: manager)
+            XCTAssertEqual(fallback.restores, 0)
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(modelManager.selectedProviderId, "local")
+            XCTAssertEqual(fallback.restores, 1)
+            XCTAssertEqual(fallback.selectionAtRestore, "local")
+        }
+    }
+
+    func testAbsentStartupSelectionRestoresChosenLocalEngine() async throws {
+        try await withManager(selected: nil) { manager, modelManager in
+            let fallback = ReconciledRestorePlugin(id: "local")
+            install(fallback, in: manager)
+            XCTAssertEqual(fallback.restores, 0)
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(fallback.restores, 1)
+        }
+    }
+
+    func testObservedRemovalAndClearedSelectionRestoreFallbackInSession() async throws {
+        try await withManager(selected: "removed") { manager, modelManager in
+            let removed = ReconciledRestorePlugin(id: "removed")
+            let fallback = ReconciledRestorePlugin(id: "local")
+            install(removed, in: manager)
+            install(fallback, in: manager)
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(fallback.restores, 0)
+            modelManager.observePluginManager()
+            // With no configured alternative, disable/uninstall clears the selection
+            // before publishing the changed plugin list. Exercise that observer route.
+            modelManager.clearProviderSelection()
+            removed.deactivate()
+            manager.loadedPlugins.removeFirst()
+            await drainMainQueue()
+            XCTAssertEqual(modelManager.selectedProviderId, "local")
+            XCTAssertEqual(fallback.restores, 1)
+        }
+    }
+
+    func testDisablingSelectedPluginThroughManagerRestoresLocalFallback() async throws {
+        let container = ServiceContainer.shared
+        let manager = container.pluginManager
+        let modelManager = container.modelManagerService
+        let savedManager = PluginManager.shared
+        let savedPlugins = manager.loadedPlugins
+        let savedSelection = modelManager.selectedProviderId
+        let defaults = UserDefaults.standard
+        let savedPersistedSelection = defaults.object(forKey: UserDefaultsKeys.selectedEngine)
+        let savedPolicy = defaults.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        let savedEnabled = defaults.object(forKey: "plugin.removed.enabled")
+        defer {
+            manager.loadedPlugins = savedPlugins
+            if let savedSelection { modelManager.selectProvider(savedSelection) }
+            else { modelManager.clearProviderSelection() }
+            defaults.set(savedPersistedSelection, forKey: UserDefaultsKeys.selectedEngine)
+            defaults.set(savedPolicy, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            defaults.set(savedEnabled, forKey: "plugin.removed.enabled")
+            PluginManager.shared = savedManager
+        }
+        PluginManager.shared = manager
+        manager.loadedPlugins = []
+        defaults.set(0, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+        modelManager.selectProvider("removed")
+        let removed = ReconciledRestorePlugin(id: "removed")
+        let fallback = ReconciledRestorePlugin(id: "local")
+        install(removed, in: manager)
+        install(fallback, in: manager)
+        // A valid bundle lets disable convert the runtime to an unloaded placeholder.
+        manager.loadedPlugins[0] = LoadedPlugin(
+            manifest: manager.loadedPlugins[0].manifest, instance: removed,
+            bundle: Bundle.main, sourceURL: Bundle.main.bundleURL, isEnabled: true
+        )
+        XCTAssertEqual(fallback.restores, 0)
+        manager.setPluginEnabled("removed", enabled: false)
+        XCTAssertNil(modelManager.selectedProviderId)
+        await drainMainQueue()
+        XCTAssertEqual(modelManager.selectedProviderId, "local")
+        XCTAssertEqual(fallback.restores, 1)
+        XCTAssertFalse(manager.loadedPlugins[0].isEnabled)
+        XCTAssertFalse(manager.loadedPlugins[0].isRuntimeLoaded)
+    }
+
+    func testReadinessChangesDoNotRetryFailedRestore() async throws {
+        try await withManager(selected: "missing") { manager, modelManager in
+            let fallback = ReconciledRestorePlugin(id: "local")
+            install(fallback, in: manager)
+            modelManager.observePluginManager()
+            modelManager.restoreProviderSelection()
+            let requests = fallback.requests
+            for _ in 0..<5 {
+                manager.notifyPluginStateChanged()
+            }
+            await drainMainQueue()
+            XCTAssertEqual(fallback.requests, requests)
+            XCTAssertEqual(fallback.restores, 1)
+        }
+    }
+
+    func testSelectionSwitchNotifiesNewEngineAndRuntimeReplacementNotifiesAgain() async throws {
+        try await withManager(selected: "one") { manager, modelManager in
+            let one = ReconciledRestorePlugin(id: "one")
+            let two = ReconciledRestorePlugin(id: "two")
+            install(one, in: manager)
+            install(two, in: manager)
+            modelManager.restoreProviderSelection()
+            modelManager.selectProvider("two")
+            XCTAssertEqual(two.restores, 1)
+            let requests = two.requests
+            modelManager.selectProvider("two")
+            XCTAssertEqual(two.requests, requests)
+            manager.loadedPlugins.removeLast()
+            let replacement = ReconciledRestorePlugin(id: "two")
+            install(replacement, in: manager)
+            let activationRequests = replacement.requests
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(replacement.requests, activationRequests + 1)
+        }
+    }
+
+    func testConfiguredCloudFallbackWinsAndTimedPolicyDoesNotRestoreLocalModel() async throws {
+        try await withManager(selected: "missing") { manager, modelManager in
+            let local = ReconciledRestorePlugin(id: "local")
+            let cloud = ReconciledRestorePlugin(id: "cloud", configured: true)
+            install(local, in: manager)
+            install(cloud, in: manager)
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(modelManager.selectedProviderId, "cloud")
+            XCTAssertEqual(local.restores, 0)
+            UserDefaults.standard.set(600, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
+            modelManager.selectProvider("local")
+            XCTAssertEqual(local.restores, 0)
+        }
+    }
+
+    private func drainMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async { continuation.resume() }
+        }
+    }
+}
+
+private final class ReconciledRestorePlugin: TranscriptionEnginePlugin, PassiveModelRestoreProviding, @unchecked Sendable {
+    static let pluginId = "test.reconciled.restore"
+    static let pluginName = "Reconciled Restore"
+    let providerId: String
+    let isConfigured: Bool
+    private var host: (any HostServices)?
+    private(set) var requests = 0
+    private(set) var restores = 0
+    private(set) var selectionAtRestore: String?
+
+    init() { providerId = "local"; isConfigured = false }
+    init(id: String, configured: Bool = false) { providerId = id; isConfigured = configured }
+    func activate(host: any HostServices) {
+        self.host = host
+        if host.shouldRestoreLoadedModelsPassively { requestPassiveModelRestore() }
+    }
+    func deactivate() { host = nil }
+    func requestPassiveModelRestore() {
+        requests += 1
+        guard host?.shouldRestoreLoadedModelsPassively == true, !isConfigured else { return }
+        restores += 1
+        selectionAtRestore = UserDefaults.standard.string(forKey: UserDefaultsKeys.selectedEngine)
+        // Remain unconfigured, like a missing asset or a failed load.
+    }
+    var providerDisplayName: String { providerId }
+    var transcriptionModels: [PluginModelInfo] { [] }
+    var selectedModelId: String? { nil }
+    func selectModel(_ modelId: String) {}
+    var supportsTranslation: Bool { false }
+    var supportsStreaming: Bool { false }
+    var supportedLanguages: [String] { [] }
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        PluginTranscriptionResult(text: "")
+    }
+}

--- a/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
+++ b/TypeWhisperTests/PassiveRestoreSelectedEngineTests.swift
@@ -481,9 +481,6 @@ final class PassiveRestoreReconciliationTests: XCTestCase {
         let savedPolicy = defaults.object(forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
         let savedEnabled = defaults.object(forKey: "plugin.removed.enabled")
         defer {
-            manager.loadedPlugins = savedPlugins
-            if let savedSelection { modelManager.selectProvider(savedSelection) }
-            else { modelManager.clearProviderSelection() }
             defaults.set(savedPersistedSelection, forKey: UserDefaultsKeys.selectedEngine)
             defaults.set(savedPolicy, forKey: UserDefaultsKeys.modelAutoUnloadSeconds)
             defaults.set(savedEnabled, forKey: "plugin.removed.enabled")
@@ -510,6 +507,29 @@ final class PassiveRestoreReconciliationTests: XCTestCase {
         XCTAssertEqual(fallback.restores, 1)
         XCTAssertFalse(manager.loadedPlugins[0].isEnabled)
         XCTAssertFalse(manager.loadedPlugins[0].isRuntimeLoaded)
+
+        manager.loadedPlugins = savedPlugins
+        await drainMainQueue()
+        if let savedSelection { modelManager.selectProvider(savedSelection) }
+        else { modelManager.clearProviderSelection() }
+        // The shared container survives this test. Drain its queued observer work
+        // before restoring the previous (possibly nil) global plugin manager.
+        await drainMainQueue()
+    }
+
+    func testAuthenticationBecomingAvailableRetriesReconciliation() async throws {
+        try await withManager(selected: nil) { manager, modelManager in
+            let plugin = ReconciledRestorePlugin(id: "local")
+            plugin.authAvailable = false
+            install(plugin, in: manager)
+            modelManager.selectProvider("local")
+            XCTAssertEqual(plugin.requests, 0)
+
+            plugin.authAvailable = true
+            modelManager.restoreProviderSelection()
+            XCTAssertEqual(plugin.requests, 1)
+            XCTAssertEqual(plugin.restores, 1)
+        }
     }
 
     func testReadinessChangesDoNotRetryFailedRestore() async throws {
@@ -571,11 +591,15 @@ final class PassiveRestoreReconciliationTests: XCTestCase {
     }
 }
 
-private final class ReconciledRestorePlugin: TranscriptionEnginePlugin, PassiveModelRestoreProviding, @unchecked Sendable {
+private final class ReconciledRestorePlugin: TranscriptionEnginePlugin, PassiveModelRestoreProviding, PluginAuthRoleStatusProviding, @unchecked Sendable {
     static let pluginId = "test.reconciled.restore"
     static let pluginName = "Reconciled Restore"
     let providerId: String
     let isConfigured: Bool
+    var authAvailable = true
+    func authStatus(for role: PluginAuthRole) -> PluginAuthRoleStatus {
+        authAvailable ? .available : .unavailable(reason: "Sign in required")
+    }
     private var host: (any HostServices)?
     private(set) var requests = 0
     private(set) var restores = 0


### PR DESCRIPTION
## Summary

When the saved transcription engine is unavailable, plugins can decline passive restore during activation before the host chooses a local fallback. The same gap occurs when disabling the selected plugin in-session. With auto-unload set to Never, the fallback then waits until first dictation to load its installed model.

Notify the selected plugin after provider reconciliation and selection changes through an optional SDK capability, adopted by Qwen3, Granite, Voxtral, WhisperKit, Parakeet, Cohere Local, and Apple Speech. Deduplicate host notifications by provider and runtime instance, coalesce passive requests, cancel them on deactivation, and serialize model loads with a fresh policy check before loading. Activation still hydrates credentials and custom profiles before fallback selection.

Passive loads use installed assets only. Parakeet uses direct local Core ML loading because FluidAudio's high-level loader can repair a corrupt cache by downloading it again; optional CTC preparation remains on the explicit/first-use path.

Closes #1279

## Test Plan

- [x] SDK suite: 744 tests, 3 skipped, no failures.
- [x] Startup, selection changes, runtime replacement, repeated readiness notifications, and the actual `setPluginEnabled` fallback route are covered. Removing the host reconciliation changes makes the new regression tests fail.
- [x] All 1,742 app tests pass. Regression coverage includes credentials becoming available after selection, missing Cohere assets preserving state, and a failed WhisperKit passive load preserving its restore marker. The shared-container test restores the unload policy and drains queued observer work before releasing its global manager.
- [x] WhisperKit lifecycle tests cover late policy changes, cancelled queued requests, missing assets, and existing in-flight loads. SDK tests cover coalescing and cancellation generations; Parakeet tests verify that corrupt local assets are preserved rather than repaired.
- [x] All seven plugin bundles built and signed locally. A real app start with an invalid saved engine and an installed Parakeet v2 model reached `ready` without opening engine settings or starting dictation.

```sh
swift test --package-path TypeWhisperPluginSDK
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -only-testing:TypeWhisperTests/PassiveRestoreReconciliationTests -only-testing:TypeWhisperTests/PassiveRestoreSelectedEngineTests -only-testing:TypeWhisperTests/WhisperKitPluginLifecycleTests CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO CODE_SIGN_IDENTITY='-' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
bash scripts/pr-preflight.sh origin/main
bash scripts/check_release_binary_instrumentation.sh --self-test
bash scripts/check_release_signing.sh --self-test
```

The preflight stops at 60 missing `zh-Hans` translations in AuthenticatedCLI and Meta. Both catalogs and the localization checker are identical to `main`; this PR changes no localization files. Its preceding Python checks pass, and the remaining release helper checks and SDK suite pass when run separately. Apple Speech selection and live-session model override tests also passed.
