### PR TITLE
Prepare TypeWhisper 1.7.0-rc1 and fix MCP timeout ordering

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     tags:
@@ -60,7 +61,7 @@ jobs:
 
   analyze-swift:
     name: Analyze (swift)
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-daily')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-daily'))
     runs-on: macos-26
     timeout-minutes: 45
 

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/MCPClientSession.swift
@@ -492,24 +492,29 @@ actor MCPServerSession {
         await client.disconnect()
     }
 
-    private func withTimeout<T: Sendable>(
+    func withTimeout<T: Sendable>(
         _ duration: Duration,
         operationName: String,
         onTimeout: @escaping @Sendable () async -> Void,
         operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await withThrowingTaskGroup(of: T.self) { group in
-            group.addTask { try await operation() }
+        try await withThrowingTaskGroup(of: T?.self) { group in
+            group.addTask { .some(try await operation()) }
             group.addTask {
                 try await Task.sleep(for: duration)
-                Task { await onTimeout() }
-                throw MCPClientError.timedOut(operationName)
+                return nil
             }
-            guard let result = try await group.next() else {
+            guard let outcome = try await group.next() else {
                 throw MCPClientError.timedOut(operationName)
             }
             group.cancelAll()
-            return result
+            if let result = outcome {
+                return result
+            }
+            // Select the timeout before cleanup can cancel the operation. Otherwise
+            // that cancellation can win the group race and hide the actual timeout.
+            await onTimeout()
+            throw MCPClientError.timedOut(operationName)
         }
     }
 

--- a/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
+++ b/TypeWhisperPluginSDK/Plugins/MCPClientPlugin/Tests/MCPClientPluginTests.swift
@@ -715,6 +715,31 @@ final class MCPClientPluginTests: XCTestCase {
         await session.close()
     }
 
+    func testTimeoutWaitsForCleanupWithoutReturningItsCancellationError() async throws {
+        let session = MCPServerSession(resolvedServer: Self.resolvedFixtureServer(try Self.fixtureResources()))
+        let probe = MCPTimeoutCleanupProbe()
+
+        do {
+            let _: Void = try await session.withTimeout(
+                .milliseconds(10),
+                operationName: "cleanup race",
+                onTimeout: {
+                    await probe.cancelOperation()
+                    try? await Task.sleep(for: .milliseconds(50))
+                    await probe.finishCleanup()
+                },
+                operation: { try await probe.waitForCancellation() }
+            )
+            XCTFail("Expected timeout")
+        } catch let error as MCPClientError {
+            guard case .timedOut = error else {
+                return XCTFail("Expected timedOut, got \(error)")
+            }
+        }
+        let cleanupFinished = await probe.cleanupFinished
+        XCTAssertTrue(cleanupFinished, "Timeout cleanup must finish before the caller resumes")
+    }
+
     func testConnectionTimeoutClosesHungInitialization() async throws {
         let fixture = try Self.fixtureResources()
         defer { try? FileManager.default.removeItem(at: fixture.counter) }
@@ -1198,5 +1223,27 @@ final class MCPClientPluginTests: XCTestCase {
         URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
+    }
+}
+
+
+private actor MCPTimeoutCleanupProbe {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var isCancelled = false
+    private(set) var cleanupFinished = false
+
+    func waitForCancellation() async throws {
+        if isCancelled { throw CancellationError() }
+        try await withCheckedThrowingContinuation { continuation = $0 }
+    }
+
+    func cancelOperation() {
+        isCancelled = true
+        continuation?.resume(throwing: CancellationError())
+        continuation = nil
+    }
+
+    func finishCleanup() {
+        cleanupFinished = true
     }
 }

--- a/docs/release-notes/1.7.0-rc1.md
+++ b/docs/release-notes/1.7.0-rc1.md
@@ -1,0 +1,22 @@
+# TypeWhisper 1.7.0 Release Candidate 1
+
+The first release candidate for TypeWhisper 1.7 follows successful everyday testing of the Daily preview.
+
+## Highlights since 1.6
+
+- iCloud synchronization for History and Inbox, with a redesigned History interface including device grouping, filtering, and search.
+- File transcription from Finder and optional web-media transcription through the Web Link plugin.
+- Spoken submit, Inline Commands, and configurable cancellation with double Escape, single Escape, or immediate cancellation.
+- Expanded plugin capabilities, including plugin pages and optional providers using authenticated command-line tools.
+- Improvements to recording startup, model restoration, text insertion, cancellation, and transcription recovery.
+- Vercel AI Gateway integration for transcription and LLM processing through one API key, available as an optional plugin.
+- Fixes for notch-indicator layout crashes and preserving the prepared built-in microphone during Bluetooth eligibility checks.
+- Updated Swift dependencies and builds with Xcode 26.6 / Swift 6.3.
+
+## Compatibility and updates
+
+Requires macOS 14 or later; supports Apple silicon and Intel Macs. The iCloud bridge is included in every release.
+
+New plugin releases from the 1.7 source line require TypeWhisper 1.7.0 or later. Existing compatible plugin releases remain available to 1.6 hosts. This app release does not republish plugins.
+
+RC1 is available through GitHub and the Release Candidate update channel. The stable release and Homebrew remain on 1.6.0. Please report regressions with the release tag, macOS version, and the affected engine or plugin.


### PR DESCRIPTION
Publish TypeWhisper 1.7.0-rc1 after successful user everyday testing of Daily 20260910, including an additional AirPods Max retest, and the explicitly requested Vercel AI Gateway integration from #1295.

Add curated RC release notes and allow manual Swift CodeQL analysis before publication. Also fix a genuine MCP timeout race exposed by the initial release attempt: cleanup could cancel the pending request before the timer published its timeout result, so callers sometimes received `CancellationError`. The timer now returns a timeout outcome; the parent selects it before cancellation, awaits cleanup, then reports the timeout. A deterministic regression fails the cleanup-order assertion against the original implementation and passes with the fix.

Closes #1296. RC1 is published as a GitHub prerelease in the Release Candidate update channel. Stable and Homebrew remain on 1.6.0.

## Validation

- [x] Final source `84f8b117874972bf17d86326edc41c4a0fe97cfd`, build **1220**: [signed release workflow](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/34489885677) passed **1,762 app tests**, **788 SDK/plugin tests** (3 expected opt-in live-provider skips), Release build, warning checks, iCloud bridge/profile checks, notarization, isolated app spawn, and canonical appcast verification. Duplicate standalone Build DMG runs were cancelled in favor of this complete release workflow, not counted as passes.
- [x] [Swift CodeQL](https://github.com/TypeWhisper/typewhisper-mac/actions/runs/34483950248) passed the post-init Metal check and traced app build at `82fffe163e149e5fa00e87647f1a3acdd83e29f4`; Swift, Python, and Actions analyses reported zero results/errors/warnings. The subsequent change touches only the optional MCP plugin and its tests, which the app CodeQL scheme does not build. App/host-SDK sources, Xcode project, dependency manifests and locks are unchanged, so the analyzed app inputs are unchanged. Final-head SDK tests include the corrected MCP implementation.
- [x] `actionlint -shellcheck= .github/workflows/codeql.yml`
- [x] `/opt/homebrew/bin/python3 -m unittest discover -s scripts -p 'test_*.py'` — 47 tests pass.
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK --force-resolved-versions --filter MCPClientPluginTests` — 38 tests pass.
- [x] `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path TypeWhisperPluginSDK --force-resolved-versions` — 788 tests, 3 expected skips, no failures.
- [x] `bash scripts/check_release_signing.sh --require-notarization /private/tmp/typewhisper-rc1-mounted/TypeWhisper.app` and `bash scripts/check_release_binary_instrumentation.sh /private/tmp/typewhisper-rc1-mounted/TypeWhisper.app/Contents/MacOS/typewhisper-cli` pass against the downloaded artifact.
- [x] Downloaded DMG/ZIP SHA-256 digests and sizes match GitHub. ZIP integrity and app/CLI/bridge contents match the verified DMG. App and SDK are universal, iCloud is enabled, and release metadata identifies RC1/build 1220.
- [x] Vercel AI Gateway 1.0.0: signed universal bundle; all 32 SDK imports exist in the published host on each architecture. Immediate dynamic loading and principal-class lookup pass natively and under Rosetta. This does not claim a live provider call or physical Intel test.
- [x] RC appcast entry is build 1220; stable and Daily entry contents are unchanged.

Published release: https://github.com/TypeWhisper/typewhisper-mac/releases/tag/v1.7.0-rc1
