### PR TITLE
Monitor Swift and Bundler dependencies with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,41 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "swift"
+    # Root discovers the Xcode project; the SDK has its own Package.swift.
+    directories: ["/", "/TypeWhisperPluginSDK"]
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    groups:
+      swift-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    allow:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+    groups:
+      bundler-minor-patch:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/dependency-coverage.yml
+++ b/.github/workflows/dependency-coverage.yml
@@ -1,0 +1,58 @@
+name: Dependency Coverage
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: ruby scripts/dependency_coverage.rb check
+      - run: ruby scripts/test_dependency_coverage.rb
+
+  submit:
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
+    needs: validate
+    runs-on: ubuntu-latest
+    concurrency:
+      group: swift-dependency-submission
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A queued run submits the latest main, never an older lockfile snapshot.
+          ref: main
+          persist-credentials: false
+      - name: Submit committed Swift lockfiles
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ruby scripts/dependency_coverage.rb check
+          sha=$(git rev-parse HEAD)
+          ruby scripts/dependency_coverage.rb snapshot "$sha" refs/heads/main > "$RUNNER_TEMP/swift-snapshot.json"
+          gh api --method POST "repos/$GITHUB_REPOSITORY/dependency-graph/snapshots" --input "$RUNNER_TEMP/swift-snapshot.json"
+      - name: Verify Swift and Ruby coverage in GitHub SBOM
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          for attempt in 1 2 3 4 5 6; do
+            gh api "repos/$GITHUB_REPOSITORY/dependency-graph/sbom" > "$RUNNER_TEMP/dependency-sbom.json"
+            if ruby scripts/dependency_coverage.rb sbom "$RUNNER_TEMP/dependency-sbom.json" "$sha"; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 6 ]; then sleep 20; fi
+          done
+          echo "GitHub SBOM did not ingest all expected dependencies. Check the submission and graph before closing the issue."
+          exit 1

--- a/docs/dependency-monitoring.md
+++ b/docs/dependency-monitoring.md
@@ -1,0 +1,101 @@
+# Dependency monitoring
+
+Dependabot checks GitHub Actions, Swift and Bundler weekly. Each ecosystem has a
+minor/patch version-update group and a limit of three open version-update PRs.
+Routine major upgrades are maintainer-led changes with a separate compatibility
+review. No dependency PR is automatically merged.
+
+The `allow.update-types` rule only restricts scheduled version updates. Security
+updates remain individual PRs and may propose a major upgrade when required for
+a fix. Do not replace this rule with a blanket `ignore`, which can also prevent
+security updates. Security updates and alerts must remain enabled in repository
+settings; `dependabot.yml` alone does not enable them.
+
+## Coverage
+
+| Files | Dependabot entry | Dependency graph source |
+| --- | --- | --- |
+| `.github/workflows/*.yml` | `github-actions`, `/` | GitHub static analysis |
+| `Gemfile`, `Gemfile.lock` | `bundler`, `/` | GitHub static analysis |
+| `TypeWhisper.xcodeproj/project.pbxproj` and `TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` | `swift`, `/` | Committed lockfile submission |
+| `TypeWhisperPluginSDK/Package.swift`, `TypeWhisperPluginSDK/Package.resolved` | `swift`, `/TypeWhisperPluginSDK` | Committed lockfile submission |
+
+The root Swift entry discovers the Xcode project; the SDK requires its own
+directory. The current upstream Swift updater handles Xcode manifests and
+lockfiles. Confirm the first hosted Dependabot runs after merging: upstream
+support alone is not proof that this repository's update jobs succeed.
+
+Both Swift locks use format 3. On 2026-09-08 GitHub's static SBOM contained Ruby
+and Actions but no Swift packages. `Dependency Coverage` therefore submits both
+committed locks on every main push and on manual runs from main. It also checks
+the inventory on every PR, so a newly tracked Swift/Bundler manifest or Xcode
+project requires an explicit coverage decision.
+
+Snapshots retain each lockfile's path and all pinned versions, including
+different versions of the same package between app and SDK. Revision-only pins
+use their exact commit SHA. The script does not resolve packages, execute Swift
+manifests, or invent dependency edges, direct/transitive labels or runtime scope
+that `Package.resolved` does not contain.
+
+Swift advisories depend on GitHub's advisory data and recognizable affected
+versions. Revision-only dependencies require manual advisory and upstream review;
+a submitted SHA does not prove advisory matching or automatic remediation.
+Exact pins and cross-package compatibility constraints also require review of
+proposed updates. Validate app and SDK together when shared dependencies change.
+
+The submission appears in the repository dependency graph and SBOM. GitHub does
+not expose API-submitted dependencies in organization-level dependency insights.
+
+## Verification
+
+Run from the repository root, with Ruby and `actionlint` available:
+
+```sh
+ruby scripts/dependency_coverage.rb check
+ruby scripts/test_dependency_coverage.rb
+actionlint .github/workflows/dependency-coverage.yml
+git diff --check
+```
+
+The check covers all tracked Swift/Bundler manifests and locks, the Xcode
+manifest, and the Actions workflow directory. When adding a dependency ecosystem,
+extend the inventory and check rather than assuming this inventory covers it.
+
+Verify settings and the complete Swift/Ruby inventory against the current main
+commit (authenticated GitHub CLI required):
+
+```sh
+gh api repos/TypeWhisper/typewhisper-mac/automated-security-fixes
+gh api --include repos/TypeWhisper/typewhisper-mac/vulnerability-alerts
+git fetch origin main
+dependency_sha=$(git rev-parse origin/main)
+gh api repos/TypeWhisper/typewhisper-mac/dependency-graph/sbom > /tmp/typewhisper-sbom.json
+ruby scripts/dependency_coverage.rb sbom /tmp/typewhisper-sbom.json "$dependency_sha"
+```
+
+Expected settings: `enabled: true`, `paused: false`, and HTTP 204 for alerts.
+The SBOM check must pass for every Swift pin in both locks and every locked Ruby
+gem, not merely find one package from each ecosystem. The workflow retries this
+check for up to 100 seconds after submission to allow GitHub indexing to finish.
+
+If the graph needs refreshing, run `Dependency Coverage` on main. For a one-off
+bootstrap before the workflow is merged, generate a snapshot for the verified
+current main SHA and submit it using the same detector/correlator as the workflow:
+
+```sh
+ruby scripts/dependency_coverage.rb snapshot "$dependency_sha" refs/heads/main > /tmp/typewhisper-swift-snapshot.json
+gh api --method POST repos/TypeWhisper/typewhisper-mac/dependency-graph/snapshots --input /tmp/typewhisper-swift-snapshot.json
+```
+
+On 2026-09-08, snapshot `98538250` for main commit
+`09ac5a1186556c472018ef598c8a0c8c037e3ad3` was accepted. The subsequent SBOM check
+confirmed all 24 app pins, all 20 SDK pins, and all 97 Ruby dependencies. Security
+updates were enabled and verified with `enabled: true`, `paused: false`.
+The configuration and ongoing submission workflow only become active after merge.
+
+References:
+
+- [Dependabot options, including version-only allow rules](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#update-types-allow)
+- [Supported ecosystems](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories)
+- [Swift Xcode file discovery](https://github.com/dependabot/dependabot-core/blob/main/swift/lib/dependabot/swift/file_fetcher.rb)
+- [Dependency submission API and limitations](https://docs.github.com/en/rest/dependency-graph/dependency-submission)

--- a/scripts/dependency_coverage.rb
+++ b/scripts/dependency_coverage.rb
@@ -66,6 +66,7 @@ module DependencyCoverage
     expected = [["github-actions", "/"], ["swift", "/"], ["swift", "/TypeWhisperPluginSDK"], ["bundler", "/"]]
     raise "Dependabot directory coverage changed: #{coverage.inspect}" unless coverage.sort == expected.sort
     entries.each do |entry|
+      raise "Expected a limit of three open version-update PRs" unless entry["open-pull-requests-limit"] == 3
       raise "Security updates must target the default branch" if entry.key?("target-branch")
       raise "Expected weekly version checks" unless entry.dig("schedule", "interval") == "weekly"
       allow = [{ "dependency-name" => "*", "update-types" => %w[version-update:semver-minor version-update:semver-patch] }]

--- a/scripts/dependency_coverage.rb
+++ b/scripts/dependency_coverage.rb
@@ -1,0 +1,125 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require "json"
+require "open3"
+require "set"
+require "time"
+require "uri"
+require "yaml"
+
+# Uses only Ruby's standard library; it never resolves or executes dependencies.
+module DependencyCoverage
+  ROOT = File.expand_path("..", __dir__)
+  LOCKS = %w[
+    TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+    TypeWhisperPluginSDK/Package.resolved
+  ].freeze
+  MANIFESTS = (LOCKS + %w[Gemfile Gemfile.lock TypeWhisperPluginSDK/Package.swift TypeWhisper.xcodeproj/project.pbxproj]).freeze
+
+  def self.git(*args)
+    output, status = Open3.capture2("git", "-C", ROOT, *args)
+    raise "git #{args.first} failed" unless status.success?
+    output
+  end
+
+  def self.read(path, sha = nil)
+    sha ? git("show", "#{sha}:#{path}") : File.read(File.join(ROOT, path))
+  end
+
+  def self.purl(pin)
+    raise "Unsupported Swift pin kind: #{pin['kind']}" unless pin.fetch("kind") == "remoteSourceControl"
+    uri = URI.parse(pin.fetch("location"))
+    raise "Unsupported Swift source URL" unless uri.scheme == "https" && uri.host && !uri.userinfo && !uri.query && !uri.fragment
+    path = uri.path.delete_suffix(".git").delete_prefix("/")
+    raise "Invalid Swift source: #{uri}" if path.split("/").size < 2
+    state = pin.fetch("state")
+    version = state["version"] || state.fetch("revision")
+    raise "Empty Swift version: #{uri}" if version.empty?
+    encode = ->(part) { URI.encode_www_form_component(part).gsub("+", "%20") }
+    "pkg:swift/#{uri.host}/#{path.split('/').map(&encode).join('/')}@#{encode.call(version)}"
+  end
+
+  def self.swift_manifests(sha = nil)
+    LOCKS.to_h do |path|
+      lock = JSON.parse(read(path, sha))
+      raise "Unsupported lock format in #{path}" unless [2, 3].include?(lock.fetch("version"))
+      pins = lock.fetch("pins")
+      raise "Empty Swift lock: #{path}" if pins.empty?
+      resolved = pins.to_h { |pin| [pin.fetch("identity"), { "package_url" => purl(pin) }] }
+      raise "Duplicate Swift identities: #{path}" unless resolved.size == pins.size
+      # Lockfiles do not encode dependency edges; do not invent directness/scope.
+      [path, { "name" => path, "file" => { "source_location" => path }, "resolved" => resolved }]
+    end
+  end
+
+  def self.check
+    tracked = git("ls-files", "-z").split("\0")
+    discovered = tracked.select { |p| %w[Package.swift Package.resolved Gemfile Gemfile.lock project.pbxproj].include?(File.basename(p)) }
+    raise "Dependency inventory changed: #{(discovered.to_set ^ MANIFESTS.to_set).to_a.join(', ')}" unless discovered.to_set == MANIFESTS.to_set
+    config = YAML.safe_load(read(".github/dependabot.yml"))
+    raise "Expected Dependabot v2" unless config.fetch("version") == 2
+    entries = config.fetch("updates")
+    coverage = entries.flat_map do |entry|
+      (entry["directories"] || [entry.fetch("directory")]).map { |dir| [entry.fetch("package-ecosystem"), dir] }
+    end
+    expected = [["github-actions", "/"], ["swift", "/"], ["swift", "/TypeWhisperPluginSDK"], ["bundler", "/"]]
+    raise "Dependabot directory coverage changed: #{coverage.inspect}" unless coverage.sort == expected.sort
+    entries.each do |entry|
+      raise "Security updates must target the default branch" if entry.key?("target-branch")
+      raise "Expected weekly version checks" unless entry.dig("schedule", "interval") == "weekly"
+      allow = [{ "dependency-name" => "*", "update-types" => %w[version-update:semver-minor version-update:semver-patch] }]
+      raise "Expected version-only minor/patch policy" unless entry["allow"] == allow && !entry.key?("ignore")
+      groups = entry.fetch("groups").values
+      raise "Expected one minor/patch version group" unless groups.size == 1 && groups.first == {
+        "applies-to" => "version-updates", "patterns" => ["*"], "update-types" => %w[minor patch]
+      }
+    end
+    manifests = swift_manifests
+    manifests.each { |path, manifest| puts "#{path}: #{manifest.fetch('resolved').size} Swift pins" }
+    puts "Covered: #{MANIFESTS.size} manifests/locks and #{tracked.count { |p| p.match?(%r{\A.github/workflows/.*\.ya?ml\z}) }} workflows"
+  end
+
+  def self.snapshot(sha, ref)
+    raise "Expected a full commit SHA" unless sha&.match?(/\A[0-9a-f]{40}\z/)
+    raise "Expected a branch ref" unless ref&.start_with?("refs/heads/")
+    {
+      "version" => 0, "sha" => sha, "ref" => ref,
+      "job" => { "id" => ENV.fetch("GITHUB_RUN_ID", "manual-#{sha}"), "correlator" => "swift-lockfiles" },
+      "detector" => { "name" => "typewhisper-swift-lockfiles", "version" => "1.0.0",
+        "url" => "https://github.com/TypeWhisper/typewhisper-mac" },
+      "scanned" => Time.now.utc.iso8601, "manifests" => swift_manifests(sha)
+    }
+  end
+
+  def self.normalize(purl)
+    # GitHub repository names are case-insensitive. Versions remain case-sensitive.
+    purl.start_with?("pkg:swift/github.com/") ? purl.split("@", 2).then { |name, version| "#{name.downcase}@#{version}" } : purl
+  end
+
+  def self.check_sbom(sbom, sha)
+    actual = sbom.fetch("sbom").fetch("packages").flat_map do |package|
+      package.fetch("externalRefs", []).filter_map { |ref| normalize(ref.fetch("referenceLocator")) if ref["referenceType"] == "purl" }
+    end.to_set
+    expected = swift_manifests(sha).values.flat_map { |manifest| manifest.fetch("resolved").values.map { |dep| dep.fetch("package_url") } }
+    gems = read("Gemfile.lock", sha).scan(/^    ([A-Za-z0-9_-]+) \(([^ )]+)\)/)
+    raise "No Ruby dependencies found" if gems.empty?
+    expected.concat(gems.map { |name, version| "pkg:gem/#{name}@#{version}" })
+    missing = expected.map { |purl| normalize(purl) }.to_set - actual
+    raise "Missing from GitHub SBOM:\n#{missing.to_a.sort.join("\n")}" unless missing.empty?
+    puts "GitHub SBOM covers all Swift pins from both locks and #{gems.size} Ruby dependencies at #{sha}."
+  end
+end
+
+if $PROGRAM_NAME == __FILE__
+  begin
+    case ARGV.shift
+    when "check" then DependencyCoverage.check
+    when "snapshot" then puts JSON.pretty_generate(DependencyCoverage.snapshot(ARGV.shift, ARGV.shift))
+    when "sbom" then DependencyCoverage.check_sbom(JSON.parse(File.read(ARGV.fetch(0))), ARGV.fetch(1))
+    else abort "Usage: ruby scripts/dependency_coverage.rb check | snapshot SHA refs/heads/BRANCH | sbom FILE SHA"
+    end
+  rescue StandardError => error
+    abort error.message
+  end
+end

--- a/scripts/test_dependency_coverage.rb
+++ b/scripts/test_dependency_coverage.rb
@@ -1,9 +1,28 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "minitest/mock"
 require_relative "dependency_coverage"
 
 class DependencyCoverageTest < Minitest::Test
+  def test_check_rejects_missing_disabled_or_increased_pr_limits_for_each_ecosystem
+    original_read = DependencyCoverage.method(:read)
+    original_config = YAML.safe_load(original_read.call(".github/dependabot.yml"))
+    capture_io { DependencyCoverage.check }
+    original_config.fetch("updates").each_index do |index|
+      [nil, 0, 4].each do |limit|
+        config = Marshal.load(Marshal.dump(original_config))
+        entry = config.fetch("updates")[index]
+        limit.nil? ? entry.delete("open-pull-requests-limit") : entry["open-pull-requests-limit"] = limit
+        read = ->(path, sha = nil) { path == ".github/dependabot.yml" ? YAML.dump(config) : original_read.call(path, sha) }
+        DependencyCoverage.stub(:read, read) do
+          error = assert_raises(RuntimeError) { capture_io { DependencyCoverage.check } }
+          assert_equal "Expected a limit of three open version-update PRs", error.message
+        end
+      end
+    end
+  end
+
   def pin(state)
     { "identity" => "example", "kind" => "remoteSourceControl",
       "location" => "https://github.com/Owner/Example.git", "state" => state }

--- a/scripts/test_dependency_coverage.rb
+++ b/scripts/test_dependency_coverage.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "minitest/autorun"
+require_relative "dependency_coverage"
+
+class DependencyCoverageTest < Minitest::Test
+  def pin(state)
+    { "identity" => "example", "kind" => "remoteSourceControl",
+      "location" => "https://github.com/Owner/Example.git", "state" => state }
+  end
+
+  def test_versions_and_revision_only_pins
+    assert_equal "pkg:swift/github.com/Owner/Example@1.2.3", DependencyCoverage.purl(pin({ "version" => "1.2.3", "revision" => "abc" }))
+    assert_equal "pkg:swift/github.com/Owner/Example@abc", DependencyCoverage.purl(pin({ "revision" => "abc", "branch" => "main" }))
+    assert_equal "pkg:swift/github.com/Owner/Example@1.0%2Bbuild", DependencyCoverage.purl(pin({ "version" => "1.0+build" }))
+  end
+
+  def test_unsupported_and_incomplete_pins_fail_instead_of_disappearing
+    assert_raises(RuntimeError) { DependencyCoverage.purl(pin({ "version" => "1" }).merge("kind" => "registry")) }
+    assert_raises(KeyError) { DependencyCoverage.purl(pin({})) }
+    assert_raises(RuntimeError) { DependencyCoverage.purl(pin({ "version" => "1" }).merge("location" => "https://user:secret@example.com/a/b")) }
+  end
+
+  def test_snapshot_preserves_both_manifests_and_does_not_invent_edges
+    sha = DependencyCoverage.git("rev-parse", "HEAD").strip
+    snapshot = DependencyCoverage.snapshot(sha, "refs/heads/main")
+    assert_equal DependencyCoverage::LOCKS.sort, snapshot.fetch("manifests").keys.sort
+    snapshot.fetch("manifests").each do |path, manifest|
+      pins = JSON.parse(DependencyCoverage.read(path, sha)).fetch("pins")
+      assert_equal pins.size, manifest.fetch("resolved").size
+      assert manifest.fetch("resolved").values.all? { |dep| dep.keys == ["package_url"] }
+    end
+    assert_equal sha, snapshot.fetch("sha")
+    assert_raises(RuntimeError) { DependencyCoverage.snapshot("HEAD", "refs/heads/main") }
+  end
+
+  def test_sbom_requires_every_version_including_different_versions_between_locks
+    sha = DependencyCoverage.git("rev-parse", "HEAD").strip
+    purls = DependencyCoverage.swift_manifests(sha).values.flat_map { |m| m.fetch("resolved").values.map { |d| d.fetch("package_url") } }
+    purls.concat(DependencyCoverage.read("Gemfile.lock", sha).scan(/^    ([A-Za-z0-9_-]+) \(([^ )]+)\)/).map { |n, v| "pkg:gem/#{n}@#{v}" })
+    sbom = { "sbom" => { "packages" => purls.uniq.map { |url| { "externalRefs" => [{ "referenceType" => "purl", "referenceLocator" => DependencyCoverage.normalize(url) }] } } } }
+    capture_io { DependencyCoverage.check_sbom(sbom, sha) }
+    sbom["sbom"]["packages"].shift
+    assert_raises(RuntimeError) { DependencyCoverage.check_sbom(sbom, sha) }
+  end
+end


### PR DESCRIPTION
## Summary

Closes #1257.

Dependabot previously monitored only GitHub Actions, automated security updates were disabled, and GitHub's SBOM omitted both committed Swift dependency sets. This adds Swift updates for the Xcode app and plugin SDK, Bundler updates, and weekly minor/patch groups for all three ecosystems. Scheduled major upgrades remain manual; the version-only allow rules leave security fixes unrestricted.

A dependency coverage workflow inventories every committed Swift/Bundler manifest and lock plus the Xcode project and Actions directory. On main it submits both Swift locks at the checked-out commit, then verifies every Swift pin and locked Ruby gem against GitHub's SBOM. PR validation is read-only. Revision-only pins retain their SHA; the snapshot does not invent dependency relationships absent from the locks.

Repository settings have already been updated and verified: security updates are enabled and not paused; alerts are enabled. A one-off submission of the existing main commit `09ac5a1186556c472018ef598c8a0c8c037e3ad3` succeeded (snapshot `98538250`), and the live SBOM now covers all 24 app pins, all 20 SDK pins, and all 97 Ruby dependencies.

## Test Plan

- [x] `ruby scripts/dependency_coverage.rb check` — six manifests/locks and eleven workflows covered.
- [x] `ruby scripts/test_dependency_coverage.rb` — five tests, thirty-two assertions pass, including missing/disabled/increased PR limits for every ecosystem, revision pins, malformed pins, exact-commit snapshots and missing SBOM entries.
- [x] `actionlint .github/workflows/dependency-coverage.yml`
- [x] `git diff --cached --check`
- [x] `gh api repos/TypeWhisper/typewhisper-mac/automated-security-fixes` — enabled, not paused.
- [x] `gh api --include repos/TypeWhisper/typewhisper-mac/vulnerability-alerts` — HTTP 204.
- [x] `gh api repos/TypeWhisper/typewhisper-mac/dependency-graph/sbom > /tmp/typewhisper-1257-sbom.json`
- [x] `ruby scripts/dependency_coverage.rb sbom /tmp/typewhisper-1257-sbom.json 09ac5a1186556c472018ef598c8a0c8c037e3ad3` — complete Swift/Ruby coverage.
- [x] CI on `95f28b673b9ada44fd3a31a39d92418eaa1c22ff`: Dependency Coverage, CodeQL, PR Guard, release builds, app tests and SDK tests pass. One SDK run hit an intermittent missing temporary file in the unchanged MCP timeout test; the parallel same-head run and the authorized single-job retry passed. Verified with `gh run view 34262161788 --repo TypeWhisper/typewhisper-mac --attempt 2 --json status,conclusion,jobs` and `gh run view 34262165771 --repo TypeWhisper/typewhisper-mac --json status,conclusion,jobs`.
- [ ] After merge: confirm the first hosted Swift/Bundler update jobs and the recurring submission workflow succeed.

No local app build or app preflight was run: this changes dependency automation and documentation, not application code or dependency versions. Automatic remediation of revision-only pins is not guaranteed; those still require manual advisory review. Submitted dependencies appear in the repository graph/SBOM, but GitHub does not include API submissions in organization-level dependency insights. The regular workflow and update policy only take effect after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update management for GitHub Actions, Swift, and Ruby dependencies.
  * Added automated dependency coverage and software bill-of-materials checks for repository changes.
  * Expanded Swift dependency monitoring to additional project locations.

* **Documentation**
  * Added guidance on dependency policies, tracked files, security updates, verification procedures, and coverage limitations.

* **Tests**
  * Added validation for dependency snapshots, version data, repository references, and software bill-of-materials completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->