### PR TITLE
Fix Escape propagation while cancelling dictation

### DIFF
--- a/TypeWhisper/Services/HotkeyService.swift
+++ b/TypeWhisper/Services/HotkeyService.swift
@@ -157,7 +157,6 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     private struct HotkeyDispatchKey: Hashable {
         enum Target: Hashable {
-            case cancel
             case meetingCountdown(UUID)
             case slot(HotkeySlotType)
             case profile(UUID)
@@ -213,6 +212,14 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     var onWorkflowDictationStart: ((UUID, UInt64) -> Void)?
     var onWorkflowTextProcessing: ((UUID) -> Void)?
     var onCancelPressed: (() -> Void)?
+    // Mirror the view model's cancellable state without entering MainActor from the event tap.
+    private let cancellationAvailable = OSAllocatedUnfairLock(initialState: false)
+    var isCancellationAvailable: Bool {
+        get { cancellationAvailable.withLock { $0 } }
+        set { cancellationAvailable.withLock { $0 = newValue } }
+    }
+    // Accessed by the event tap and NSEvent monitors on the main run loop.
+    private var isEscapeKeySuppressed = false
     var onPushToTalkInterruption: (() -> Void)?
     var discardPushToTalkRecordingOnExtraKeyPress = false
     var modifierFlagsStateProvider: () -> NSEvent.ModifierFlags = {
@@ -242,7 +249,6 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private static let doubleTapThreshold: TimeInterval = 0.4
     private static let monitorDedupWindow: TimeInterval = 0.12
     private static let escapeKeyCode: UInt16 = 0x35
-    private static let escapeHotkey = UnifiedHotkey(keyCode: escapeKeyCode, modifierFlags: 0, isFn: false)
     private static let meetingCountdownHotkey = UnifiedHotkey(
         keyCode: 0x2F,
         modifierFlags: NSEvent.ModifierFlags.command.rawValue,
@@ -650,8 +656,8 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     private func installLocalEventMonitor(includeMouse: Bool) {
         let mask = eventMonitorMask(includeMouse: includeMouse)
         localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
-            _ = self?.handleEvent(event, source: .monitor)
-            return event
+            guard let self else { return event }
+            return self.handleLocalMonitorEvent(event)
         }
     }
 
@@ -662,10 +668,17 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
             _ = self?.handleEvent(event, source: .monitor)
         }
 
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
-            _ = self?.handleEvent(event, source: .monitor)
-            return event
+        installLocalEventMonitor(includeMouse: includeMouse)
+    }
+
+    private func handleLocalMonitorEvent(_ event: NSEvent) -> NSEvent? {
+        let shouldSuppress = handleEvent(event, source: .monitor)
+        if shouldSuppress,
+           event.type == .keyDown || event.type == .keyUp,
+           event.keyCode == Self.escapeKeyCode {
+            return nil
         }
+        return event
     }
 
     private func eventMonitorMask(includeMouse: Bool) -> NSEvent.EventTypeMask {
@@ -679,6 +692,7 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     private func tearDownMonitor() {
         cancelPendingHybridModifierHold()
+        isEscapeKeySuppressed = false
         tearDownCarbonHotkeys()
 
         if let monitor = globalMonitor {
@@ -1128,20 +1142,22 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
 
     @discardableResult
     private func handleEvent(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
-        // Escape key cancels active recording/transcription
+        // Own the entire Escape press, including repeats and key-up after cancellation.
+        if event.type == .keyUp && event.keyCode == Self.escapeKeyCode && isEscapeKeySuppressed {
+            isEscapeKeySuppressed = false
+            return true
+        }
         if event.type == .keyDown && event.keyCode == Self.escapeKeyCode {
             cancelPendingHybridModifierHold()
-            if shouldDispatch(
-                target: .cancel,
-                phase: .down,
-                hotkey: Self.escapeHotkey,
-                source: source
-            ) {
-                performHotkeyAction(source: source) { [weak self] in
-                    self?.onCancelPressed?()
-                }
+            if isEscapeKeySuppressed { return true }
+            guard isCancellationAvailable, !event.isARepeat else { return false }
+
+            isEscapeKeySuppressed = true
+            // The press latch deduplicates fallback delivery without dropping a quick second press.
+            performHotkeyAction(source: source) { [weak self] in
+                self?.onCancelPressed?()
             }
-            return false
+            return true
         }
 
         cancelPendingHybridModifierHoldIfInterrupted(by: event)
@@ -1594,6 +1610,9 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     }
 
     private func recoverReleasedActiveHotkeyAfterEventTapDisable() {
+        if isEscapeKeySuppressed, !keyStateProvider(Self.escapeKeyCode) {
+            isEscapeKeySuppressed = false
+        }
         guard isActive,
               currentMode == .pushToTalk,
               activeProfileId == nil,
@@ -1669,6 +1688,10 @@ final class HotkeyService: ObservableObject, @unchecked Sendable {
     @discardableResult
     func processEventForTesting(_ event: NSEvent, source: HotkeyEventSource) -> Bool {
         handleEvent(event, source: source)
+    }
+
+    func processLocalEventForTesting(_ event: NSEvent) -> NSEvent? {
+        handleLocalMonitorEvent(event)
     }
 
     func recoverReleasedActiveHotkeyAfterEventTapDisableForTesting() {

--- a/TypeWhisper/ViewModels/DictationViewModel.swift
+++ b/TypeWhisper/ViewModels/DictationViewModel.swift
@@ -231,7 +231,10 @@ final class DictationViewModel: ObservableObject {
     }
 
     @Published var state: State = .idle {
-        didSet { clearCancelWarningIfStateNoLongerMatches() }
+        didSet {
+            hotkeyService.isCancellationAvailable = cancelWarningTargetForCurrentState() != nil
+            clearCancelWarningIfStateNoLongerMatches()
+        }
     }
     @Published var audioLevel: Float = 0
     @Published var recordingDuration: TimeInterval = 0

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -7651,7 +7651,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(0x35), keyDown: true)
         )
         let escapeEvent = try XCTUnwrap(NSEvent(cgEvent: escapeCGEvent))
-        XCTAssertFalse(context.hotkeyService.processEventForTesting(escapeEvent, source: .monitor))
+        XCTAssertTrue(context.hotkeyService.processEventForTesting(escapeEvent, source: .monitor))
 
         XCTAssertEqual(context.dictationViewModel.recordingDuration, 0)
         XCTAssertFalse(context.dictationViewModel.isRecordingInputReady)
@@ -12936,12 +12936,24 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                 context.dictationViewModel.cancellationBehavior = behavior
                 context.dictationViewModel.state = state
 
-                context.dictationViewModel.handleCancelHotkey()
+                let downCGEvent = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x35, keyDown: true))
+                let upCGEvent = try XCTUnwrap(CGEvent(keyboardEventSource: nil, virtualKey: 0x35, keyDown: false))
+                let down = try XCTUnwrap(NSEvent(cgEvent: downCGEvent))
+                let up = try XCTUnwrap(NSEvent(cgEvent: upCGEvent))
+                XCTAssertTrue(context.hotkeyService.processEventForTesting(down, source: .eventTap))
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.main.async { continuation.resume() }
+                }
+                XCTAssertTrue(context.hotkeyService.processEventForTesting(up, source: .eventTap))
                 if behavior == .doubleEscape {
                     XCTAssertEqual(context.dictationViewModel.state, state)
                     XCTAssertNotNil(context.dictationViewModel.cancelWarningMessage)
                     XCTAssertNil(context.dictationViewModel.actionFeedbackMessage)
-                    context.dictationViewModel.handleCancelHotkey()
+                    XCTAssertTrue(context.hotkeyService.processEventForTesting(down, source: .eventTap))
+                    await withCheckedContinuation { continuation in
+                        DispatchQueue.main.async { continuation.resume() }
+                    }
+                    XCTAssertTrue(context.hotkeyService.processEventForTesting(up, source: .eventTap))
                 }
 
                 XCTAssertNil(context.dictationViewModel.cancelWarningMessage)
@@ -12952,6 +12964,8 @@ final class TypeWhisperIntegrationTests: XCTestCase {
                     XCTAssertEqual(context.dictationViewModel.state, .inserting)
                     XCTAssertEqual(context.dictationViewModel.actionFeedbackMessage, String(localized: "Cancelled"))
                 }
+                XCTAssertFalse(context.hotkeyService.processEventForTesting(down, source: .eventTap))
+                XCTAssertFalse(context.hotkeyService.processEventForTesting(up, source: .eventTap))
                 await context.dictationViewModel.testingWaitForRecordingCleanup()
             }
         }
@@ -13641,7 +13655,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     }
 
     @MainActor
-    func testEscapeKeyStillInvokesCancelHandlerWithoutSuppression() throws {
+    func testEscapeKeyPassesThroughWithoutCancellableOperation() throws {
         let service = HotkeyService()
         service.suspendMonitoring()
 
@@ -13653,27 +13667,131 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         let escape = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
 
         XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
-        XCTAssertEqual(cancelCount, 1)
+        XCTAssertEqual(cancelCount, 0)
+        let keyUp = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+        XCTAssertFalse(service.processEventForTesting(keyUp, source: .monitor))
     }
 
     @MainActor
     func testEscapeKeyDedupesFollowingEventTapDispatch() async throws {
         let service = HotkeyService()
         service.suspendMonitoring()
+        service.isCancellationAvailable = true
 
         var cancelCount = 0
-        service.onCancelPressed = {
+        let cancelled = expectation(description: "Escape cancellation dispatched")
+        service.onCancelPressed = { [weak service] in
             cancelCount += 1
+            service?.isCancellationAvailable = false
+            cancelled.fulfill()
         }
 
         let escape = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        XCTAssertTrue(service.processEventForTesting(escape, source: .eventTap))
+        await fulfillment(of: [cancelled], timeout: 1)
+        XCTAssertEqual(cancelCount, 1)
 
+        XCTAssertTrue(service.processEventForTesting(escape, source: .monitor))
+        XCTAssertEqual(cancelCount, 1)
+        let keyUp = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+        XCTAssertTrue(service.processEventForTesting(keyUp, source: .eventTap))
         XCTAssertFalse(service.processEventForTesting(escape, source: .eventTap))
-        await Task.yield()
-        XCTAssertEqual(cancelCount, 1)
+    }
 
-        XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
+    @MainActor
+    func testEscapeKeyConsumesHeldPressAfterCancellationUntilRelease() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.isCancellationAvailable = true
+        var cancelCount = 0
+        service.onCancelPressed = { [weak service] in
+            cancelCount += 1
+            service?.isCancellationAvailable = false
+        }
+        let down = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        let repeated = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [], isRepeat: true)
+        let up = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+
+        XCTAssertTrue(service.processEventForTesting(down, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(repeated, source: .monitor))
         XCTAssertEqual(cancelCount, 1)
+        XCTAssertTrue(service.processEventForTesting(up, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(down, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(up, source: .monitor))
+        XCTAssertEqual(cancelCount, 1)
+    }
+
+    @MainActor
+    func testEscapeKeyRequiresSeparatePressesAndAcceptsQuickSecondPress() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.isCancellationAvailable = true
+        var cancelCount = 0
+        service.onCancelPressed = { cancelCount += 1 }
+        let down = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        let repeated = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [], isRepeat: true)
+        let up = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+
+        XCTAssertTrue(service.processEventForTesting(down, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(repeated, source: .monitor))
+        XCTAssertEqual(cancelCount, 1)
+        XCTAssertTrue(service.processEventForTesting(up, source: .monitor))
+        XCTAssertTrue(service.processEventForTesting(down, source: .monitor))
+        XCTAssertEqual(cancelCount, 2)
+        XCTAssertTrue(service.processEventForTesting(up, source: .monitor))
+    }
+
+    @MainActor
+    func testEscapeHeldBeforeDictationDoesNotCancelOnRepeat() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        var cancelCount = 0
+        service.onCancelPressed = { cancelCount += 1 }
+        let down = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        let repeated = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [], isRepeat: true)
+        let up = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+
+        XCTAssertFalse(service.processEventForTesting(down, source: .monitor))
+        service.isCancellationAvailable = true
+        XCTAssertFalse(service.processEventForTesting(repeated, source: .monitor))
+        XCTAssertFalse(service.processEventForTesting(up, source: .monitor))
+        XCTAssertEqual(cancelCount, 0)
+    }
+
+    @MainActor
+    func testEscapeKeyRecoversMissedReleaseAfterEventTapDisable() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        service.isCancellationAvailable = true
+        var escapeIsDown = true
+        service.keyStateProvider = { _ in escapeIsDown }
+        let down = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        let repeated = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [], isRepeat: true)
+
+        XCTAssertTrue(service.processEventForTesting(down, source: .monitor))
+        service.isCancellationAvailable = false
+        service.recoverReleasedActiveHotkeyAfterEventTapDisableForTesting()
+        XCTAssertTrue(service.processEventForTesting(repeated, source: .monitor))
+        escapeIsDown = false
+        service.recoverReleasedActiveHotkeyAfterEventTapDisableForTesting()
+        XCTAssertFalse(service.processEventForTesting(down, source: .monitor))
+    }
+
+    @MainActor
+    func testLocalMonitorConsumesEscapeOnlyDuringCancellation() throws {
+        let service = HotkeyService()
+        service.suspendMonitoring()
+        let down = try makeKeyboardEvent(keyCode: 0x35, keyDown: true, flags: [])
+        let up = try makeKeyboardEvent(keyCode: 0x35, keyDown: false, flags: [])
+        XCTAssertNotNil(service.processLocalEventForTesting(down))
+        XCTAssertNotNil(service.processLocalEventForTesting(up))
+        service.isCancellationAvailable = true
+        service.onCancelPressed = { [weak service] in service?.isCancellationAvailable = false }
+        XCTAssertNil(service.processLocalEventForTesting(down))
+        XCTAssertNil(service.processLocalEventForTesting(up))
+        XCTAssertNotNil(service.processLocalEventForTesting(down))
+        let unrelated = try makeKeyboardEvent(keyCode: 0x00, keyDown: true, flags: [])
+        XCTAssertNotNil(service.processLocalEventForTesting(unrelated))
     }
 
     @MainActor
@@ -14928,7 +15046,7 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
         XCTAssertFalse(service.processEventForTesting(escape, source: .monitor))
 
         try await Task.sleep(for: .milliseconds(50))
-        XCTAssertEqual(cancelCount, 1)
+        XCTAssertEqual(cancelCount, 0)
         XCTAssertEqual(startCount, 0)
         XCTAssertNil(service.currentMode)
 
@@ -16000,12 +16118,14 @@ final class HotkeyServiceCompatibilityTests: XCTestCase {
     private func makeKeyboardEvent(
         keyCode: UInt16,
         keyDown: Bool,
-        flags: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+        flags: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand],
+        isRepeat: Bool = false
     ) throws -> NSEvent {
         let event = try XCTUnwrap(
             CGEvent(keyboardEventSource: nil, virtualKey: CGKeyCode(keyCode), keyDown: keyDown)
         )
         event.flags = flags
+        event.setIntegerValueField(.keyboardEventAutorepeat, value: isRepeat ? 1 : 0)
         return try XCTUnwrap(NSEvent(cgEvent: event))
     }
 

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Fixes
+
+- Escape used to cancel dictation is now consumed by TypeWhisper instead of reaching the target app and potentially dismissing a text field or navigating back. This applies during microphone startup, recording, and transcription, including both presses in double-Escape mode. Holding Escape does not count as a second press. Escape works normally again after cancellation and releasing the key. (#1303)


### PR DESCRIPTION
## Summary

Escape used to cancel dictation also reached the target app, which could dismiss its input field, discard an existing draft, or navigate back (#1303). TypeWhisper now consumes the complete Escape press during microphone startup, recording, and transcription, while preserving the double-Escape, single-Escape, and instant cancellation modes.

- Consume key-down, held-key repeats, and key-up, even when cancellation has already returned the app to idle.
- Require separate presses for double-Escape cancellation, including quick successive presses; restore normal Escape behavior afterward.
- Suppress Escape in the local monitor fallback and recover a missed release after an event-tap interruption.
- Add regression coverage and an unreleased release note.

Closes #1303

## Test plan

- [x] 96 targeted tests passed with Xcode 26.6 / Swift 6.3:

```bash
xcodebuild test -skipPackagePluginValidation -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -parallel-testing-enabled NO -derivedDataPath /tmp/typewhisper-1303-tests -only-testing:TypeWhisperTests/HotkeyServiceCompatibilityTests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testCancellationModesApplyToRecordingAndProcessing -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests/testBluetoothPreparationCanBeCancelledByEscapeBeforeReadiness CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO > /tmp/typewhisper-1303-tests-final.log 2>&1
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-1303-tests-final.log
git diff --check
```

- [x] No first-party compiler warnings.
- [x] Signed development build built and launched successfully.
- [x] Marco manually verified the Escape fix in WhatsApp using that development build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Escape cancellation is now handled consistently during microphone startup, recording, and transcription.
  - Escape presses used for cancellation no longer reach the active app, including repeated or held presses.
  - Double-Escape cancellation is more reliable, while held keys are excluded from double-press detection.
  - Normal Escape behavior resumes after cancellation and key release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->