### PR TITLE
Reduce Bluetooth recording startup time by ~95% with prepared input reuse

### DIFF
--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -11139,24 +11139,24 @@
         }
       }
     },
-    "Faster AirPods start" : {
+    "Faster Bluetooth start" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schnellerer AirPods-Start"
+            "value" : "Schnellerer Bluetooth-Start"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "AirPodsの起動を高速化"
+            "value" : "Bluetoothの起動を高速化"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "更快启动 AirPods"
+            "value" : "更快启动蓝牙麦克风"
           }
         }
       }
@@ -13896,24 +13896,24 @@
         }
       }
     },
-    "Keeps the AirPods microphone active between dictations. This shows the orange microphone indicator, uses more battery, and keeps AirPods audio in call-quality mode." : {
+    "Keeps the Bluetooth microphone active between dictations. Audio between dictations is discarded. This shows the orange microphone indicator, uses more battery, and keeps headset audio in call-quality mode." : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hält das AirPods-Mikrofon zwischen Diktaten aktiv. Dadurch wird der orangefarbene Mikrofonindikator angezeigt, der Akku stärker beansprucht und die AirPods-Audioqualität im Telefonie-Modus gehalten."
+            "value" : "Hält das Bluetooth-Mikrofon zwischen Diktaten aktiv. Audio zwischen Diktaten wird verworfen. Dadurch wird der orangefarbene Mikrofonindikator angezeigt, der Akku stärker beansprucht und die Headset-Audioqualität im Telefonie-Modus gehalten."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "音声入力の合間もAirPodsのマイクを有効に保ちます。オレンジ色のマイクインジケータが表示され、バッテリー消費が増え、AirPodsの音質は通話品質のままになります。"
+            "value" : "音声入力の合間もBluetoothマイクを有効に保ちます。入力の合間の音声は破棄されます。オレンジ色のマイクインジケータが表示され、バッテリー消費が増え、ヘッドセットの音質は通話品質のままになります。"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在两次听写之间保持 AirPods 麦克风处于启用状态。这会显示橙色麦克风指示器、增加耗电量，并让 AirPods 音频保持通话音质模式。"
+            "value" : "在两次听写之间保持蓝牙麦克风处于启用状态。两次听写之间的音频会被丢弃。这会显示橙色麦克风指示器、增加耗电量，并让耳机音频保持通话音质模式。"
           }
         }
       }

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -3167,6 +3167,7 @@ enum AudioInputFormatStabilizer {
             let currentTime = now()
             guard currentTime < deadline else { break }
             sleep(min(pollInterval, max(0, deadline - currentTime)))
+            if shouldCancel() { throw CancellationError() }
             lastFormat = readFormat()
         }
 

--- a/TypeWhisper/Services/AudioDeviceService.swift
+++ b/TypeWhisper/Services/AudioDeviceService.swift
@@ -3150,13 +3150,16 @@ enum AudioInputFormatStabilizer {
         timeout: TimeInterval = defaultTimeout,
         pollInterval: TimeInterval = defaultPollInterval,
         now: () -> TimeInterval = { CFAbsoluteTimeGetCurrent() },
+        shouldCancel: () -> Bool = { false },
         readFormat: () -> AVAudioFormat,
         sleep: (TimeInterval) -> Void = { Thread.sleep(forTimeInterval: $0) }
     ) throws -> AVAudioFormat {
         let deadline = now() + timeout
+        if shouldCancel() { throw CancellationError() }
         var lastFormat = readFormat()
 
         while true {
+            if shouldCancel() { throw CancellationError() }
             if isSettled(lastFormat, expectedHardwareFormat: expectedHardwareFormat) {
                 return lastFormat
             }
@@ -3257,12 +3260,14 @@ final class CoreAudioBluetoothInputRouteStabilizer: BluetoothInputRouteStabilizi
 func settledInputFormat(
     for inputNode: AVAudioInputNode,
     preferredDeviceID: AudioDeviceID?,
-    label: String
+    label: String,
+    shouldCancel: () -> Bool = { false }
 ) throws -> AVAudioFormat {
     let expectedHardwareFormat = AudioInputFormatStabilizer.expectedHardwareFormat(for: preferredDeviceID)
     return try AudioInputFormatStabilizer.waitForSettledFormat(
         label: label,
         expectedHardwareFormat: expectedHardwareFormat,
+        shouldCancel: shouldCancel,
         readFormat: { inputNode.outputFormat(forBus: 0) }
     )
 }

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -1146,11 +1146,11 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.audioRoutingConflict
         }
 
+        let hasRunningPreparedInput = engineLock.withLock {
+            self.preparedBluetoothInput?.deviceID == routeActivationRequest.inputDeviceID
+                && self.preparedBluetoothInput?.engine.isRunning == true
+        }
         do {
-            let hasRunningPreparedInput = engineLock.withLock {
-                self.preparedBluetoothInput?.deviceID == routeActivationRequest.inputDeviceID
-                    && self.preparedBluetoothInput?.engine.isRunning == true
-            }
             if !hasRunningPreparedInput {
                 try waitForBluetoothRouteStabilizationIfNeeded(
                     inputDeviceID: routeActivationRequest.inputDeviceID,
@@ -1243,6 +1243,15 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         installConfigurationObserver(for: engine)
 
         do {
+            if hasRunningPreparedInput, preparedBluetoothInput == nil {
+                try waitForBluetoothRouteStabilizationIfNeeded(
+                    inputDeviceID: routeActivationRequest.inputDeviceID,
+                    usesBluetoothTransport: routeActivationRequest.usesBluetoothTransport,
+                    reason: "recording-cold-fallback",
+                    readinessDeadline: readinessDeadline,
+                    shouldCancel: shouldCancel
+                )
+            }
             if let preparedBluetoothInput {
                 try startPreparedBluetoothEngineWithFallback(
                     preparedBluetoothInput,
@@ -1735,6 +1744,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         installConfigurationObserver(for: replacementEngine)
         teardownEngine(engine)
         engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        try waitForBluetoothRouteStabilizationIfNeeded(
+            inputDeviceID: preparedInput.deviceID,
+            usesBluetoothTransport: true,
+            reason: "\(label)-bluetooth-cold-fallback",
+            readinessDeadline: readinessDeadline,
+            shouldCancel: shouldCancel
+        )
         try startEngineWithRecovery(
             replacementEngine,
             label: "\(label)-bluetooth-cold-fallback",

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -519,11 +519,6 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         prepareRecordingInputIfEligible()
     }
 
-    private func inputSelectionDidChange(reason: String) {
-        invalidatePreparedRecordingInputs(reason: reason)
-        prepareRecordingInputIfEligible()
-    }
-
     private func performRecordingInputPreparationIfEligible() {
         guard !hasPendingRecordingStart else { return }
         if bluetoothInputPreparationDeviceID() != nil {
@@ -2991,7 +2986,21 @@ extension AudioRecordingService {
         engineLock.withLock { audioEngine }
     }
 
+    func testingClaimPreparedBluetoothInput(_ engine: AVAudioEngine, deviceID: AudioDeviceID) -> Bool {
+        let format = AVAudioFormat(standardFormatWithSampleRate: Self.targetSampleRate, channels: 1)!
+        engineLock.withLock {
+            preparedBluetoothInput = PreparedBluetoothInput(
+                engine: engine,
+                deviceID: deviceID,
+                tapFormat: format,
+                inputGeneration: 1
+            )
+        }
+        return claimPreparedBluetoothInputIfEligible() != nil
+    }
+
     func testingHasPreparedUSBInput(deviceID: AudioDeviceID) -> Bool {
+
         engineLock.withLock { preparedUSBInput?.deviceID == deviceID }
     }
 

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -912,6 +912,9 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             teardownPreparedEngine(staleInput.engine)
             bluetoothInputStartupTracker.reset()
             inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-stale")
+        } else if claimedInput != nil {
+            // Recording acquired its own activation reference. Release the preparation reference.
+            inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-claimed")
         }
         return claimedInput
     }
@@ -1428,13 +1431,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     /// Keep the working stream but discard all audio between dictations.
     private func keepBluetoothInputPrepared(_ engine: AVAudioEngine) -> Bool {
+        let preparationGeneration = engineLock.withLock { preparedInputGeneration }
         guard let deviceID = bluetoothInputPreparationDeviceID(),
               engine.isRunning,
               defaultInputController.defaultInputDeviceID() == deviceID,
               let generation = bluetoothInputStartupTracker.currentGenerationIfAvailable else {
             return false
         }
-        let preparationGeneration = engineLock.withLock { preparedInputGeneration }
         let format = engine.inputNode.outputFormat(forBus: 0)
         processingQueue.sync {
             bluetoothInputStartupTracker.disarm(generation: generation)
@@ -1796,7 +1799,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         let inputNode = engine.inputNode
-        var inputFormat = try settledInputFormat(for: inputNode, preferredDeviceID: inputRoute.engineDeviceID, label: label)
+        var inputFormat = try settledInputFormat(
+            for: inputNode,
+            preferredDeviceID: inputRoute.engineDeviceID,
+            label: label,
+            shouldCancel: shouldCancel
+        )
         if try enableVoiceProcessingIfNeeded(
             on: inputNode,
             inputRoute: inputRoute,
@@ -1806,7 +1814,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             inputFormat = try settledInputFormat(
                 for: inputNode,
                 preferredDeviceID: inputRoute.engineDeviceID,
-                label: "\(label)-voice-processing"
+                label: "\(label)-voice-processing",
+                shouldCancel: shouldCancel
             )
         }
         logger.info("\(label, privacy: .public) input format: sampleRate=\(inputFormat.sampleRate), channels=\(inputFormat.channelCount)")
@@ -1822,7 +1831,12 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             throw AudioRecordingError.engineStartFailed("Cannot create target audio format")
         }
 
-        let currentInputFormat = try settledInputFormat(for: inputNode, preferredDeviceID: inputRoute.engineDeviceID, label: "\(label)-tap")
+        let currentInputFormat = try settledInputFormat(
+            for: inputNode,
+            preferredDeviceID: inputRoute.engineDeviceID,
+            label: "\(label)-tap",
+            shouldCancel: shouldCancel
+        )
         try validateTapInstallationPreconditions(expected: inputFormat, current: currentInputFormat)
 
         let tapFormat = Self.tapFormat(for: currentInputFormat)

--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -42,29 +42,17 @@ enum USBRecordingInputPreparationPolicy {
     }
 }
 
-enum AirPodsRecordingInputPreparationPolicy {
-    static func isAirPods(deviceName: String?, usesBluetoothTransport: Bool) -> Bool {
-        guard usesBluetoothTransport, let deviceName else { return false }
-        return deviceName.range(
-            of: "AirPods",
-            options: [.caseInsensitive, .diacriticInsensitive]
-        ) != nil
-    }
-
+enum BluetoothRecordingInputPreparationPolicy {
     static func isEligible(
         hasMicrophonePermission: Bool,
         isEnabled: Bool,
         selectedDeviceID: AudioDeviceID?,
-        selectedDeviceName: String?,
         usesBluetoothTransport: Bool
     ) -> Bool {
         hasMicrophonePermission
             && isEnabled
             && selectedDeviceID != nil
-            && isAirPods(
-                deviceName: selectedDeviceName,
-                usesBluetoothTransport: usesBluetoothTransport
-            )
+            && usesBluetoothTransport
     }
 }
 
@@ -484,7 +472,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     /// Prepares the automatic built-in microphone or explicitly selected USB input
-    /// without starting capture. If the user explicitly opts in, an active AirPods
+    /// without starting capture. If the user explicitly opts in, an active Bluetooth
     /// stream can also be kept ready and reused by the next recording.
     func prepareRecordingInputIfEligible() {
         scheduleRecordingInputPreparation(after: 0)
@@ -508,16 +496,14 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             return changed
         }
         if changed {
-            inputSelectionDidChange(reason: "input-selection-changed")
-        } else {
-            prepareRecordingInputIfEligible()
+            invalidatePreparedRecordingInputs(reason: "input-selection-changed")
         }
     }
 
-    func handleAirPodsInstantStartPreferenceChange() {
+    func handleBluetoothInstantStartPreferenceChange() {
         recordingStartQueue.async { [weak self] in
             guard let self else { return }
-            self.invalidatePreparedRecordingInputs(reason: "airpods-instant-start-setting-changed")
+            self.invalidatePreparedRecordingInputs(reason: "bluetooth-instant-start-setting-changed")
             self.performRecordingInputPreparationIfEligible()
         }
     }
@@ -539,6 +525,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
     }
 
     private func performRecordingInputPreparationIfEligible() {
+        guard !hasPendingRecordingStart else { return }
         if bluetoothInputPreparationDeviceID() != nil {
             performBluetoothInputPreparationIfEligible()
         } else if builtInInputPreparationDeviceID() != nil {
@@ -552,15 +539,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         let selection = configLock.withLock {
             (
                 selectedDeviceID: _selectedDeviceID,
-                selectedDeviceName: _selectedInputDeviceName,
                 usesBluetoothTransport: _selectedInputDeviceUsesBluetoothTransport
             )
         }
-        guard AirPodsRecordingInputPreparationPolicy.isEligible(
+        guard BluetoothRecordingInputPreparationPolicy.isEligible(
             hasMicrophonePermission: hasMicrophonePermission,
             isEnabled: UserDefaults.standard.bool(forKey: UserDefaultsKeys.airPodsInstantStartEnabled),
             selectedDeviceID: selection.selectedDeviceID,
-            selectedDeviceName: selection.selectedDeviceName,
             usesBluetoothTransport: selection.usesBluetoothTransport
         ), let selectedDeviceID = selection.selectedDeviceID else {
             return nil
@@ -723,6 +708,61 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
     }
 
+    private var hasPendingRecordingStart: Bool {
+        asyncRecordingStartState.withLock { $0.activeRequestID != nil }
+    }
+
+    private func prepareBluetoothEngine(
+        deviceID: AudioDeviceID,
+        preparationGeneration: UInt64,
+        deadline: TimeInterval
+    ) throws -> PreparedBluetoothInput {
+        let shouldCancel = { [self] in
+            hasPendingRecordingStart
+                || engineLock.withLock { preparedInputGeneration != preparationGeneration }
+        }
+        while true {
+            try throwIfRecordingStartCancelled(shouldCancel)
+            try throwIfRecordingStartExpired(deadline)
+            let engine = AVAudioEngine()
+            do {
+                let capture = try configureEngineCapture(
+                    engine,
+                    label: "bluetooth-preparation",
+                    readinessDeadline: deadline,
+                    shouldCancel: shouldCancel
+                )
+                guard let generation = capture.bluetoothInputGeneration else {
+                    throw AudioRecordingError.engineStartFailed("Missing Bluetooth input generation")
+                }
+                try engine.start()
+                try waitForInitialInputReadinessIfNeeded(
+                    label: "bluetooth-preparation",
+                    generation: generation,
+                    deadline: deadline,
+                    isEngineRunning: { engine.isRunning },
+                    shouldCancel: shouldCancel
+                )
+                return PreparedBluetoothInput(
+                    engine: engine,
+                    deviceID: deviceID,
+                    tapFormat: capture.tapFormat,
+                    inputGeneration: generation
+                )
+            } catch {
+                teardownPreparedEngine(engine)
+                bluetoothInputStartupTracker.reset()
+                guard AudioEngineRecoveryPolicy.isRetryable(error: error) else { throw error }
+                logger.info("Bluetooth preparation retry after route change")
+                try waitBeforeRecordingStartRetry(
+                    0.05,
+                    readinessDeadline: deadline,
+                    shouldCancel: shouldCancel
+                )
+            }
+        }
+    }
+
     private func performBluetoothInputPreparationIfEligible() {
         guard !isRecordingActive,
               let deviceID = bluetoothInputPreparationDeviceID() else {
@@ -735,14 +775,13 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         guard !alreadyPrepared else { return }
         let preparationGeneration = engineLock.withLock { preparedInputGeneration }
         let preparationStart = CFAbsoluteTimeGetCurrent()
-        let engine = AVAudioEngine()
         let readinessDeadline = CFAbsoluteTimeGetCurrent() + Self.bluetoothInputReadinessTimeout
 
         outputVolumeGuard.captureBaseline()
         guard inputActivationGuard.activateIfNeeded(
             deviceID: deviceID,
             usesBluetoothTransport: true,
-            reason: "airpods-instant-start-prewarm"
+            reason: "bluetooth-instant-start-prewarm"
         ) else {
             outputVolumeGuard.clear()
             return
@@ -752,44 +791,17 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             try waitForBluetoothRouteStabilizationIfNeeded(
                 inputDeviceID: deviceID,
                 usesBluetoothTransport: true,
-                reason: "airpods-instant-start-prewarm",
+                reason: "bluetooth-instant-start-prewarm",
                 readinessDeadline: readinessDeadline,
-                shouldCancel: { false }
+                shouldCancel: { [self] in hasPendingRecordingStart }
             )
-            let configuredCapture = try configureEngineCapture(
-                engine,
-                label: "airpods-instant-start-prewarm",
-                readinessDeadline: readinessDeadline,
-                shouldCancel: { false }
-            )
-            guard let inputGeneration = configuredCapture.bluetoothInputGeneration else {
-                throw AudioRecordingError.engineStartFailed("Missing Bluetooth input generation")
-            }
-            try engine.start()
-            try waitForInitialInputReadinessIfNeeded(
-                label: "airpods-instant-start-prewarm",
-                generation: inputGeneration,
-                deadline: readinessDeadline,
-                isEngineRunning: { engine.isRunning },
-                shouldCancel: { false }
-            )
-            bluetoothInputStartupTracker.disarm(generation: inputGeneration)
-
-            guard !isRecordingActive,
-                  bluetoothInputPreparationDeviceID() == deviceID else {
-                teardownPreparedEngine(engine)
-                bluetoothInputStartupTracker.reset()
-                inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-ineligible")
-                outputVolumeGuard.clear()
-                return
-            }
-
-            let preparedInput = PreparedBluetoothInput(
-                engine: engine,
+            let preparedInput = try prepareBluetoothEngine(
                 deviceID: deviceID,
-                tapFormat: configuredCapture.tapFormat,
-                inputGeneration: inputGeneration
+                preparationGeneration: preparationGeneration,
+                deadline: readinessDeadline
             )
+            bluetoothInputStartupTracker.disarm(generation: preparedInput.inputGeneration)
+
             let storageResult = engineLock.withLock { () -> (stored: Bool, replaced: PreparedBluetoothInput?) in
                 guard preparedInputGeneration == preparationGeneration,
                       audioEngine == nil,
@@ -805,25 +817,24 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             }
             guard storageResult.stored else {
                 bluetoothInputStartupTracker.reset()
-                inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-not-stored")
+                inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-not-stored")
                 outputVolumeGuard.clear()
                 return
             }
 
-            outputVolumeGuard.restoreIfRaised(reason: "airpods-instant-start-prewarm")
+            outputVolumeGuard.restoreIfRaised(reason: "bluetooth-instant-start-prewarm")
             outputVolumeGuard.clear()
             let elapsedMs = (CFAbsoluteTimeGetCurrent() - preparationStart) * 1000
             logger.warning(
-                "AirPods Instant Start is ready in \(String(format: "%.1f", elapsedMs), privacy: .public)ms"
+                "Bluetooth Instant Start is ready in \(String(format: "%.1f", elapsedMs), privacy: .public)ms"
             )
         } catch {
-            teardownPreparedEngine(engine)
             bluetoothInputStartupTracker.reset()
-            inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-failed")
-            outputVolumeGuard.restoreIfRaised(reason: "airpods-instant-start-prewarm-failed")
+            inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-failed")
+            outputVolumeGuard.restoreIfRaised(reason: "bluetooth-instant-start-prewarm-failed")
             outputVolumeGuard.clear()
             logger.warning(
-                "AirPods Instant Start preparation failed; keeping cold-start fallback: \(error.localizedDescription, privacy: .public)"
+                "Bluetooth Instant Start preparation failed; keeping cold-start fallback: \(error.localizedDescription, privacy: .public)"
             )
         }
     }
@@ -900,9 +911,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         if let staleInput {
             teardownPreparedEngine(staleInput.engine)
             bluetoothInputStartupTracker.reset()
-            inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-stale")
-        } else if claimedInput != nil {
-            inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-claimed")
+            inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-stale")
         }
         return claimedInput
     }
@@ -925,7 +934,7 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         if let bluetoothInput = preparedInputs.2 {
             teardownPreparedEngine(bluetoothInput.engine)
             bluetoothInputStartupTracker.reset()
-            inputActivationGuard.restore(reason: "airpods-instant-start-prewarm-invalidated")
+            inputActivationGuard.restore(reason: "bluetooth-instant-start-prewarm-invalidated")
         }
         guard preparedInputs.0 != nil || preparedInputs.1 != nil || preparedInputs.2 != nil else { return }
         logger.info("Invalidated prepared recording input: \(reason, privacy: .public)")
@@ -1140,13 +1149,19 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         }
 
         do {
-            try waitForBluetoothRouteStabilizationIfNeeded(
-                inputDeviceID: routeActivationRequest.inputDeviceID,
-                usesBluetoothTransport: routeActivationRequest.usesBluetoothTransport,
-                reason: "recording-start",
-                readinessDeadline: readinessDeadline,
-                shouldCancel: shouldCancel
-            )
+            let hasRunningPreparedInput = engineLock.withLock {
+                self.preparedBluetoothInput?.deviceID == routeActivationRequest.inputDeviceID
+                    && self.preparedBluetoothInput?.engine.isRunning == true
+            }
+            if !hasRunningPreparedInput {
+                try waitForBluetoothRouteStabilizationIfNeeded(
+                    inputDeviceID: routeActivationRequest.inputDeviceID,
+                    usesBluetoothTransport: routeActivationRequest.usesBluetoothTransport,
+                    reason: "recording-start",
+                    readinessDeadline: readinessDeadline,
+                    shouldCancel: shouldCancel
+                )
+            }
         } catch {
             outputVolumeGuard.restoreIfRaised(reason: "recording-start-route-stabilization-failed")
             outputVolumeGuard.clear()
@@ -1383,13 +1398,17 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
         removeConfigurationObserver()
         outputVolumeGuard.captureBaseline()
-        teardownEngine(engine)
-        // Keep the engine alive briefly so CoreAudio's internal teardown callbacks
-        // cannot outlive the AVAudioEngine objects they still reference.
-        engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        let keptPreparedInput = keepBluetoothInputPrepared(engine)
+        if !keptPreparedInput {
+            teardownEngine(engine)
+            // CoreAudio teardown callbacks can outlive the stopped engine.
+            engineTeardownRetainer.retain(engine, for: Self.engineTeardownRetentionInterval)
+        }
         outputVolumeGuard.restoreIfRaised(reason: "recording-stop")
         outputVolumeGuard.clear()
-        inputActivationGuard.restore(reason: "recording-stop")
+        if !keptPreparedInput {
+            inputActivationGuard.restore(reason: "recording-stop")
+        }
 
         // Flush pending audio processing before grabbing the buffer
         processingQueue.sync { }
@@ -1405,6 +1424,33 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
         scheduleRecordingInputPreparation(after: Self.postRecordingInputPreparationDelay)
 
         return samples
+    }
+
+    /// Keep the working stream but discard all audio between dictations.
+    private func keepBluetoothInputPrepared(_ engine: AVAudioEngine) -> Bool {
+        guard let deviceID = bluetoothInputPreparationDeviceID(),
+              engine.isRunning,
+              defaultInputController.defaultInputDeviceID() == deviceID,
+              let generation = bluetoothInputStartupTracker.currentGenerationIfAvailable else {
+            return false
+        }
+        let preparationGeneration = engineLock.withLock { preparedInputGeneration }
+        let format = engine.inputNode.outputFormat(forBus: 0)
+        processingQueue.sync {
+            bluetoothInputStartupTracker.disarm(generation: generation)
+        }
+        return engineLock.withLock {
+            guard preparedInputGeneration == preparationGeneration,
+                  audioEngine == nil,
+                  preparedBluetoothInput == nil else { return false }
+            preparedBluetoothInput = PreparedBluetoothInput(
+                engine: engine,
+                deviceID: deviceID,
+                tapFormat: Self.tapFormat(for: format),
+                inputGeneration: generation
+            )
+            return true
+        }
     }
 
     /// Re-setup the audio engine after a system configuration change (e.g. notification sound).
@@ -1657,10 +1703,17 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
             }
 
             recoveryCoordinator.noteEngineStarted()
-            try waitForInitialInputReadinessIfNeeded(
+            // This stream was validated before the click. Require a fresh buffer
+            // from the new generation, including silence, before reporting ready.
+            try BluetoothInputReadinessChecker(
+                silentFallback: 0,
+                requiredSignalBufferCount: 1
+            ).waitForInitialInput(
                 label: "\(label)-prepared-bluetooth",
-                generation: recordingInputGeneration,
                 deadline: readinessDeadline,
+                readinessSnapshot: { [bluetoothInputStartupTracker] in
+                    bluetoothInputStartupTracker.snapshot(for: recordingInputGeneration)
+                },
                 isEngineRunning: { [recoveryCoordinator] in
                     engine.isRunning && !recoveryCoordinator.hasPendingConfigurationChange
                 },

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -1157,6 +1157,7 @@ final class DictationViewModel: ObservableObject {
             usesBluetoothTransport: resolvedInputSelection.usesBluetoothTransport,
             deviceName: resolvedInputSelection.deviceName
         )
+        audioRecordingService.prepareRecordingInputIfEligible()
     }
 
     func handleCancelHotkey() {

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -684,7 +684,7 @@ struct RecordingSettingsView: View {
     @State private var selectedProvider: String?
     @State private var customSounds: [String] = SoundChoice.installedCustomSounds()
     @State private var draggedInputDevicePriorityItem: AudioInputDevicePriorityItem?
-    @AppStorage(UserDefaultsKeys.airPodsInstantStartEnabled) private var airPodsInstantStartEnabled = false
+    @AppStorage(UserDefaultsKeys.airPodsInstantStartEnabled) private var bluetoothInstantStartEnabled = false
     private let soundService = ServiceContainer.shared.soundService
     private let audioRecordingService = ServiceContainer.shared.audioRecordingService
 
@@ -692,12 +692,9 @@ struct RecordingSettingsView: View {
         dictation.needsMicPermission || dictation.needsAccessibilityPermission
     }
 
-    private var usesAirPodsInput: Bool {
+    private var usesBluetoothInput: Bool {
         let selection = audioDevice.resolvedRecordingInputSelection()
-        return AirPodsRecordingInputPreparationPolicy.isAirPods(
-            deviceName: selection.deviceName,
-            usesBluetoothTransport: selection.usesBluetoothTransport
-        )
+        return selection.usesBluetoothTransport
     }
 
     private func transcriptionAuthNotice(for engines: [TranscriptionEnginePlugin]) -> String? {
@@ -970,16 +967,16 @@ struct RecordingSettingsView: View {
 
                 microphonePriorityEditor
 
-                if usesAirPodsInput {
+                if usesBluetoothInput {
                     Toggle(
-                        String(localized: "Faster AirPods start"),
-                        isOn: $airPodsInstantStartEnabled
+                        String(localized: "Faster Bluetooth start"),
+                        isOn: $bluetoothInstantStartEnabled
                     )
-                    .onChange(of: airPodsInstantStartEnabled) { _, _ in
-                        audioRecordingService.handleAirPodsInstantStartPreferenceChange()
+                    .onChange(of: bluetoothInstantStartEnabled) { _, _ in
+                        audioRecordingService.handleBluetoothInstantStartPreferenceChange()
                     }
 
-                    Text(String(localized: "Keeps the AirPods microphone active between dictations. This shows the orange microphone indicator, uses more battery, and keeps AirPods audio in call-quality mode."))
+                    Text(String(localized: "Keeps the Bluetooth microphone active between dictations. Audio between dictations is discarded. This shows the orange microphone indicator, uses more battery, and keeps headset audio in call-quality mode."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -266,35 +266,31 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         ))
     }
 
-    func testAirPodsInputPreparationRequiresExplicitOptInAndAirPodsBluetoothRoute() {
-        let airPodsID = AudioDeviceID(5)
+    func testBluetoothInputPreparationRequiresExplicitOptInAndBluetoothRoute() {
+        let deviceID = AudioDeviceID(5)
 
-        XCTAssertTrue(AirPodsRecordingInputPreparationPolicy.isEligible(
+        XCTAssertTrue(BluetoothRecordingInputPreparationPolicy.isEligible(
             hasMicrophonePermission: true,
             isEnabled: true,
-            selectedDeviceID: airPodsID,
-            selectedDeviceName: "AirPods Pro von Marco - Find My",
+            selectedDeviceID: deviceID,
             usesBluetoothTransport: true
         ))
-        XCTAssertFalse(AirPodsRecordingInputPreparationPolicy.isEligible(
+        XCTAssertFalse(BluetoothRecordingInputPreparationPolicy.isEligible(
             hasMicrophonePermission: true,
             isEnabled: false,
-            selectedDeviceID: airPodsID,
-            selectedDeviceName: "AirPods Pro",
+            selectedDeviceID: deviceID,
             usesBluetoothTransport: true
         ))
-        XCTAssertFalse(AirPodsRecordingInputPreparationPolicy.isEligible(
-            hasMicrophonePermission: true,
+        XCTAssertFalse(BluetoothRecordingInputPreparationPolicy.isEligible(
+            hasMicrophonePermission: false,
             isEnabled: true,
-            selectedDeviceID: airPodsID,
-            selectedDeviceName: "Jabra PRO 930",
+            selectedDeviceID: deviceID,
             usesBluetoothTransport: true
         ))
-        XCTAssertFalse(AirPodsRecordingInputPreparationPolicy.isEligible(
+        XCTAssertFalse(BluetoothRecordingInputPreparationPolicy.isEligible(
             hasMicrophonePermission: true,
             isEnabled: true,
-            selectedDeviceID: airPodsID,
-            selectedDeviceName: "AirPods Pro",
+            selectedDeviceID: deviceID,
             usesBluetoothTransport: false
         ))
     }
@@ -2687,6 +2683,35 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(engineRunningProbeCalls, 2)
     }
 
+    func testPreparedBluetoothInputWaitsForFreshSilentBuffer() throws {
+        let clock = FakeReadinessClock()
+        let tracker = BluetoothInputStartupTracker(now: { clock.now })
+        let oldGeneration = tracker.beginGeneration()
+        _ = tracker.consume(samples: [0.8], inputRMS: 0.8, generation: oldGeneration)
+        tracker.disarm(generation: oldGeneration)
+        let generation = try XCTUnwrap(tracker.armExistingGeneration(oldGeneration))
+        let checker = BluetoothInputReadinessChecker(
+            silentFallback: 0,
+            requiredSignalBufferCount: 1,
+            now: { clock.now },
+            sleep: { delay in
+                clock.now += delay
+                _ = tracker.consume(samples: [0], inputRMS: 0, generation: generation)
+            }
+        )
+
+        try checker.waitForInitialInput(
+            label: "prepared-test",
+            deadline: nil,
+            readinessSnapshot: { tracker.snapshot(for: generation) },
+            isEngineRunning: { true },
+            shouldCancel: { false }
+        )
+
+        XCTAssertEqual(clock.now, 0.01, accuracy: 0.001)
+        XCTAssertEqual(tracker.promoteCurrentGeneration()?.samples, [0])
+    }
+
     func testBluetoothInputReadinessRejectsReadyCandidateAfterRouteChange() {
         let checker = BluetoothInputReadinessChecker()
 
@@ -3145,6 +3170,7 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
             hasExplicitDeviceSelection: true,
             usesBluetoothTransport: false
         )
+        service.prepareRecordingInputIfEligible()
         await fulfillment(of: [prepared], timeout: 1.0)
         inputCaptureFactory.prepareHook = nil
         let didStorePreparedInput = await waitUntil(timeout: 1.0) {
@@ -3189,6 +3215,7 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
             hasExplicitDeviceSelection: true,
             usesBluetoothTransport: false
         )
+        service.prepareRecordingInputIfEligible()
         await fulfillment(of: [prepared], timeout: 1.0)
         inputCaptureFactory.prepareHook = nil
         let didStorePreparedInput = await waitUntil(timeout: 1.0) {

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -2710,7 +2710,43 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(engineRunningProbeCalls, 2)
     }
 
+    func testPreparedBluetoothClaimTransfersActivationOwnershipAcrossDictations() {
+        let preferenceKey = UserDefaultsKeys.airPodsInstantStartEnabled
+        let originalPreference = UserDefaults.standard.object(forKey: preferenceKey)
+        UserDefaults.standard.set(true, forKey: preferenceKey)
+        defer {
+            if let originalPreference {
+                UserDefaults.standard.set(originalPreference, forKey: preferenceKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: preferenceKey)
+            }
+        }
+        let controller = FakeAudioInputDeviceDefaultController(defaultInputDeviceID: 1)
+        let activation = AudioInputDeviceActivationGuard(controller: controller)
+        let service = AudioRecordingService(inputActivationGuard: activation)
+        service.hasMicrophonePermissionOverride = true
+        service.configureInputSelection(
+            deviceID: 2,
+            hasExplicitDeviceSelection: true,
+            usesBluetoothTransport: true
+        )
+        XCTAssertTrue(activation.activate(deviceID: 2, reason: "preparation"))
+
+        for _ in 0..<3 {
+            XCTAssertTrue(activation.activate(deviceID: 2, reason: "recording-start"))
+            XCTAssertTrue(service.testingClaimPreparedBluetoothInput(RunningAudioEngine(), deviceID: 2))
+            XCTAssertEqual(controller.setCalls, [2])
+            service.testingSetAudioEngine(nil)
+        }
+
+        activation.restore(reason: "preparation-invalidated")
+        XCTAssertEqual(controller.setCalls, [2, 1])
+        XCTAssertTrue(activation.activate(deviceID: 3, reason: "different-input"))
+        activation.restore(reason: "test-finished")
+    }
+
     func testPreparedBluetoothInputWaitsForFreshSilentBuffer() throws {
+
         let clock = FakeReadinessClock()
         let tracker = BluetoothInputStartupTracker(now: { clock.now })
         let oldGeneration = tracker.beginGeneration()
@@ -4363,6 +4399,10 @@ private final class FakeCoreAudioHALInputOperations: CoreAudioHALInputOperating,
         var timestamp = AudioTimeStamp()
         return inputProc(inputProcRefCon, &flags, &timestamp, 1, frameCount, nil)
     }
+}
+
+private final class RunningAudioEngine: AVAudioEngine {
+    override var isRunning: Bool { true }
 }
 
 private final class FakeReadinessClock: @unchecked Sendable {

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -418,7 +418,34 @@ final class AudioEngineRecoverySupportTests: XCTestCase {
         XCTAssertEqual(formats.count, 0)
     }
 
+    func testInputFormatStabilizerCancelsBeforeTheNextPoll() throws {
+        let staleFormat = try XCTUnwrap(AVAudioFormat(
+            commonFormat: .pcmFormatFloat32,
+            sampleRate: 48_000,
+            channels: 1,
+            interleaved: false
+        ))
+        var now: TimeInterval = 0
+        var cancelled = false
+
+        XCTAssertThrowsError(try AudioInputFormatStabilizer.waitForSettledFormat(
+            label: "test",
+            expectedHardwareFormat: AudioInputHardwareFormat(sampleRate: 16_000, channelCount: 1),
+            now: { now },
+            shouldCancel: { cancelled },
+            readFormat: { staleFormat },
+            sleep: {
+                now += $0
+                cancelled = true
+            }
+        )) { error in
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertEqual(now, AudioInputFormatStabilizer.defaultPollInterval)
+    }
+
     func testInputFormatStabilizerThrowsRetryableMismatchWhenFormatDoesNotSettle() {
+
         let staleDefaultFormat = AVAudioFormat(
             commonFormat: .pcmFormatFloat32,
             sampleRate: 48_000,


### PR DESCRIPTION
## Summary

Bluetooth recording startup can repeat route setup and readiness checks even when the microphone stream is already running. Extend the existing opt-in AirPods preparation to all Bluetooth inputs and reuse the working stream between dictations.

- Keep the prepared engine active after stop and discard audio between dictations. Require a fresh buffer from the next recording generation before reporting readiness, including when the input is silent.
- Skip route stabilization for a running prepared engine. Preserve cold-start recovery when that engine cannot be reused.
- Keep background preparation off the recording configuration path. Retry transient route changes within its deadline and cancel preparation when a recording request arrives, including during format polling.
- Balance input activation references across repeated dictations and prevent opt-out invalidation from racing with retained stop.

The setting remains off by default. It explains the active microphone indicator, battery use, and headset call-quality audio. The existing preference key is retained for compatibility. Transcription engine selection is unchanged; the local hardware test used Apple Speech Analyzer.

### Why recording startup was slow

- Active input preparation was limited to devices whose names matched AirPods. Other Bluetooth microphones could not use the prepared-stream path.
- Stopping a dictation shut down the working audio engine. The next dictation had to start capture again, even with the faster-start option enabled.
- A cold start waited for the Bluetooth route to settle, then waited for enough audio buffers to confirm readiness. A route change during startup could invalidate the engine and require another attempt. The observed baseline included such a retry.
- Input configuration could queue background preparation ahead of the recording request on the same serial queue. Preparation could therefore add work after the click. The format-stabilization loop also lacked cancellation checks and could hold that queue for up to one second.

The change moves preparation before the recording request and keeps the validated stream available between dictations. A prepared start still waits for a fresh buffer, but does not repeat the cold-start route wait. Background preparation yields to a pending recording request. Initial Bluetooth setup still takes time; the option keeps the microphone active to avoid repeating that work on each click.

### Measured startup time

Measured request-to-recording-readiness on a Sony WH-1000XM4:

| Measurement | Recording ready |
| --- | ---: |
| Installed v1.6.0, build 1091, one start including an engine retry | 1804.8 ms |
| Prepared stream, experimental build, start 1 | 82.6 ms |
| Prepared stream, experimental build, start 2 | 68.8 ms |
| Prepared stream, experimental build, start 3 | 76.8 ms |

The prepared-start median is **76.8 ms**, a **95.7%** reduction against that single observed baseline, summarized as **~95%** in the title. Initial background preparation took 1702 ms before the three recording requests.

This is an observed cold-to-prepared comparison across different builds, not a controlled benchmark against current `main` or a cold-start guarantee. These hardware measurements came from the experimental implementation before PR cleanup and review fixes. The final PR commit was built and unit-tested; its exact hardware timings have not been remeasured.

## Test Plan

- Built the final code and passed all **152 selected audio tests**, including fresh silent-buffer readiness, cancellable format polling, and activation ownership across repeated dictations.
- `swift test --package-path TypeWhisperPluginSDK`: **744 tests, 3 skipped, 0 failures**.
- `bash scripts/pr-preflight.sh origin/main`: script tests pass; localization check reports **60 missing zh-Hans translations** in AuthenticatedCLIPlugin and MetaPlugin. Verified identical output on unmodified official `main` at `fb058db5`.
- Ran the remaining preflight helpers separately: `bash scripts/check_release_binary_instrumentation.sh --self-test` and `bash scripts/check_release_signing.sh --self-test`; both pass.
- `git diff --check origin/main...HEAD` passes. Branch is based on official `main`, with no unrelated fork commits or experimental app identity/build changes.

Audio test command (local build and package cache directories supplied through these variables):

```sh
xcodebuild test -project TypeWhisper.xcodeproj -scheme TypeWhisper \
  -configuration Debug -destination 'platform=macOS,arch=arm64' \
  -parallel-testing-enabled NO -derivedDataPath "$DERIVED_DATA" \
  -clonedSourcePackagesDirPath "$PACKAGE_CACHE" -disableAutomaticPackageResolution \
  -only-testing:TypeWhisperTests/AudioEngineRecoverySupportTests \
  -only-testing:TypeWhisperTests/AudioRecordingServiceSelectedDeviceTests \
  -only-testing:TypeWhisperTests/AudioDeviceServiceCompatibilityTests \
  -only-testing:TypeWhisperTests/CoreAudioHALInputCaptureSessionTests \
  -only-testing:TypeWhisperTests/AudioOutputVolumeGuardTests \
  -only-testing:TypeWhisperTests/AudioOutputVolumeIntegrationTests \
  CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
```

Prepared with Codex. GPT-6 Astra performed a detailed code review and a second review after all three findings were fixed; the second review found no remaining blockers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preparation support for selected Bluetooth microphones and headsets, beyond AirPods.
  * Improved reuse of prepared Bluetooth audio devices between dictations.
  * Bluetooth microphone mode now discards audio captured between dictations.

* **Bug Fixes**
  * Improved recording startup reliability through route-readiness checks, retries, and fresh audio-buffer validation.
  * Recording preparation now stops promptly when cancellation is requested.

* **Localization**
  * Updated German, Japanese, and Simplified Chinese text to reference Bluetooth microphones and headsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
