### PR TITLE
Backport OpenRouter audio format fix for plugin 1.1.7

### DIFF
--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/OpenRouterPlugin.swift
@@ -141,8 +141,14 @@ final class OpenRouterPlugin: NSObject,
             throw PluginTranscriptionError.apiError("OpenRouter speech-to-text does not support translation.")
         }
 
-        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
-            ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        let preferredUpload: PluginAudioUploadFile
+        if modelId == "microsoft/mai-transcribe-2" {
+            // MAI is known to reject M4A. Avoid a failed upload before the WAV retry.
+            preferredUpload = PluginAudioUploadEncoder.wavUpload(from: audio)
+        } else {
+            preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: audio))
+                ?? PluginAudioUploadEncoder.wavUpload(from: audio)
+        }
         var request = try Self.makeTranscriptionRequest(
             uploadFile: preferredUpload,
             apiKey: apiKey,
@@ -153,7 +159,7 @@ final class OpenRouterPlugin: NSObject,
         var (data, response) = try await PluginHTTPClient.data(for: request)
         if let httpResponse = response as? HTTPURLResponse,
            preferredUpload.format != "wav",
-           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+           Self.shouldRetryTranscriptionWithWav(
             statusCode: httpResponse.statusCode,
             responseData: data
            ) {
@@ -168,6 +174,20 @@ final class OpenRouterPlugin: NSObject,
         }
         try Self.validateTranscriptionResponse(data: data, response: response)
         return try Self.parseTranscriptionResponse(data)
+    }
+
+    private static func shouldRetryTranscriptionWithWav(statusCode: Int, responseData: Data) -> Bool {
+        if PluginAudioUploadEncoder.shouldRetryWithWavUpload(statusCode: statusCode, responseData: responseData) {
+            return true
+        }
+
+        // OpenRouter can hide the upstream format rejection behind this generic
+        // error. Try WAV once for any model; explicit request errors stay errors.
+        guard statusCode == 400,
+              let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any],
+              let error = json["error"] as? [String: Any],
+              let message = error["message"] as? String else { return false }
+        return message == "Provider returned 400"
     }
 
     static func makeTranscriptionRequest(

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/Tests/OpenRouterPluginTests.swift
@@ -383,6 +383,37 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(inputAudio["format"] as? String, "m4a")
     }
 
+    func testMAITranscribe2SendsWavOnFirstRequest() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("microsoft/mai-transcribe-2")
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"text":"MAI transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let audio = Self.audio()
+        let result = try await plugin.transcribe(audio: audio, language: "en", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "MAI transcript")
+        let requests = store.sessions.flatMap(\.requestedRequests)
+        XCTAssertEqual(requests.count, 1)
+        let body = try Self.jsonBody(from: XCTUnwrap(requests.first))
+        XCTAssertEqual(body["model"] as? String, "microsoft/mai-transcribe-2")
+        XCTAssertEqual(body["language"] as? String, "en")
+        let inputAudio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+        XCTAssertEqual(inputAudio["format"] as? String, "wav")
+        let encodedAudio = try XCTUnwrap(inputAudio["data"] as? String)
+        XCTAssertEqual(Data(base64Encoded: encodedAudio), PluginAudioUploadEncoder.wavUpload(from: audio).data)
+    }
+
     func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
         let host = try PluginTestHostServices(
             defaults: ["selectedModel": "openai/whisper-1"],
@@ -423,6 +454,89 @@ final class OpenRouterPluginTests: XCTestCase {
         XCTAssertEqual(retryAudio["format"] as? String, "wav")
         XCTAssertEqual(retryBody["model"] as? String, "openai/whisper-1")
         XCTAssertEqual(retryBody["language"] as? String, "de")
+    }
+
+    func testGenericProvider400RetriesOtherModelsWithWav() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+        let plugin = OpenRouterPlugin()
+        plugin.activate(host: host)
+        plugin.selectModel("example/new-transcription-model")
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"Provider returned 400","code":400}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 400)
+                ),
+                .success(
+                    Data(#"{"text":"recovered transcript"}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(audio: Self.audio(), language: "de", translate: false, prompt: nil)
+        XCTAssertEqual(result.text, "recovered transcript")
+        let requests = store.sessions.flatMap(\.requestedRequests)
+        XCTAssertEqual(requests.count, 2)
+        for (index, request) in requests.enumerated() {
+            let body = try Self.jsonBody(from: request)
+            XCTAssertEqual(body["model"] as? String, "example/new-transcription-model")
+            XCTAssertEqual(body["language"] as? String, "de")
+            let audio = try XCTUnwrap(body["input_audio"] as? [String: Any])
+            XCTAssertEqual(audio["format"] as? String, index == 0 ? "m4a" : "wav")
+        }
+    }
+
+    func testGenericProvider400DoesNotRetryWavAgain() async throws {
+        for model in ["example/new-transcription-model", "microsoft/mai-transcribe-2"] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+            let plugin = OpenRouterPlugin()
+            plugin.activate(host: host)
+            plugin.selectModel(model)
+            let store = PluginHTTPClientSessionStore()
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: Array(repeating: .success(
+                    Data(#"{"error":{"message":"Provider returned 400","code":400}}"#.utf8),
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: 400)
+                ), count: 3))
+            }
+            do {
+                _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+                XCTFail("Expected provider error")
+            } catch {
+                guard case PluginTranscriptionError.apiError(let message) = error else {
+                    return XCTFail("Unexpected error: \(error)")
+                }
+                XCTAssertEqual(message, "HTTP 400: Provider returned 400")
+            }
+            XCTAssertEqual(store.sessions.flatMap(\.requestedRequests).count, model == "microsoft/mai-transcribe-2" ? 1 : 2)
+        }
+    }
+
+    func testExplicitRequestErrorsDoNotTriggerWavRetry() async throws {
+        for (status, message) in [(400, "Model not found"), (401, "Invalid API key"), (403, "Forbidden"), (429, "Rate limited")] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(secrets: ["api-key": "openrouter-key"])
+            let plugin = OpenRouterPlugin()
+            plugin.activate(host: host)
+            let store = PluginHTTPClientSessionStore()
+            let responseData = try JSONSerialization.data(withJSONObject: ["error": ["message": message]])
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: [.success(
+                    responseData,
+                    Self.httpResponse(url: "https://openrouter.ai/api/v1/audio/transcriptions", statusCode: status)
+                )])
+            }
+            do {
+                _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+                XCTFail("Expected HTTP \(status)")
+            } catch {
+                XCTAssertTrue(error is PluginTranscriptionError)
+            }
+            XCTAssertEqual(store.sessions.flatMap(\.requestedRequests).count, 1, "HTTP \(status)")
+        }
     }
 
     func testTranscriptionHTTPErrorMapping() {

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
     "version": "1.1.7",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.5.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -1,8 +1,8 @@
 {
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
-    "version": "1.1.5",
-    "minHostVersion": "1.5.0",
+    "version": "1.1.7",
+    "minHostVersion": "1.6.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",


### PR DESCRIPTION
Backport #1289 to the TypeWhisper 1.6 release branch and prepare OpenRouter plugin 1.1.7.

The 1.1.6 release build from main stopped before publication because its OpenRouter plugin references four newer SDK helpers absent from the released TypeWhisper 1.6 host (`PluginHTTPErrorBodyFormatter` methods and `PluginOpenAIChatHelper.chatMessageContent`). Building the same audio fix on the 1.6 source line retains the supported host API surface. The unused 1.1.6 tag is preserved; 1.1.7 is the next release version.

The behavior is unchanged from the reviewed fix: send WAV immediately for MAI Transcribe 2, and retry opaque OpenRouter provider 400 responses once with WAV for other models. Preserve explicit errors and avoid repeated WAV uploads. Set the manifest to 1.1.7 with the existing minimum host version 1.5.0.

### Validation
- Passed: `swift test --package-path /tmp/typewhisper-mai-check/harness --filter OpenRouterPluginTests` (19 tests, temporary isolated package compiling the 1.6 plugin and SDK sources).
- Live: `swift run --package-path /tmp/typewhisper-mai-check/harness OpenRouterPlugin` (synthetic speech through the actual plugin and OpenRouter API; credentials loaded from Keychain).
- Passed: `swift test --package-path TypeWhisperPluginSDK` (600 tests, 0 failures, clean build). A first attempt with a reused scratch directory failed due to duplicate Clang module cache paths; the clean build resolved that local cache problem.
- Passed after restoring the 1.5 host floor: `swift test --package-path TypeWhisperPluginSDK --filter OpenRouterPluginTests` (19 tests).
- Passed: `git diff --check origin/release/1.6...HEAD`.
- Release publication remains gated by the existing binary SDK compatibility, signing, and notarization checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved transcription compatibility with Microsoft MAI Transcribe 2 by sending audio in WAV format.
  - Added automatic WAV retry handling for eligible provider errors, while preventing repeated retries and preserving explicit request errors.

- **Compatibility**
  - OpenRouter plugin now supports host versions starting with 1.5.0.

- **Tests**
  - Added coverage for WAV uploads, fallback behavior, retry limits, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->