### PR TITLE
fix: preserve prepared built-in microphone during Bluetooth eligibility check

### DIFF
--- a/TypeWhisper/Services/AudioRecordingService.swift
+++ b/TypeWhisper/Services/AudioRecordingService.swift
@@ -884,7 +884,8 @@ final class AudioRecordingService: ObservableObject, @unchecked Sendable {
 
     private func claimPreparedBluetoothInputIfEligible() -> PreparedBluetoothInput? {
         guard let deviceID = bluetoothInputPreparationDeviceID() else {
-            invalidatePreparedRecordingInputs(reason: "bluetooth-recording-route-ineligible")
+            // The built-in input is claimed next when Bluetooth is ineligible.
+            // Preserve its prepared engine; route changes invalidate inputs separately.
             return nil
         }
 
@@ -2986,6 +2987,25 @@ final class BluetoothInputReadinessChecker: AudioInputReadinessChecking {
 
 #if DEBUG
 extension AudioRecordingService {
+    func testingSetPreparedBuiltInInput(_ engine: AVAudioEngine, deviceID: AudioDeviceID) {
+        let format = AVAudioFormat(standardFormatWithSampleRate: Self.targetSampleRate, channels: 1)!
+        engineLock.withLock {
+            preparedBuiltInInput = PreparedBuiltInInput(
+                engine: engine,
+                defaultInputDeviceID: deviceID,
+                tapFormat: format
+            )
+        }
+    }
+
+    func testingClaimPreparedBluetoothInputIfEligible() -> Bool {
+        claimPreparedBluetoothInputIfEligible() != nil
+    }
+
+    func testingClaimPreparedBuiltInInputIfEligible() -> AVAudioEngine? {
+        claimPreparedBuiltInInputIfEligible()?.engine
+    }
+
     @discardableResult
     func testingReplaceAudioEngineForRecoveryIfNeeded(_ engine: AVAudioEngine) -> AVAudioEngine? {
         replaceAudioEngineForRecoveryIfNeeded(engine)

--- a/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
+++ b/TypeWhisperTests/AudioEngineRecoverySupportTests.swift
@@ -2710,6 +2710,27 @@ final class AudioRecordingServiceSelectedDeviceTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(engineRunningProbeCalls, 2)
     }
 
+    func testIneligibleBluetoothClaimPreservesPreparedBuiltInInputAcrossDictations() {
+        let deviceID = AudioDeviceID(733)
+        let service = AudioRecordingService(
+            defaultInputController: FakeAudioInputDeviceDefaultController(defaultInputDeviceID: deviceID),
+            inputTransportResolver: FakeAudioDeviceTransportResolver(
+                transports: [deviceID: kAudioDeviceTransportTypeBuiltIn]
+            )
+        )
+        service.hasMicrophonePermissionOverride = true
+
+        for _ in 0..<3 {
+            let engine = AVAudioEngine()
+            service.testingSetPreparedBuiltInInput(engine, deviceID: deviceID)
+
+            XCTAssertFalse(service.testingClaimPreparedBluetoothInputIfEligible())
+            XCTAssertTrue(service.testingClaimPreparedBuiltInInputIfEligible() === engine)
+            XCTAssertTrue(service.testingCurrentAudioEngine() === engine)
+            service.testingSetAudioEngine(nil)
+        }
+    }
+
     func testPreparedBluetoothClaimTransfersActivationOwnershipAcrossDictations() {
         let preferenceKey = UserDefaultsKeys.airPodsInstantStartEnabled
         let originalPreference = UserDefaults.standard.object(forKey: preferenceKey)


### PR DESCRIPTION
## Summary

Preserve the prepared built-in microphone when the Bluetooth input eligibility check returns false. Recording startup checks Bluetooth before claiming the built-in input; previously, the Bluetooth check invalidated all prepared inputs, discarding the built-in engine immediately before it could be reused.

Observed on v1.6.0 with the MacBook Air built-in microphone: logs show successful input preparation followed by `bluetooth-recording-route-ineligible` invalidation at each dictation, with approximately 483–700 ms from shortcut to first audio buffer. The same code remains on main. Route-change invalidation remains in place.

Adds a regression test checking that the same prepared built-in engine survives the Bluetooth check and is claimed across three simulated dictations. Actual latency improvement has not yet been measured.

## Test Plan

- [x] `swiftc -frontend -parse TypeWhisper/Services/AudioRecordingService.swift TypeWhisperTests/AudioEngineRecoverySupportTests.swift`
- [x] `git diff --check`
- [ ] Run `AudioEngineRecoverySupportTests`, including `testIneligibleBluetoothClaimPreservesPreparedBuiltInInputAcrossDictations`.
- [ ] Build and manually verify repeated built-in-microphone dictation, comparing request-to-first-buffer timings.

Local build and XCTest execution are unavailable because the development Mac has Command Line Tools only, without full Xcode. The PR build workflow can validate compilation; XCTest and physical microphone latency remain to be verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio input recovery when Bluetooth recording is unavailable.
  * Preserves the prepared built-in microphone so it can be reused for the next recording instead of being discarded.

* **Tests**
  * Added coverage confirming built-in audio input remains available across repeated recording attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->