### PR TITLE
Prepare the Swift 6.3 Daily before TypeWhisper 1.7 RC1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Build App
         run: |
           set -o pipefail
-          xcodebuild -project $PROJECT \
+          xcodebuild -skipPackagePluginValidation -project $PROJECT \
             -scheme $SCHEME \
             -configuration Release \
             -derivedDataPath build \
@@ -135,7 +135,7 @@ jobs:
       - name: Run App Tests
         run: |
           set -o pipefail
-          xcodebuild test -project $PROJECT \
+          xcodebuild test -skipPackagePluginValidation -project $PROJECT \
             -scheme $SCHEME \
             -destination 'platform=macOS,arch=arm64' \
             -parallel-testing-enabled NO \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   release-build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Resolve Swift packages
         run: |
@@ -106,7 +106,7 @@ jobs:
           retention-days: 14
 
   app-tests:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Resolve Swift packages
         run: |
@@ -147,7 +147,7 @@ jobs:
         run: bash scripts/check_first_party_warnings.sh test.log
 
   plugin-sdk-tests:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Build Swift for CodeQL
         run: |
           set -o pipefail
-          xcodebuild -project "$PROJECT" \
+          xcodebuild -skipPackagePluginValidation -project "$PROJECT" \
             -scheme "$SCHEME" \
             -configuration Debug \
             -derivedDataPath codeql-build \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,7 +61,7 @@ jobs:
   analyze-swift:
     name: Analyze (swift)
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-daily')
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 45
 
     steps:
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -94,6 +94,16 @@ jobs:
           build-mode: manual
           queries: security-and-quality
 
+      # CodeQL tracing can change Metal toolchain visibility on macOS 26.
+      # Check from the traced process environment, after init, before compiling MLX.
+      - name: Verify Metal toolchain after CodeQL initialization
+        run: |
+          if ! xcrun metal -v; then
+            xcodebuild -downloadComponent MetalToolchain
+          fi
+          xcrun --find metal
+          xcrun metal -v
+
       - name: Build Swift for CodeQL
         run: |
           set -o pipefail

--- a/.github/workflows/icloud-release-policy.yml
+++ b/.github/workflows/icloud-release-policy.yml
@@ -1,0 +1,23 @@
+name: iCloud Release Policy
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/icloud-release-policy.yml'
+      - '.github/workflows/release.yml'
+      - 'scripts/archive_release.sh'
+      - 'scripts/build-release-local.sh'
+      - 'scripts/check_release_signing.sh'
+      - 'scripts/test_icloud_release_policy.py'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - run: python3 scripts/test_icloud_release_policy.py

--- a/.github/workflows/plugin-release-policy.yml
+++ b/.github/workflows/plugin-release-policy.yml
@@ -1,0 +1,31 @@
+name: Plugin Release Policy
+
+on:
+  pull_request:
+    paths:
+      - 'TypeWhisperPluginSDK/Plugins/**/manifest.json'
+      - 'scripts/*plugin*release*.py'
+      - '.github/workflows/plugin-release*.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'TypeWhisperPluginSDK/Plugins/**/manifest.json'
+      - 'scripts/*plugin*release*.py'
+      - '.github/workflows/plugin-release*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Validate new plugin release manifests
+        run: python3 scripts/validate_plugin_release_manifest.py TypeWhisperPluginSDK/Plugins/*/manifest.json
+      - name: Test release policy and minimum host resolution
+        run: |
+          python3 scripts/test_validate_plugin_release_manifest.py
+          python3 scripts/test_resolve_plugin_host_release.py

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -253,7 +253,7 @@ jobs:
               "LD_RUNPATH_SEARCH_PATHS=@loader_path/../Frameworks"
             )
           fi
-          xcodebuild -project TypeWhisper.xcodeproj \
+          xcodebuild -skipPackagePluginValidation -project TypeWhisper.xcodeproj \
             -target "$TARGET" \
             -configuration Release \
             SYMROOT="$(pwd)/build" \

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -178,6 +178,17 @@ jobs:
           fi
           python3 scripts/assemble_community_plugin_registry.py
 
+      - name: Validate release manifest
+        run: |
+          MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
+          if [ ! -f "$MANIFEST" ]; then
+            echo "Missing manifest for ${TARGET}: $MANIFEST"
+            exit 1
+          fi
+          python3 scripts/validate_plugin_release_manifest.py "$MANIFEST" --version "$PLUGIN_VERSION"
+          echo "Validated $MANIFEST for release $PLUGIN_VERSION"
+          cat "$MANIFEST"
+
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
@@ -188,59 +199,6 @@ jobs:
           xcodebuild -resolvePackageDependencies \
             -project TypeWhisper.xcodeproj \
             -scheme TypeWhisper
-
-      - name: Validate release manifest
-        run: |
-          MANIFEST="TypeWhisperPluginSDK/Plugins/${TARGET}/manifest.json"
-          if [ ! -f "$MANIFEST" ]; then
-            echo "Missing manifest for ${TARGET}: $MANIFEST"
-            exit 1
-          fi
-          export MANIFEST
-          python3 <<'PYEOF'
-          import json
-          import os
-          import re
-
-          manifest_path = os.environ["MANIFEST"]
-          expected_version = os.environ["PLUGIN_VERSION"]
-
-          with open(manifest_path) as manifest_file:
-              manifest = json.load(manifest_file)
-
-          actual_version = manifest.get("version")
-          if actual_version != expected_version:
-              raise SystemExit(
-                  f"manifest version {actual_version!r} does not match release version {expected_version!r}"
-              )
-
-          min_host_version = manifest.get("minHostVersion")
-          if not isinstance(min_host_version, str) or not re.fullmatch(
-              r"[0-9]+\.[0-9]+\.[0-9]+",
-              min_host_version,
-          ):
-              raise SystemExit(
-                  f"manifest minHostVersion {min_host_version!r} must be a release version like 1.6.0"
-              )
-          minimum_host_version = (1, 6, 0)
-          host_version = tuple(int(part) for part in min_host_version.split("."))
-          if host_version < minimum_host_version:
-              raise SystemExit(
-                  f"manifest minHostVersion {min_host_version!r} must be 1.6.0 or newer"
-              )
-
-          sdk_compatibility_version = manifest.get("sdkCompatibilityVersion")
-          if not isinstance(sdk_compatibility_version, str) or not re.fullmatch(
-              r"v[1-9][0-9]*",
-              sdk_compatibility_version,
-          ):
-              raise SystemExit(
-                  "manifest sdkCompatibilityVersion "
-                  f"{sdk_compatibility_version!r} must use the format vN"
-              )
-          PYEOF
-          echo "Validated $MANIFEST for release $PLUGIN_VERSION"
-          cat "$MANIFEST"
 
       - name: Build Plugin
         run: |

--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -33,7 +33,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     concurrency:
       group: plugin-release-${{ github.event_name == 'workflow_dispatch' && format('{0}-{1}-v{2}', inputs.distribution_source, inputs.plugin_name, inputs.plugin_version) || github.ref_name }}
       cancel-in-progress: true
@@ -145,13 +145,13 @@ jobs:
             *) echo "Unknown plugin: $PLUGIN_NAME" && exit 1 ;;
           esac
           # Set deployment target and Swift embedding per plugin
-          # All plugins use Xcode 26.3 (mlx-audio-swift requires Swift 6.2+ for package resolution,
+          # All plugins use Xcode 26.6 (mlx-swift 0.31.6 requires Swift 6.3+ for package resolution,
           # and workspace-state.json v7 from Xcode 26.x is incompatible with Xcode 16.2)
           # - SpeechAnalyzer: macOS 26 deployment target
           # - Qwen3/Voxtral/Granite/Gemma4: macOS 14 + embed Swift compat libs (MLX uses Swift 6.2 features)
           # - All others: macOS 14, no compat libs needed (simple Foundation/SDK code)
           EMBED_SWIFT_LIBS="NO"
-          XCODE_VERSION="26.3"
+          XCODE_VERSION="26.6"
           if [ "$TARGET" = "SpeechAnalyzerPlugin" ]; then
             DEPLOY_TARGET="26.0"
           elif [ "$TARGET" = "Qwen3Plugin" ] || [ "$TARGET" = "VoxtralPlugin" ] || [ "$TARGET" = "GranitePlugin" ] || [ "$TARGET" = "Gemma4Plugin" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
   verify-release-tools:
     needs: [prepare]
     if: needs.prepare.outputs.should_run == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -120,7 +120,7 @@ jobs:
   app-tests:
     needs: [prepare]
     if: needs.prepare.outputs.should_run == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -130,7 +130,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Resolve Swift packages
         run: |
@@ -155,7 +155,7 @@ jobs:
   plugin-sdk-tests:
     needs: [prepare]
     if: needs.prepare.outputs.should_run == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -165,7 +165,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Run Plugin SDK Tests
         run: swift test --package-path TypeWhisperPluginSDK
@@ -177,7 +177,7 @@ jobs:
       - app-tests
       - plugin-sdk-tests
     if: needs.prepare.outputs.should_run == 'true'
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
       WITHOUT_ICLOUD: ${{ needs.prepare.outputs.without_icloud }}
@@ -190,7 +190,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
-          xcode-version: "26.3"
+          xcode-version: "26.6"
 
       - name: Resolve Swift packages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Run App Tests
         run: |
           set -o pipefail
-          xcodebuild test -project $PROJECT \
+          xcodebuild test -skipPackagePluginValidation -project $PROJECT \
             -scheme $SCHEME \
             -destination 'platform=macOS,arch=arm64' \
             -parallel-testing-enabled NO \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,6 @@ on:
         description: Optional exact release tag (for example v1.7.0-daily.20260825.1)
         required: false
         type: string
-      without_icloud:
-        description: Build the bridge without iCloud (fallback when its Developer ID profile is unavailable)
-        required: false
-        default: false
-        type: boolean
 
 env:
   SCHEME: TypeWhisper
@@ -33,7 +28,6 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
       should_run: ${{ steps.resolve.outputs.should_run }}
-      without_icloud: ${{ steps.resolve.outputs.without_icloud }}
     steps:
       - name: Checkout
         if: github.event_name != 'push'
@@ -48,18 +42,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REF_NAME: ${{ github.ref_name }}
           REQUESTED_TAG: ${{ inputs.release_tag }}
-          REQUESTED_WITHOUT_ICLOUD: ${{ inputs.without_icloud }}
-          SCHEDULED_WITHOUT_ICLOUD: ${{ vars.MACOS_SCHEDULED_WITHOUT_ICLOUD }}
         run: |
-          WITHOUT_ICLOUD="false"
-          # Tagged releases use the dedicated iCloud bridge profile. Scheduled
-          # and manually dispatched builds retain their explicit fallback controls.
-          if [ "$REQUESTED_WITHOUT_ICLOUD" = "true" ] ||
-            { [ "$EVENT_NAME" = "schedule" ] && [ "$SCHEDULED_WITHOUT_ICLOUD" = "true" ]; }; then
-            WITHOUT_ICLOUD="true"
-          fi
-          echo "without_icloud=$WITHOUT_ICLOUD" >> "$GITHUB_OUTPUT"
-
           if [ "$EVENT_NAME" = "push" ]; then
             printf 'tag=%s\n' "$REF_NAME" >> "$GITHUB_OUTPUT"
             echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -116,6 +99,7 @@ jobs:
         run: |
           bash scripts/check_release_binary_instrumentation.sh --self-test
           bash scripts/check_release_signing.sh --self-test
+          python3 scripts/test_icloud_release_policy.py
 
   app-tests:
     needs: [prepare]
@@ -180,7 +164,6 @@ jobs:
     runs-on: macos-26
     env:
       RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
-      WITHOUT_ICLOUD: ${{ needs.prepare.outputs.without_icloud }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -225,13 +208,12 @@ jobs:
           bash scripts/check_release_signing.sh --self-test
 
       - name: Decode iCloud Bridge Developer ID Provisioning Profile
-        if: needs.prepare.outputs.without_icloud != 'true'
         env:
           MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE: ${{ secrets.MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE }}
         run: |
           PROFILE_PATH="${RUNNER_TEMP}/TypeWhisperICloudBridge.provisionprofile"
           if [ -z "$MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE" ]; then
-            echo "MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE is not set; use without_icloud to build the fallback" >&2
+            echo "MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE is required for every app release" >&2
             exit 1
           fi
           printf '%s' "$MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE" | base64 --decode > "$PROFILE_PATH"
@@ -273,11 +255,7 @@ jobs:
             --build-number "$BUILD_NUMBER"
             --signing-identity "$MACOS_SIGNING_IDENTITY"
           )
-          if [ "$WITHOUT_ICLOUD" = "true" ]; then
-            ARCHIVE_ARGS+=(--without-icloud)
-          else
-            ARCHIVE_ARGS+=(--profile "$MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH")
-          fi
+          ARCHIVE_ARGS+=(--profile "$MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH")
 
           set -o pipefail
           bash scripts/archive_release.sh "${ARCHIVE_ARGS[@]}" | tee build.log
@@ -290,11 +268,7 @@ jobs:
 
       - name: Check Developer ID Signing
         run: |
-          CHECK_ARGS=()
-          if [ "$WITHOUT_ICLOUD" = "true" ]; then
-            CHECK_ARGS+=(--without-icloud)
-          fi
-          bash scripts/check_release_signing.sh "${CHECK_ARGS[@]}" build/export/TypeWhisper.app
+          bash scripts/check_release_signing.sh build/export/TypeWhisper.app
 
       - name: Notarize App
         env:
@@ -319,12 +293,7 @@ jobs:
 
       - name: Verify Notarized App and Spawn
         run: |
-          CHECK_ARGS=()
-          if [ "$WITHOUT_ICLOUD" = "true" ]; then
-            CHECK_ARGS+=(--without-icloud)
-          fi
           bash scripts/check_release_signing.sh \
-            "${CHECK_ARGS[@]}" \
             --require-notarization \
             --spawn \
             build/export/TypeWhisper.app

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -8731,7 +8731,7 @@
 			repositoryURL = "https://github.com/huggingface/swift-huggingface.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.9.0;
+				version = 0.10.1;
 			};
 		};
 		D20600000000000000000001 /* XCRemoteSwiftPackageReference "onnxruntime-swift-package-manager" */ = {

--- a/TypeWhisper.xcodeproj/project.pbxproj
+++ b/TypeWhisper.xcodeproj/project.pbxproj
@@ -8683,7 +8683,7 @@
 			repositoryURL = "https://github.com/FluidInference/FluidAudio.git";
 			requirement = {
 				kind = exactVersion;
-				version = 0.15.5;
+				version = 0.15.6;
 			};
 		};
 		RR00000000000000000004 /* XCRemoteSwiftPackageReference "Sparkle" */ = {

--- a/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TypeWhisper.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "bd64824505da71a1a403adb221f6e25413c0bc7f",
-        "version" : "1.4.0"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
-        "version" : "0.15.5"
+        "revision" : "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b",
+        "version" : "0.15.6"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
-        "version" : "0.31.4"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle.git",
       "state" : {
-        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
-        "version" : "2.9.4"
+        "revision" : "ac2def288cbff5cfc7df3ffef6abdf45b72bcb0a",
+        "version" : "2.9.6"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
       }
     },
     {
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
-        "version" : "1.5.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -122,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
       "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
+        "revision" : "b5403ed09403f674601fd1123e07c5b32914d16f",
+        "version" : "0.10.1"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "d81197f35f41445bc10e94600795e68c6f5e94b0",
-        "version" : "2.3.1"
+        "revision" : "12ea4955e380dae6b0cd98299effe48c7fe584fc",
+        "version" : "2.5.0"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -185,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "704705c5c51156ede21172a38654d522ce487074",
-        "version" : "1.8.0"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "58c4bc11963a140358d791f678a60a2745a23146",
-        "version" : "1.2.1"
+        "revision" : "c21fdcde390313a6d98d8e33a346f2c3486c3ab0",
+        "version" : "1.3.4"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.resolved
+++ b/TypeWhisperPluginSDK/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7db945d6326e77e543d9b4d3432693af49a6bc3734dd4c835fc4c8696d8920b2",
+  "originHash" : "72f1f86b8dcc0d9e6490a2ffa168942c8774e1b1068bb9d5990099c7632eb45f",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
       "state" : {
-        "revision" : "9ebe9cb568ff9ebe2f1bcd3ae7d925fbb45ec8d2",
-        "version" : "0.10.0"
+        "revision" : "b5403ed09403f674601fd1123e07c5b32914d16f",
+        "version" : "0.10.1"
       }
     },
     {
@@ -113,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
-        "version" : "2.4.2"
+        "revision" : "12ea4955e380dae6b0cd98299effe48c7fe584fc",
+        "version" : "2.5.0"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.resolved
+++ b/TypeWhisperPluginSDK/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "08183abe19700c116da9c113149e80a20628463fbc07968be89df2812a5f292e",
+  "originHash" : "7db945d6326e77e543d9b4d3432693af49a6bc3734dd4c835fc4c8696d8920b2",
   "pins" : [
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mattt/EventSource.git",
       "state" : {
-        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
-        "version" : "1.4.1"
+        "revision" : "86b5096ac59ab46e66bd1f6377c604bc1dab0bc2",
+        "version" : "1.5.1"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidInference/FluidAudio.git",
       "state" : {
-        "revision" : "19600a485baa4998812e4654b70d2bab8f2c9949",
-        "version" : "0.15.5"
+        "revision" : "4dbf4f9f9a5ff3a53ade848d7ba4e3df13db859b",
+        "version" : "0.15.6"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift.git",
       "state" : {
-        "revision" : "dc43e62d7055353c7f99fa071a4e71d29dfddc44",
-        "version" : "0.31.4"
+        "revision" : "0bb916c67f4b9e5c682cbe02a42c701c93ab5021",
+        "version" : "0.31.6"
       }
     },
     {
@@ -55,12 +55,21 @@
       }
     },
     {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "6a52f3251125d74daf04fcbd5e6f08a75d074382",
+        "version" : "1.8.2"
+      }
+    },
+    {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
       "state" : {
-        "revision" : "b721959445b617d0bf03910b2b4aced345fd93bf",
-        "version" : "0.9.0"
+        "revision" : "9ebe9cb568ff9ebe2f1bcd3ae7d925fbb45ec8d2",
+        "version" : "0.10.0"
       }
     },
     {
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
       }
     },
     {
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
-        "version" : "2.101.3"
+        "revision" : "a931f2c1de8dd49381ce3bf2e279d033f68d8865",
+        "version" : "2.102.0"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
-        "version" : "1.7.5"
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {
@@ -167,8 +176,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers.git",
       "state" : {
-        "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
-        "version" : "1.3.3"
+        "revision" : "c21fdcde390313a6d98d8e33a346f2c3486c3ab0",
+        "version" : "1.3.4"
       }
     },
     {

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -10,12 +10,12 @@ let package = Package(
         .library(name: "TypeWhisperPluginSDKTesting", targets: ["TypeWhisperPluginSDKTesting"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.15.5"),
+        .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.15.6"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
-        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.9.0"),
+        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.10.0"),
         // swift-transformers 1.3.3 is incompatible with swift-jinja 2.4's ObjectKey API.
-        .package(url: "https://github.com/huggingface/swift-jinja.git", exact: "2.3.6"),
-        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.4"),
+        .package(url: "https://github.com/huggingface/swift-jinja.git", exact: "2.4.2"),
+        .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.6"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.1"),
     ],

--- a/TypeWhisperPluginSDK/Package.swift
+++ b/TypeWhisperPluginSDK/Package.swift
@@ -12,9 +12,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/FluidInference/FluidAudio.git", exact: "0.15.6"),
         .package(url: "https://github.com/Blaizzy/mlx-audio-swift.git", revision: "2685c640d4079641a01ef3489cacb684c34109fd"),
-        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.10.0"),
-        // swift-transformers 1.3.3 is incompatible with swift-jinja 2.4's ObjectKey API.
-        .package(url: "https://github.com/huggingface/swift-jinja.git", exact: "2.4.2"),
+        .package(url: "https://github.com/huggingface/swift-huggingface.git", exact: "0.10.1"),
+        .package(url: "https://github.com/huggingface/swift-jinja.git", exact: "2.5.0"),
         .package(url: "https://github.com/ml-explore/mlx-swift.git", exact: "0.31.6"),
         .package(url: "https://github.com/microsoft/onnxruntime-swift-package-manager.git", from: "1.24.2"),
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", exact: "0.12.1"),

--- a/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/AssemblyAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.assemblyai",
     "name": "AssemblyAI",
     "version": "1.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CartesiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cartesia",
     "name": "Cartesia",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CerebrasPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cerebras",
     "name": "Cerebras",
     "version": "1.0.5",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ClaudePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.claude",
     "name": "Claude",
     "version": "1.1.1",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CloudflareASRPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cloudflare-asr",
     "name": "Cloudflare ASR",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "yunluyl",

--- a/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cohere-transcribe",
     "name": "Cohere Transcribe (Local)",
     "version": "1.0.1",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/CoherePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.cohere",
     "name": "Cohere",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ContributorPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ContributorPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.improve",
     "name": "Improve TypeWhisper",
     "version": "0.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/DeepgramPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.deepgram",
     "name": "Deepgram",
     "version": "1.0.15",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ElevenLabsPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.elevenlabs",
     "name": "ElevenLabs",
     "version": "1.0.11",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileJobScriptPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.file-job-script",
     "name": "File Job Script",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FileMemoryPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.memory.file",
     "name": "File Memory",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FillerWordsPlugin/manifest.json
@@ -2,7 +2,7 @@
   "id": "com.typewhisper.filler-words",
   "name": "Filler Words",
   "version": "1.0.1",
-  "minHostVersion": "1.6.0",
+  "minHostVersion": "1.7.0",
   "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/FireworksPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.fireworks",
     "name": "Fireworks AI",
     "version": "1.0.6",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GeminiPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gemini",
     "name": "Gemini",
     "version": "1.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Gemma4Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gemma4",
     "name": "Gemma 4",
     "version": "1.1.6",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "supportedArchitectures": [
         "arm64"

--- a/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GladiaPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.gladia",
     "name": "Gladia",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GoogleCloudSTTPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.google-cloud-stt",
     "name": "Google Cloud Speech-to-Text",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GranitePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.granite",
     "name": "Granite Speech",
     "version": "1.0.10",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.groq",
     "name": "Groq",
     "version": "1.0.24",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/LinearPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/LinearPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.linear",
     "name": "Linear",
     "version": "1.0.10",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/LiveTranscriptPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.livetranscript",
     "name": "Live Transcript",
     "version": "1.0.3",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/Fixtures/mcp_http_fixture.py
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/Fixtures/mcp_http_fixture.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import signal
 import json
 import pathlib
 import sys
@@ -123,6 +124,9 @@ class MCPHandler(BaseHTTPRequestHandler):
                 "error": {"code": -32601, "message": "Method not found"},
             })
 
+
+if "--ignore-termination" in sys.argv[4:]:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 server = ThreadingHTTPServer(("127.0.0.1", 0), MCPHandler)
 port_path.write_text(str(server.server_port), encoding="utf-8")

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import TypeWhisperPluginSDK
 import TypeWhisperPluginSDKTesting
@@ -578,7 +579,7 @@ final class MCPClientPluginTests: XCTestCase {
     func testStreamableHTTPContractSupportsNoAuthenticationAndBearerToken() async throws {
         for token in [nil, "fixture-bearer-token"] as [String?] {
             let fixture = try await Self.startHTTPFixture(expectedToken: token)
-            defer { Self.stopHTTPFixture(fixture) }
+            addTeardownBlock { await Self.stopHTTPFixture(fixture) }
             let configuration = MCPServerConfiguration(
                 name: "HTTP Fixture",
                 transport: .streamableHTTP,
@@ -615,6 +616,18 @@ final class MCPClientPluginTests: XCTestCase {
             XCTAssertTrue(methods.contains("tools/list"))
             XCTAssertTrue(methods.contains("tools/call"))
         }
+    }
+
+    func testHTTPFixtureCleanupKillsServerIgnoringTermination() async throws {
+        let fixture = try await Self.startHTTPFixture(expectedToken: nil, ignoreTermination: true)
+        addTeardownBlock { await Self.stopHTTPFixture(fixture) }
+        try "fixture counter".write(to: fixture.counter, atomically: true, encoding: .utf8)
+
+        await Self.stopHTTPFixture(fixture)
+
+        XCTAssertFalse(fixture.process.isRunning)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.portFile.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.counter.path))
     }
 
     func testDraftDiscoveryDoesNotPersistServerOrSecrets() async throws {
@@ -1080,14 +1093,17 @@ final class MCPClientPluginTests: XCTestCase {
         return (pythonPath, script, counter)
     }
 
-    private struct HTTPFixture {
+    private struct HTTPFixture: Sendable {
         let process: Process
         let endpoint: URL
         let portFile: URL
         let counter: URL
     }
 
-    private static func startHTTPFixture(expectedToken: String?) async throws -> HTTPFixture {
+    private static func startHTTPFixture(
+        expectedToken: String?,
+        ignoreTermination: Bool = false
+    ) async throws -> HTTPFixture {
         let pythonPath = "/usr/bin/python3"
         guard FileManager.default.isExecutableFile(atPath: pythonPath) else {
             throw XCTSkip("System Python is unavailable")
@@ -1103,36 +1119,58 @@ final class MCPClientPluginTests: XCTestCase {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: pythonPath)
         process.arguments = [script.path, portFile.path, counter.path, expectedToken ?? ""]
+        if ignoreTermination { process.arguments?.append("--ignore-termination") }
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
         try process.run()
 
-        for _ in 0..<200 {
-            if let value = try? String(contentsOf: portFile, encoding: .utf8),
-               let port = Int(value),
-               let endpoint = URL(string: "http://127.0.0.1:\(port)/mcp") {
-                return HTTPFixture(process: process, endpoint: endpoint, portFile: portFile, counter: counter)
+        do {
+            for _ in 0..<200 {
+                if let value = try? String(contentsOf: portFile, encoding: .utf8),
+                   let port = Int(value),
+                   let endpoint = URL(string: "http://127.0.0.1:\(port)/mcp") {
+                    return HTTPFixture(process: process, endpoint: endpoint, portFile: portFile, counter: counter)
+                }
+                guard process.isRunning else {
+                    throw MCPClientError.invalidConfiguration("HTTP fixture stopped before publishing its port.")
+                }
+                try await Task.sleep(for: .milliseconds(10))
             }
-            guard process.isRunning else {
-                throw MCPClientError.invalidConfiguration("HTTP fixture stopped before publishing its port.")
-            }
-            try await Task.sleep(for: .milliseconds(10))
+            throw MCPClientError.timedOut("HTTP fixture startup")
+        } catch {
+            await stopHTTPFixtureProcess(process)
+            try? FileManager.default.removeItem(at: portFile)
+            try? FileManager.default.removeItem(at: counter)
+            throw error
         }
-
-        if process.isRunning {
-            process.terminate()
-            process.waitUntilExit()
-        }
-        throw MCPClientError.timedOut("HTTP fixture startup")
     }
 
-    private static func stopHTTPFixture(_ fixture: HTTPFixture) {
-        if fixture.process.isRunning {
-            fixture.process.terminate()
-            fixture.process.waitUntilExit()
-        }
+    private static func stopHTTPFixture(_ fixture: HTTPFixture) async {
+        await stopHTTPFixtureProcess(fixture.process)
         try? FileManager.default.removeItem(at: fixture.portFile)
         try? FileManager.default.removeItem(at: fixture.counter)
+    }
+
+    private static func stopHTTPFixtureProcess(_ process: Process) async {
+        // Cleanup must finish even when the test's task was cancelled. Yielding also
+        // avoids blocking Foundation's process-exit delivery with waitUntilExit().
+        await Task.detached {
+            guard process.isRunning else { return }
+            process.terminate()
+            let clock = ContinuousClock()
+            let terminationDeadline = clock.now.advanced(by: .seconds(2))
+            while process.isRunning, clock.now < terminationDeadline {
+                try? await Task.sleep(for: .milliseconds(20))
+            }
+            if process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                let killDeadline = clock.now.advanced(by: .seconds(2))
+                while process.isRunning, clock.now < killDeadline {
+                    try? await Task.sleep(for: .milliseconds(20))
+                }
+            }
+            XCTAssertFalse(process.isRunning, "HTTP fixture did not exit after SIGKILL")
+        }.value
     }
 
     private static func resolvedFixtureServer(

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
@@ -27,7 +27,7 @@ final class MCPClientPluginTests: XCTestCase {
 
         XCTAssertEqual(manifest.id, "com.typewhisper.mcp-client")
         XCTAssertEqual(manifest.version, "0.2.1")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
         XCTAssertEqual(manifest.category, "action")
 

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.mcp-client",
     "name": "MCP Client",
     "version": "0.2.1",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MemPalacePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.mempalace.memory",
     "name": "MemPalace",
     "version": "0.3.5",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": ["arm64"],

--- a/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/MistralAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.minerale.mistralai",
     "name": "Mistral AI",
     "version": "1.0.5",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "MinerAle",

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/Tests/ObsidianPluginTests.swift
@@ -52,7 +52,7 @@ final class ObsidianPluginTests: XCTestCase {
 
         XCTAssertEqual(manifest.id, "com.typewhisper.obsidian")
         XCTAssertEqual(manifest.version, "1.1.0")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, "v1")
     }
 

--- a/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ObsidianPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.obsidian",
     "name": "Obsidian",
     "version": "1.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAICompatiblePlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openai-compatible",
     "name": "OpenAI Compatible",
     "version": "1.1.8",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openai",
     "name": "OpenAI / ChatGPT",
     "version": "1.3.3",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenAIVectorMemoryPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.memory.openai-vector",
     "name": "OpenAI Vector Memory",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/OpenRouterPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.openrouter",
     "name": "OpenRouter",
     "version": "1.1.6",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.parakeet",
     "name": "Parakeet",
     "version": "1.3.1",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.qwen3",
     "name": "Qwen3 ASR",
     "version": "1.1.8",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/README.md
+++ b/TypeWhisperPluginSDK/Plugins/README.md
@@ -55,7 +55,7 @@ Plugins can subscribe to events without modifying the transcription pipeline:
     "id": "com.yourname.plugin-id",
     "name": "My Plugin",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": ["arm64"],

--- a/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/Reson8Plugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.reson8",
     "name": "Reson8",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "Y. Vos",

--- a/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SaluteSpeechPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.sber-salutespeech",
     "name": "Sber SaluteSpeech",
     "version": "0.1.1",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/ScriptPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/ScriptPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.script",
     "name": "Script Runner",
     "version": "1.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SmallestAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.smallest-pulse",
     "name": "Smallest Pulse",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechAnalyzerPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.speechanalyzer",
     "name": "Apple Speech",
     "version": "1.0.15",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "26.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SpeechmaticsPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.speechmatics",
     "name": "Speechmatics",
     "version": "1.0.8",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/Tests/SupertonicPluginTests.swift
@@ -5,7 +5,7 @@ import XCTest
 @testable import SupertonicPlugin
 
 final class SupertonicPluginTests: XCTestCase {
-    func testManifestDeclaresLocalTTSPluginForHost16AndArm64() throws {
+    func testManifestDeclaresLocalTTSPluginForHost17AndArm64() throws {
         let manifestURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -21,7 +21,7 @@ final class SupertonicPluginTests: XCTestCase {
         XCTAssertEqual(manifest.category, "tts")
         XCTAssertEqual(manifest.hosting, .local)
         XCTAssertEqual(manifest.requiresAPIKey, false)
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
     }
 

--- a/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SupertonicPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.tts.supertonic",
     "name": "Supertonic (Experimental)",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/SystemTTSPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.tts.system",
     "name": "System Voice",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.voxtral",
     "name": "Voxtral",
     "version": "1.0.14",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WebhookPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.webhook",
     "name": "Webhook Notifications",
     "version": "1.1.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.whisperkit",
     "name": "WhisperKit",
     "version": "1.2.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "supportedArchitectures": [

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/Tests/XAIPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/Tests/XAIPluginTests.swift
@@ -90,7 +90,7 @@ final class XAIPluginTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.id, "com.typewhisper.xai")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.category, "transcription")
         XCTAssertEqual(manifest.categories, ["transcription", "llm", "tts"])
         XCTAssertEqual(manifest.resolvedCategoryIdentifiers, ["transcription", "llm", "tts"])

--- a/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
+++ b/TypeWhisperPluginSDK/Plugins/XAIPlugin/manifest.json
@@ -2,7 +2,7 @@
     "id": "com.typewhisper.xai",
     "name": "xAI / Grok",
     "version": "1.0.0",
-    "minHostVersion": "1.6.0",
+    "minHostVersion": "1.7.0",
     "sdkCompatibilityVersion": "v1",
     "minOSVersion": "14.0",
     "author": "TypeWhisper",

--- a/TypeWhisperPluginSDK/README.md
+++ b/TypeWhisperPluginSDK/README.md
@@ -21,7 +21,7 @@ Create `Contents/Resources/manifest.json` in your bundle:
   "id": "com.yourname.myplugin",
   "name": "My Plugin",
   "version": "1.0.0",
-  "minHostVersion": "1.6.0",
+  "minHostVersion": "1.7.0",
   "sdkCompatibilityVersion": "v1",
   "minOSVersion": "14.0",
   "author": "Your Name",
@@ -31,9 +31,26 @@ Create `Contents/Resources/manifest.json` in your bundle:
 
 - `id` - Unique reverse-domain identifier
 - `principalClass` - Must match `@objc(ClassName)` on your plugin class
-- `minHostVersion` - Minimum published stable TypeWhisper version required; new releases must use `1.6.0` or newer. Official releases verify the built plugin's SDK imports against the framework shipped by this exact host release.
+- `minHostVersion` - Minimum published stable TypeWhisper version required; new releases must use `1.7.0` or newer. Official releases verify the built plugin's SDK imports against the framework shipped by this exact host release.
 - `sdkCompatibilityVersion` - Must match `PluginSDKCompatibility.currentVersion` for marketplace/external plugins
 - `minOSVersion` - Minimum macOS version required (plugin is skipped on older systems)
+
+New plugin releases are built from the TypeWhisper 1.7 SDK line and require at
+least TypeWhisper 1.7.0. Keep `sdkCompatibilityVersion` at `v1`; raising the host
+minimum does not change the SDK compatibility line. Validate a release manifest
+before building:
+
+```sh
+python3 scripts/validate_plugin_release_manifest.py path/to/manifest.json --version 1.0.0
+```
+
+The release workflow rejects older minimum hosts before building and verifies
+the resulting binary against the SDK shipped by the declared host release.
+Until stable 1.7.0 is published, manual preview releases require the explicit
+`allow_prerelease_host` option to use a matching 1.7.0 daily host for that check.
+Previously published plugin binaries and registry releases retain their original
+host requirements. Use a new plugin version for a new build; preserve old release
+entries so TypeWhisper 1.6 can keep selecting its newest compatible release.
 
 ### 3. Implement the Plugin
 
@@ -500,7 +517,7 @@ let wavData = PluginWavEncoder.encode(samples, sampleRate: 16000)
 | `id` | Yes | Unique reverse-domain ID (e.g. `com.yourname.myplugin`) |
 | `name` | Yes | Display name |
 | `version` | Yes | Semver string (e.g. `1.0.0`) |
-| `minHostVersion` | Yes | Minimum TypeWhisper version; new releases must use `1.6.0` or newer |
+| `minHostVersion` | Yes | Minimum TypeWhisper version; new releases must use `1.7.0` or newer |
 | `sdkCompatibilityVersion` | No | Exact plugin SDK compatibility line. Marketplace/external plugins must match `PluginSDKCompatibility.currentVersion`. |
 | `minOSVersion` | No | Minimum macOS version (e.g. `14.0`, `26.0`). Plugin is skipped on older systems. |
 | `author` | No | Author name |

--- a/TypeWhisperTests/PluginManifestValidationTests.swift
+++ b/TypeWhisperTests/PluginManifestValidationTests.swift
@@ -34,9 +34,9 @@ final class PluginManifestValidationTests: XCTestCase {
                 "\(manifestURL.lastPathComponent) must declare a stable three-component host version"
             )
             XCTAssertNotEqual(
-                PluginRegistryService.compareVersions(minHostVersion, "1.6.0"),
+                PluginRegistryService.compareVersions(minHostVersion, "1.7.0"),
                 .orderedAscending,
-                "\(manifestURL.lastPathComponent) must require TypeWhisper 1.6.0 or newer"
+                "\(manifestURL.lastPathComponent) must require TypeWhisper 1.7.0 or newer"
             )
             XCTAssertEqual(
                 manifest.sdkCompatibilityVersion,
@@ -102,8 +102,8 @@ final class PluginManifestValidationTests: XCTestCase {
 
     func testSourceFootageProgressPluginsDeclareCapability() throws {
         let manifestExpectations = [
-            ("TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json", "1.6.0"),
-            ("TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json", "1.6.0"),
+            ("TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json", "1.7.0"),
+            ("TypeWhisperPluginSDK/Plugins/ParakeetPlugin/manifest.json", "1.7.0"),
             ("TypeWhisperPluginSDK/Plugins/SonioxPlugin/manifest.json", "1.7.0"),
         ]
 
@@ -116,7 +116,7 @@ final class PluginManifestValidationTests: XCTestCase {
         }
     }
 
-    func testWhisperKitPlugin12RequiresCompatibleHost16() throws {
+    func testWhisperKitPlugin12RequiresCompatibleHost17() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent(
             "TypeWhisperPluginSDK/Plugins/WhisperKitPlugin/manifest.json"
         )
@@ -124,12 +124,12 @@ final class PluginManifestValidationTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.version, "1.2.0")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
     }
 
-    func testMLXStoragePluginReleasesRequireHost16() throws {
+    func testMLXStoragePluginReleasesRequireHost17() throws {
         let manifestExpectations = [
             ("TypeWhisperPluginSDK/Plugins/Qwen3Plugin/manifest.json", "1.1.8"),
             ("TypeWhisperPluginSDK/Plugins/VoxtralPlugin/manifest.json", "1.0.14"),
@@ -142,11 +142,11 @@ final class PluginManifestValidationTests: XCTestCase {
             let data = try Data(contentsOf: manifestURL)
             let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
             XCTAssertEqual(manifest.version, expectedVersion, relativePath)
-            XCTAssertEqual(manifest.minHostVersion, "1.6.0", relativePath)
+            XCTAssertEqual(manifest.minHostVersion, "1.7.0", relativePath)
         }
     }
 
-    func testCohereLocalPlugin101RequiresCompatibleHost16() throws {
+    func testCohereLocalPlugin101RequiresCompatibleHost17() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent(
             "TypeWhisperPluginSDK/Plugins/CohereLocalPlugin/manifest.json"
         )
@@ -154,18 +154,18 @@ final class PluginManifestValidationTests: XCTestCase {
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.version, "1.0.1")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
         XCTAssertEqual(manifest.supportedArchitectures, ["arm64"])
     }
 
-    func testOpenAIPlugin133RequiresCompatibleHost16AndDeclaresCloudHosting() throws {
+    func testOpenAIPlugin133RequiresCompatibleHost17AndDeclaresCloudHosting() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/OpenAIPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.version, "1.3.3")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
         XCTAssertEqual(manifest.hosting, .cloud)
         XCTAssertEqual(manifest.requiresAPIKey, false)
@@ -197,13 +197,13 @@ final class PluginManifestValidationTests: XCTestCase {
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }
 
-    func testGroqPluginReleaseRequiresHost16() throws {
+    func testGroqPluginReleaseRequiresHost17() throws {
         let manifestURL = TestSupport.repoRoot.appendingPathComponent("TypeWhisperPluginSDK/Plugins/GroqPlugin/manifest.json")
         let data = try Data(contentsOf: manifestURL)
         let manifest = try JSONDecoder().decode(PluginManifest.self, from: data)
 
         XCTAssertEqual(manifest.version, "1.0.24")
-        XCTAssertEqual(manifest.minHostVersion, "1.6.0")
+        XCTAssertEqual(manifest.minHostVersion, "1.7.0")
         XCTAssertEqual(manifest.sdkCompatibilityVersion, PluginSDKCompatibility.currentVersion)
     }
 

--- a/TypeWhisperTests/PluginRegistryServiceTests.swift
+++ b/TypeWhisperTests/PluginRegistryServiceTests.swift
@@ -191,6 +191,49 @@ final class PluginRegistryServiceTests: XCTestCase {
         XCTAssertEqual(plugins14.first?.downloadURL, "https://example.com/requires-1.4.zip")
     }
 
+    func testNew17PluginReleasePreservesCompatibleUpdateFor16Host() throws {
+        let data = Data(
+            """
+            {
+              "schemaVersion": 2,
+              "plugins": [{
+                "id": "com.typewhisper.example",
+                "name": "Example",
+                "author": "TypeWhisper",
+                "description": "Host-gated plugin updates.",
+                "category": "transcription",
+                "releases": [
+                  {
+                    "version": "2.0.0",
+                    "minHostVersion": "1.7.0",
+                    "sdkCompatibilityVersion": "v1",
+                    "size": 20,
+                    "downloadURL": "https://example.com/requires-1.7.zip"
+                  },
+                  {
+                    "version": "1.9.0",
+                    "minHostVersion": "1.6.0",
+                    "sdkCompatibilityVersion": "v1",
+                    "size": 10,
+                    "downloadURL": "https://example.com/compatible-1.6.zip"
+                  }
+                ]
+              }]
+            }
+            """.utf8
+        )
+        let response = try JSONDecoder().decode(PluginRegistryResponse.self, from: data)
+        let legacy = response.resolvedPlugins(appVersion: "1.6.0", sdkCompatibilityVersion: "v1")
+        let current = response.resolvedPlugins(appVersion: "1.7.0", sdkCompatibilityVersion: "v1")
+
+        XCTAssertEqual(legacy.count, 1)
+        XCTAssertEqual(legacy.first?.version, "1.9.0")
+        XCTAssertEqual(legacy.first?.downloadURL, "https://example.com/compatible-1.6.zip")
+        XCTAssertEqual(current.count, 1)
+        XCTAssertEqual(current.first?.version, "2.0.0")
+        XCTAssertEqual(current.first?.downloadURL, "https://example.com/requires-1.7.zip")
+    }
+
     func testRegistryEntryDecodesMultipleCategoryIdentifiers() throws {
         let data = Data(
             """

--- a/docs/release-notes/1.7.0-daily.20260909.1.md
+++ b/docs/release-notes/1.7.0-daily.20260909.1.md
@@ -1,0 +1,20 @@
+# TypeWhisper 1.7 preview: Swift 6.3 validation daily
+
+This daily includes the dependency update from #1293 and the new plugin compatibility policy from #1294. It is the everyday-testing build before 1.7.0-rc1.
+
+## What's new since 1.6
+
+- iCloud synchronization for History and Inbox, alongside a redesigned History interface with device grouping, filtering, and search. iCloud sync has already been tested; this build keeps it enabled.
+- Transcribe files from Finder and use the optional Web Link plugin to transcribe web media.
+- More workflow controls, including spoken submit, Inline Commands, and a choice of double Escape, single Escape, or immediate cancellation.
+- Expanded plugin capabilities, including plugin pages and optional providers that use authenticated command-line tools.
+- Improvements to Bluetooth recording startup, model restoration, cancellation, text insertion, and transcription recovery.
+
+## Changes being validated in this daily
+
+- Build and release workflows now use Xcode 26.6 and Swift 6.3. App and SDK dependency constraints agree, including Hugging Face 0.10.1 and Jinja 2.5.0, with MLX Swift 0.31.6.
+- Future plugin releases built from this source line require TypeWhisper 1.7.0 or newer. Existing published plugin binaries and historical registry entries remain available to compatible 1.6 hosts. This app release does not republish plugins.
+
+Please test your usual dictation workflows, installed plugins, and iCloud synchronization on this build. Track findings and candidate validation in [#1296](https://github.com/TypeWhisper/typewhisper-mac/issues/1296). RC1 follows the everyday test.
+
+This is a **Daily-channel prerelease**, available from GitHub and the Daily update channel. The stable channel and Homebrew stay on the stable release.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -4,8 +4,8 @@ This document defines the release and maintenance gates for the current `1.x`
 product path, with stable `1.6.0` as its published baseline.
 
 TypeWhisper `1.x` is a stable direct-download release line for macOS. The Mac
-App Store remains out of scope. The `main` branch is the current `1.6`
-development and maintenance line. The `release/1.5` branch is retained only for
+App Store remains out of scope. The `main` branch is the current `1.7`
+development line. The `release/1.5` branch is retained only for
 explicitly approved legacy backports; it is no longer the stable baseline.
 
 ## Audience
@@ -36,14 +36,17 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
 - Widgets
 - Watch Folder
 
-## `1.6` Maintenance Focus
+## `1.7` Development and `1.6` Compatibility
 
-- Keep `main` on the current `1.6` version line; daily builds currently publish
-  as `v1.6.0-daily.*`.
+- Keep `main` on the current `1.7` version line; daily builds publish
+  as `v1.7.0-daily.*`.
 - Treat stable `1.6.0` as the release baseline and `release/1.5` as a legacy
   backport branch only.
 - Preserve the `1.x` stability contracts for the HTTP API, CLI, plugin SDK, widgets, and watch folders.
-- Avoid raising plugin `minHostVersion` values to `1.6.0` unless a plugin genuinely requires new host APIs.
+- New plugin release builds require `minHostVersion: "1.7.0"` or newer and use
+  the 1.7 SDK line. Preserve published plugin binaries and their historical
+  registry entries so 1.6 hosts retain compatible releases. Keep
+  `sdkCompatibilityVersion` unchanged unless the SDK compatibility contract changes.
 - Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.
 - Keep tagged app releases on the no-iCloud distribution path until the production container and Developer ID provisioning profile are approved and validated. Tag pushes matching `v*` therefore build without automatic private iCloud sync; scheduled builds continue to use `MACOS_SCHEDULED_WITHOUT_ICLOUD`, and manual dispatches continue to use the explicit `without_icloud` input.
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -44,7 +44,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
   backport branch only.
 - Preserve the `1.x` stability contracts for the HTTP API, CLI, plugin SDK, widgets, and watch folders.
 - New plugin release builds require `minHostVersion: "1.7.0"` or newer and use
-  the 1.7 SDK line. Preserve published plugin binaries and their historical
+  the SDK shipped with 1.7 on the current `v1` compatibility line. Preserve published plugin binaries and their historical
   registry entries so 1.6 hosts retain compatible releases. Keep
   `sdkCompatibilityVersion` unchanged unless the SDK compatibility contract changes.
 - Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -48,7 +48,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
   registry entries so 1.6 hosts retain compatible releases. Keep
   `sdkCompatibilityVersion` unchanged unless the SDK compatibility contract changes.
 - Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.
-- Tagged and manually dispatched app releases include iCloud sync by default, using the dedicated Developer ID provisioning profile for the isolated iCloud helper. Scheduled builds honor `MACOS_SCHEDULED_WITHOUT_ICLOUD`; manual dispatches retain the explicit `without_icloud` fallback.
+- Every app release (Daily, RC, stable, and local Developer ID build) includes iCloud through the isolated bridge. The production Developer ID provisioning profile is required; there is no no-iCloud release switch or scheduled fallback.
 
 ## Stability Contracts for `1.x`
 
@@ -97,7 +97,7 @@ are met:
   appear in the shared Sparkle appcast only on their own channels, and do not
   update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
-- iCloud-enabled builds require the embedded production Developer ID provisioning profile and matching signed iCloud entitlements. Record real-device sync and Sparkle upgrade validation for the candidate in its release checklist. Automatic private iCloud sync remains hidden in explicit no-iCloud fallback builds.
+- Every release must include the bridge with its embedded production Developer ID provisioning profile and matching signed iCloud entitlements. Record real-device sync and Sparkle upgrade validation for the candidate in its release checklist.
 
 ## Manual Release Validation
 

--- a/docs/release-readiness.md
+++ b/docs/release-readiness.md
@@ -48,7 +48,7 @@ These surfaces remain part of `1.x`, but they are positioned as advanced or auto
   registry entries so 1.6 hosts retain compatible releases. Keep
   `sdkCompatibilityVersion` unchanged unless the SDK compatibility contract changes.
 - Keep release-channel behavior stable: RC and daily builds are prereleases, while Homebrew and stable website messaging update only at the final stable tag.
-- Keep tagged app releases on the no-iCloud distribution path until the production container and Developer ID provisioning profile are approved and validated. Tag pushes matching `v*` therefore build without automatic private iCloud sync; scheduled builds continue to use `MACOS_SCHEDULED_WITHOUT_ICLOUD`, and manual dispatches continue to use the explicit `without_icloud` input.
+- Tagged and manually dispatched app releases include iCloud sync by default, using the dedicated Developer ID provisioning profile for the isolated iCloud helper. Scheduled builds honor `MACOS_SCHEDULED_WITHOUT_ICLOUD`; manual dispatches retain the explicit `without_icloud` fallback.
 
 ## Stability Contracts for `1.x`
 
@@ -97,7 +97,7 @@ are met:
   appear in the shared Sparkle appcast only on their own channels, and do not
   update Homebrew.
 - The appcast entry for preview builds advertises `minimumSystemVersion` `14.0`.
-- Automatic private iCloud sync remains hidden in no-iCloud builds. Enabling it for a future release requires the explicit build flag, an embedded Developer ID provisioning profile, matching signed iCloud entitlements, Sparkle upgrade proof, and a real two-Mac sync validation.
+- iCloud-enabled builds require the embedded production Developer ID provisioning profile and matching signed iCloud entitlements. Record real-device sync and Sparkle upgrade validation for the candidate in its release checklist. Automatic private iCloud sync remains hidden in explicit no-iCloud fallback builds.
 
 ## Manual Release Validation
 

--- a/scripts/archive_release.sh
+++ b/scripts/archive_release.sh
@@ -212,6 +212,8 @@ echo "Archiving $release_tag (build $build_number, channel $release_channel)"
 
 set -o pipefail
 archive_arguments=(
+  # The pinned MLX dependency includes CudaBuild (a no-op on macOS).
+  -skipPackagePluginValidation
   archive
   -project "$project" \
   -scheme "$scheme" \

--- a/scripts/archive_release.sh
+++ b/scripts/archive_release.sh
@@ -15,7 +15,6 @@ release_tag=""
 release_channel=""
 build_number=""
 signing_identity="${MACOS_SIGNING_IDENTITY:-}"
-without_icloud=false
 
 usage() {
   cat >&2 <<'USAGE'
@@ -24,7 +23,7 @@ Usage: scripts/archive_release.sh \
   --export-path PATH \
   --release-tag TAG \
   --build-number NUMBER \
-  (--profile ICLOUD_HELPER_PROFILE | --without-icloud) \
+  --profile ICLOUD_HELPER_PROFILE \
   [--release-channel CHANNEL] \
   [--signing-identity IDENTITY]
 USAGE
@@ -69,7 +68,6 @@ while [[ $# -gt 0 ]]; do
     --release-channel) release_channel="${2:-}"; shift 2 ;;
     --build-number) build_number="${2:-}"; shift 2 ;;
     --signing-identity) signing_identity="${2:-}"; shift 2 ;;
-    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
   esac
@@ -83,15 +81,11 @@ for required_value in archive_path export_path release_tag build_number; do
   fi
 done
 
-if [[ "$without_icloud" == true && -n "$profile_path" ]]; then
-  echo "error: --profile and --without-icloud cannot be combined" >&2
-  exit 2
-fi
-if [[ "$without_icloud" == false && -z "$profile_path" ]]; then
+if [[ -z "$profile_path" ]]; then
   echo "error: --profile or MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is required" >&2
   exit 2
 fi
-if [[ "$without_icloud" == false && ! -f "$profile_path" ]]; then
+if [[ ! -f "$profile_path" ]]; then
   echo "error: provisioning profile not found: $profile_path" >&2
   exit 2
 fi
@@ -140,72 +134,67 @@ decoded_profile="$temporary_dir/profile.plist"
 profile_name=""
 main_entitlements="$repo_root/TypeWhisper/Resources/TypeWhisper.entitlements"
 full_helper_entitlements="$repo_root/TypeWhisperICloudBridge/TypeWhisperICloudBridge.entitlements"
-helper_build_entitlements="$temporary_dir/TypeWhisperICloudBridge-NoICloud.entitlements"
+helper_build_entitlements="$temporary_dir/TypeWhisperICloudBridge-Archive.entitlements"
+# Export without the helper profile, then always embed and re-sign it below.
 cp "$full_helper_entitlements" "$helper_build_entitlements"
 /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.icloud-container-identifiers' "$helper_build_entitlements"
 /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.icloud-services' "$helper_build_entitlements"
 /usr/libexec/PlistBuddy -c 'Delete :com.apple.developer.ubiquity-container-identifiers' "$helper_build_entitlements"
-icloud_enabled="YES"
 
-if [[ "$without_icloud" == true ]]; then
-  icloud_enabled="NO"
-  echo "Building the iCloud helper without iCloud entitlements or a provisioning profile"
-else
-  security cms -D -i "$profile_path" > "$decoded_profile"
+security cms -D -i "$profile_path" > "$decoded_profile"
 
-  profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$decoded_profile")"
-  profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$decoded_profile")"
-  profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
-  profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
-  profile_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.icloud-container-environment' "$decoded_profile" 2>/dev/null || true)"
-  profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
-  profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
+profile_name="$(/usr/libexec/PlistBuddy -c 'Print :Name' "$decoded_profile")"
+profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print :UUID' "$decoded_profile")"
+profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
+profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
+profile_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.icloud-container-environment' "$decoded_profile" 2>/dev/null || true)"
+profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
+profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
 
-  if [[ "$profile_team" != "$team_id" ]]; then
-    echo "error: profile team is '$profile_team', expected '$team_id'" >&2
-    exit 1
-  fi
-  if [[ "$profile_app_id" != "$team_id.$helper_bundle_id" ]]; then
-    echo "error: profile application identifier is '$profile_app_id', expected '$team_id.$helper_bundle_id'" >&2
-    exit 1
-  fi
-  if [[ "$profile_all_devices" != "true" ]]; then
-    echo "error: profile is not a Developer ID provisioning profile" >&2
-    exit 1
-  fi
-  if [[ "$profile_icloud_environment" != "Production" ]]; then
-    echo "error: profile iCloud environment is '$profile_icloud_environment', expected 'Production'" >&2
-    exit 1
-  fi
-  if ! plist_array_contains \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.icloud-container-identifiers" \
-    "$icloud_container"; then
-    echo "error: profile does not contain iCloud container '$icloud_container'" >&2
-    exit 1
-  fi
-  if ! plist_array_contains \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.ubiquity-container-identifiers" \
-    "$icloud_container"; then
-    echo "error: profile does not contain ubiquity container '$icloud_container'" >&2
-    exit 1
-  fi
-  if ! plist_array_contains_or_wildcard \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.icloud-services" \
-    "CloudDocuments"; then
-    echo "error: profile does not enable CloudDocuments" >&2
-    exit 1
-  fi
-  expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
-  if (( expiration_epoch <= $(date '+%s') )); then
-    echo "error: provisioning profile expired at $profile_expiration" >&2
-    exit 1
-  fi
-
-  echo "Using profile: $profile_name ($profile_uuid, expires $profile_expiration)"
+if [[ "$profile_team" != "$team_id" ]]; then
+  echo "error: profile team is '$profile_team', expected '$team_id'" >&2
+  exit 1
 fi
+if [[ "$profile_app_id" != "$team_id.$helper_bundle_id" ]]; then
+  echo "error: profile application identifier is '$profile_app_id', expected '$team_id.$helper_bundle_id'" >&2
+  exit 1
+fi
+if [[ "$profile_all_devices" != "true" ]]; then
+  echo "error: profile is not a Developer ID provisioning profile" >&2
+  exit 1
+fi
+if [[ "$profile_icloud_environment" != "Production" ]]; then
+  echo "error: profile iCloud environment is '$profile_icloud_environment', expected 'Production'" >&2
+  exit 1
+fi
+if ! plist_array_contains \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.icloud-container-identifiers" \
+  "$icloud_container"; then
+  echo "error: profile does not contain iCloud container '$icloud_container'" >&2
+  exit 1
+fi
+if ! plist_array_contains \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.ubiquity-container-identifiers" \
+  "$icloud_container"; then
+  echo "error: profile does not contain ubiquity container '$icloud_container'" >&2
+  exit 1
+fi
+if ! plist_array_contains_or_wildcard \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.icloud-services" \
+  "CloudDocuments"; then
+  echo "error: profile does not enable CloudDocuments" >&2
+  exit 1
+fi
+expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
+if (( expiration_epoch <= $(date '+%s') )); then
+  echo "error: provisioning profile expired at $profile_expiration" >&2
+  exit 1
+fi
+
+echo "Using profile: $profile_name ($profile_uuid, expires $profile_expiration)"
 
 echo "Using signing identity: $signing_identity"
 echo "Archiving $release_tag (build $build_number, channel $release_channel)"
@@ -227,7 +216,7 @@ archive_arguments=(
   TYPEWHISPER_ICLOUD_HELPER_PROFILE_SPECIFIER=""
   TYPEWHISPER_ICLOUD_HELPER_ENTITLEMENTS="$helper_build_entitlements"
   TYPEWHISPER_MAIN_ENTITLEMENTS="$main_entitlements"
-  TYPEWHISPER_ICLOUD_ENABLED="$icloud_enabled"
+  TYPEWHISPER_ICLOUD_ENABLED=YES
   TYPEWHISPER_RELEASE_CHANNEL="$release_channel" \
   TYPEWHISPER_RELEASE_TAG="$release_tag" \
   MARKETING_VERSION="$marketing_version" \
@@ -255,59 +244,57 @@ if [[ ! -d "$app_path" ]]; then
   exit 1
 fi
 
-if [[ "$without_icloud" == false ]]; then
-  helper_path="$app_path/Contents/XPCServices/TypeWhisperICloudBridge.xpc"
-  if [[ ! -d "$helper_path" ]]; then
-    echo "error: exported iCloud helper not found: $helper_path" >&2
-    exit 1
-  fi
-
-  expanded_helper_entitlements="$temporary_dir/TypeWhisperICloudBridge-Signing.entitlements"
-  cp "$full_helper_entitlements" "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Set :com.apple.security.application-groups:0 $app_group" \
-    "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Set :com.apple.developer.icloud-container-identifiers:0 $icloud_container" \
-    "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Set :com.apple.developer.ubiquity-container-identifiers:0 $icloud_container" \
-    "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Add :com.apple.application-identifier string $team_id.$helper_bundle_id" \
-    "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Add :com.apple.developer.team-identifier string $team_id" \
-    "$expanded_helper_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c 'Add :com.apple.developer.icloud-container-environment string Production' \
-    "$expanded_helper_entitlements"
-
-  cp "$profile_path" "$helper_path/Contents/embedded.provisionprofile"
-  codesign \
-    --force \
-    --sign "$signing_identity" \
-    --timestamp \
-    --options runtime \
-    --entitlements "$expanded_helper_entitlements" \
-    "$helper_path"
-
-  expanded_main_entitlements="$temporary_dir/TypeWhisper-Signing.entitlements"
-  cp "$main_entitlements" "$expanded_main_entitlements"
-  /usr/libexec/PlistBuddy \
-    -c "Set :com.apple.security.application-groups:0 $app_group" \
-    "$expanded_main_entitlements"
-  codesign \
-    --force \
-    --sign "$signing_identity" \
-    --timestamp \
-    --options runtime \
-    --preserve-metadata=requirements \
-    --entitlements "$expanded_main_entitlements" \
-    "$app_path"
-  codesign --verify --deep --strict --verbose=2 "$app_path"
-
-  echo "Embedded the production iCloud profile and re-signed the isolated helper"
+helper_path="$app_path/Contents/XPCServices/TypeWhisperICloudBridge.xpc"
+if [[ ! -d "$helper_path" ]]; then
+  echo "error: exported iCloud helper not found: $helper_path" >&2
+  exit 1
 fi
+
+expanded_helper_entitlements="$temporary_dir/TypeWhisperICloudBridge-Signing.entitlements"
+cp "$full_helper_entitlements" "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Set :com.apple.security.application-groups:0 $app_group" \
+  "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Set :com.apple.developer.icloud-container-identifiers:0 $icloud_container" \
+  "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Set :com.apple.developer.ubiquity-container-identifiers:0 $icloud_container" \
+  "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Add :com.apple.application-identifier string $team_id.$helper_bundle_id" \
+  "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Add :com.apple.developer.team-identifier string $team_id" \
+  "$expanded_helper_entitlements"
+/usr/libexec/PlistBuddy \
+  -c 'Add :com.apple.developer.icloud-container-environment string Production' \
+  "$expanded_helper_entitlements"
+
+cp "$profile_path" "$helper_path/Contents/embedded.provisionprofile"
+codesign \
+  --force \
+  --sign "$signing_identity" \
+  --timestamp \
+  --options runtime \
+  --entitlements "$expanded_helper_entitlements" \
+  "$helper_path"
+
+expanded_main_entitlements="$temporary_dir/TypeWhisper-Signing.entitlements"
+cp "$main_entitlements" "$expanded_main_entitlements"
+/usr/libexec/PlistBuddy \
+  -c "Set :com.apple.security.application-groups:0 $app_group" \
+  "$expanded_main_entitlements"
+codesign \
+  --force \
+  --sign "$signing_identity" \
+  --timestamp \
+  --options runtime \
+  --preserve-metadata=requirements \
+  --entitlements "$expanded_main_entitlements" \
+  "$app_path"
+codesign --verify --deep --strict --verbose=2 "$app_path"
+
+echo "Embedded the production iCloud profile and re-signed the isolated helper"
 
 echo "Exported Developer ID app: $app_path"

--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -16,6 +16,10 @@ Usage: scripts/build-release-local.sh \
   [--release-tag TAG] \
   [--build-number NUMBER] \
   [--skip-dmg]
+
+A profile is required. Omit --profile when
+MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is set.
+MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is also accepted as a legacy fallback.
 USAGE
 }
 

--- a/scripts/build-release-local.sh
+++ b/scripts/build-release-local.sh
@@ -8,12 +8,11 @@ profile_path="${MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH:-${MA
 release_tag=""
 build_number=""
 skip_dmg=false
-without_icloud=false
 
 usage() {
   cat >&2 <<'USAGE'
 Usage: scripts/build-release-local.sh \
-  [--profile ICLOUD_HELPER_PROFILE | --without-icloud] \
+  [--profile ICLOUD_HELPER_PROFILE] \
   [--release-tag TAG] \
   [--build-number NUMBER] \
   [--skip-dmg]
@@ -26,18 +25,17 @@ while [[ $# -gt 0 ]]; do
     --release-tag) release_tag="${2:-}"; shift 2 ;;
     --build-number) build_number="${2:-}"; shift 2 ;;
     --skip-dmg) skip_dmg=true; shift ;;
-    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     *) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
   esac
 done
 
-if [[ "$without_icloud" == true && -n "$profile_path" ]]; then
-  echo "error: --profile and --without-icloud cannot be combined" >&2
+if [[ -z "$profile_path" ]]; then
+  echo "error: --profile or MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is required" >&2
   exit 2
 fi
-if [[ "$without_icloud" == false && -z "$profile_path" ]]; then
-  echo "error: --profile or MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH is required" >&2
+if [[ ! -f "$profile_path" ]]; then
+  echo "error: provisioning profile not found: $profile_path" >&2
   exit 2
 fi
 if [[ -z "$release_tag" ]]; then
@@ -64,7 +62,7 @@ mkdir -p "$build_dir"
 echo "=== TypeWhisper Local Developer ID Release ==="
 echo "Tag: $release_tag"
 echo "Build: $build_number"
-echo "iCloud: $([[ "$without_icloud" == true ]] && echo disabled || echo enabled)"
+echo "iCloud: enabled through the production bridge"
 
 xcodebuild -resolvePackageDependencies \
   -project "$project_dir/TypeWhisper.xcodeproj" \
@@ -78,20 +76,14 @@ archive_arguments=(
   --release-channel local \
   --build-number "$build_number"
 )
-check_arguments=()
-if [[ "$without_icloud" == true ]]; then
-  archive_arguments+=(--without-icloud)
-  check_arguments+=(--without-icloud)
-else
-  archive_arguments+=(--profile "$profile_path")
-fi
+archive_arguments+=(--profile "$profile_path")
 bash "$script_dir/archive_release.sh" "${archive_arguments[@]}" |
   tee "$build_dir/build.log"
 
 bash "$script_dir/check_first_party_warnings.sh" "$build_dir/build.log"
 bash "$script_dir/check_release_binary_instrumentation.sh" \
   "$app_path/Contents/MacOS/typewhisper-cli"
-bash "$script_dir/check_release_signing.sh" "${check_arguments[@]}" "$app_path"
+bash "$script_dir/check_release_signing.sh" "$app_path"
 
 if [[ "$skip_dmg" == false ]]; then
   if ! command -v dmgbuild >/dev/null 2>&1; then

--- a/scripts/check_release_signing.sh
+++ b/scripts/check_release_signing.sh
@@ -10,11 +10,10 @@ app_group="$team_id.com.typewhisper.mac"
 icloud_container="iCloud.com.typewhisper.sync"
 require_notarization=false
 spawn_test=false
-without_icloud=false
 app_path=""
 
 usage() {
-  echo "Usage: $0 [--without-icloud] [--require-notarization] [--spawn] <TypeWhisper.app> | --self-test" >&2
+  echo "Usage: $0 [--require-notarization] [--spawn] <TypeWhisper.app> | --self-test" >&2
 }
 
 contains_unresolved_variable() {
@@ -172,7 +171,6 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --require-notarization) require_notarization=true; shift ;;
     --spawn) spawn_test=true; shift ;;
-    --without-icloud) without_icloud=true; shift ;;
     -h|--help) usage; exit 0 ;;
     -*) echo "error: unknown option: $1" >&2; usage; exit 2 ;;
     *)
@@ -242,95 +240,80 @@ if plutil -convert xml1 -o - "$main_entitlements" | main_has_icloud_entitlement;
   echo "error: main app contains iCloud entitlements; its existing TCC identity must stay unchanged" >&2
   exit 1
 fi
-if [[ "$without_icloud" == true ]]; then
-  [[ ! -f "$helper_profile_path" ]] || {
-    echo "error: no-iCloud helper unexpectedly contains a provisioning profile" >&2
-    exit 1
-  }
-  [[ "$icloud_enabled" == "NO" ]] || {
-    echo "error: no-iCloud release does not declare iCloud disabled" >&2
-    exit 1
-  }
-  if plutil -convert xml1 -o - "$helper_entitlements" | main_has_icloud_entitlement; then
-    echo "error: no-iCloud helper contains iCloud entitlements" >&2
-    exit 1
-  fi
-else
-  [[ -f "$helper_profile_path" ]] || {
-    echo "error: Developer ID provisioning profile is missing from the iCloud helper" >&2
-    exit 1
-  }
-  security cms -D -i "$helper_profile_path" > "$decoded_profile"
-  profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
-  profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
-  profile_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.icloud-container-environment' "$decoded_profile" 2>/dev/null || true)"
-  profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
-  profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
+[[ -f "$helper_profile_path" ]] || {
+  echo "error: Developer ID provisioning profile is missing from the iCloud helper" >&2
+  exit 1
+}
+security cms -D -i "$helper_profile_path" > "$decoded_profile"
+profile_team="$(/usr/libexec/PlistBuddy -c 'Print :TeamIdentifier:0' "$decoded_profile")"
+profile_app_id="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.application-identifier' "$decoded_profile")"
+profile_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :Entitlements:com.apple.developer.icloud-container-environment' "$decoded_profile" 2>/dev/null || true)"
+profile_expiration="$(plutil -extract ExpirationDate raw -o - "$decoded_profile")"
+profile_all_devices="$(/usr/libexec/PlistBuddy -c 'Print :ProvisionsAllDevices' "$decoded_profile" 2>/dev/null || true)"
 
-  [[ "$icloud_enabled" == "YES" ]] || {
-    echo "error: iCloud release does not declare iCloud enabled" >&2
-    exit 1
-  }
-  [[ "$profile_team" == "$team_id" ]] || {
-    echo "error: profile team is '$profile_team'" >&2
-    exit 1
-  }
-  [[ "$profile_app_id" == "$team_id.$helper_bundle_id" ]] || {
-    echo "error: profile application identifier is '$profile_app_id'" >&2
-    exit 1
-  }
-  [[ "$profile_all_devices" == "true" ]] || {
-    echo "error: embedded profile is not a Developer ID profile" >&2
-    exit 1
-  }
-  [[ "$profile_icloud_environment" == "Production" ]] || {
-    echo "error: embedded profile iCloud environment is '$profile_icloud_environment'" >&2
-    exit 1
-  }
-  plist_array_contains \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.icloud-container-identifiers" \
-    "$icloud_container" || {
-    echo "error: profile is missing iCloud container '$icloud_container'" >&2
-    exit 1
-  }
-  plist_array_contains \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.ubiquity-container-identifiers" \
-    "$icloud_container" || {
-    echo "error: profile is missing ubiquity container '$icloud_container'" >&2
-    exit 1
-  }
-  plist_array_contains_or_wildcard \
-    "$decoded_profile" \
-    "Entitlements:com.apple.developer.icloud-services" \
-    "CloudDocuments" || {
-    echo "error: profile does not enable CloudDocuments" >&2
-    exit 1
-  }
-  expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
-  (( expiration_epoch > $(date '+%s') )) || {
-    echo "error: profile expired at $profile_expiration" >&2
-    exit 1
-  }
+[[ "$icloud_enabled" == "YES" ]] || {
+  echo "error: iCloud release does not declare iCloud enabled" >&2
+  exit 1
+}
+[[ "$profile_team" == "$team_id" ]] || {
+  echo "error: profile team is '$profile_team'" >&2
+  exit 1
+}
+[[ "$profile_app_id" == "$team_id.$helper_bundle_id" ]] || {
+  echo "error: profile application identifier is '$profile_app_id'" >&2
+  exit 1
+}
+[[ "$profile_all_devices" == "true" ]] || {
+  echo "error: embedded profile is not a Developer ID profile" >&2
+  exit 1
+}
+[[ "$profile_icloud_environment" == "Production" ]] || {
+  echo "error: embedded profile iCloud environment is '$profile_icloud_environment'" >&2
+  exit 1
+}
+plist_array_contains \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.icloud-container-identifiers" \
+  "$icloud_container" || {
+  echo "error: profile is missing iCloud container '$icloud_container'" >&2
+  exit 1
+}
+plist_array_contains \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.ubiquity-container-identifiers" \
+  "$icloud_container" || {
+  echo "error: profile is missing ubiquity container '$icloud_container'" >&2
+  exit 1
+}
+plist_array_contains_or_wildcard \
+  "$decoded_profile" \
+  "Entitlements:com.apple.developer.icloud-services" \
+  "CloudDocuments" || {
+  echo "error: profile does not enable CloudDocuments" >&2
+  exit 1
+}
+expiration_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' "$profile_expiration" '+%s')"
+(( expiration_epoch > $(date '+%s') )) || {
+  echo "error: profile expired at $profile_expiration" >&2
+  exit 1
+}
 
-  helper_application_id="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$helper_entitlements")"
-  helper_team="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' "$helper_entitlements")"
-  helper_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.icloud-container-environment' "$helper_entitlements")"
+helper_application_id="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.application-identifier' "$helper_entitlements")"
+helper_team="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.team-identifier' "$helper_entitlements")"
+helper_icloud_environment="$(/usr/libexec/PlistBuddy -c 'Print :com.apple.developer.icloud-container-environment' "$helper_entitlements")"
 
-  [[ "$helper_application_id" == "$team_id.$helper_bundle_id" ]] || {
-    echo "error: signed helper application identifier is '$helper_application_id'" >&2
-    exit 1
-  }
-  [[ "$helper_team" == "$team_id" ]] || {
-    echo "error: signed helper team identifier is '$helper_team'" >&2
-    exit 1
-  }
-  [[ "$helper_icloud_environment" == "Production" ]] || {
-    echo "error: signed helper iCloud environment is '$helper_icloud_environment'" >&2
-    exit 1
-  }
-fi
+[[ "$helper_application_id" == "$team_id.$helper_bundle_id" ]] || {
+  echo "error: signed helper application identifier is '$helper_application_id'" >&2
+  exit 1
+}
+[[ "$helper_team" == "$team_id" ]] || {
+  echo "error: signed helper team identifier is '$helper_team'" >&2
+  exit 1
+}
+[[ "$helper_icloud_environment" == "Production" ]] || {
+  echo "error: signed helper iCloud environment is '$helper_icloud_environment'" >&2
+  exit 1
+}
 
 plist_array_equals_single_value \
   "$main_entitlements" \
@@ -367,22 +350,20 @@ if plutil -convert xml1 -o - "$helper_entitlements" | helper_has_forbidden_entit
   echo "error: iCloud helper contains TCC-sensitive or unrelated entitlements" >&2
   exit 1
 fi
-if [[ "$without_icloud" == false ]]; then
-  if ! plist_array_equals_single_value \
-      "$helper_entitlements" \
-      "com.apple.developer.icloud-container-identifiers" \
-      "$icloud_container" ||
-    ! plist_array_equals_single_value \
-      "$helper_entitlements" \
-      "com.apple.developer.ubiquity-container-identifiers" \
-      "$icloud_container" ||
-    ! plist_array_equals_single_value \
-      "$helper_entitlements" \
-      "com.apple.developer.icloud-services" \
-      "CloudDocuments"; then
-    echo "error: signed helper iCloud containers are incorrect" >&2
-    exit 1
-  fi
+if ! plist_array_equals_single_value \
+    "$helper_entitlements" \
+    "com.apple.developer.icloud-container-identifiers" \
+    "$icloud_container" ||
+  ! plist_array_equals_single_value \
+    "$helper_entitlements" \
+    "com.apple.developer.ubiquity-container-identifiers" \
+    "$icloud_container" ||
+  ! plist_array_equals_single_value \
+    "$helper_entitlements" \
+    "com.apple.developer.icloud-services" \
+    "CloudDocuments"; then
+  echo "error: signed helper iCloud containers are incorrect" >&2
+  exit 1
 fi
 if /usr/libexec/PlistBuddy -c 'Print :com.apple.developer.applesignin' "$main_entitlements" >/dev/null 2>&1; then
   echo "error: native Sign in with Apple entitlement must not be signed into the Developer ID app" >&2

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -42,6 +42,7 @@ python3 scripts/test_check_plugin_sdk_symbol_compatibility.py
 python3 scripts/test_plugin_registry_metadata.py
 python3 scripts/test_resolve_plugin_host_release.py
 python3 scripts/test_verify_appcast_publication.py
+python3 scripts/test_icloud_release_policy.py
 
 log "checking plugin release policy"
 python3 scripts/validate_plugin_release_manifest.py TypeWhisperPluginSDK/Plugins/*/manifest.json

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -43,6 +43,10 @@ python3 scripts/test_plugin_registry_metadata.py
 python3 scripts/test_resolve_plugin_host_release.py
 python3 scripts/test_verify_appcast_publication.py
 
+log "checking plugin release policy"
+python3 scripts/validate_plugin_release_manifest.py TypeWhisperPluginSDK/Plugins/*/manifest.json
+python3 scripts/test_validate_plugin_release_manifest.py
+
 log "checking main-app localization completeness"
 python3 scripts/check_localization_completeness.py
 

--- a/scripts/resolve_plugin_host_release.py
+++ b/scripts/resolve_plugin_host_release.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import json
 import re

--- a/scripts/test_icloud_release_policy.py
+++ b/scripts/test_icloud_release_policy.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Check that release entry points cannot bypass the production bridge profile."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+class ICloudReleasePolicyTests(unittest.TestCase):
+    def setUp(self):
+        self.directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.directory.cleanup)
+        self.root = Path(self.directory.name)
+        scripts = self.root / "scripts"
+        scripts.mkdir()
+        for name in ("archive_release.sh", "build-release-local.sh", "check_release_signing.sh"):
+            shutil.copyfile(Path(__file__).with_name(name), scripts / name)
+        self.environment = os.environ.copy()
+        for name in ("MACOS_ICLOUD_HELPER_DEVELOPER_ID_PROVISIONING_PROFILE_PATH",
+                     "MACOS_DEVELOPER_ID_PROVISIONING_PROFILE_PATH"):
+            self.environment.pop(name, None)
+        self.archive_arguments = [
+            "--archive-path", str(self.root / "app.xcarchive"),
+            "--export-path", str(self.root / "export"),
+            "--release-tag", "v1.7.0-daily.20260909.1", "--build-number", "1",
+        ]
+
+    def run_script(self, name, arguments):
+        return subprocess.run(
+            ["bash", str(self.root / "scripts" / name), *arguments],
+            env=self.environment, capture_output=True, text=True, timeout=5,
+        )
+
+    def test_removed_switch_is_rejected_by_every_entry_point(self):
+        for name in ("archive_release.sh", "build-release-local.sh", "check_release_signing.sh"):
+            with self.subTest(script=name):
+                result = self.run_script(name, ["--without-icloud"])
+                self.assertEqual(result.returncode, 2)
+                self.assertIn("unknown option: --without-icloud", result.stderr)
+
+    def test_archive_requires_profile_before_creating_outputs(self):
+        result = self.run_script("archive_release.sh", self.archive_arguments)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("PROVISIONING_PROFILE_PATH is required", result.stderr)
+        self.assertFalse((self.root / "app.xcarchive").exists())
+        self.assertFalse((self.root / "export").exists())
+
+    def test_archive_rejects_missing_profile_file(self):
+        result = self.run_script(
+            "archive_release.sh", self.archive_arguments + ["--profile", str(self.root / "missing.profile")]
+        )
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("provisioning profile not found", result.stderr)
+        self.assertFalse((self.root / "app.xcarchive").exists())
+
+    def assert_local_build_preserved(self, arguments, error):
+        build = self.root / "build-release"
+        build.mkdir()
+        sentinel = build / "previous-build"
+        sentinel.write_text("preserve me")
+        result = self.run_script("build-release-local.sh", arguments)
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(error, result.stderr)
+        self.assertEqual(sentinel.read_text(), "preserve me")
+
+    def test_local_build_requires_profile_before_removing_previous_build(self):
+        self.assert_local_build_preserved([], "PROVISIONING_PROFILE_PATH is required")
+
+    def test_local_build_rejects_missing_profile_before_removing_previous_build(self):
+        self.assert_local_build_preserved(
+            ["--profile", str(self.root / "missing.profile")], "provisioning profile not found"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_validate_plugin_release_manifest.py
+++ b/scripts/test_validate_plugin_release_manifest.py
@@ -36,10 +36,10 @@ class PluginReleaseManifestTests(unittest.TestCase):
             validate_manifest(self.manifest(), "1.2.4")
 
     def test_sdk_compatibility_line_remains_required(self):
-        for sdk in (None, "1.7.0", "v0", "v1-beta"):
+        for sdk in (None, "1.7.0", "v0", "v1-beta", "v2", "v10"):
             manifest = self.manifest()
             manifest["sdkCompatibilityVersion"] = sdk
-            with self.subTest(sdk=sdk), self.assertRaisesRegex(ValueError, "format vN"):
+            with self.subTest(sdk=sdk), self.assertRaisesRegex(ValueError, "must be 'v1'"):
                 validate_manifest(manifest)
 
     def test_validation_does_not_rewrite_metadata(self):

--- a/scripts/test_validate_plugin_release_manifest.py
+++ b/scripts/test_validate_plugin_release_manifest.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Regression tests for the minimum host of new plugin releases."""
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from validate_plugin_release_manifest import validate_manifest
+
+
+class PluginReleaseManifestTests(unittest.TestCase):
+    def manifest(self, host="1.7.0"):
+        return {"version": "1.2.3", "minHostVersion": host, "sdkCompatibilityVersion": "v1"}
+
+    def test_rejects_older_hosts(self):
+        for host in ("1.5.0", "1.6.0", "1.6.99"):
+            with self.subTest(host=host), self.assertRaisesRegex(ValueError, "1.7.0 or newer"):
+                validate_manifest(self.manifest(host), "1.2.3")
+
+    def test_accepts_current_and_newer_hosts(self):
+        for host in ("1.7.0", "1.7.1", "1.10.0", "2.0.0"):
+            with self.subTest(host=host):
+                validate_manifest(self.manifest(host), "1.2.3")
+
+    def test_prerelease_permission_does_not_change_manifest_version_format(self):
+        for host in (None, 1.7, "1.7", "v1.7.0", "1.7.0-daily.20260908"):
+            with self.subTest(host=host), self.assertRaisesRegex(ValueError, "release version"):
+                validate_manifest(self.manifest(host))
+
+    def test_release_version_must_match(self):
+        with self.assertRaisesRegex(ValueError, "does not match release version"):
+            validate_manifest(self.manifest(), "1.2.4")
+
+    def test_sdk_compatibility_line_remains_required(self):
+        for sdk in (None, "1.7.0", "v0", "v1-beta"):
+            manifest = self.manifest()
+            manifest["sdkCompatibilityVersion"] = sdk
+            with self.subTest(sdk=sdk), self.assertRaisesRegex(ValueError, "format vN"):
+                validate_manifest(manifest)
+
+    def test_validation_does_not_rewrite_metadata(self):
+        manifest = self.manifest()
+        original = copy.deepcopy(manifest)
+        validate_manifest(manifest)
+        self.assertEqual(manifest, original)
+
+    def test_cli_checks_every_manifest_and_reports_failure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = [Path(directory) / name for name in ("current.json", "old.json")]
+            paths[0].write_text(json.dumps(self.manifest()))
+            paths[1].write_text(json.dumps(self.manifest("1.6.0")))
+            result = subprocess.run(
+                [sys.executable, str(Path(__file__).with_name("validate_plugin_release_manifest.py")),
+                 *map(str, paths)], capture_output=True, text=True
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("old.json", result.stderr)
+            self.assertIn("1.7.0 or newer", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate_plugin_release_manifest.py
+++ b/scripts/validate_plugin_release_manifest.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Validate manifests for newly built TypeWhisper plugin releases."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+MINIMUM_HOST_VERSION = (1, 7, 0)
+
+
+def validate_manifest(manifest: dict, expected_version: str | None = None) -> None:
+    if expected_version is not None and manifest.get("version") != expected_version:
+        raise ValueError(
+            f"manifest version {manifest.get('version')!r} does not match "
+            f"release version {expected_version!r}"
+        )
+
+    minimum = ".".join(str(part) for part in MINIMUM_HOST_VERSION)
+    min_host_version = manifest.get("minHostVersion")
+    if not isinstance(min_host_version, str) or not re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+", min_host_version
+    ):
+        raise ValueError(
+            f"manifest minHostVersion {min_host_version!r} must be a release version like {minimum}"
+        )
+    if tuple(int(part) for part in min_host_version.split(".")) < MINIMUM_HOST_VERSION:
+        raise ValueError(
+            f"manifest minHostVersion {min_host_version!r} must be {minimum} or newer"
+        )
+
+    sdk_version = manifest.get("sdkCompatibilityVersion")
+    if not isinstance(sdk_version, str) or not re.fullmatch(r"v[1-9][0-9]*", sdk_version):
+        raise ValueError(
+            f"manifest sdkCompatibilityVersion {sdk_version!r} must use the format vN"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest", type=Path, nargs="+")
+    parser.add_argument("--version", help="Expected plugin release version")
+    args = parser.parse_args()
+    for path in args.manifest:
+        try:
+            manifest = json.loads(path.read_text())
+            if not isinstance(manifest, dict):
+                raise ValueError("manifest must be a JSON object")
+            validate_manifest(manifest, args.version)
+        except (OSError, ValueError) as error:
+            print(f"error: {path}: {error}", file=sys.stderr)
+            return 1
+        print(f"Validated {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_plugin_release_manifest.py
+++ b/scripts/validate_plugin_release_manifest.py
@@ -34,9 +34,9 @@ def validate_manifest(manifest: dict, expected_version: str | None = None) -> No
         )
 
     sdk_version = manifest.get("sdkCompatibilityVersion")
-    if not isinstance(sdk_version, str) or not re.fullmatch(r"v[1-9][0-9]*", sdk_version):
+    if sdk_version != "v1":
         raise ValueError(
-            f"manifest sdkCompatibilityVersion {sdk_version!r} must use the format vN"
+            f"manifest sdkCompatibilityVersion {sdk_version!r} must be 'v1'"
         )
 
 


### PR DESCRIPTION
Prepare `v1.7.0-daily.20260909.1` as the everyday-testing build before RC1. Integrate #1293 and #1294 so the Daily contains the Swift dependency update, Xcode 26.6 / Swift 6.3 CI and release support, and the 1.7 minimum-host policy for newly published plugins.

Align the app and SDK constraints on Hugging Face 0.10.1 and Jinja 2.5.0. Permit the pinned MLX package build plugin in unattended Xcode builds; its CUDA work is disabled on macOS. Update manifest tests and require the current `v1` SDK compatibility line before plugin publication. Previously published plugin binaries and registry history remain unchanged.

Add curated Daily notes and correct the release-readiness documentation to match the iCloud-enabled release workflow. Validation and everyday-test follow-up are tracked in #1296; RC1 remains deferred until that everyday test. Use a merge commit to retain both included PR histories and the release build-number ancestry.

## Test plan

- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK --force-resolved-versions` — 754 tests, 3 expected skips, no failures on the integrated source.
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project TypeWhisper.xcodeproj -scheme TypeWhisper -configuration Debug -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -derivedDataPath /private/tmp/typewhisper-pr1293-swift63-evidence/DerivedData -onlyUsePackageVersionsFromResolvedFile CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` — 1,758 tests pass.
- [x] `bash scripts/check_first_party_warnings.sh /private/tmp/typewhisper-pr1293-swift63-evidence/app-tests-integrated.log` — no first-party warnings.
- [x] `/opt/homebrew/bin/python3 -m unittest discover -s scripts -p 'test_*.py'` — 47 tests pass.
- [x] `/opt/homebrew/opt/ruby@3.3/bin/ruby scripts/test_dependency_coverage.rb` — 5 tests / 32 assertions pass.
- [x] `python3 scripts/validate_plugin_release_manifest.py TypeWhisperPluginSDK/Plugins/*/manifest.json` — 49 manifests pass.
- [x] `actionlint -shellcheck= .github/workflows/build.yml .github/workflows/release.yml .github/workflows/plugin-release.yml .github/workflows/codeql.yml .github/workflows/plugin-release-policy.yml`
- [x] All 49 arm64 Release plugin-target builds pass without first-party warnings. All 49 bundles load, conform to the host SDK, and initialize successfully. Existing installed Parakeet 1.3.1 and Contributor 0.1.0 bundles also load with the new host SDK.
- [x] Cross-build all 40 plugins declaring Intel support — no first-party warnings. All 40 also load and initialize under Rosetta; this is not physical Intel hardware validation. All 14 existing installed dev bundles load against the new host SDK.
- [x] Release-source validation and signed Daily publication: [release workflow](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/34354421213) at `4e411e801f9051af9086e5286c91d75e724f99e8`. Its app tests, SDK tests, release-tool checks and signed Release build supersede duplicate standalone Build DMG runs for this commit. Publication passed the iCloud profile, notarization and canonical Daily appcast gates. The downloaded DMG passes the mandatory iCloud signing/notarization checks; DMG/ZIP SHA-256 digests and contents agree. All 49 arm64 and 40 Intel plugin bundles also load and initialize against the published host SDK (Intel under Rosetta).

The bundle smoke check verifies loading, principal-class conformance to the host SDK, and initialization. Live provider calls, hardware dictation, and everyday behavior are covered by the subsequent Daily test.

Review follow-up: check Metal availability after Swift CodeQL initialization and install the optional component only if missing. That Swift analysis job is reserved for non-Daily release tags; its traced-runner validation remains part of RC1 readiness.

Release follow-up: every release now requires the production iCloud bridge and profile; the no-iCloud switches are removed. Five regression tests cover the release entry points and preserve prior local build output when the profile is missing. The first release attempt was cancelled because the MCP HTTP test fixture blocked indefinitely during cleanup. Cleanup now yields asynchronously, escalates from SIGTERM to SIGKILL with bounded waits, and has a regression test using a server that ignores SIGTERM. All 37 focused MCP tests and the complete 754-test SDK suite pass locally (3 expected opt-in live-provider skips).

Final PR head: `760b57f6f7ccdcf20181d21aa5cc1a9badcac3fa`. Its only difference from the published, fully tested release source is four lines of local command help. `bash -n scripts/build-release-local.sh`, `bash scripts/build-release-local.sh --help`, and `python3 scripts/test_icloud_release_policy.py` pass for that follow-up. Final policy, CodeQL and CodeRabbit checks pass with no unresolved review threads; redundant standalone Build DMG runs were cancelled in favor of the successful release workflow, not treated as passing runs.
