### PR TITLE
Fix OpenRouter transcription fallback and prepare plugin 1.1.6

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -143,8 +143,7 @@ final class OpenRouterPlugin: NSObject,
 
         let preferredUpload: PluginAudioUploadFile
         if modelId == "microsoft/mai-transcribe-2" {
-            // MAI rejects M4A with a generic provider 400, which cannot trigger
-            // the format-specific WAV retry. Send supported audio immediately.
+            // MAI is known to reject M4A. Avoid a failed upload before the WAV retry.
             preferredUpload = PluginAudioUploadEncoder.wavUpload(from: audio)
         } else {
             preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
@@ -160,7 +159,7 @@ final class OpenRouterPlugin: NSObject,
         var (data, response) = try await PluginHTTPClient.data(for: request)
         if let httpResponse = response as? HTTPURLResponse,
            preferredUpload.format != "wav",
-           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+           Self.shouldRetryTranscriptionWithWav(
             statusCode: httpResponse.statusCode,
             responseData: data
            ) {
@@ -175,6 +174,20 @@ final class OpenRouterPlugin: NSObject,
         }
         try Self.validateTranscriptionResponse(data: data, response: response)
         return try Self.parseTranscriptionResponse(data)
+    }
+
+    private static func shouldRetryTranscriptionWithWav(statusCode: Int, responseData: Data) -> Bool {
+        if PluginAudioUploadEncoder.shouldRetryWithWavUpload(statusCode: statusCode, responseData: responseData) {
+            return true
+        }
+
+        // OpenRouter can hide the upstream format rejection behind this generic
+        // error. Try WAV once for any model; explicit request errors stay errors.
+        guard statusCode == 400,
+              let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let error = json["error"] as? [String: Any],
+              let message = error["message"] as? String else { return false }
+        return message == "Provider returned 400"
     }
 
     static func makeTranscriptionRequest(

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -141,8 +141,15 @@ final class OpenRouterPlugin: NSObject,
             throw PluginTranscriptionError.apiError("OpenRouter speech-to-text does not support translation.")
         }
 
-        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
-            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        let preferredUpload: PluginAudioUploadFile
+        if modelId == "microsoft/mai-transcribe-2" {
+            // MAI rejects M4A with a generic provider 400, which cannot trigger
+            // the format-specific WAV retry. Send supported audio immediately.
+            preferredUpload = PluginAudioUploadEncoder.wavUpload(from: audio)
+        } else {
+            preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+                ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        }
         var request = try Self.makeTranscriptionRequest(
             uploadFile: preferredUpload,
             apiKey: apiKey,

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -456,6 +456,89 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(retryBody["language"] as? String, "de")
     }
 
+    func testGenericProvider400RetriesOtherModelsWithWav() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("example/new-transcription-model")
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"Provider returned 400","code":400}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"text":"recovered transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(audio: Self.audio(), language: "de", translate: false, prompt: nil)
+        XCTAssertEqual(result.text, "recovered transcript")
+        let requests = store.sessions.flatMap(\.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        for (index, request) in requests.enumerated() {
+            let body = try Self.jsonBody(from: request)
+            XCTAssertEqual(body["model"] as? String, "example/new-transcription-model")
+            XCTAssertEqual(body["language"] as? String, "de")
+            let audio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+            XCTAssertEqual(audio["format"] as? String, index == 0 ? "m4a" : "wav")
+        }
+    }
+
+    func testGenericProvider400DoesNotRetryWavAgain() async throws {
+        for model in ["example/new-transcription-model", "microsoft/mai-transcribe-2"] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+            let plugin = OpenRouterPlugin()
+            plugin.activate(host: host)
+            plugin.selectModel(model)
+            let store = PluginHTTPClientSessionStore()
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: Array(repeating: .success(
+                    Data(#"{"error":{"message":"Provider returned 400","code":400}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 400)
+                ), count: 3))
+            }
+            do {
+                _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+                XCTFail("Expected provider error")
+            } catch {
+                guard case PluginTranscriptionError.apiError(let message) = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                XCTAssertEqual(message, "HTTP 400: Provider returned 400")
+            }
+            XCTAssertEqual(store.sessions.flatMap(\.requestedRequests).count, model == "microsoft/mai-transcribe-2" ? 1 : 2)
+        }
+    }
+
+    func testExplicitRequestErrorsDoNotTriggerWavRetry() async throws {
+        for (status, message) in [(400, "Model not found"), (401, "Invalid API key"), (403, "Forbidden"), (429, "Rate limited")] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+            let plugin = OpenRouterPlugin()
+            plugin.activate(host: host)
+            let store = PluginHTTPClientSessionStore()
+            let responseData = try JSONSerialization.data(withJSONObject: ["error": ["message": message]])
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: [.success(
+                    responseData,
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: status)
+                )])
+            }
+            do {
+                _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+                XCTFail("Expected HTTP \(status)")
+            } catch {
+                XCTAssertTrue(error is PluginTranscriptionError)
+            }
+            XCTAssertEqual(store.sessions.flatMap(\.requestedRequests).count, 1, "HTTP \(status)")
+        }
+    }
+
     func testTranscriptionHTTPErrorMapping() {
         XCTAssertThrowsError(try OpenRouterPlugin.validateTranscriptionResponse(
             data: Data(#"{"error":{"message":"bad key"}}"#.utf8),

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -383,6 +383,37 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(inputAudio["format"] as? String, "m4a")
     }
 
+    func testMAITranscribe2SendsWavOnFirstRequest() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("microsoft/mai-transcribe-2")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"MAI transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let audio = Self.audio()
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "MAI transcript")
+        let requests = store.sessions.flatMap(\.requestedRequests)
+        XCTAssertEqual(requests.count, 1)
+        let body = try Self.jsonBody(from: XCTUnwrap(requests.first))
+        XCTAssertEqual(body["model"] as? String, "microsoft/mai-transcribe-2")
+        XCTAssertEqual(body["language"] as? String, "en")
+        let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+        XCTAssertEqual(inputAudio["format"] as? String, "wav")
+        let encodedAudio = try XCTUnwrap(inputAudio["data"] as? String)
+        XCTAssertEqual(Data(base64Encoded: encodedAudio), PluginAudioUploadEncoder.wavUpload(from: audio).data)
+    }
+
     func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedModel": "openai/whisper-1"],

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",


### PR DESCRIPTION
OpenRouter transcription can reject an M4A upload with only `HTTP 400: Provider returned 400`, hiding the underlying format error and preventing the existing format-specific WAV fallback. A Discord report for MAI Transcribe 2 was reproduced live: M4A returns 400 and the same recording as WAV returns 200, with either automatic or explicit English language selection.

Retry this exact opaque provider 400 once with WAV for any transcription model. Keep the existing format-specific fallback and preserve explicit request/authentication/rate-limit errors without an extra upload. Already-WAV requests are never retried with WAV again. Send WAV immediately for the confirmed incompatible `microsoft/mai-transcribe-2` model to avoid a known failed request.

OpenRouter's model and endpoint metadata currently advertise audio input but do not enumerate accepted audio formats per model/provider, so they cannot reliably select M4A versus WAV in advance.

Bump the OpenRouter plugin manifest from 1.1.5 to 1.1.6.

### Validation
- Passed: `swift test --package-path TypeWhisperPluginSDK --filter OpenRouterPluginTests` (21 tests).
- Passed: `git diff --check` and `python3 -m json.tool TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json`.
- Passed live: `swift run --package-path /tmp/typewhisper-mai-check/harness OpenRouterPlugin` (temporary local harness compiling the current plugin/SDK source, using synthetic speech and a Keychain-loaded API key). The fixed plugin returned the expected transcript; M4A controls returned 400 and WAV controls returned 200. No credentials are stored in the repository.
- The tests cover unknown-model recovery, first-request WAV for MAI, preserving model/language/audio, retry exhaustion, already-WAV failures, and explicit 400/401/403/429 errors.
- Passed: `swift test --package-path TypeWhisperPluginSDK` (753 tests, 3 expected skips, 0 failures).

Live validation covers encoding, the plugin request/response path, and the remote API. Microphone capture and the app UI were not exercised. This PR does not publish a plugin release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription retries when OpenRouter returns a generic provider error.
  * WAV-format retries now apply consistently while avoiding repeated retry attempts.
  * Preserved direct WAV handling for the MAI transcription model.

* **Chores**
  * Updated the OpenRouter plugin to version 1.1.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->