### PR TITLE
feat(plugins): add Vercel AI Gateway plugin

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -132,6 +132,7 @@ jobs:
             web-link) TARGET="WebLinkPlugin" ;;
             cerebras) TARGET="CerebrasPlugin" ;;
             openrouter) TARGET="OpenRouterPlugin" ;;
+            vercel-ai-gateway) TARGET="VercelAIGatewayPlugin" ;;
             soniox) TARGET="SonioxPlugin" ;;
             sber-salutespeech) TARGET="SaluteSpeechPlugin" ;;
             reson8) TARGET="Reson8Plugin" ;;

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -440,6 +440,11 @@
 		4D4554410000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 4D4554410000000000000012 /* Localizable.xcstrings */; };
 		4D4554410000000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 4D4554410000000000000034 /* TypeWhisperPluginSDK */; };
 		4D4554410000000000000005 /* meta.svg in Resources */ = {isa = PBXBuildFile; fileRef = 4D4554410000000000000014 /* meta.svg */; };
+		564552434500000000000001 /* VercelAIGatewayPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564552434500000000000010 /* VercelAIGatewayPlugin.swift */; };
+		564552434500000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 564552434500000000000011 /* manifest.json */; };
+		564552434500000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 564552434500000000000012 /* Localizable.xcstrings */; };
+		564552434500000000000004 /* TypeWhisperPluginSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 564552434500000000000034 /* TypeWhisperPluginSDK */; };
+		564552434500000000000005 /* vercel.svg in Resources */ = {isa = PBXBuildFile; fileRef = 564552434500000000000014 /* vercel.svg */; };
 		4D4149000000000000000001 /* MicrosoftAIPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4149000000000000000010 /* MicrosoftAIPlugin.swift */; };
 		4D4149000000000000000002 /* manifest.json in Resources */ = {isa = PBXBuildFile; fileRef = 4D4149000000000000000011 /* manifest.json */; };
 		4D4149000000000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = 4D4149000000000000000012 /* Localizable.xcstrings */; };
@@ -1024,6 +1029,11 @@
 		4D4554410000000000000012 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		4D4554410000000000000013 /* MetaPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MetaPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D4554410000000000000014 /* meta.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = meta.svg; sourceTree = "<group>"; };
+		564552434500000000000010 /* VercelAIGatewayPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VercelAIGatewayPlugin.swift; sourceTree = "<group>"; };
+		564552434500000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
+		564552434500000000000012 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		564552434500000000000013 /* VercelAIGatewayPlugin.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = VercelAIGatewayPlugin.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		564552434500000000000014 /* vercel.svg */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = vercel.svg; sourceTree = "<group>"; };
 		4D4149000000000000000010 /* MicrosoftAIPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MicrosoftAIPlugin.swift; sourceTree = "<group>"; };
 		4D4149000000000000000011 /* manifest.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		4D4149000000000000000012 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -1487,6 +1497,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		564552434500000000000032 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564552434500000000000004 /* TypeWhisperPluginSDK in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4D4554410000000000000032 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -1721,6 +1739,7 @@
 				CC00000000000000000033 /* GranitePlugin */,
 				CC00000000000000000034 /* CloudflareASRPlugin */,
 				4D4554410000000000000020 /* MetaPlugin */,
+				564552434500000000000020 /* VercelAIGatewayPlugin */,
 				4D4149000000000000000020 /* MicrosoftAIPlugin */,
 				CC00000000000000000035 /* FileMemoryPlugin */,
 				C10000000000000000000001 /* SystemTTSPlugin */,
@@ -2434,6 +2453,18 @@
 			path = TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin;
 			sourceTree = "<group>";
 		};
+		564552434500000000000020 /* VercelAIGatewayPlugin */ = {
+			isa = PBXGroup;
+			children = (
+				564552434500000000000010 /* VercelAIGatewayPlugin.swift */,
+				564552434500000000000011 /* manifest.json */,
+				564552434500000000000012 /* Localizable.xcstrings */,
+				564552434500000000000014 /* vercel.svg */,
+			);
+			name = VercelAIGatewayPlugin;
+			path = TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin;
+			sourceTree = "<group>";
+		};
 		4D4554410000000000000020 /* MetaPlugin */ = {
 			isa = PBXGroup;
 			children = (
@@ -2720,6 +2751,7 @@
 				BB00000000000000000224 /* GranitePlugin.bundle */,
 				BB00000000000000000227 /* CloudflareASRPlugin.bundle */,
 				4D4554410000000000000013 /* MetaPlugin.bundle */,
+				564552434500000000000013 /* VercelAIGatewayPlugin.bundle */,
 				4D4149000000000000000013 /* MicrosoftAIPlugin.bundle */,
 				BB00000000000000000231 /* FileMemoryPlugin.bundle */,
 				B10000000000000000000003 /* SystemTTSPlugin.bundle */,
@@ -3533,6 +3565,26 @@
 			productReference = BB00000000000000000227 /* CloudflareASRPlugin.bundle */;
 			productType = "com.apple.product-type.bundle";
 		};
+		564552434500000000000030 /* VercelAIGatewayPlugin */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 564552434500000000000042 /* Build configuration list for PBXNativeTarget "VercelAIGatewayPlugin" */;
+			buildPhases = (
+				564552434500000000000031 /* Sources */,
+				564552434500000000000032 /* Frameworks */,
+				564552434500000000000033 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VercelAIGatewayPlugin;
+			packageProductDependencies = (
+				564552434500000000000034 /* TypeWhisperPluginSDK */,
+			);
+			productName = VercelAIGatewayPlugin;
+			productReference = 564552434500000000000013 /* VercelAIGatewayPlugin.bundle */;
+			productType = "com.apple.product-type.bundle";
+		};
 		4D4554410000000000000030 /* MetaPlugin */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4D4554410000000000000042 /* Build configuration list for PBXNativeTarget "MetaPlugin" */;
@@ -4046,6 +4098,7 @@
 				DD00000000000000000021 /* GranitePlugin */,
 				DD00000000000000000022 /* CloudflareASRPlugin */,
 				4D4554410000000000000030 /* MetaPlugin */,
+				564552434500000000000030 /* VercelAIGatewayPlugin */,
 				4D4149000000000000000030 /* MicrosoftAIPlugin */,
 				DD00000000000000000023 /* FileMemoryPlugin */,
 				D10000000000000000000001 /* SystemTTSPlugin */,
@@ -4361,6 +4414,16 @@
 			files = (
 				AA00000000000000000238 /* manifest.json in Resources */,
 				AA0000000000000000023A /* Localizable.xcstrings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564552434500000000000033 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564552434500000000000002 /* manifest.json in Resources */,
+				564552434500000000000003 /* Localizable.xcstrings in Resources */,
+				564552434500000000000005 /* vercel.svg in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -5143,6 +5206,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00000000000000000237 /* CloudflareASRPlugin.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		564552434500000000000031 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				564552434500000000000001 /* VercelAIGatewayPlugin.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7171,6 +7242,54 @@
 			};
 			name = Release;
 		};
+		564552434500000000000040 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Vercel AI Gateway";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = VercelAIGatewayPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.vercel-ai-gateway";
+				PRODUCT_NAME = VercelAIGatewayPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Debug;
+		};
+		564552434500000000000041 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleDisplayName = "Vercel AI Gateway";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSPrincipalClass = VercelAIGatewayPlugin;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Bundles";
+				MACOSX_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.typewhisper.vercel-ai-gateway";
+				PRODUCT_NAME = VercelAIGatewayPlugin;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 6.0;
+				WRAPPER_EXTENSION = bundle;
+			};
+			name = Release;
+		};
 		4D4554410000000000000040 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -8480,6 +8599,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		564552434500000000000042 /* Build configuration list for PBXNativeTarget "VercelAIGatewayPlugin" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				564552434500000000000040 /* Debug */,
+				564552434500000000000041 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4D4554410000000000000042 /* Build configuration list for PBXNativeTarget "MetaPlugin" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -8921,6 +9049,10 @@
 			productName = MLXAudioCore;
 		};
 		PP00000000000000000031 /* TypeWhisperPluginSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TypeWhisperPluginSDK;
+		};
+		564552434500000000000034 /* TypeWhisperPluginSDK */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = TypeWhisperPluginSDK;
 		};

--- a/TypeWhisper/Views/PluginSettingsView.swift
+++ b/TypeWhisper/Views/PluginSettingsView.swift
@@ -1487,6 +1487,7 @@ private let typeWhisperAddonSlugsByPluginID: [String: String] = [
     "com.typewhisper.speechanalyzer": "apple-speech",
     "com.typewhisper.speechmatics": "speechmatics",
     "com.typewhisper.tts.supertonic": "supertonic",
+    "com.typewhisper.vercel-ai-gateway": "vercel-ai-gateway",
     "com.typewhisper.voxtral": "voxtral",
     "com.typewhisper.webhook": "webhook",
     "com.typewhisper.whisperkit": "whisperkit",

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -78,6 +78,17 @@ let package = Package(
             ]
         ),
         .target(
+            name: "VercelAIGatewayPlugin",
+            dependencies: ["TypeWhisperPluginSDK"],
+            path: "Plugins/VercelAIGatewayPlugin",
+            exclude: ["Tests"],
+            resources: [
+                .process("Localizable.xcstrings"),
+                .process("manifest.json"),
+                .process("vercel.svg"),
+            ]
+        ),
+        .target(
             name: "GroqPlugin",
             dependencies: ["TypeWhisperPluginSDK"],
             path: "Plugins/GroqPlugin",
@@ -446,6 +457,15 @@ let package = Package(
                 "OpenRouterPlugin",
             ],
             path: "Plugins/OpenRouterPlugin/Tests"
+        ),
+        .testTarget(
+            name: "VercelAIGatewayPluginTests",
+            dependencies: [
+                "TypeWhisperPluginSDK",
+                "TypeWhisperPluginSDKTesting",
+                "VercelAIGatewayPlugin",
+            ],
+            path: "Plugins/VercelAIGatewayPlugin/Tests"
         ),
         .testTarget(
             name: "GroqPluginTests",

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
@@ -177,6 +177,28 @@
         }
       }
     },
+    "Pricing unavailable": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preis nicht verfügbar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "料金情報なし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "价格不可用"
+          }
+        }
+      }
+    },
     "Provider Default": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
@@ -1,0 +1,424 @@
+{
+  "sourceLanguage": "en",
+  "strings": {
+    "API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥"
+          }
+        }
+      }
+    },
+    "API keys are stored securely in the Keychain": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel werden sicher im Schlüsselbund gespeichert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーはセキュアにキーチェーンに保存されます"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥安全存储在钥匙串中"
+          }
+        }
+      }
+    },
+    "Balance: $%@": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guthaben: $%@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "残高: $%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "余额：$%@"
+          }
+        }
+      }
+    },
+    "Custom": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Benutzerdefiniert"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "カスタム"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自定义"
+          }
+        }
+      }
+    },
+    "Free": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kostenlos"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無料"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "免费"
+          }
+        }
+      }
+    },
+    "Get API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API-Schlüssel erhalten"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "APIキーを取得"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "获取 API 密钥"
+          }
+        }
+      }
+    },
+    "Invalid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ungültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無効なAPIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥无效"
+          }
+        }
+      }
+    },
+    "LLM Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM-Modell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLMモデル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "LLM 模型"
+          }
+        }
+      }
+    },
+    "Provider Default": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anbieter-Standard"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロバイダーのデフォルト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供商默认"
+          }
+        }
+      }
+    },
+    "Refresh": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Entfernen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichern"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "Search models...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Modelle suchen..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "モデルを検索..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "搜索模型..."
+          }
+        }
+      }
+    },
+    "Speech to text on Vercel AI Gateway is in beta. Transcription models may not be enabled for your team yet.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spracherkennung über Vercel AI Gateway ist in der Beta. Transkriptionsmodelle sind für Ihr Team möglicherweise noch nicht freigeschaltet."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vercel AI Gatewayの音声認識はベータ版です。チームで文字起こしモデルがまだ有効になっていない場合があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vercel AI Gateway 的语音转文字功能处于测试阶段。您的团队可能尚未启用转录模型。"
+          }
+        }
+      }
+    },
+    "Temperature": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperatur"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度"
+          }
+        }
+      }
+    },
+    "Transcription Model": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transkriptionsmodell"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文字起こしモデル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "转录模型"
+          }
+        }
+      }
+    },
+    "Using default models. Press Refresh to fetch all available models.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standardmodelle werden verwendet. Klicken Sie auf Aktualisieren, um alle verfügbaren Modelle abzurufen."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトモデルを使用中です。「更新」を押してすべての利用可能なモデルを取得してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在使用默认模型。点击刷新以获取所有可用模型。"
+          }
+        }
+      }
+    },
+    "Valid API Key": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gültiger API-Schlüssel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効なAPIキー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "API 密钥有效"
+          }
+        }
+      }
+    },
+    "Validating...": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Überprüfung..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検証中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在验证..."
+          }
+        }
+      }
+    }
+  },
+  "version": "1.0"
+}

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Localizable.xcstrings
@@ -331,6 +331,28 @@
         }
       }
     },
+    "Temperature Mode": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Temperaturmodus"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度モード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温度模式"
+          }
+        }
+      }
+    },
     "Transcription Model": {
       "localizations": {
         "de": {

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
@@ -1,0 +1,618 @@
+import Foundation
+import TypeWhisperPluginSDK
+import XCTest
+@_spi(Testing) import TypeWhisperPluginSDKTesting
+@testable import VercelAIGatewayPlugin
+
+final class VercelAIGatewayPluginTests: XCTestCase {
+    override func tearDown() {
+        PluginHTTPClientTestHarness.reset()
+        super.tearDown()
+    }
+
+    func testCapabilitiesAndFallbackModels() throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.providerId, "vercel-ai-gateway")
+        XCTAssertEqual(plugin.providerDisplayName, "Vercel AI Gateway")
+        XCTAssertEqual(plugin.providerName, "Vercel AI Gateway")
+        XCTAssertFalse(plugin.isConfigured)
+        XCTAssertFalse(plugin.isAvailable)
+        XCTAssertFalse(plugin.supportsTranslation)
+        XCTAssertFalse(plugin.supportsStreaming)
+        XCTAssertEqual(plugin.dictionaryTermsSupport, .unsupported)
+        XCTAssertEqual(plugin.selectedModelId, "openai/whisper-1")
+        XCTAssertEqual(plugin.selectedLLMModelId, "openai/gpt-4o-mini")
+        XCTAssertEqual(
+            plugin.transcriptionModels.map(\.id),
+            [
+                "openai/whisper-1",
+                "openai/gpt-4o-mini-transcribe",
+                "openai/gpt-4o-transcribe",
+                "google/gemini-3.5-transcribe",
+            ]
+        )
+        XCTAssertEqual(plugin.supportedModels.first?.id, "openai/gpt-4o-mini")
+    }
+
+    func testSelectedModelsPersistAcrossActivation() throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        plugin.selectModel("openai/gpt-4o-transcribe")
+        plugin.selectLLMModel("anthropic/claude-sonnet-5")
+        plugin.deactivate()
+
+        let reloaded = VercelAIGatewayPlugin()
+        reloaded.activate(host: host)
+
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai/gpt-4o-transcribe")
+        XCTAssertEqual(reloaded.selectedModelId, "openai/gpt-4o-transcribe")
+        XCTAssertEqual(reloaded.selectedLLMModelId, "anthropic/claude-sonnet-5")
+    }
+
+    func testInvalidPersistedModelSelectionsFallbackAndPersistValidDefaults() throws {
+        let host = try PluginTestHostServices(defaults: [
+            "selectedModel": " retired-stt-model ",
+            "selectedLLMModel": "retired-llm-model",
+        ])
+        let plugin = VercelAIGatewayPlugin()
+
+        plugin.activate(host: host)
+
+        XCTAssertEqual(plugin.selectedModelId, "openai/whisper-1")
+        XCTAssertEqual(plugin.selectedLLMModelId, "openai/gpt-4o-mini")
+        XCTAssertEqual(host.userDefault(forKey: "selectedModel") as? String, "openai/whisper-1")
+        XCTAssertEqual(host.userDefault(forKey: "selectedLLMModel") as? String, "openai/gpt-4o-mini")
+    }
+
+    // MARK: - Chat
+
+    func testProcessSendsOpenAICompatibleChatRequestAndParsesText() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "vck_test"])
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+        plugin.setLLMTemperatureMode(.custom)
+        plugin.setLLMTemperatureValue(0.7)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"id":"gen_01","choices":[{"message":{"content":" hello from gateway \n"}}]}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/chat/completions", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.process(
+            systemPrompt: "System prompt",
+            userText: "User text",
+            model: nil
+        )
+
+        XCTAssertEqual(result, "hello from gateway")
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://ai-gateway.vercel.sh/v1/chat/completions")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer vck_test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.timeoutInterval, 30)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["model"] as? String, "openai/gpt-4o-mini")
+        XCTAssertEqual(body["temperature"] as? Double, 0.7)
+
+        let messages = try XCTUnwrap(body["messages"] as? [[String: String]])
+        XCTAssertEqual(messages, [
+            ["role": "system", "content": "System prompt"],
+            ["role": "user", "content": "User text"],
+        ])
+    }
+
+    func testProcessFailsWithoutAPIKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.process(systemPrompt: "s", userText: "u", model: nil)
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginChatError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testProcessMapsInvalidAPIKeyResponse() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "vck_bad"])
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"Invalid API key","type":"authentication_error"}}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/chat/completions", statusCode: 401)
+                ),
+            ])
+        }
+
+        do {
+            _ = try await plugin.process(systemPrompt: "s", userText: "u", model: "openai/gpt-4o-mini")
+            XCTFail("Expected invalidApiKey")
+        } catch let error as PluginChatError {
+            guard case .invalidApiKey = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Model catalogue
+
+    func testModelCatalogSplitsLanguageAndTranscriptionModelsAndCaches() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "vck_test"])
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        """
+                        {
+                          "object": "list",
+                          "data": [
+                            {
+                              "id": "openai/whisper-1",
+                              "name": "Whisper",
+                              "type": "transcription",
+                              "pricing": { "input": "0.0000000001", "transcription_duration_cost_per_second": "0.0001" }
+                            },
+                            {
+                              "id": "openai/gpt-realtime-whisper",
+                              "name": "gpt-realtime-whisper",
+                              "type": "transcription",
+                              "tags": ["websocket-realtime", "websocket-transcription"]
+                            },
+                            {
+                              "id": "google/gemini-3.5-transcribe-live",
+                              "name": "Gemini 3.5 Transcribe Live",
+                              "type": "transcription",
+                              "tags": ["websocket-transcription"]
+                            },
+                            {
+                              "id": "spacexai/grok-stt",
+                              "name": "Grok STT",
+                              "type": "transcription",
+                              "tags": ["websocket-transcription"]
+                            },
+                            {
+                              "id": "anthropic/claude-sonnet-5",
+                              "name": "Claude Sonnet 5",
+                              "type": "language",
+                              "pricing": { "input": "0.000002", "output": "0.00001" }
+                            },
+                            {
+                              "id": "openai/gpt-4o-mini",
+                              "name": "GPT-4o mini",
+                              "type": "language",
+                              "pricing": { "input": "0.00000015", "output": "0.0000006" }
+                            },
+                            {
+                              "id": "openai/text-embedding-3-small",
+                              "name": "Embedding 3 Small",
+                              "type": "embedding",
+                              "pricing": { "input": "0.00000002" }
+                            },
+                            {
+                              "id": "openai/tts-1",
+                              "name": "TTS-1",
+                              "type": "speech"
+                            }
+                          ]
+                        }
+                        """.utf8
+                    ),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/models", statusCode: 200)
+                ),
+            ])
+        }
+
+        let catalog = await plugin.fetchModelCatalog()
+        plugin.setFetchedLLMModels(catalog.llmModels)
+        plugin.setFetchedTranscriptionModels(catalog.transcriptionModels)
+
+        XCTAssertEqual(catalog.llmModels.map(\.id), ["anthropic/claude-sonnet-5", "openai/gpt-4o-mini"])
+        XCTAssertEqual(catalog.transcriptionModels.map(\.id), ["spacexai/grok-stt", "openai/whisper-1"])
+        XCTAssertEqual(catalog.llmModels[0].formattedPricing, "$2.00/$10.00 per 1M")
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["anthropic/claude-sonnet-5", "openai/gpt-4o-mini"])
+        XCTAssertEqual(plugin.transcriptionModels.map(\.id), ["spacexai/grok-stt", "openai/whisper-1"])
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://ai-gateway.vercel.sh/v1/models")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer vck_test")
+        XCTAssertNotNil(host.userDefault(forKey: "fetchedModels") as? Data)
+        XCTAssertNotNil(host.userDefault(forKey: "fetchedTranscriptionModels") as? Data)
+
+        let reloaded = VercelAIGatewayPlugin()
+        reloaded.activate(host: host)
+        XCTAssertEqual(reloaded.supportedModels.map(\.id), ["anthropic/claude-sonnet-5", "openai/gpt-4o-mini"])
+        XCTAssertEqual(reloaded.transcriptionModels.map(\.id), ["spacexai/grok-stt", "openai/whisper-1"])
+    }
+
+    func testModelCatalogReturnsEmptyOnHTTPError() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"down"}}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/models", statusCode: 503)
+                ),
+            ])
+        }
+
+        let catalog = await plugin.fetchModelCatalog()
+        XCTAssertTrue(catalog.llmModels.isEmpty)
+        XCTAssertTrue(catalog.transcriptionModels.isEmpty)
+        XCTAssertEqual(plugin.supportedModels.first?.id, "openai/gpt-4o-mini")
+    }
+
+    func testFreePricingLabel() {
+        let model = VercelAIGatewayFetchedModel(id: "x/y", name: "Y", inputPrice: "0", outputPrice: "0")
+        XCTAssertEqual(model.formattedPricing, "Free")
+    }
+
+    // MARK: - Credits and key validation
+
+    func testValidateAPIKeyUsesCreditsEndpoint() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"balance":"95.50","total_used":"4.50"}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/credits", statusCode: 200)
+                ),
+            ])
+        }
+
+        let isValid = await plugin.validateApiKey("vck_test")
+        XCTAssertTrue(isValid)
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.absoluteString, "https://ai-gateway.vercel.sh/v1/credits")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer vck_test")
+    }
+
+    func testValidateAPIKeyRejectsUnauthorized() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"Unauthorized"}}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/credits", statusCode: 401)
+                ),
+            ])
+        }
+
+        let isValid = await plugin.validateApiKey("vck_bad")
+        XCTAssertFalse(isValid)
+        let isEmptyValid = await plugin.validateApiKey("")
+        XCTAssertFalse(isEmptyValid)
+    }
+
+    func testParseCreditBalance() {
+        XCTAssertEqual(
+            VercelAIGatewayPlugin.parseCreditBalance(Data(#"{"balance":"95.50","total_used":"4.50"}"#.utf8)),
+            95.5
+        )
+        XCTAssertEqual(
+            VercelAIGatewayPlugin.parseCreditBalance(Data(#"{"balance":12.25}"#.utf8)),
+            12.25
+        )
+        XCTAssertNil(VercelAIGatewayPlugin.parseCreditBalance(Data(#"{"total_used":"4.50"}"#.utf8)))
+    }
+
+    // MARK: - Transcription
+
+    func testTranscribeFailsWithoutAPIKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+            XCTFail("Expected notConfigured")
+        } catch let error as PluginTranscriptionError {
+            guard case .notConfigured = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testTranscribeRejectsTranslateRequests() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "vck_test"])
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        do {
+            _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: true, prompt: nil)
+            XCTFail("Expected apiError")
+        } catch let error as PluginTranscriptionError {
+            guard case .apiError(let message) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "Vercel AI Gateway speech-to-text does not support translation.")
+        }
+    }
+
+    func testTranscriptionRequestUsesGatewayProtocolHeadersAndBase64JSON() throws {
+        let request = try VercelAIGatewayPlugin.makeTranscriptionRequest(
+            uploadFile: Self.m4aUpload(),
+            apiKey: "vck_test",
+            modelId: "openai/whisper-1",
+            language: " de ",
+            timeout: 120
+        )
+
+        XCTAssertEqual(request.httpMethod, "POST")
+        XCTAssertEqual(request.url?.absoluteString, "https://ai-gateway.vercel.sh/v4/ai/transcription-model")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer vck_test")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ai-gateway-protocol-version"), "0.0.1")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ai-transcription-model-specification-version"), "4")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ai-model-id"), "openai/whisper-1")
+        XCTAssertEqual(request.timeoutInterval, 120)
+
+        let body = try Self.jsonBody(from: request)
+        XCTAssertNil(body["model"])
+        XCTAssertEqual(body["mediaType"] as? String, "audio/mp4")
+        XCTAssertEqual(body["audio"] as? String, Data("m4a".utf8).base64EncodedString())
+        let providerOptions = try XCTUnwrap(body["providerOptions"] as? [String: Any])
+        let openAIOptions = try XCTUnwrap(providerOptions["openai"] as? [String: Any])
+        XCTAssertEqual(openAIOptions["language"] as? String, "de")
+    }
+
+    func testTranscriptionRequestOmitsProviderOptionsWithoutLanguageOrForOtherCreators() throws {
+        let noLanguage = try VercelAIGatewayPlugin.makeTranscriptionRequest(
+            uploadFile: Self.m4aUpload(),
+            apiKey: "vck_test",
+            modelId: "openai/whisper-1",
+            language: " ",
+            timeout: 120
+        )
+        XCTAssertNil(try Self.jsonBody(from: noLanguage)["providerOptions"])
+
+        let otherCreator = try VercelAIGatewayPlugin.makeTranscriptionRequest(
+            uploadFile: Self.m4aUpload(),
+            apiKey: "vck_test",
+            modelId: "google/gemini-3.5-transcribe",
+            language: "de",
+            timeout: 120
+        )
+        XCTAssertNil(try Self.jsonBody(from: otherCreator)["providerOptions"])
+        XCTAssertEqual(otherCreator.value(forHTTPHeaderField: "ai-model-id"), "google/gemini-3.5-transcribe")
+    }
+
+    func testTranscribeParsesAISDKResultShape() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "openai/whisper-1"],
+            secrets: ["api-key": "vck_test"]
+        )
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(
+                        #"{"text":"hello from gateway","segments":[{"text":"hello from","startSecond":0.0,"endSecond":1.25},{"text":"gateway","startSecond":1.25,"endSecond":2.5}],"language":"en","durationInSeconds":2.5,"warnings":[]}"#.utf8
+                    ),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v4/ai/transcription-model", statusCode: 200)
+                ),
+            ])
+        }
+
+        let result = try await plugin.transcribe(
+            audio: Self.audio(),
+            language: "en",
+            translate: false,
+            prompt: "ignored dictionary terms"
+        )
+
+        XCTAssertEqual(result.text, "hello from gateway")
+        XCTAssertEqual(result.detectedLanguage, "en")
+        XCTAssertEqual(result.segments.count, 2)
+        XCTAssertEqual(result.segments[0].text, "hello from")
+        XCTAssertEqual(result.segments[0].start, 0.0)
+        XCTAssertEqual(result.segments[0].end, 1.25)
+        XCTAssertEqual(result.segments[1].text, "gateway")
+        XCTAssertEqual(result.segments[1].start, 1.25)
+        XCTAssertEqual(result.segments[1].end, 2.5)
+
+        let request = try XCTUnwrap(store.sessions.first?.requestedRequests.first)
+        XCTAssertEqual(request.url?.path, "/v4/ai/transcription-model")
+        XCTAssertEqual(request.value(forHTTPHeaderField: "ai-model-id"), "openai/whisper-1")
+        let body = try Self.jsonBody(from: request)
+        XCTAssertEqual(body["mediaType"] as? String, "audio/mp4")
+    }
+
+    func testTranscribeRetriesWithWavWhenM4AIsRejected() async throws {
+        let host = try PluginTestHostServices(
+            defaults: ["selectedModel": "openai/whisper-1"],
+            secrets: ["api-key": "vck_test"]
+        )
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let store = PluginHTTPClientSessionStore()
+        PluginHTTPClientTestHarness.configure { _ in
+            store.makeSession(outcomes: [
+                .success(
+                    Data(#"{"error":{"message":"unsupported audio format"}}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v4/ai/transcription-model", statusCode: 415)
+                ),
+                .success(
+                    Data(#"{"text":"fallback transcript","segments":[],"language":"de","durationInSeconds":1,"warnings":[]}"#.utf8),
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v4/ai/transcription-model", statusCode: 200)
+                ),
+            ])
+        }
+
+        let audio = Self.audio()
+        let result = try await plugin.transcribe(audio: audio, language: "de", translate: false, prompt: nil)
+
+        XCTAssertEqual(result.text, "fallback transcript")
+        let requests = store.sessions[0].requestedRequests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(try Self.jsonBody(from: requests[0])["mediaType"] as? String, "audio/mp4")
+        let retryBody = try Self.jsonBody(from: requests[1])
+        XCTAssertEqual(retryBody["mediaType"] as? String, "audio/wav")
+        let encodedAudio = try XCTUnwrap(retryBody["audio"] as? String)
+        XCTAssertEqual(Data(base64Encoded: encodedAudio), PluginAudioUploadEncoder.wavUpload(from: audio).data)
+    }
+
+    func testExplicitRequestErrorsDoNotTriggerWavRetry() async throws {
+        for (status, message) in [(400, "Model not found"), (401, "Invalid API key"), (402, "Insufficient credits"), (429, "Rate limited")] {
+            PluginHTTPClientTestHarness.reset()
+            let host = try PluginTestHostServices(secrets: ["api-key": "vck_test"])
+            let plugin = VercelAIGatewayPlugin()
+            plugin.activate(host: host)
+            let store = PluginHTTPClientSessionStore()
+            let responseData = try JSONSerialization.data(withJSONObject: ["error": ["message": message]])
+            PluginHTTPClientTestHarness.configure { _ in
+                store.makeSession(outcomes: [.success(
+                    responseData,
+                    Self.httpResponse(url: "https://ai-gateway.vercel.sh/v4/ai/transcription-model", statusCode: status)
+                )])
+            }
+            do {
+                _ = try await plugin.transcribe(audio: Self.audio(), language: nil, translate: false, prompt: nil)
+                XCTFail("Expected HTTP \(status)")
+            } catch {
+                XCTAssertTrue(error is PluginTranscriptionError, "HTTP \(status)")
+            }
+            XCTAssertEqual(store.sessions.flatMap(\.requestedRequests).count, 1, "HTTP \(status)")
+        }
+    }
+
+    func testTranscriptionHTTPErrorMapping() {
+        let url = "https://ai-gateway.vercel.sh/v4/ai/transcription-model"
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"bad key"}}"#.utf8),
+            response: Self.httpResponse(url: url, statusCode: 401)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .invalidApiKey = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"slow down"}}"#.utf8),
+            response: Self.httpResponse(url: url, statusCode: 429)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .rateLimited = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":{"message":"No credit balance","type":"payment_required"}}"#.utf8),
+            response: Self.httpResponse(url: url, statusCode: 402)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "HTTP 402: No credit balance")
+        }
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.validateTranscriptionResponse(
+            data: Data(#"{"error":"Model not available for this team"}"#.utf8),
+            response: Self.httpResponse(url: url, statusCode: 403)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(message, "HTTP 403: Model not available for this team")
+        }
+    }
+
+    func testTranscriptionRejectsHTMLSuccessBody() {
+        let data = Data("<html><head><title>Proxy failure</title></head><body>secret</body></html>".utf8)
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.validateTranscriptionResponse(
+            data: data,
+            response: Self.httpResponse(url: "https://ai-gateway.vercel.sh/v4/ai/transcription-model", statusCode: 200)
+        )) { error in
+            guard let pluginError = error as? PluginTranscriptionError,
+                  case .apiError(let message) = pluginError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertTrue(message.contains("upstream returned an HTML error page"))
+            XCTAssertTrue(message.contains("Proxy failure"))
+            XCTAssertFalse(message.contains("secret"))
+        }
+    }
+
+    func testTranscriptionParseFallsBackToTextOnlyBody() throws {
+        let result = try VercelAIGatewayPlugin.parseTranscriptionResponse(Data(#"{"text":"only text"}"#.utf8))
+        XCTAssertEqual(result.text, "only text")
+        XCTAssertTrue(result.segments.isEmpty)
+
+        XCTAssertThrowsError(try VercelAIGatewayPlugin.parseTranscriptionResponse(Data(#"{"warnings":[]}"#.utf8)))
+    }
+
+    // MARK: - Helpers
+
+    private static func audio() -> AudioData {
+        let samples = [Float](repeating: 0.1, count: 16_000)
+        return AudioData(samples: samples, wavData: PluginWavEncoder.encode(samples), duration: 1)
+    }
+
+    private static func m4aUpload() -> PluginAudioUploadFile {
+        PluginAudioUploadFile(
+            data: Data("m4a".utf8),
+            filename: "audio.m4a",
+            contentType: "audio/mp4",
+            format: "m4a"
+        )
+    }
+
+    private static func jsonBody(from request: URLRequest) throws -> [String: Any] {
+        let data = try XCTUnwrap(request.httpBody)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private static func httpResponse(url: String, statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: URL(string: url)!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
@@ -827,6 +827,166 @@ final class VercelAIGatewayPluginTests: XCTestCase {
         XCTAssertEqual(host.loadSecret(key: "api-key"), "vck_bad")
     }
 
+    // MARK: - Key commit ordering against host side effects
+
+    /// Wraps the test host so a test can pause inside a host write and
+    /// observe how the plugin orders its side effects around it.
+    private final class BarrierHostServices: HostServices, @unchecked Sendable {
+        let inner: PluginTestHostServices
+        private let lock = NSLock()
+        private var secretBarrierValue: String?
+        private var defaultsBarrierKey: String?
+        private var reached = false
+        private let proceed = DispatchSemaphore(value: 0)
+
+        init(inner: PluginTestHostServices) { self.inner = inner }
+
+        /// Pause the next `storeSecret` that writes `value`.
+        func pauseStoreSecret(value: String) { lock.withLock { secretBarrierValue = value } }
+        /// Pause the next `setUserDefault` for `key`.
+        func pauseSetUserDefault(key: String) { lock.withLock { defaultsBarrierKey = key } }
+
+        var hasReachedBarrier: Bool { lock.withLock { reached } }
+        func waitUntilBarrierReached() async {
+            while !hasReachedBarrier { try? await Task.sleep(nanoseconds: 1_000_000) }
+        }
+        func releaseBarrier() { proceed.signal() }
+
+        private func block() {
+            lock.withLock { reached = true }
+            proceed.wait()
+        }
+
+        func storeSecret(key: String, value: String) throws {
+            let shouldBlock = lock.withLock {
+                guard secretBarrierValue == value else { return false }
+                secretBarrierValue = nil
+                return true
+            }
+            if shouldBlock { block() }
+            try inner.storeSecret(key: key, value: value)
+        }
+
+        func setUserDefault(_ value: Any?, forKey key: String) {
+            let shouldBlock = lock.withLock {
+                guard defaultsBarrierKey == key else { return false }
+                defaultsBarrierKey = nil
+                return true
+            }
+            if shouldBlock { block() }
+            inner.setUserDefault(value, forKey: key)
+        }
+
+        func loadSecret(key: String) -> String? { inner.loadSecret(key: key) }
+        func userDefault(forKey key: String) -> Any? { inner.userDefault(forKey: key) }
+        var pluginDataDirectory: URL { inner.pluginDataDirectory }
+        var activeAppBundleId: String? { inner.activeAppBundleId }
+        var activeAppName: String? { inner.activeAppName }
+        var eventBus: EventBusProtocol { inner.eventBus }
+        var availableRuleNames: [String] { inner.availableRuleNames }
+        var availableWorkflows: [PluginWorkflowInfo] { inner.availableWorkflows }
+        func notifyCapabilitiesChanged() { inner.notifyCapabilitiesChanged() }
+        func openPluginSettings() { inner.openPluginSettings() }
+        func openSettingsSidebarItem(_ itemId: String) { inner.openSettingsSidebarItem(itemId) }
+        func enqueueImportedMediaForTranscription(
+            _ media: PluginImportedMedia,
+            fromMediaImporterId mediaImporterId: String
+        ) async -> Bool {
+            await inner.enqueueImportedMediaForTranscription(media, fromMediaImporterId: mediaImporterId)
+        }
+        func setStreamingDisplayActive(_ active: Bool) { inner.setStreamingDisplayActive(active) }
+    }
+
+    func testRemovalDuringPausedSaveCannotRestoreRemovedKey() async throws {
+        let inner = try PluginTestHostServices()
+        let host = BarrierHostServices(inner: inner)
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        // The older save is paused right before its Keychain write lands.
+        host.pauseStoreSecret(value: "vck_old")
+        let oldSave = Task.detached {
+            await plugin.saveApiKey("vck_old", validate: { _ in true })
+        }
+        await host.waitUntilBarrierReached()
+
+        // The removal must queue behind the paused commit instead of being
+        // overwritten by it once the save resumes.
+        let removal = Task.detached { plugin.removeApiKey() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        host.releaseBarrier()
+        _ = await removal.value
+        let oldResult = await oldSave.value
+
+        XCTAssertNil(oldResult, "The superseded save must not publish a result")
+        XCTAssertFalse(plugin.isAvailable)
+        XCTAssertEqual(inner.loadSecret(key: "api-key") ?? "", "")
+
+        let reactivated = VercelAIGatewayPlugin()
+        reactivated.activate(host: inner)
+        XCTAssertFalse(reactivated.isConfigured, "Reactivation must not resurrect the removed key")
+    }
+
+    func testNewerSaveWinsOverPausedOlderSaveInKeychain() async throws {
+        let inner = try PluginTestHostServices()
+        let host = BarrierHostServices(inner: inner)
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        host.pauseStoreSecret(value: "vck_old")
+        let oldSave = Task.detached {
+            await plugin.saveApiKey("vck_old", validate: { _ in true })
+        }
+        await host.waitUntilBarrierReached()
+
+        let newSave = Task.detached {
+            await plugin.saveApiKey("vck_new", validate: { _ in false })
+        }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        host.releaseBarrier()
+        let newResult = await newSave.value
+        let oldResult = await oldSave.value
+
+        XCTAssertNil(oldResult)
+        XCTAssertEqual(newResult?.isValid, false)
+        XCTAssertEqual(inner.loadSecret(key: "api-key"), "vck_new")
+
+        let reactivated = VercelAIGatewayPlugin()
+        reactivated.activate(host: inner)
+        XCTAssertTrue(reactivated.isConfigured)
+    }
+
+    func testCatalogPublicationAndRemovalAreOrdered() async throws {
+        let inner = try PluginTestHostServices()
+        let host = BarrierHostServices(inner: inner)
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: Self.catalogAndCreditsOutcomes(balance: "5.00"))
+        }
+
+        // Pause after the generation check passed, inside the catalogue write.
+        host.pauseSetUserDefault(key: "fetchedModels")
+        let save = Task.detached {
+            await plugin.saveApiKey("vck_A", validate: { _ in true })
+        }
+        await host.waitUntilBarrierReached()
+
+        let removal = Task.detached { plugin.removeApiKey() }
+        try await Task.sleep(nanoseconds: 20_000_000)
+        host.releaseBarrier()
+        _ = await removal.value
+        let result = await save.value
+
+        // The save was current when it committed, so its catalogue stands;
+        // the removal is applied strictly after that commit.
+        XCTAssertEqual(result?.isValid, true)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["x/current"])
+        XCTAssertFalse(plugin.isAvailable)
+        XCTAssertEqual(inner.loadSecret(key: "api-key") ?? "", "")
+    }
+
     // MARK: - Helpers
 
     private static func audio() -> AudioData {

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
@@ -586,6 +586,40 @@ final class VercelAIGatewayPluginTests: XCTestCase {
         XCTAssertThrowsError(try VercelAIGatewayPlugin.parseTranscriptionResponse(Data(#"{"warnings":[]}"#.utf8)))
     }
 
+    func testConcurrentSettingsMutationsDoNotCorruptState() async throws {
+        let host = try PluginTestHostServices(secrets: ["api-key": "vck_test"])
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        // Hammer writers and readers from many tasks at once. With unguarded
+        // state this trips the Swift runtime's exclusivity checks or tears the
+        // model arrays; with the lock every read sees a whole value.
+        await withTaskGroup(of: Void.self) { group in
+            for index in 0..<200 {
+                group.addTask {
+                    let models = [
+                        VercelAIGatewayFetchedModel(id: "x/model-\(index)", name: "Model \(index)", inputPrice: "0", outputPrice: "0"),
+                    ]
+                    plugin.setFetchedLLMModels(models)
+                    plugin.selectLLMModel("x/model-\(index)")
+                    plugin.setLLMTemperatureValue(Double(index % 20) / 10)
+                    plugin.setApiKey(index.isMultiple(of: 2) ? "vck_even" : "vck_odd")
+                }
+                group.addTask {
+                    _ = plugin.supportedModels
+                    _ = plugin.selectedLLMModelId
+                    _ = plugin.llmTemperatureValue
+                    _ = plugin.isAvailable
+                    _ = plugin.transcriptionModels
+                }
+            }
+        }
+
+        XCTAssertEqual(plugin.supportedModels.count, 1)
+        XCTAssertTrue(plugin.isAvailable)
+        XCTAssertTrue(plugin.selectedLLMModelId?.hasPrefix("x/model-") ?? false)
+    }
+
     // MARK: - Helpers
 
     private static func audio() -> AudioData {

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/Tests/VercelAIGatewayPluginTests.swift
@@ -269,9 +269,39 @@ final class VercelAIGatewayPluginTests: XCTestCase {
         XCTAssertEqual(plugin.supportedModels.first?.id, "openai/gpt-4o-mini")
     }
 
-    func testFreePricingLabel() {
-        let model = VercelAIGatewayFetchedModel(id: "x/y", name: "Y", inputPrice: "0", outputPrice: "0")
-        XCTAssertEqual(model.formattedPricing, "Free")
+    func testPricingLabelsDistinguishFreeFromUnknown() {
+        let free = VercelAIGatewayFetchedModel(id: "x/free", name: "Free", inputPrice: "0", outputPrice: "0")
+        XCTAssertEqual(free.formattedPricing, "Free")
+
+        let paid = VercelAIGatewayFetchedModel(id: "x/paid", name: "Paid", inputPrice: "0.00000015", outputPrice: "0.0000006")
+        XCTAssertEqual(paid.formattedPricing, "$0.15/$0.60 per 1M")
+
+        let unknown = VercelAIGatewayFetchedModel(id: "x/unknown", name: "Unknown")
+        XCTAssertEqual(unknown.formattedPricing, "Pricing unavailable")
+
+        let partial = VercelAIGatewayFetchedModel(id: "x/partial", name: "Partial", inputPrice: "0.000001", outputPrice: nil)
+        XCTAssertEqual(partial.formattedPricing, "Pricing unavailable")
+    }
+
+    func testFallbackModelsNeverClaimToBeFree() throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        // No catalogue fetched and nothing cached: every picker entry comes
+        // from the static fallback list and must not read as free.
+        for model in VercelAIGatewayPlugin.fallbackLLMModels + VercelAIGatewayPlugin.fallbackTranscriptionModels {
+            XCTAssertNil(model.inputPrice, model.id)
+            XCTAssertNil(model.outputPrice, model.id)
+            XCTAssertEqual(model.formattedPricing, "Pricing unavailable", model.id)
+        }
+    }
+
+    func testCatalogModelWithoutPricingIsUnknownNotFree() throws {
+        let catalog = try VercelAIGatewayPlugin.parseModelCatalog(Data(
+            #"{"data":[{"id":"x/no-price","name":"No Price","type":"language"},{"id":"x/zero","name":"Zero","type":"language","pricing":{"input":"0","output":"0"}}]}"#.utf8
+        ))
+        XCTAssertEqual(catalog.llmModels.map(\.formattedPricing), ["Pricing unavailable", "Free"])
     }
 
     // MARK: - Credits and key validation
@@ -598,7 +628,7 @@ final class VercelAIGatewayPluginTests: XCTestCase {
             for index in 0..<200 {
                 group.addTask {
                     let models = [
-                        VercelAIGatewayFetchedModel(id: "x/model-\(index)", name: "Model \(index)", inputPrice: "0", outputPrice: "0"),
+                        VercelAIGatewayFetchedModel(id: "x/model-\(index)", name: "Model \(index)"),
                     ]
                     plugin.setFetchedLLMModels(models)
                     plugin.selectLLMModel("x/model-\(index)")
@@ -618,6 +648,183 @@ final class VercelAIGatewayPluginTests: XCTestCase {
         XCTAssertEqual(plugin.supportedModels.count, 1)
         XCTAssertTrue(plugin.isAvailable)
         XCTAssertTrue(plugin.selectedLLMModelId?.hasPrefix("x/model-") ?? false)
+    }
+
+    // MARK: - API key save ordering
+
+    /// Lets a test decide when an injected validation completes, and observe
+    /// when a save has reached validation (i.e. has claimed its generation).
+    private final class ValidationGate: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuations: [String: CheckedContinuation<Bool, Never>] = [:]
+        private var pending: [String: Bool] = [:]
+        private var started: Set<String> = []
+        private var startWaiters: [String: CheckedContinuation<Void, Never>] = [:]
+
+        func wait(_ key: String) async -> Bool {
+            let startWaiter = lock.withLock {
+                started.insert(key)
+                return startWaiters.removeValue(forKey: key)
+            }
+            startWaiter?.resume()
+            return await withCheckedContinuation { continuation in
+                lock.withLock {
+                    if let verdict = pending.removeValue(forKey: key) {
+                        continuation.resume(returning: verdict)
+                    } else {
+                        continuations[key] = continuation
+                    }
+                }
+            }
+        }
+
+        func waitUntilStarted(_ key: String) async {
+            await withCheckedContinuation { continuation in
+                let alreadyStarted = lock.withLock {
+                    if started.contains(key) { return true }
+                    startWaiters[key] = continuation
+                    return false
+                }
+                if alreadyStarted { continuation.resume() }
+            }
+        }
+
+        func release(_ key: String, isValid: Bool) {
+            let continuation = lock.withLock {
+                let waiting = continuations.removeValue(forKey: key)
+                if waiting == nil { pending[key] = isValid }
+                return waiting
+            }
+            continuation?.resume(returning: isValid)
+        }
+    }
+
+    /// `saveApiKey` fetches the catalogue and the balance concurrently, and the
+    /// mock session hands out outcomes in call order, so a single body that
+    /// satisfies both parsers keeps these tests independent of scheduling.
+    private static func catalogAndCreditsOutcomes(balance: String) -> [PluginHTTPClientTestOutcome] {
+        let body = """
+        {"data":[{"id":"x/current","name":"Current","type":"language","pricing":{"input":"0.000001","output":"0.000002"}}],"balance":"\(balance)","total_used":"0"}
+        """
+        return [
+            .success(
+                Data(body.utf8),
+                Self.httpResponse(url: "https://ai-gateway.vercel.sh/v1/models", statusCode: 200)
+            ),
+        ]
+    }
+
+    func testSaveApiKeyDiscardsResultWhenSupersededByNewerSave() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+        let gate = ValidationGate()
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: Self.catalogAndCreditsOutcomes(balance: "42.00"))
+        }
+
+        let saveA = Task { await plugin.saveApiKey("vck_A", validate: { await gate.wait($0) }) }
+        await gate.waitUntilStarted("vck_A")
+        let saveB = Task { await plugin.saveApiKey("vck_B", validate: { await gate.wait($0) }) }
+        await gate.waitUntilStarted("vck_B")
+
+        // B finishes first and wins; A completes afterwards and must be dropped
+        // even though A's key was reported valid.
+        gate.release("vck_B", isValid: true)
+        let resultB = await saveB.value
+        gate.release("vck_A", isValid: true)
+        let resultA = await saveA.value
+
+        XCTAssertNil(resultA)
+        let unwrappedB = try XCTUnwrap(resultB)
+        XCTAssertTrue(unwrappedB.isValid)
+        XCTAssertEqual(unwrappedB.balance, 42)
+        XCTAssertEqual(unwrappedB.catalog.llmModels.map(\.id), ["x/current"])
+        XCTAssertTrue(plugin.isAvailable)
+        XCTAssertEqual(host.loadSecret(key: "api-key"), "vck_B")
+    }
+
+    func testStaleInvalidVerdictDoesNotOverrideNewerValidKey() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+        let gate = ValidationGate()
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: Self.catalogAndCreditsOutcomes(balance: "7.50"))
+        }
+
+        let saveOld = Task { await plugin.saveApiKey("vck_old", validate: { await gate.wait($0) }) }
+        await gate.waitUntilStarted("vck_old")
+        let saveNew = Task { await plugin.saveApiKey("vck_new", validate: { await gate.wait($0) }) }
+        await gate.waitUntilStarted("vck_new")
+
+        gate.release("vck_new", isValid: true)
+        let resultNew = await saveNew.value
+        gate.release("vck_old", isValid: false)
+        let resultOld = await saveOld.value
+
+        XCTAssertNil(resultOld, "A rejected verdict for a replaced key must not be published")
+        XCTAssertEqual(try XCTUnwrap(resultNew).isValid, true)
+        XCTAssertTrue(plugin.isAvailable)
+    }
+
+    func testRemovingKeyDuringValidationDiscardsPendingResult() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+        let gate = ValidationGate()
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: Self.catalogAndCreditsOutcomes(balance: "99.00"))
+        }
+
+        let save = Task { await plugin.saveApiKey("vck_A", validate: { await gate.wait($0) }) }
+        await gate.waitUntilStarted("vck_A")
+        plugin.removeApiKey()
+        gate.release("vck_A", isValid: true)
+        let result = await save.value
+
+        XCTAssertNil(result)
+        XCTAssertFalse(plugin.isAvailable)
+        // The test host keeps an empty string for a deleted secret.
+        XCTAssertEqual(host.loadSecret(key: "api-key") ?? "", "")
+        XCTAssertEqual(plugin.supportedModels.first?.id, "openai/gpt-4o-mini", "Catalogue from the cancelled save must not be published")
+        XCTAssertNil(host.userDefault(forKey: "fetchedModels"))
+    }
+
+    func testSaveApiKeyPublishesCatalogAndBalanceWhenCurrent() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        PluginHTTPClientTestHarness.configure { _ in
+            PluginHTTPClientMockSession(outcomes: Self.catalogAndCreditsOutcomes(balance: "12.00"))
+        }
+
+        let saved = await plugin.saveApiKey("vck_A", validate: { _ in true })
+        let result = try XCTUnwrap(saved)
+
+        XCTAssertTrue(result.isValid)
+        XCTAssertEqual(result.balance, 12)
+        XCTAssertEqual(plugin.supportedModels.map(\.id), ["x/current"])
+        XCTAssertNotNil(host.userDefault(forKey: "fetchedModels"))
+        XCTAssertEqual(host.loadSecret(key: "api-key"), "vck_A")
+    }
+
+    func testSaveApiKeyKeepsRejectedKeyStoredButReportsInvalid() async throws {
+        let host = try PluginTestHostServices()
+        let plugin = VercelAIGatewayPlugin()
+        plugin.activate(host: host)
+
+        let saved = await plugin.saveApiKey("vck_bad", validate: { _ in false })
+        let result = try XCTUnwrap(saved)
+
+        XCTAssertFalse(result.isValid)
+        XCTAssertNil(result.balance)
+        XCTAssertTrue(result.catalog.llmModels.isEmpty)
+        XCTAssertEqual(host.loadSecret(key: "api-key"), "vck_bad")
     }
 
     // MARK: - Helpers

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
@@ -41,6 +41,10 @@ final class VercelAIGatewayPlugin: NSObject,
         var llmTemperatureValue: Double = 0.3
         var fetchedLLMModels: [VercelAIGatewayFetchedModel] = []
         var fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] = []
+        /// Bumped on every key save or removal. An in-flight validation
+        /// compares its captured value against this before publishing, so
+        /// key A's late completion cannot overwrite key B's status.
+        var apiKeyGeneration = 0
     }
 
     private let lock = NSLock()
@@ -157,11 +161,11 @@ final class VercelAIGatewayPlugin: NSObject,
         return !key.isEmpty
     }
 
-    fileprivate static let fallbackTranscriptionModels: [VercelAIGatewayFetchedModel] = [
-        VercelAIGatewayFetchedModel(id: "openai/whisper-1", name: "Whisper", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini-transcribe", name: "GPT-4o mini Transcribe", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-transcribe", name: "GPT-4o Transcribe", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-transcribe", name: "Gemini 3.5 Transcribe", inputPrice: "0", outputPrice: "0"),
+    static let fallbackTranscriptionModels: [VercelAIGatewayFetchedModel] = [
+        VercelAIGatewayFetchedModel(id: "openai/whisper-1", name: "Whisper"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini-transcribe", name: "GPT-4o mini Transcribe"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-transcribe", name: "GPT-4o Transcribe"),
+        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-transcribe", name: "Gemini 3.5 Transcribe"),
     ]
 
     var transcriptionModels: [PluginModelInfo] {
@@ -357,12 +361,12 @@ final class VercelAIGatewayPlugin: NSObject,
 
     var isAvailable: Bool { isConfigured }
 
-    fileprivate static let fallbackLLMModels: [VercelAIGatewayFetchedModel] = [
-        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini", name: "GPT-4o mini", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "openai/gpt-5.4-mini", name: "GPT 5.4 Mini", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "anthropic/claude-haiku-4.5", name: "Claude Haiku 4.5", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5", inputPrice: "0", outputPrice: "0"),
-        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash", inputPrice: "0", outputPrice: "0"),
+    static let fallbackLLMModels: [VercelAIGatewayFetchedModel] = [
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini", name: "GPT-4o mini"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-5.4-mini", name: "GPT 5.4 Mini"),
+        VercelAIGatewayFetchedModel(id: "anthropic/claude-haiku-4.5", name: "Claude Haiku 4.5"),
+        VercelAIGatewayFetchedModel(id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5"),
+        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash"),
     ]
 
     var supportedModels: [PluginModelInfo] {
@@ -444,7 +448,7 @@ final class VercelAIGatewayPlugin: NSObject,
     // MARK: - API Key Management
 
     func setApiKey(_ key: String) {
-        updateState { $0.apiKey = key }
+        _ = beginApiKeyUpdate(key)
         if let host {
             do {
                 try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
@@ -456,7 +460,7 @@ final class VercelAIGatewayPlugin: NSObject,
     }
 
     func removeApiKey() {
-        updateState { $0.apiKey = nil }
+        _ = beginApiKeyUpdate(nil)
         if let host {
             do {
                 try host.storeSecret(key: Self.StorageKeys.apiKey, value: "")
@@ -465,6 +469,72 @@ final class VercelAIGatewayPlugin: NSObject,
             }
             host.notifyCapabilitiesChanged()
         }
+    }
+
+    /// Stores the key in memory and returns the generation token that any
+    /// asynchronous follow-up work must present via `isCurrentApiKeyUpdate`.
+    private func beginApiKeyUpdate(_ key: String?) -> Int {
+        lock.withLock {
+            state.apiKey = key
+            state.apiKeyGeneration += 1
+            return state.apiKeyGeneration
+        }
+    }
+
+    func isCurrentApiKeyUpdate(_ generation: Int) -> Bool {
+        readState { $0.apiKeyGeneration == generation }
+    }
+
+    /// Result of `saveApiKey`. `catalog` and `balance` are only populated
+    /// when the key validated.
+    struct ApiKeySaveResult: Sendable {
+        let isValid: Bool
+        let catalog: VercelAIGatewayModelCatalog
+        let balance: Double?
+    }
+
+    /// Persists the key, validates it, and loads the catalogue and balance.
+    /// Returns `nil` when a newer save or a removal superseded this call
+    /// while it was in flight; callers must then discard the outcome.
+    func saveApiKey(_ key: String) async -> ApiKeySaveResult? {
+        await saveApiKey(key, validate: { [self] in await validateApiKey($0) })
+    }
+
+    /// `validate` is injectable so tests can control completion order.
+    func saveApiKey(
+        _ key: String,
+        validate: @Sendable (String) async -> Bool
+    ) async -> ApiKeySaveResult? {
+        let generation = beginApiKeyUpdate(key)
+        if let host {
+            do {
+                try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
+            } catch {
+                print("[VercelAIGatewayPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+
+        let isValid = await validate(key)
+        guard isCurrentApiKeyUpdate(generation) else { return nil }
+        guard isValid else {
+            return ApiKeySaveResult(isValid: false, catalog: .empty, balance: nil)
+        }
+
+        async let catalogTask = fetchModelCatalog()
+        async let creditsTask = fetchCredits()
+        let (catalog, balance) = await (catalogTask, creditsTask)
+        guard isCurrentApiKeyUpdate(generation) else { return nil }
+
+        // Publish the catalogue from here so a superseded save can never
+        // reach `setFetched*` through the view.
+        if !catalog.llmModels.isEmpty {
+            setFetchedLLMModels(catalog.llmModels)
+        }
+        if !catalog.transcriptionModels.isEmpty {
+            setFetchedTranscriptionModels(catalog.transcriptionModels)
+        }
+        return ApiKeySaveResult(isValid: true, catalog: catalog, balance: balance)
     }
 
     /// `/v1/models` is public, so it cannot prove a key works. `/v1/credits`
@@ -532,20 +602,15 @@ final class VercelAIGatewayPlugin: NSObject,
                 VercelAIGatewayFetchedModel(
                     id: model.id,
                     name: model.name ?? model.id,
-                    inputPrice: model.pricing?.input ?? "0",
-                    outputPrice: model.pricing?.output ?? "0"
+                    inputPrice: model.pricing?.input,
+                    outputPrice: model.pricing?.output
                 )
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         let transcription = decoded.data
             .filter { $0.type == "transcription" && Self.supportsRecordedAudio($0) }
             .map { model in
-                VercelAIGatewayFetchedModel(
-                    id: model.id,
-                    name: model.name ?? model.id,
-                    inputPrice: "0",
-                    outputPrice: "0"
-                )
+                VercelAIGatewayFetchedModel(id: model.id, name: model.name ?? model.id)
             }
             .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
         return VercelAIGatewayModelCatalog(llmModels: llm, transcriptionModels: transcription)
@@ -623,15 +688,30 @@ struct VercelAIGatewayModelCatalog: Sendable {
 struct VercelAIGatewayFetchedModel: Codable, Sendable, Equatable {
     let id: String
     let name: String
-    /// USD per token, as returned by the gateway catalogue.
-    let inputPrice: String
-    let outputPrice: String
+    /// USD per token as returned by the gateway catalogue. `nil` means the
+    /// price is unknown (static fallback entry, or the catalogue omitted it),
+    /// which must never be rendered as free.
+    let inputPrice: String?
+    let outputPrice: String?
+
+    init(id: String, name: String, inputPrice: String? = nil, outputPrice: String? = nil) {
+        self.id = id
+        self.name = name
+        self.inputPrice = inputPrice
+        self.outputPrice = outputPrice
+    }
 
     var formattedPricing: String {
-        let inputPer1M = (Double(inputPrice) ?? 0) * 1_000_000
-        let outputPer1M = (Double(outputPrice) ?? 0) * 1_000_000
+        let bundle = Bundle(for: VercelAIGatewayPlugin.self)
+        guard let inputPrice, let outputPrice,
+              let inputPerToken = Double(inputPrice),
+              let outputPerToken = Double(outputPrice) else {
+            return String(localized: "Pricing unavailable", bundle: bundle)
+        }
+        let inputPer1M = inputPerToken * 1_000_000
+        let outputPer1M = outputPerToken * 1_000_000
         if inputPer1M == 0 && outputPer1M == 0 {
-            return String(localized: "Free", bundle: Bundle(for: VercelAIGatewayPlugin.self))
+            return String(localized: "Free", bundle: bundle)
         }
         return String(format: "$%.2f/$%.2f per 1M", inputPer1M, outputPer1M)
     }
@@ -726,6 +806,7 @@ private struct VercelAIGatewaySettingsView: View {
                     if plugin.isAvailable {
                         Button(String(localized: "Remove", bundle: bundle)) {
                             apiKeyInput = ""
+                            isValidating = false
                             validationResult = nil
                             creditBalance = nil
                             plugin.removeApiKey()
@@ -918,27 +999,17 @@ private struct VercelAIGatewaySettingsView: View {
         let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedKey.isEmpty else { return }
 
-        plugin.setApiKey(trimmedKey)
-
         isValidating = true
         validationResult = nil
         Task {
-            let isValid = await plugin.validateApiKey(trimmedKey)
-            if isValid {
-                async let catalogTask = plugin.fetchModelCatalog()
-                async let creditsTask = plugin.fetchCredits()
-                let (catalog, balance) = await (catalogTask, creditsTask)
-                await MainActor.run {
-                    isValidating = false
-                    validationResult = true
-                    creditBalance = balance
-                    applyCatalog(catalog)
-                }
-            } else {
-                await MainActor.run {
-                    isValidating = false
-                    validationResult = false
-                }
+            // `nil` means a later save or removal superseded this one; that
+            // call owns the UI state now.
+            guard let result = await plugin.saveApiKey(trimmedKey) else { return }
+            await MainActor.run {
+                isValidating = false
+                validationResult = result.isValid
+                creditBalance = result.balance
+                syncSelections(with: result.catalog)
             }
         }
     }
@@ -954,8 +1025,19 @@ private struct VercelAIGatewaySettingsView: View {
 
     private func applyCatalog(_ catalog: VercelAIGatewayModelCatalog) {
         if !catalog.llmModels.isEmpty {
-            fetchedLLMModels = catalog.llmModels
             plugin.setFetchedLLMModels(catalog.llmModels)
+        }
+        if !catalog.transcriptionModels.isEmpty {
+            plugin.setFetchedTranscriptionModels(catalog.transcriptionModels)
+        }
+        syncSelections(with: catalog)
+    }
+
+    /// Mirrors a freshly published catalogue into the pickers and moves a
+    /// selection that the catalogue no longer contains to the first entry.
+    private func syncSelections(with catalog: VercelAIGatewayModelCatalog) {
+        if !catalog.llmModels.isEmpty {
+            fetchedLLMModels = catalog.llmModels
             if !catalog.llmModels.contains(where: { $0.id == selectedLLMModel }),
                let first = catalog.llmModels.first {
                 selectedLLMModel = first.id
@@ -964,7 +1046,6 @@ private struct VercelAIGatewaySettingsView: View {
         }
         if !catalog.transcriptionModels.isEmpty {
             fetchedTranscriptionModels = catalog.transcriptionModels
-            plugin.setFetchedTranscriptionModels(catalog.transcriptionModels)
             if !catalog.transcriptionModels.contains(where: { $0.id == selectedTranscriptionModel }),
                let first = catalog.transcriptionModels.first {
                 selectedTranscriptionModel = first.id

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
@@ -50,6 +50,12 @@ final class VercelAIGatewayPlugin: NSObject,
     private let lock = NSLock()
     private var state = State()
 
+    /// Serialises API key commits (generation bump plus the Keychain and
+    /// defaults writes that belong to them). `lock` alone only orders the
+    /// in-memory change; without this, an older save could still write its
+    /// key to the Keychain after a newer save or removal.
+    private let apiKeyCommitLock = NSLock()
+
     private func readState<T>(_ body: (State) -> T) -> T {
         lock.withLock { body(state) }
     }
@@ -448,41 +454,70 @@ final class VercelAIGatewayPlugin: NSObject,
     // MARK: - API Key Management
 
     func setApiKey(_ key: String) {
-        _ = beginApiKeyUpdate(key)
-        if let host {
-            do {
-                try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
-            } catch {
-                print("[VercelAIGatewayPlugin] Failed to store API key: \(error)")
-            }
-            host.notifyCapabilitiesChanged()
-        }
+        _ = commitApiKey(key)
     }
 
     func removeApiKey() {
-        _ = beginApiKeyUpdate(nil)
-        if let host {
-            do {
-                try host.storeSecret(key: Self.StorageKeys.apiKey, value: "")
-            } catch {
-                print("[VercelAIGatewayPlugin] Failed to delete API key: \(error)")
-            }
-            host.notifyCapabilitiesChanged()
-        }
+        _ = commitApiKey(nil)
     }
 
-    /// Stores the key in memory and returns the generation token that any
-    /// asynchronous follow-up work must present via `isCurrentApiKeyUpdate`.
-    private func beginApiKeyUpdate(_ key: String?) -> Int {
-        lock.withLock {
-            state.apiKey = key
-            state.apiKeyGeneration += 1
-            return state.apiKeyGeneration
+    /// Commits a key change as one ordered operation: bump the generation,
+    /// update memory, and write the Keychain, all under `apiKeyCommitLock`.
+    /// Returns the generation token that asynchronous follow-up work must
+    /// present to `commitCatalogIfCurrent`. The capability notification is
+    /// sent after the lock is released because the host may call back into
+    /// the plugin.
+    private func commitApiKey(_ key: String?) -> Int {
+        let (generation, host) = apiKeyCommitLock.withLock {
+            let generation = lock.withLock {
+                state.apiKey = key
+                state.apiKeyGeneration += 1
+                return state.apiKeyGeneration
+            }
+            let host = self.host
+            if let host {
+                do {
+                    try host.storeSecret(key: Self.StorageKeys.apiKey, value: key ?? "")
+                } catch {
+                    print("[VercelAIGatewayPlugin] Failed to store API key: \(error)")
+                }
+            }
+            return (generation, host)
         }
+        host?.notifyCapabilitiesChanged()
+        return generation
     }
 
     func isCurrentApiKeyUpdate(_ generation: Int) -> Bool {
         readState { $0.apiKeyGeneration == generation }
+    }
+
+    /// Publishes a fetched catalogue only if `generation` is still the
+    /// current key generation, with the check and the memory/defaults
+    /// writes in the same critical section as key commits. A save that was
+    /// superseded while its requests were in flight therefore publishes
+    /// nothing, and a removal cannot slip in between the check and the write.
+    private func commitCatalogIfCurrent(_ generation: Int, catalog: VercelAIGatewayModelCatalog) -> Bool {
+        let committedHost: HostServices?? = apiKeyCommitLock.withLock {
+            guard readState({ $0.apiKeyGeneration == generation }) else { return nil }
+            let host = self.host
+            if !catalog.llmModels.isEmpty {
+                updateState { $0.fetchedLLMModels = catalog.llmModels }
+                if let data = try? JSONEncoder().encode(catalog.llmModels) {
+                    host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedModels)
+                }
+            }
+            if !catalog.transcriptionModels.isEmpty {
+                updateState { $0.fetchedTranscriptionModels = catalog.transcriptionModels }
+                if let data = try? JSONEncoder().encode(catalog.transcriptionModels) {
+                    host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedTranscriptionModels)
+                }
+            }
+            return .some(host)
+        }
+        guard let committedHost else { return false }
+        committedHost?.notifyCapabilitiesChanged()
+        return true
     }
 
     /// Result of `saveApiKey`. `catalog` and `balance` are only populated
@@ -505,15 +540,7 @@ final class VercelAIGatewayPlugin: NSObject,
         _ key: String,
         validate: @Sendable (String) async -> Bool
     ) async -> ApiKeySaveResult? {
-        let generation = beginApiKeyUpdate(key)
-        if let host {
-            do {
-                try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
-            } catch {
-                print("[VercelAIGatewayPlugin] Failed to store API key: \(error)")
-            }
-            host.notifyCapabilitiesChanged()
-        }
+        let generation = commitApiKey(key)
 
         let isValid = await validate(key)
         guard isCurrentApiKeyUpdate(generation) else { return nil }
@@ -524,16 +551,10 @@ final class VercelAIGatewayPlugin: NSObject,
         async let catalogTask = fetchModelCatalog()
         async let creditsTask = fetchCredits()
         let (catalog, balance) = await (catalogTask, creditsTask)
-        guard isCurrentApiKeyUpdate(generation) else { return nil }
 
-        // Publish the catalogue from here so a superseded save can never
-        // reach `setFetched*` through the view.
-        if !catalog.llmModels.isEmpty {
-            setFetchedLLMModels(catalog.llmModels)
-        }
-        if !catalog.transcriptionModels.isEmpty {
-            setFetchedTranscriptionModels(catalog.transcriptionModels)
-        }
+        // The generation check and the publication happen in one ordered
+        // commit, so a superseded save can never publish a stale catalogue.
+        guard commitCatalogIfCurrent(generation, catalog: catalog) else { return nil }
         return ApiKeySaveResult(isValid: true, catalog: catalog, balance: balance)
     }
 

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
@@ -1,0 +1,918 @@
+import Foundation
+import SwiftUI
+import TypeWhisperPluginSDK
+
+// MARK: - Plugin Entry Point
+
+/// Vercel AI Gateway (https://vercel.com/docs/ai-gateway) fronts hundreds of
+/// models behind one API key. Chat completions use the OpenAI-compatible
+/// `/v1/chat/completions` surface. Speech-to-text does *not* go through the
+/// OpenAI multipart endpoint (the gateway returns 404 for
+/// `/v1/audio/transcriptions`); it uses the gateway's dedicated
+/// `/v4/ai/transcription-model` endpoint which takes base64 audio in JSON.
+@objc(VercelAIGatewayPlugin)
+final class VercelAIGatewayPlugin: NSObject,
+    TranscriptionEnginePlugin,
+    DictionaryTermsCapabilityProviding,
+    LLMProviderPlugin,
+    LLMTemperatureControllableProvider,
+    LLMModelSelectable,
+    @unchecked Sendable
+{
+    static let pluginId = "com.typewhisper.vercel-ai-gateway"
+    static let pluginName = "Vercel AI Gateway"
+
+    static let baseURL = "https://ai-gateway.vercel.sh"
+    static let modelsURL = "\(baseURL)/v1/models"
+    static let creditsURL = "\(baseURL)/v1/credits"
+    static let transcriptionURL = "\(baseURL)/v4/ai/transcription-model"
+    static let apiKeysURL = "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys"
+
+    fileprivate var host: HostServices?
+    fileprivate var _apiKey: String?
+    fileprivate var _selectedModelId: String?
+    fileprivate var _selectedLLMModelId: String?
+    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+    fileprivate var _llmTemperatureValue: Double = 0.3
+    fileprivate var _fetchedLLMModels: [VercelAIGatewayFetchedModel] = []
+    fileprivate var _fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] = []
+
+    private static let chatRequestTimeout: TimeInterval = 30
+    private static let transcriptionRequestTimeout: TimeInterval = 120
+
+    private let chatHelper = PluginOpenAIChatHelper(baseURL: VercelAIGatewayPlugin.baseURL)
+
+    private enum StorageKeys {
+        static let apiKey = "api-key"
+        static let selectedModel = "selectedModel"
+        static let selectedLLMModel = "selectedLLMModel"
+        static let llmTemperatureMode = "llmTemperatureMode"
+        static let llmTemperatureValue = "llmTemperatureValue"
+        static let fetchedModels = "fetchedModels"
+        static let fetchedTranscriptionModels = "fetchedTranscriptionModels"
+    }
+
+    required override init() {
+        super.init()
+    }
+
+    func activate(host: HostServices) {
+        self.host = host
+        _apiKey = host.loadSecret(key: Self.StorageKeys.apiKey)
+        if let data = host.userDefault(forKey: Self.StorageKeys.fetchedModels) as? Data,
+           let models = try? JSONDecoder().decode([VercelAIGatewayFetchedModel].self, from: data) {
+            _fetchedLLMModels = models
+        }
+        if let data = host.userDefault(forKey: Self.StorageKeys.fetchedTranscriptionModels) as? Data,
+           let models = try? JSONDecoder().decode([VercelAIGatewayFetchedModel].self, from: data) {
+            _fetchedTranscriptionModels = models
+        }
+        _selectedModelId = Self.resolvedStoredModelId(
+            host.userDefault(forKey: Self.StorageKeys.selectedModel) as? String,
+            availableModels: transcriptionModels,
+            storageKey: Self.StorageKeys.selectedModel,
+            host: host
+        )
+        _selectedLLMModelId = Self.resolvedStoredModelId(
+            host.userDefault(forKey: Self.StorageKeys.selectedLLMModel) as? String,
+            availableModels: supportedModels,
+            storageKey: Self.StorageKeys.selectedLLMModel,
+            host: host
+        )
+        _llmTemperatureModeRaw = host.userDefault(forKey: Self.StorageKeys.llmTemperatureMode) as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        _llmTemperatureValue = host.userDefault(forKey: Self.StorageKeys.llmTemperatureValue) as? Double
+            ?? 0.3
+    }
+
+    /// A persisted selection can point at a model the gateway has since retired.
+    /// Fall back to the first available model and persist that so the picker
+    /// and the transcription path agree on what is selected.
+    private static func resolvedStoredModelId(
+        _ storedModelId: String?,
+        availableModels: [PluginModelInfo],
+        storageKey: String,
+        host: HostServices
+    ) -> String? {
+        let trimmedModelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let selectedModelId = trimmedModelId.flatMap { modelId in
+            availableModels.contains(where: { $0.id == modelId }) ? modelId : nil
+        } ?? availableModels.first?.id
+
+        if selectedModelId != storedModelId {
+            host.setUserDefault(selectedModelId, forKey: storageKey)
+        }
+
+        return selectedModelId
+    }
+
+    func deactivate() {
+        host = nil
+    }
+
+    // MARK: - TranscriptionEnginePlugin
+
+    var providerId: String { "vercel-ai-gateway" }
+    var providerDisplayName: String { "Vercel AI Gateway" }
+
+    var isConfigured: Bool {
+        guard let key = _apiKey else { return false }
+        return !key.isEmpty
+    }
+
+    fileprivate static let fallbackTranscriptionModels: [VercelAIGatewayFetchedModel] = [
+        VercelAIGatewayFetchedModel(id: "openai/whisper-1", name: "Whisper", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini-transcribe", name: "GPT-4o mini Transcribe", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-transcribe", name: "GPT-4o Transcribe", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-transcribe", name: "Gemini 3.5 Transcribe", inputPrice: "0", outputPrice: "0"),
+    ]
+
+    var transcriptionModels: [PluginModelInfo] {
+        let models = _fetchedTranscriptionModels.isEmpty
+            ? Self.fallbackTranscriptionModels
+            : _fetchedTranscriptionModels
+        return models.map {
+            PluginModelInfo(id: $0.id, displayName: $0.name)
+        }
+    }
+
+    var selectedModelId: String? { _selectedModelId }
+
+    func selectModel(_ modelId: String) {
+        _selectedModelId = modelId
+        host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedModel)
+    }
+
+    var supportsTranslation: Bool { false }
+    var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
+
+    func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginTranscriptionError.notConfigured
+        }
+        guard let modelId = _selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !modelId.isEmpty else {
+            throw PluginTranscriptionError.noModelSelected
+        }
+        guard !translate else {
+            throw PluginTranscriptionError.apiError("Vercel AI Gateway speech-to-text does not support translation.")
+        }
+
+        let uploadAudio = PluginAudioUploadEncoder.normalizedAudioForUpload(audio)
+        let preferredUpload = (try? PluginAudioUploadEncoder.compressedM4AUpload(from: uploadAudio))
+            ?? PluginAudioUploadEncoder.wavUpload(from: uploadAudio)
+        var request = try Self.makeTranscriptionRequest(
+            uploadFile: preferredUpload,
+            apiKey: apiKey,
+            modelId: modelId,
+            language: language,
+            timeout: Self.transcriptionRequestTimeout
+        )
+        var (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: Self.transcriptionRequestTimeout)
+        if let httpResponse = response as? HTTPURLResponse,
+           preferredUpload.format != "wav",
+           PluginAudioUploadEncoder.shouldRetryWithWavUpload(
+            statusCode: httpResponse.statusCode,
+            responseData: data
+           ) {
+            request = try Self.makeTranscriptionRequest(
+                uploadFile: PluginAudioUploadEncoder.wavUpload(from: uploadAudio),
+                apiKey: apiKey,
+                modelId: modelId,
+                language: language,
+                timeout: Self.transcriptionRequestTimeout
+            )
+            (data, response) = try await PluginHTTPClient.data(for: request, resourceTimeout: Self.transcriptionRequestTimeout)
+        }
+        try Self.validateTranscriptionResponse(data: data, response: response)
+        return try Self.parseTranscriptionResponse(data)
+    }
+
+    /// Builds the request for the gateway's AI SDK transcription protocol
+    /// (https://vercel.com/docs/ai-gateway/modalities/speech-to-text#transcribe-with-the-rest-api).
+    /// The model travels in the `ai-model-id` header, not the body.
+    static func makeTranscriptionRequest(
+        uploadFile: PluginAudioUploadFile,
+        apiKey: String,
+        modelId: String,
+        language: String?,
+        timeout: TimeInterval
+    ) throws -> URLRequest {
+        guard let url = URL(string: transcriptionURL) else {
+            throw PluginTranscriptionError.apiError("Invalid Vercel AI Gateway transcription URL.")
+        }
+
+        var body: [String: Any] = [
+            "audio": uploadFile.data.base64EncodedString(),
+            "mediaType": uploadFile.contentType,
+        ]
+        if let providerOptions = transcriptionProviderOptions(modelId: modelId, language: language) {
+            body["providerOptions"] = providerOptions
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("0.0.1", forHTTPHeaderField: "ai-gateway-protocol-version")
+        request.setValue("4", forHTTPHeaderField: "ai-transcription-model-specification-version")
+        request.setValue(modelId, forHTTPHeaderField: "ai-model-id")
+        request.timeoutInterval = timeout
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+
+    /// The gateway forwards `providerOptions` keyed by the upstream provider.
+    /// Only OpenAI's transcription options document a `language` hint, so the
+    /// hint is limited to `openai/*` models to avoid 400s from other creators.
+    private static func transcriptionProviderOptions(modelId: String, language: String?) -> [String: Any]? {
+        let trimmedLanguage = language?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmedLanguage.isEmpty else { return nil }
+        let creator = modelId.split(separator: "/", maxSplits: 1).first.map(String.init)?.lowercased()
+        guard creator == "openai" else { return nil }
+        return ["openai": ["language": trimmedLanguage]]
+    }
+
+    static func validateTranscriptionResponse(data: Data, response: URLResponse) throws {
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw PluginTranscriptionError.networkError("Invalid response")
+        }
+
+        switch httpResponse.statusCode {
+        case 200:
+            if let htmlPageSummary = PluginHTTPErrorBodyFormatter.htmlPageSummary(
+                from: data,
+                response: httpResponse
+            ) {
+                throw PluginTranscriptionError.apiError(
+                    "Failed to parse transcription response: \(htmlPageSummary)"
+                )
+            }
+            return
+        case 401:
+            throw PluginTranscriptionError.invalidApiKey
+        case 429:
+            throw PluginTranscriptionError.rateLimited
+        case 413:
+            throw PluginTranscriptionError.fileTooLarge
+        default:
+            let errorMessage = Self.apiErrorMessage(from: data, response: httpResponse)
+            throw PluginTranscriptionError.apiError("HTTP \(httpResponse.statusCode): \(errorMessage)")
+        }
+    }
+
+    static func parseTranscriptionResponse(_ data: Data) throws -> PluginTranscriptionResult {
+        // Segment field names follow the AI SDK transcription result shape.
+        struct Segment: Decodable {
+            let text: String
+            let startSecond: Double
+            let endSecond: Double
+        }
+
+        struct Response: Decodable {
+            let text: String
+            let language: String?
+            let segments: [Segment]?
+        }
+
+        do {
+            let response = try JSONDecoder().decode(Response.self, from: data)
+            let segments = (response.segments ?? []).map {
+                PluginTranscriptionSegment(text: $0.text, start: $0.startSecond, end: $0.endSecond)
+            }
+            return PluginTranscriptionResult(
+                text: response.text,
+                detectedLanguage: response.language,
+                segments: segments
+            )
+        } catch {
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let text = json["text"] as? String {
+                return PluginTranscriptionResult(text: text)
+            }
+            throw PluginTranscriptionError.apiError("Failed to parse transcription response")
+        }
+    }
+
+    /// The gateway returns OpenAI-shaped `{"error":{"message":...}}` on most
+    /// surfaces, but the AI SDK protocol endpoint can also return a bare
+    /// `{"error":"..."}` string or a top-level `message`.
+    private static func apiErrorMessage(from data: Data, response: HTTPURLResponse) -> String {
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            if let error = json["error"] as? [String: Any],
+               let message = error["message"] as? String {
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
+            }
+            if let message = json["error"] as? String {
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
+            }
+            if let message = json["message"] as? String {
+                return PluginHTTPErrorBodyFormatter.summary(from: message)
+            }
+        }
+        return PluginHTTPErrorBodyFormatter.summary(from: data, response: response)
+    }
+
+    // MARK: - LLMProviderPlugin
+
+    var providerName: String { "Vercel AI Gateway" }
+
+    var isAvailable: Bool { isConfigured }
+
+    fileprivate static let fallbackLLMModels: [VercelAIGatewayFetchedModel] = [
+        VercelAIGatewayFetchedModel(id: "openai/gpt-4o-mini", name: "GPT-4o mini", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "openai/gpt-5.4-mini", name: "GPT 5.4 Mini", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "anthropic/claude-haiku-4.5", name: "Claude Haiku 4.5", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5", inputPrice: "0", outputPrice: "0"),
+        VercelAIGatewayFetchedModel(id: "google/gemini-3.5-flash", name: "Gemini 3.5 Flash", inputPrice: "0", outputPrice: "0"),
+    ]
+
+    var supportedModels: [PluginModelInfo] {
+        let models = _fetchedLLMModels.isEmpty ? Self.fallbackLLMModels : _fetchedLLMModels
+        return models.map {
+            PluginModelInfo(id: $0.id, displayName: $0.name)
+        }
+    }
+
+    func process(systemPrompt: String, userText: String, model: String?) async throws -> String {
+        try await process(
+            systemPrompt: systemPrompt,
+            userText: userText,
+            model: model,
+            temperatureDirective: .inheritProviderSetting
+        )
+    }
+
+    func process(
+        systemPrompt: String,
+        userText: String,
+        model: String?,
+        temperatureDirective: PluginLLMTemperatureDirective
+    ) async throws -> String {
+        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+            throw PluginChatError.notConfigured
+        }
+        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        return try await chatHelper.process(
+            apiKey: apiKey,
+            model: modelId,
+            systemPrompt: systemPrompt,
+            userText: userText,
+            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            requestTimeout: Self.chatRequestTimeout
+        )
+    }
+
+    func selectLLMModel(_ modelId: String) {
+        _selectedLLMModelId = modelId
+        host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedLLMModel)
+    }
+
+    var selectedLLMModelId: String? { _selectedLLMModelId }
+    @objc var preferredModelId: String? { _selectedLLMModelId }
+    var llmTemperatureMode: PluginLLMTemperatureMode {
+        PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
+    }
+    var llmTemperatureValue: Double { _llmTemperatureValue }
+    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
+        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
+    }
+
+    func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
+        _llmTemperatureModeRaw = mode.rawValue
+        host?.setUserDefault(mode.rawValue, forKey: Self.StorageKeys.llmTemperatureMode)
+    }
+
+    func setLLMTemperatureValue(_ value: Double) {
+        let clamped = min(max(value, 0.0), 2.0)
+        _llmTemperatureValue = clamped
+        host?.setUserDefault(clamped, forKey: Self.StorageKeys.llmTemperatureValue)
+    }
+
+    // MARK: - Settings View
+
+    var settingsView: AnyView? {
+        AnyView(VercelAIGatewaySettingsView(plugin: self))
+    }
+
+    // MARK: - API Key Management
+
+    func setApiKey(_ key: String) {
+        _apiKey = key
+        if let host {
+            do {
+                try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
+            } catch {
+                print("[VercelAIGatewayPlugin] Failed to store API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    func removeApiKey() {
+        _apiKey = nil
+        if let host {
+            do {
+                try host.storeSecret(key: Self.StorageKeys.apiKey, value: "")
+            } catch {
+                print("[VercelAIGatewayPlugin] Failed to delete API key: \(error)")
+            }
+            host.notifyCapabilitiesChanged()
+        }
+    }
+
+    /// `/v1/models` is public, so it cannot prove a key works. `/v1/credits`
+    /// requires authentication and is the cheapest authenticated call.
+    func validateApiKey(_ key: String) async -> Bool {
+        guard !key.isEmpty, let url = URL(string: Self.creditsURL) else { return false }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (_, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else { return false }
+            return httpResponse.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Model Fetching
+
+    func setFetchedLLMModels(_ models: [VercelAIGatewayFetchedModel]) {
+        _fetchedLLMModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedModels)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    func setFetchedTranscriptionModels(_ models: [VercelAIGatewayFetchedModel]) {
+        _fetchedTranscriptionModels = models
+        if let data = try? JSONEncoder().encode(models) {
+            host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedTranscriptionModels)
+        }
+        host?.notifyCapabilitiesChanged()
+    }
+
+    /// One catalogue call covers every modality; the `type` field splits
+    /// language models from transcription models.
+    func fetchModelCatalog() async -> VercelAIGatewayModelCatalog {
+        guard let url = URL(string: Self.modelsURL) else { return .empty }
+
+        var request = URLRequest(url: url)
+        if let apiKey = _apiKey, !apiKey.isEmpty {
+            request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        }
+        request.timeoutInterval = 15
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return .empty }
+            return try Self.parseModelCatalog(data)
+        } catch {
+            return .empty
+        }
+    }
+
+    static func parseModelCatalog(_ data: Data) throws -> VercelAIGatewayModelCatalog {
+        let decoded = try JSONDecoder().decode(VercelAIGatewayModelsResponse.self, from: data)
+        let llm = decoded.data
+            .filter { $0.type == "language" }
+            .map { model in
+                VercelAIGatewayFetchedModel(
+                    id: model.id,
+                    name: model.name ?? model.id,
+                    inputPrice: model.pricing?.input ?? "0",
+                    outputPrice: model.pricing?.output ?? "0"
+                )
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        let transcription = decoded.data
+            .filter { $0.type == "transcription" && Self.supportsRecordedAudio($0) }
+            .map { model in
+                VercelAIGatewayFetchedModel(
+                    id: model.id,
+                    name: model.name ?? model.id,
+                    inputPrice: "0",
+                    outputPrice: "0"
+                )
+            }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        return VercelAIGatewayModelCatalog(llmModels: llm, transcriptionModels: transcription)
+    }
+
+    /// Realtime/live models only accept audio over WebSocket streams, which the
+    /// REST transcription endpoint cannot serve.
+    private static func supportsRecordedAudio(_ model: VercelAIGatewayAPIModel) -> Bool {
+        if (model.tags ?? []).contains("websocket-realtime") { return false }
+        return !model.id.lowercased().hasSuffix("-live")
+    }
+
+    // MARK: - Credits
+
+    fileprivate func fetchCredits() async -> Double? {
+        guard let apiKey = _apiKey, !apiKey.isEmpty,
+              let url = URL(string: Self.creditsURL) else { return nil }
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await PluginHTTPClient.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse,
+                  httpResponse.statusCode == 200 else { return nil }
+            return Self.parseCreditBalance(data)
+        } catch {
+            return nil
+        }
+    }
+
+    /// `/v1/credits` returns `{"balance":"95.50","total_used":"4.50"}` with
+    /// USD amounts as strings.
+    static func parseCreditBalance(_ data: Data) -> Double? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
+        if let balance = json["balance"] as? String {
+            return Double(balance)
+        }
+        if let balance = json["balance"] as? Double {
+            return balance
+        }
+        return nil
+    }
+}
+
+// MARK: - API Response Models
+
+private struct VercelAIGatewayModelsResponse: Decodable {
+    let data: [VercelAIGatewayAPIModel]
+}
+
+private struct VercelAIGatewayAPIModel: Decodable {
+    let id: String
+    let name: String?
+    let type: String?
+    let tags: [String]?
+    let pricing: VercelAIGatewayPricing?
+}
+
+private struct VercelAIGatewayPricing: Decodable {
+    let input: String?
+    let output: String?
+}
+
+struct VercelAIGatewayModelCatalog: Sendable {
+    let llmModels: [VercelAIGatewayFetchedModel]
+    let transcriptionModels: [VercelAIGatewayFetchedModel]
+
+    static let empty = VercelAIGatewayModelCatalog(llmModels: [], transcriptionModels: [])
+}
+
+// MARK: - Fetched Model (persisted)
+
+struct VercelAIGatewayFetchedModel: Codable, Sendable, Equatable {
+    let id: String
+    let name: String
+    /// USD per token, as returned by the gateway catalogue.
+    let inputPrice: String
+    let outputPrice: String
+
+    var formattedPricing: String {
+        let inputPer1M = (Double(inputPrice) ?? 0) * 1_000_000
+        let outputPer1M = (Double(outputPrice) ?? 0) * 1_000_000
+        if inputPer1M == 0 && outputPer1M == 0 {
+            return String(localized: "Free", bundle: Bundle(for: VercelAIGatewayPlugin.self))
+        }
+        return String(format: "$%.2f/$%.2f per 1M", inputPer1M, outputPer1M)
+    }
+}
+
+// MARK: - Settings View
+
+private struct VercelAIGatewaySettingsView: View {
+    let plugin: VercelAIGatewayPlugin
+    @State private var apiKeyInput = ""
+    @State private var isValidating = false
+    @State private var validationResult: Bool?
+    @State private var showApiKey = false
+    @State private var selectedLLMModel = ""
+    @State private var selectedTranscriptionModel = ""
+    @State private var llmTemperatureMode: PluginLLMTemperatureMode = .providerDefault
+    @State private var llmTemperatureValue: Double = 0.3
+    @State private var fetchedLLMModels: [VercelAIGatewayFetchedModel] = []
+    @State private var fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] = []
+    @State private var llmSearchText = ""
+    @State private var transcriptionSearchText = ""
+    @State private var creditBalance: Double?
+    private let bundle = Bundle(for: VercelAIGatewayPlugin.self)
+
+    private var llmModels: [VercelAIGatewayFetchedModel] {
+        fetchedLLMModels.isEmpty ? VercelAIGatewayPlugin.fallbackLLMModels : fetchedLLMModels
+    }
+
+    private var transcriptionModels: [VercelAIGatewayFetchedModel] {
+        fetchedTranscriptionModels.isEmpty
+            ? VercelAIGatewayPlugin.fallbackTranscriptionModels
+            : fetchedTranscriptionModels
+    }
+
+    private var filteredLLMModels: [VercelAIGatewayFetchedModel] {
+        filtered(models: llmModels, searchText: llmSearchText)
+    }
+
+    private var filteredTranscriptionModels: [VercelAIGatewayFetchedModel] {
+        filtered(models: transcriptionModels, searchText: transcriptionSearchText)
+    }
+
+    private func filtered(models: [VercelAIGatewayFetchedModel], searchText: String) -> [VercelAIGatewayFetchedModel] {
+        if searchText.isEmpty { return models }
+        let query = searchText.lowercased()
+        return models.filter {
+            $0.name.lowercased().contains(query) || $0.id.lowercased().contains(query)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("API Key", bundle: bundle)
+                    .font(.headline)
+
+                HStack(spacing: 8) {
+                    if showApiKey {
+                        TextField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                            .font(.system(.body, design: .monospaced))
+                    } else {
+                        SecureField("API Key", text: $apiKeyInput)
+                            .textFieldStyle(.roundedBorder)
+                    }
+
+                    Button {
+                        showApiKey.toggle()
+                    } label: {
+                        Image(systemName: showApiKey ? "eye.slash" : "eye")
+                    }
+                    .buttonStyle(.borderless)
+
+                    if plugin.isAvailable {
+                        Button(String(localized: "Remove", bundle: bundle)) {
+                            apiKeyInput = ""
+                            validationResult = nil
+                            creditBalance = nil
+                            plugin.removeApiKey()
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .foregroundStyle(.red)
+                    } else {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+
+                if isValidating {
+                    HStack(spacing: 4) {
+                        ProgressView().controlSize(.small)
+                        Text("Validating...", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if let result = validationResult {
+                    HStack(spacing: 4) {
+                        Image(systemName: result ? "checkmark.circle.fill" : "xmark.circle.fill")
+                            .foregroundStyle(result ? .green : .red)
+                        Text(result ? String(localized: "Valid API Key", bundle: bundle) : String(localized: "Invalid API Key", bundle: bundle))
+                            .font(.caption)
+                            .foregroundStyle(result ? .green : .red)
+                    }
+                }
+
+                if let balance = creditBalance {
+                    HStack(spacing: 4) {
+                        Image(systemName: "creditcard")
+                            .foregroundStyle(.secondary)
+                        Text("Balance: $\(String(format: "%.2f", balance))", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Link(String(localized: "Get API Key", bundle: bundle),
+                     destination: URL(string: VercelAIGatewayPlugin.apiKeysURL)!)
+                    .font(.caption)
+            }
+
+            if plugin.isAvailable {
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Transcription Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    TextField(String(localized: "Search models...", bundle: bundle), text: $transcriptionSearchText)
+                        .textFieldStyle(.roundedBorder)
+
+                    let models = filteredTranscriptionModels
+                    Picker("Transcription Model", selection: $selectedTranscriptionModel) {
+                        ForEach(models, id: \.id) { model in
+                            Text(model.name).tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedTranscriptionModel) {
+                        guard !selectedTranscriptionModel.isEmpty else { return }
+                        plugin.selectModel(selectedTranscriptionModel)
+                    }
+
+                    if fetchedTranscriptionModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+
+                    Text("Speech to text on Vercel AI Gateway is in beta. Transcription models may not be enabled for your team yet.", bundle: bundle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("LLM Model", bundle: bundle)
+                            .font(.headline)
+
+                        Spacer()
+
+                        Button {
+                            refreshModels()
+                        } label: {
+                            Label(String(localized: "Refresh", bundle: bundle), systemImage: "arrow.clockwise")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                    }
+
+                    TextField(String(localized: "Search models...", bundle: bundle), text: $llmSearchText)
+                        .textFieldStyle(.roundedBorder)
+
+                    let models = filteredLLMModels
+                    Picker("LLM Model", selection: $selectedLLMModel) {
+                        ForEach(models, id: \.id) { model in
+                            Text("\(model.name) - \(model.formattedPricing)").tag(model.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .onChange(of: selectedLLMModel) {
+                        guard !selectedLLMModel.isEmpty else { return }
+                        plugin.selectLLMModel(selectedLLMModel)
+                    }
+
+                    if fetchedLLMModels.isEmpty {
+                        Text("Using default models. Press Refresh to fetch all available models.", bundle: bundle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Temperature", bundle: bundle)
+                        .font(.headline)
+
+                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                        Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
+                        Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
+                    }
+                    .onChange(of: llmTemperatureMode) {
+                        plugin.setLLMTemperatureMode(llmTemperatureMode)
+                    }
+
+                    if llmTemperatureMode == .custom {
+                        HStack {
+                            Text("Temperature", bundle: bundle)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Spacer()
+                            Text(llmTemperatureValue, format: .number.precision(.fractionLength(2)))
+                                .foregroundStyle(.secondary)
+                                .monospacedDigit()
+                        }
+
+                        Slider(value: $llmTemperatureValue, in: 0...2, step: 0.1)
+                            .onChange(of: llmTemperatureValue) {
+                                plugin.setLLMTemperatureValue(llmTemperatureValue)
+                            }
+                    }
+                }
+            }
+
+            Text("API keys are stored securely in the Keychain", bundle: bundle)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding()
+        .onAppear {
+            if let key = plugin._apiKey, !key.isEmpty {
+                apiKeyInput = key
+            }
+            fetchedLLMModels = plugin._fetchedLLMModels
+            fetchedTranscriptionModels = plugin._fetchedTranscriptionModels
+            selectedLLMModel = plugin.selectedLLMModelId ?? plugin.supportedModels.first?.id ?? ""
+            selectedTranscriptionModel = plugin.selectedModelId ?? plugin.transcriptionModels.first?.id ?? ""
+            llmTemperatureMode = plugin.llmTemperatureMode
+            llmTemperatureValue = plugin.llmTemperatureValue
+
+            if plugin.isAvailable {
+                Task {
+                    if let balance = await plugin.fetchCredits() {
+                        await MainActor.run {
+                            creditBalance = balance
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func saveApiKey() {
+        let trimmedKey = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedKey.isEmpty else { return }
+
+        plugin.setApiKey(trimmedKey)
+
+        isValidating = true
+        validationResult = nil
+        Task {
+            let isValid = await plugin.validateApiKey(trimmedKey)
+            if isValid {
+                async let catalogTask = plugin.fetchModelCatalog()
+                async let creditsTask = plugin.fetchCredits()
+                let (catalog, balance) = await (catalogTask, creditsTask)
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = true
+                    creditBalance = balance
+                    applyCatalog(catalog)
+                }
+            } else {
+                await MainActor.run {
+                    isValidating = false
+                    validationResult = false
+                }
+            }
+        }
+    }
+
+    private func refreshModels() {
+        Task {
+            let catalog = await plugin.fetchModelCatalog()
+            await MainActor.run {
+                applyCatalog(catalog)
+            }
+        }
+    }
+
+    private func applyCatalog(_ catalog: VercelAIGatewayModelCatalog) {
+        if !catalog.llmModels.isEmpty {
+            fetchedLLMModels = catalog.llmModels
+            plugin.setFetchedLLMModels(catalog.llmModels)
+            if !catalog.llmModels.contains(where: { $0.id == selectedLLMModel }),
+               let first = catalog.llmModels.first {
+                selectedLLMModel = first.id
+                plugin.selectLLMModel(first.id)
+            }
+        }
+        if !catalog.transcriptionModels.isEmpty {
+            fetchedTranscriptionModels = catalog.transcriptionModels
+            plugin.setFetchedTranscriptionModels(catalog.transcriptionModels)
+            if !catalog.transcriptionModels.contains(where: { $0.id == selectedTranscriptionModel }),
+               let first = catalog.transcriptionModels.first {
+                selectedTranscriptionModel = first.id
+                plugin.selectModel(first.id)
+            }
+        }
+    }
+}

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/VercelAIGatewayPlugin.swift
@@ -28,14 +28,42 @@ final class VercelAIGatewayPlugin: NSObject,
     static let transcriptionURL = "\(baseURL)/v4/ai/transcription-model"
     static let apiKeysURL = "https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai-gateway%2Fapi-keys"
 
-    fileprivate var host: HostServices?
-    fileprivate var _apiKey: String?
-    fileprivate var _selectedModelId: String?
-    fileprivate var _selectedLLMModelId: String?
-    fileprivate var _llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
-    fileprivate var _llmTemperatureValue: Double = 0.3
-    fileprivate var _fetchedLLMModels: [VercelAIGatewayFetchedModel] = []
-    fileprivate var _fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] = []
+    /// `transcribe`/`process` are nonisolated async and run off the caller's
+    /// actor, while the settings view mutates configuration on the main actor.
+    /// Every read and write of this state goes through `lock` so a request
+    /// always sees a coherent key/model/temperature snapshot.
+    private struct State {
+        var host: HostServices?
+        var apiKey: String?
+        var selectedModelId: String?
+        var selectedLLMModelId: String?
+        var llmTemperatureModeRaw: String = PluginLLMTemperatureMode.providerDefault.rawValue
+        var llmTemperatureValue: Double = 0.3
+        var fetchedLLMModels: [VercelAIGatewayFetchedModel] = []
+        var fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] = []
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+
+    private func readState<T>(_ body: (State) -> T) -> T {
+        lock.withLock { body(state) }
+    }
+
+    /// Host callbacks (Keychain, defaults, capability notifications) run
+    /// outside the lock; the closure only updates in-memory state.
+    private func updateState(_ body: (inout State) -> Void) {
+        lock.withLock { body(&state) }
+    }
+
+    fileprivate var host: HostServices? { readState { $0.host } }
+    fileprivate var _apiKey: String? { readState { $0.apiKey } }
+    fileprivate var _selectedModelId: String? { readState { $0.selectedModelId } }
+    fileprivate var _selectedLLMModelId: String? { readState { $0.selectedLLMModelId } }
+    fileprivate var _llmTemperatureModeRaw: String { readState { $0.llmTemperatureModeRaw } }
+    fileprivate var _llmTemperatureValue: Double { readState { $0.llmTemperatureValue } }
+    fileprivate var _fetchedLLMModels: [VercelAIGatewayFetchedModel] { readState { $0.fetchedLLMModels } }
+    fileprivate var _fetchedTranscriptionModels: [VercelAIGatewayFetchedModel] { readState { $0.fetchedTranscriptionModels } }
 
     private static let chatRequestTimeout: TimeInterval = 30
     private static let transcriptionRequestTimeout: TimeInterval = 120
@@ -57,32 +85,41 @@ final class VercelAIGatewayPlugin: NSObject,
     }
 
     func activate(host: HostServices) {
-        self.host = host
-        _apiKey = host.loadSecret(key: Self.StorageKeys.apiKey)
+        var loaded = State()
+        loaded.host = host
+        loaded.apiKey = host.loadSecret(key: Self.StorageKeys.apiKey)
         if let data = host.userDefault(forKey: Self.StorageKeys.fetchedModels) as? Data,
            let models = try? JSONDecoder().decode([VercelAIGatewayFetchedModel].self, from: data) {
-            _fetchedLLMModels = models
+            loaded.fetchedLLMModels = models
         }
         if let data = host.userDefault(forKey: Self.StorageKeys.fetchedTranscriptionModels) as? Data,
            let models = try? JSONDecoder().decode([VercelAIGatewayFetchedModel].self, from: data) {
-            _fetchedTranscriptionModels = models
+            loaded.fetchedTranscriptionModels = models
         }
-        _selectedModelId = Self.resolvedStoredModelId(
+        loaded.llmTemperatureModeRaw = host.userDefault(forKey: Self.StorageKeys.llmTemperatureMode) as? String
+            ?? PluginLLMTemperatureMode.providerDefault.rawValue
+        loaded.llmTemperatureValue = host.userDefault(forKey: Self.StorageKeys.llmTemperatureValue) as? Double
+            ?? 0.3
+        updateState { $0 = loaded }
+
+        // Selections validate against the model lists, so resolve them once
+        // the lists above are published.
+        let selectedModelId = Self.resolvedStoredModelId(
             host.userDefault(forKey: Self.StorageKeys.selectedModel) as? String,
             availableModels: transcriptionModels,
             storageKey: Self.StorageKeys.selectedModel,
             host: host
         )
-        _selectedLLMModelId = Self.resolvedStoredModelId(
+        let selectedLLMModelId = Self.resolvedStoredModelId(
             host.userDefault(forKey: Self.StorageKeys.selectedLLMModel) as? String,
             availableModels: supportedModels,
             storageKey: Self.StorageKeys.selectedLLMModel,
             host: host
         )
-        _llmTemperatureModeRaw = host.userDefault(forKey: Self.StorageKeys.llmTemperatureMode) as? String
-            ?? PluginLLMTemperatureMode.providerDefault.rawValue
-        _llmTemperatureValue = host.userDefault(forKey: Self.StorageKeys.llmTemperatureValue) as? Double
-            ?? 0.3
+        updateState {
+            $0.selectedModelId = selectedModelId
+            $0.selectedLLMModelId = selectedLLMModelId
+        }
     }
 
     /// A persisted selection can point at a model the gateway has since retired.
@@ -107,7 +144,7 @@ final class VercelAIGatewayPlugin: NSObject,
     }
 
     func deactivate() {
-        host = nil
+        updateState { $0.host = nil }
     }
 
     // MARK: - TranscriptionEnginePlugin
@@ -139,7 +176,7 @@ final class VercelAIGatewayPlugin: NSObject,
     var selectedModelId: String? { _selectedModelId }
 
     func selectModel(_ modelId: String) {
-        _selectedModelId = modelId
+        updateState { $0.selectedModelId = modelId }
         host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedModel)
     }
 
@@ -147,10 +184,11 @@ final class VercelAIGatewayPlugin: NSObject,
     var dictionaryTermsSupport: DictionaryTermsSupport { .unsupported }
 
     func transcribe(audio: AudioData, language: String?, translate: Bool, prompt: String?) async throws -> PluginTranscriptionResult {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        let (storedApiKey, storedModelId) = readState { ($0.apiKey, $0.selectedModelId) }
+        guard let apiKey = storedApiKey, !apiKey.isEmpty else {
             throw PluginTranscriptionError.notConfigured
         }
-        guard let modelId = _selectedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
+        guard let modelId = storedModelId?.trimmingCharacters(in: .whitespacesAndNewlines),
               !modelId.isEmpty else {
             throw PluginTranscriptionError.noModelSelected
         }
@@ -349,22 +387,33 @@ final class VercelAIGatewayPlugin: NSObject,
         model: String?,
         temperatureDirective: PluginLLMTemperatureDirective
     ) async throws -> String {
-        guard let apiKey = _apiKey, !apiKey.isEmpty else {
+        let snapshot = readState { state in
+            (
+                apiKey: state.apiKey,
+                selectedModelId: state.selectedLLMModelId,
+                fallbackModels: state.fetchedLLMModels.isEmpty ? Self.fallbackLLMModels : state.fetchedLLMModels,
+                temperature: PluginLLMTemperatureDirective(
+                    mode: PluginLLMTemperatureMode(rawValue: state.llmTemperatureModeRaw) ?? .providerDefault,
+                    value: state.llmTemperatureValue
+                )
+            )
+        }
+        guard let apiKey = snapshot.apiKey, !apiKey.isEmpty else {
             throw PluginChatError.notConfigured
         }
-        let modelId = model ?? _selectedLLMModelId ?? supportedModels.first!.id
+        let modelId = model ?? snapshot.selectedModelId ?? snapshot.fallbackModels.first!.id
         return try await chatHelper.process(
             apiKey: apiKey,
             model: modelId,
             systemPrompt: systemPrompt,
             userText: userText,
-            temperature: providerTemperatureDirective.resolvedTemperature(applying: temperatureDirective),
+            temperature: snapshot.temperature.resolvedTemperature(applying: temperatureDirective),
             requestTimeout: Self.chatRequestTimeout
         )
     }
 
     func selectLLMModel(_ modelId: String) {
-        _selectedLLMModelId = modelId
+        updateState { $0.selectedLLMModelId = modelId }
         host?.setUserDefault(modelId, forKey: Self.StorageKeys.selectedLLMModel)
     }
 
@@ -374,18 +423,15 @@ final class VercelAIGatewayPlugin: NSObject,
         PluginLLMTemperatureMode(rawValue: _llmTemperatureModeRaw) ?? .providerDefault
     }
     var llmTemperatureValue: Double { _llmTemperatureValue }
-    fileprivate var providerTemperatureDirective: PluginLLMTemperatureDirective {
-        PluginLLMTemperatureDirective(mode: llmTemperatureMode, value: _llmTemperatureValue)
-    }
 
     func setLLMTemperatureMode(_ mode: PluginLLMTemperatureMode) {
-        _llmTemperatureModeRaw = mode.rawValue
+        updateState { $0.llmTemperatureModeRaw = mode.rawValue }
         host?.setUserDefault(mode.rawValue, forKey: Self.StorageKeys.llmTemperatureMode)
     }
 
     func setLLMTemperatureValue(_ value: Double) {
         let clamped = min(max(value, 0.0), 2.0)
-        _llmTemperatureValue = clamped
+        updateState { $0.llmTemperatureValue = clamped }
         host?.setUserDefault(clamped, forKey: Self.StorageKeys.llmTemperatureValue)
     }
 
@@ -398,7 +444,7 @@ final class VercelAIGatewayPlugin: NSObject,
     // MARK: - API Key Management
 
     func setApiKey(_ key: String) {
-        _apiKey = key
+        updateState { $0.apiKey = key }
         if let host {
             do {
                 try host.storeSecret(key: Self.StorageKeys.apiKey, value: key)
@@ -410,7 +456,7 @@ final class VercelAIGatewayPlugin: NSObject,
     }
 
     func removeApiKey() {
-        _apiKey = nil
+        updateState { $0.apiKey = nil }
         if let host {
             do {
                 try host.storeSecret(key: Self.StorageKeys.apiKey, value: "")
@@ -442,7 +488,7 @@ final class VercelAIGatewayPlugin: NSObject,
     // MARK: - Model Fetching
 
     func setFetchedLLMModels(_ models: [VercelAIGatewayFetchedModel]) {
-        _fetchedLLMModels = models
+        updateState { $0.fetchedLLMModels = models }
         if let data = try? JSONEncoder().encode(models) {
             host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedModels)
         }
@@ -450,7 +496,7 @@ final class VercelAIGatewayPlugin: NSObject,
     }
 
     func setFetchedTranscriptionModels(_ models: [VercelAIGatewayFetchedModel]) {
-        _fetchedTranscriptionModels = models
+        updateState { $0.fetchedTranscriptionModels = models }
         if let data = try? JSONEncoder().encode(models) {
             host?.setUserDefault(data, forKey: Self.StorageKeys.fetchedTranscriptionModels)
         }
@@ -628,6 +674,15 @@ private struct VercelAIGatewaySettingsView: View {
         filtered(models: transcriptionModels, searchText: transcriptionSearchText)
     }
 
+    /// A rejected key stays stored (matching the other cloud plugins, so an
+    /// offline save is not lost), so Save must remain reachable whenever the
+    /// field no longer matches the stored key.
+    private var hasUnsavedApiKeyInput: Bool {
+        let trimmed = apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return !plugin.isAvailable }
+        return trimmed != (plugin._apiKey ?? "")
+    }
+
     private func filtered(models: [VercelAIGatewayFetchedModel], searchText: String) -> [VercelAIGatewayFetchedModel] {
         if searchText.isEmpty { return models }
         let query = searchText.lowercased()
@@ -644,11 +699,11 @@ private struct VercelAIGatewaySettingsView: View {
 
                 HStack(spacing: 8) {
                     if showApiKey {
-                        TextField("API Key", text: $apiKeyInput)
+                        TextField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                             .font(.system(.body, design: .monospaced))
                     } else {
-                        SecureField("API Key", text: $apiKeyInput)
+                        SecureField(String(localized: "API Key", bundle: bundle), text: $apiKeyInput)
                             .textFieldStyle(.roundedBorder)
                     }
 
@@ -658,6 +713,15 @@ private struct VercelAIGatewaySettingsView: View {
                         Image(systemName: showApiKey ? "eye.slash" : "eye")
                     }
                     .buttonStyle(.borderless)
+
+                    if hasUnsavedApiKeyInput {
+                        Button(String(localized: "Save", bundle: bundle)) {
+                            saveApiKey()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
 
                     if plugin.isAvailable {
                         Button(String(localized: "Remove", bundle: bundle)) {
@@ -669,13 +733,6 @@ private struct VercelAIGatewaySettingsView: View {
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .foregroundStyle(.red)
-                    } else {
-                        Button(String(localized: "Save", bundle: bundle)) {
-                            saveApiKey()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .controlSize(.small)
-                        .disabled(apiKeyInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
                     }
                 }
 
@@ -802,7 +859,7 @@ private struct VercelAIGatewaySettingsView: View {
                     Text("Temperature", bundle: bundle)
                         .font(.headline)
 
-                    Picker("Temperature Mode", selection: $llmTemperatureMode) {
+                    Picker(String(localized: "Temperature Mode", bundle: bundle), selection: $llmTemperatureMode) {
                         Text("Provider Default", bundle: bundle).tag(PluginLLMTemperatureMode.providerDefault)
                         Text("Custom", bundle: bundle).tag(PluginLLMTemperatureMode.custom)
                     }

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/manifest.json
@@ -1,0 +1,26 @@
+{
+    "id": "com.typewhisper.vercel-ai-gateway",
+    "name": "Vercel AI Gateway",
+    "version": "1.0.0",
+    "minHostVersion": "1.7.0",
+    "sdkCompatibilityVersion": "v1",
+    "minOSVersion": "14.0",
+    "author": "TypeWhisper",
+    "description": "Access speech-to-text models and hundreds of LLMs from OpenAI, Anthropic, Google, xAI and more through Vercel AI Gateway with a single API key. Shows model pricing and credit balance.",
+    "descriptions": {
+        "de": "Zugriff auf Spracherkennungsmodelle und Hunderte LLMs von OpenAI, Anthropic, Google, xAI und mehr über Vercel AI Gateway mit einem einzigen API-Schlüssel. Zeigt Modellpreise und Guthaben.",
+        "ja": "Vercel AI Gateway経由で、OpenAI、Anthropic、Google、xAIなどの音声認識モデルと数百のLLMに1つのAPIキーでアクセスできます。モデル料金とクレジット残高を表示します。"
+    },
+    "category": "transcription",
+    "categories": [
+        "transcription",
+        "llm"
+    ],
+    "hosting": "cloud",
+    "iconSystemName": "triangle.fill",
+    "iconResourceName": "vercel.svg",
+    "principalClass": "VercelAIGatewayPlugin",
+    "requiresAPIKey": true,
+    "detailsURL": "https://www.typewhisper.com/addons/vercel-ai-gateway/",
+    "homepageURL": "https://vercel.com/ai-gateway"
+}

--- a/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/vercel.svg
+++ b/TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/vercel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 76 65" preserveAspectRatio="xMidYMid"><path d="M37.5274 0L75.0548 65H0L37.5274 0Z" fill="currentColor"/></svg>

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -197,6 +197,20 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }
 
+    func testVercelAIGatewayPlugin100RequiresCompatibleHost17() throws {
+        let manifestURL = TestSupport.repoRoot.appendingPathComponent(
+            "TypeWhisperPluginSDK/Plugins/VercelAIGatewayPlugin/manifest.json"
+        )
+        let data = try Data(contentsOf: manifestURL)
+        let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
+
+        XCTAssertEqual(manifest.version, "1.0.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
+        XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
+        XCTAssertEqual(manifest.hosting, .cloud)
+        XCTAssertEqual(manifest.categories, ["transcription", "llm"])
+    }
+
     func testGroqPluginReleaseRequiresHost16() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,6 +94,7 @@ PLUGIN_SCREENSHOTS = [
   { slug: "soniox", target: "SonioxPlugin", id: "com.typewhisper.soniox" },
   { slug: "speechmatics", target: "SpeechmaticsPlugin", id: "com.typewhisper.speechmatics" },
   { slug: "supertonic", target: "SupertonicPlugin", id: "com.typewhisper.tts.supertonic", size: [560, 536] },
+  { slug: "vercel-ai-gateway", target: "VercelAIGatewayPlugin", id: "com.typewhisper.vercel-ai-gateway" },
   { slug: "voxtral", target: "VoxtralPlugin", id: "com.typewhisper.voxtral" },
   { slug: "webhook", target: "WebhookPlugin", id: "com.typewhisper.webhook" },
   { slug: "whisperkit", target: "WhisperKitPlugin", id: "com.typewhisper.whisperkit", size: [560, 557] },


### PR DESCRIPTION
Hi! First of all, thank you for building and maintaining TypeWhisper. I use it every day and the plugin SDK made adding a new provider a pleasure, so I hope this contribution is useful to others as well.

## Summary

Adds a new cloud plugin, **Vercel AI Gateway** (`com.typewhisper.vercel-ai-gateway`), that provides both speech-to-text and LLM prompt processing through [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) with a single API key. It follows the OpenRouter plugin's structure and reuses the shared SDK helpers wherever the gateway is OpenAI-compatible.

![Vercel AI Gateway plugin card in Integrations](https://github.com/user-attachments/assets/b8d2411f-7f92-4044-8a5b-8428909d38a4)

![Vercel AI Gateway plugin settings with API key, transcription model, LLM model and temperature](https://github.com/user-attachments/assets/5c1805d9-6225-493b-897a-bea1c323f8d1)

## What changed

- **LLM (text to text)**: `POST /v1/chat/completions` via `PluginOpenAIChatHelper` with `baseURL: https://ai-gateway.vercel.sh`. Temperature mode/value and model selection match the OpenRouter and Cerebras plugins.
- **Speech to text**: the gateway does not expose the OpenAI multipart endpoint (`/v1/audio/transcriptions` returns 404), so the plugin uses the documented [`POST /v4/ai/transcription-model`](https://vercel.com/docs/ai-gateway/modalities/speech-to-text#transcribe-with-the-rest-api) endpoint: base64 audio in a JSON body, model in the `ai-model-id` header, plus the `ai-gateway-protocol-version` / `ai-transcription-model-specification-version` headers. Uploads M4A first and retries once with WAV on a format rejection. Parses the AI SDK result shape (`segments[].startSecond/endSecond`, `language`). A `language` hint is forwarded as `providerOptions.openai.language` for `openai/*` models only.
- **Model catalogue**: a single `GET /v1/models` call is split by the `type` field into language and transcription lists (with pricing shown for LLMs). WebSocket-only transcription models (`websocket-realtime` tag or `-live` suffix) are excluded because the REST endpoint cannot serve them. Fetched lists are cached in plugin defaults with static fallbacks.
- **Key validation and balance**: `GET /v1/credits` (the models endpoint is unauthenticated, so it cannot validate a key). The balance is shown in the settings view.
- **Registration**: SwiftPM target and test target, Xcode bundle target, `plugin-release.yml` slug `vercel-ai-gateway`, Fastfile screenshot entry, brand-logo slug in `PluginSettingsView`, manifest validation test, `de`/`ja`/`zh-Hans` string catalogue, bundled `vercel.svg` icon.

## Why

Vercel AI Gateway gives access to ~250 language models and the OpenAI/Google/xAI transcription models behind one key with no markup, which is convenient for users who already run their inference through it.

## Notes for reviewers

- `minHostVersion` is `1.7.0`: the plugin uses `PluginHTTPErrorBodyFormatter.htmlPageSummary`, which is not in the 1.6.0 SDK. The plugin is verified to load on the `v1.7.0-daily.20260909` host.
- Vercel documents speech to text as beta with gradual rollout, so the settings view carries a note that transcription models may not be enabled for every team.
- The `/v4/ai/transcription-model` headers mirror the AI SDK protocol; if Vercel bumps the specification version, the constants in `makeTranscriptionRequest` are the only place to update.

## Testing

```sh
swift test --package-path TypeWhisperPluginSDK --filter VercelAIGatewayPluginTests
xcodebuild -project TypeWhisper.xcodeproj -scheme VercelAIGatewayPlugin -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build
```

- 22 unit tests pass (chat request shape and error mapping, catalogue splitting and caching, credits parsing, transcription headers/body, WAV retry, HTTP error mapping, HTML-body rejection, persisted-selection fallback).
- Verified against the live gateway with a real key: `/v1/credits` 200, `/v1/chat/completions` with `openai/gpt-4o-mini` returned corrected text, `/v4/ai/transcription-model` with `openai/whisper-1` transcribed a test clip in both WAV and M4A.
- Built the Release bundle with the same flags as `plugin-release.yml`, installed it into `~/Library/Application Support/TypeWhisper/Plugins/` on a 1.7.0 daily host, and confirmed it appears in Integrations, validates the key, lists models, and works as the dictation engine (see screenshots above).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vercel AI Gateway integration for AI chat and audio transcription.
  * Added model selection, API key validation, credit tracking, pricing, and temperature controls.
  * Added model catalog search, filtering, persistence, and automatic fallback options.
  * Added support for compressed M4A and WAV audio formats, provider-specific transcription languages, and retry handling.
  * Added localized plugin content in German, Japanese, and Simplified Chinese.

* **Bug Fixes**
  * Improved API-key and model-catalog updates to prevent stale settings or pricing information from overwriting newer changes.
  * Added clearer error handling for failed requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

