### PR TITLE
Add a minimum threshold for spoken number normalization

### DIFF
--- a/TypeWhisper/App/TypeWhisperApp.swift
+++ b/TypeWhisper/App/TypeWhisperApp.swift
@@ -766,6 +766,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
             UserDefaultsKeys.updateChannel: AppConstants.defaultReleaseChannel.rawValue,
             UserDefaultsKeys.appFormattingEnabled: true,
             UserDefaultsKeys.transcriptionNumberNormalizationEnabled: true,
+            UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue: TranscriptionNormalizationService.defaultNumberNormalizationMinimumValue,
             UserDefaultsKeys.targetAppCorrectionLearningEnabled: false,
             UserDefaultsKeys.calendarMeetingStartMode: CalendarMeetingStartMode.off.rawValue,
             UserDefaultsKeys.calendarMeetingAutoStopEnabled: false,

--- a/TypeWhisper/App/UserDefaultsKeys.swift
+++ b/TypeWhisper/App/UserDefaultsKeys.swift
@@ -119,6 +119,7 @@ enum UserDefaultsKeys {
     // MARK: - Formatting
     static let appFormattingEnabled = "appFormattingEnabled"
     static let transcriptionNumberNormalizationEnabled = "transcriptionNumberNormalizationEnabled"
+    static let transcriptionNumberNormalizationMinimumValue = "transcriptionNumberNormalizationMinimumValue"
     static let dictationPunctuationProfiles = "dictationPunctuationProfiles"
 
     // MARK: - Accessibility

--- a/TypeWhisper/Resources/Localizable.xcstrings
+++ b/TypeWhisper/Resources/Localizable.xcstrings
@@ -1,6 +1,72 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "10 and above" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ab 10"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10以上"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "10及以上"
+          }
+        }
+      }
+    },
+    "100 and above" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ab 100"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100以上"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "100及以上"
+          }
+        }
+      }
+    },
+    "Convert numbers to digits" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zahlen in Ziffern umwandeln"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "数字に変換する範囲"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "转换为数字的范围"
+          }
+        }
+      }
+    },
     "No Integration Commands" : {
       "localizations" : {
         "de" : {
@@ -253,6 +319,28 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "2回：Escキーを2回押してキャンセルします。1回：Escキーを1回押します。どちらもキャンセル通知を1.5秒間表示します。即時：Escキーを1回押すと、通知を表示せずにキャンセルします。録音中と処理中の両方に適用されます。"
+          }
+        }
+      }
+    },
+    "Smaller numbers stay as spoken words. Decimals and digit sequences still convert to digits. Existing digits stay unchanged." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kleinere Zahlen bleiben ausgeschrieben. Dezimalzahlen und Ziffernfolgen werden weiterhin in Ziffern umgewandelt. Vorhandene Ziffern bleiben unverändert."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "小さい数は元の表記を保持します。小数と数字の並びは引き続き数字に変換します。既存の数字は変更しません。"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "较小的数保留原来的文字写法。小数和逐位口述的数字串仍会转换为数字。已有的数字保持不变。"
           }
         }
       }
@@ -3298,6 +3386,12 @@
     },
     "Always" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Immer"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18038,6 +18132,12 @@
     },
     "Normalize spoken numbers to digits" : {
       "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gesprochene Zahlen in Ziffern umwandeln"
+          }
+        },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",

--- a/TypeWhisper/Services/NumberNormalization/DutchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/DutchNumberWordParser.swift
@@ -39,10 +39,12 @@ enum DutchNumberWordParser {
         }
         index = integer.nextIndex
         var replacement = "\(integer.value)"
+        var kind = NumberWordNormalizer.ParsedWords.Kind.number
 
         if index < normalizedWords.count, normalizedWords[index] == "komma" {
             let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
             if !decimal.digits.isEmpty {
+                kind = .decimal
                 replacement += ",\(decimal.digits)"
                 index = decimal.nextIndex
             }
@@ -52,7 +54,7 @@ enum DutchNumberWordParser {
             replacement = "-" + replacement
         }
 
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index, kind: kind)
     }
 
     private static func parseInteger(

--- a/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/EnglishNumberWordParser.swift
@@ -84,10 +84,12 @@ enum EnglishNumberWordParser {
             }
 
             var replacement = "\(integer.value)"
+            var kind = NumberWordNormalizer.ParsedWords.Kind.number
 
             if index < normalizedWords.count, normalizedWords[index] == "point" {
                 let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
                 if !decimal.digits.isEmpty {
+                    kind = .decimal
                     replacement += ".\(decimal.digits)"
                     index = decimal.nextIndex
                 }
@@ -97,7 +99,7 @@ enum EnglishNumberWordParser {
                 replacement = "-" + replacement
             }
 
-            return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+            return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index, kind: kind)
         }
 
         // Standalone ordinal word ("eighth", "twelfth", "twentieth", ...),
@@ -142,7 +144,7 @@ enum EnglishNumberWordParser {
             sequence += "\(unitValues[words[position]] ?? 0)"
         }
 
-        return NumberWordNormalizer.ParsedWords(value: sequence, consumedWords: positions)
+        return NumberWordNormalizer.ParsedWords(value: sequence, consumedWords: positions, kind: .digitSequence)
     }
 
     private static func makeResult(_ value: Int, ordinal: Bool, isNegative: Bool, consumedWords: Int) -> NumberWordNormalizer.ParsedWords {

--- a/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/FrenchNumberWordParser.swift
@@ -33,10 +33,12 @@ enum FrenchNumberWordParser {
         }
         index = integer.nextIndex
         var replacement = "\(integer.value)"
+        var kind = NumberWordNormalizer.ParsedWords.Kind.number
 
         if index < normalizedWords.count, let decimalSeparator = decimalSeparator(for: normalizedWords[index]) {
             let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
             if !decimal.digits.isEmpty {
+                kind = .decimal
                 replacement += "\(decimalSeparator)\(decimal.digits)"
                 index = decimal.nextIndex
             }
@@ -46,7 +48,7 @@ enum FrenchNumberWordParser {
             replacement = "-" + replacement
         }
 
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index, kind: kind)
     }
 
     private static func parseInteger(

--- a/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/GermanNumberWordParser.swift
@@ -35,10 +35,12 @@ enum GermanNumberWordParser {
         guard let integer = parseInteger(normalizedWords, startingAt: index) else { return nil }
         index = integer.nextIndex
         var replacement = "\(integer.value)"
+        var kind = NumberWordNormalizer.ParsedWords.Kind.number
 
         if index < normalizedWords.count, normalizedWords[index] == "komma" {
             let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
             if !decimal.digits.isEmpty {
+                kind = .decimal
                 replacement += ",\(decimal.digits)"
                 index = decimal.nextIndex
             }
@@ -48,7 +50,7 @@ enum GermanNumberWordParser {
             replacement = "-" + replacement
         }
 
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index, kind: kind)
     }
 
     private static func parseInteger(_ words: [String], startingAt startIndex: Int) -> (value: Int, nextIndex: Int)? {

--- a/TypeWhisper/Services/NumberNormalization/HanNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/HanNumberWordParser.swift
@@ -38,7 +38,7 @@ enum HanNumberWordParser {
         let numberText = pieces.joined()
         guard containsNumberMarker(numberText) else { return nil }
         guard let parsed = parseNumberText(numberText) else { return nil }
-        return NumberWordNormalizer.ParsedWords(value: parsed, consumedWords: consumedWords)
+        return NumberWordNormalizer.ParsedWords(value: parsed, consumedWords: consumedWords, kind: parsed.contains(".") ? .decimal : .number)
     }
 
     private static func parseNumberText(_ text: String) -> String? {

--- a/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
+++ b/TypeWhisper/Services/NumberNormalization/SpanishNumberWordParser.swift
@@ -47,10 +47,12 @@ enum SpanishNumberWordParser {
         }
         index = integer.nextIndex
         var replacement = "\(integer.value)"
+        var kind = NumberWordNormalizer.ParsedWords.Kind.number
 
         if index < normalizedWords.count, normalizedWords[index] == "coma" {
             let decimal = parseDecimalDigits(normalizedWords, startingAt: index + 1)
             if !decimal.digits.isEmpty {
+                kind = .decimal
                 replacement += ",\(decimal.digits)"
                 index = decimal.nextIndex
             }
@@ -60,7 +62,7 @@ enum SpanishNumberWordParser {
             replacement = "-" + replacement
         }
 
-        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index)
+        return NumberWordNormalizer.ParsedWords(value: replacement, consumedWords: index, kind: kind)
     }
 
     private static func parseInteger(

--- a/TypeWhisper/Services/NumberWordNormalizer.swift
+++ b/TypeWhisper/Services/NumberWordNormalizer.swift
@@ -4,7 +4,7 @@ enum NumberWordNormalizer {
     private static let supportedLanguageCodes: Set<String> = ["en", "de", "fr", "es", "nl", "zh", "ja"]
     private static let cjkNumberCharacters = Set("零〇一二两兩三四五六七八九十百千万萬亿億点點負负".map { $0 })
 
-    static func normalize(text: String, language: String?) -> String {
+    static func normalize(text: String, language: String?, minimumValue: Int = 0) -> String {
         guard let languageCode = PunctuationLanguageNormalizer.normalize(language),
               supportedLanguageCodes.contains(languageCode),
               !text.isEmpty else {
@@ -22,7 +22,12 @@ enum NumberWordNormalizer {
                 index = decimal.endIndex
             } else if tokens[index].isWord,
                let parsed = parseNumber(startingAt: index, in: tokens, languageCode: languageCode) {
-                result.append(parsed.replacement)
+                if parsed.words.shouldNormalize(minimumValue: minimumValue) {
+                    result.append(parsed.words.value)
+                } else {
+                    // Consume the entire expression even when keeping its original spelling.
+                    result.append(contentsOf: tokens[index..<parsed.endIndex].map(\.text).joined())
+                }
                 index = parsed.endIndex
             } else {
                 result.append(tokens[index].text)
@@ -34,8 +39,29 @@ enum NumberWordNormalizer {
     }
 
     struct ParsedWords {
+        enum Kind {
+            case number
+            case decimal
+            case digitSequence
+        }
+
         let value: String
         let consumedWords: Int
+        let kind: Kind
+
+        init(value: String, consumedWords: Int, kind: Kind = .number) {
+            self.value = value
+            self.consumedWords = consumedWords
+            self.kind = kind
+        }
+
+        func shouldNormalize(minimumValue: Int) -> Bool {
+            guard minimumValue > 0, kind == .number else { return true }
+            // Parsers emit ASCII digits, optionally signed and with an ordinal suffix.
+            let magnitude = value.drop(while: { $0 == "-" }).prefix(while: { $0.isASCII && $0.isNumber })
+            guard let number = UInt64(magnitude) else { return false }
+            return number >= UInt64(minimumValue)
+        }
     }
 
     private enum TokenKind {
@@ -72,8 +98,10 @@ enum NumberWordNormalizer {
     }
 
     private struct ParsedNumber {
-        let replacement: String
+        let words: ParsedWords
         let endIndex: Int
+
+        var replacement: String { words.value }
     }
 
     private struct WordCandidate {
@@ -94,7 +122,11 @@ enum NumberWordNormalizer {
         }
 
         return ParsedNumber(
-            replacement: tokens[index].text + decimalSeparator + tokens[index + 4].text,
+            words: ParsedWords(
+                value: tokens[index].text + decimalSeparator + tokens[index + 4].text,
+                consumedWords: 1,
+                kind: .decimal
+            ),
             endIndex: index + 5
         )
     }
@@ -143,7 +175,7 @@ enum NumberWordNormalizer {
         }
 
         let finalTokenIndex = words[parsed.consumedWords - 1].tokenIndex
-        return ParsedNumber(replacement: parsed.value, endIndex: finalTokenIndex + 1)
+        return ParsedNumber(words: parsed, endIndex: finalTokenIndex + 1)
     }
 
     private static func wordCandidates(startingAt index: Int, in tokens: [Token]) -> [WordCandidate] {

--- a/TypeWhisper/Services/SettingsBackupExporter.swift
+++ b/TypeWhisper/Services/SettingsBackupExporter.swift
@@ -176,6 +176,8 @@ enum SettingsBackupExporter {
         var liveFieldTranscriptEnabled: Bool? = nil
         var indicatorTranscriptPreviewFontSizeOffset: Int? = nil
         var preserveClipboard: Bool? = nil
+        var transcriptionNumberNormalizationEnabled: Bool? = nil
+        var transcriptionNumberNormalizationMinimumValue: Int? = nil
         var mediaPauseEnabled: Bool? = nil
         var transcribeShortQuietClipsAggressively: Bool? = nil
         var microphoneBoostEnabled: Bool? = nil
@@ -227,6 +229,8 @@ enum SettingsBackupExporter {
             if liveFieldTranscriptEnabled != nil { count += 1 }
             if indicatorTranscriptPreviewFontSizeOffset != nil { count += 1 }
             if preserveClipboard != nil { count += 1 }
+            if transcriptionNumberNormalizationEnabled != nil { count += 1 }
+            if transcriptionNumberNormalizationMinimumValue != nil { count += 1 }
             if mediaPauseEnabled != nil { count += 1 }
             if transcribeShortQuietClipsAggressively != nil { count += 1 }
             if microphoneBoostEnabled != nil { count += 1 }
@@ -575,6 +579,10 @@ enum SettingsBackupExporter {
                 liveFieldTranscriptEnabled: userDefaults.object(forKey: UserDefaultsKeys.liveFieldTranscriptEnabled) as? Bool,
                 indicatorTranscriptPreviewFontSizeOffset: userDefaults.object(forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset) as? Int,
                 preserveClipboard: userDefaults.object(forKey: UserDefaultsKeys.preserveClipboard) as? Bool,
+                transcriptionNumberNormalizationEnabled: userDefaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) as? Bool,
+                transcriptionNumberNormalizationMinimumValue: userDefaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue) == nil
+                    ? nil
+                    : TranscriptionNormalizationService.numberNormalizationMinimumValue(defaults: userDefaults),
                 mediaPauseEnabled: userDefaults.object(forKey: UserDefaultsKeys.mediaPauseEnabled) as? Bool,
                 transcribeShortQuietClipsAggressively: userDefaults.object(forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively) as? Bool,
                 microphoneBoostEnabled: userDefaults.object(forKey: UserDefaultsKeys.microphoneBoostEnabled) as? Bool,
@@ -858,6 +866,11 @@ enum SettingsBackupExporter {
         }
         apply(preferences.indicatorTranscriptPreviewFontSizeOffset, forKey: UserDefaultsKeys.indicatorTranscriptPreviewFontSizeOffset)
         apply(preferences.preserveClipboard, forKey: UserDefaultsKeys.preserveClipboard)
+        apply(preferences.transcriptionNumberNormalizationEnabled, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        if let minimumValue = preferences.transcriptionNumberNormalizationMinimumValue,
+           [0, 10, 100].contains(minimumValue) {
+            apply(minimumValue, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        }
         apply(preferences.mediaPauseEnabled, forKey: UserDefaultsKeys.mediaPauseEnabled)
         apply(preferences.transcribeShortQuietClipsAggressively, forKey: UserDefaultsKeys.transcribeShortQuietClipsAggressively)
         apply(preferences.microphoneBoostEnabled, forKey: UserDefaultsKeys.microphoneBoostEnabled)

--- a/TypeWhisper/Services/TranscriptionNormalizationService.swift
+++ b/TypeWhisper/Services/TranscriptionNormalizationService.swift
@@ -1,6 +1,16 @@
 import Foundation
 
 enum TranscriptionNormalizationService {
+    static let defaultNumberNormalizationMinimumValue = 10
+
+    static func numberNormalizationMinimumValue(defaults: UserDefaults = .standard) -> Int {
+        guard let value = defaults.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue) as? Int,
+              [0, 10, 100].contains(value) else {
+            return defaultNumberNormalizationMinimumValue
+        }
+        return value
+    }
+
     static func numberNormalizationEnabled(
         override: Bool? = nil,
         defaults: UserDefaults = .standard
@@ -45,8 +55,9 @@ enum TranscriptionNormalizationService {
             return text
         }
 
+        let minimumValue = numberNormalizationMinimumValue(defaults: defaults)
         for language in prioritizedLanguages(primary: nil, candidates: languages) {
-            let normalized = NumberWordNormalizer.normalize(text: text, language: language)
+            let normalized = NumberWordNormalizer.normalize(text: text, language: language, minimumValue: minimumValue)
             if normalized != text {
                 return normalized
             }

--- a/TypeWhisper/Views/SettingsView.swift
+++ b/TypeWhisper/Views/SettingsView.swift
@@ -685,6 +685,9 @@ struct RecordingSettingsView: View {
     @State private var customSounds: [String] = SoundChoice.installedCustomSounds()
     @State private var draggedInputDevicePriorityItem: AudioInputDevicePriorityItem?
     @AppStorage(UserDefaultsKeys.airPodsInstantStartEnabled) private var bluetoothInstantStartEnabled = false
+    @AppStorage(UserDefaultsKeys.transcriptionNumberNormalizationEnabled) private var numberNormalizationEnabled = true
+    @AppStorage(UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+    private var numberNormalizationMinimumValue = TranscriptionNormalizationService.defaultNumberNormalizationMinimumValue
     private let soundService = ServiceContainer.shared.soundService
     private let audioRecordingService = ServiceContainer.shared.audioRecordingService
 
@@ -1071,12 +1074,16 @@ struct RecordingSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
 
-                Toggle(String(localized: "Normalize spoken numbers to digits"), isOn: Binding(
-                    get: { TranscriptionNormalizationService.numberNormalizationEnabled() },
-                    set: { UserDefaults.standard.set($0, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled) }
-                ))
+                Toggle(String(localized: "Normalize spoken numbers to digits"), isOn: $numberNormalizationEnabled)
 
-                Text(String(localized: "Converts spoken numbers in supported languages into digits before insertion and export."))
+                Picker(String(localized: "Convert numbers to digits"), selection: $numberNormalizationMinimumValue) {
+                    Text(String(localized: "Always")).tag(0)
+                    Text(String(localized: "10 and above")).tag(10)
+                    Text(String(localized: "100 and above")).tag(100)
+                }
+                .disabled(!numberNormalizationEnabled)
+
+                Text(String(localized: "Smaller numbers stay as spoken words. Decimals and digit sequences still convert to digits. Existing digits stay unchanged."))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/TypeWhisperTests/NumberWordNormalizerTests.swift
+++ b/TypeWhisperTests/NumberWordNormalizerTests.swift
@@ -2,6 +2,83 @@ import XCTest
 @testable import TypeWhisper
 
 final class NumberWordNormalizerTests: XCTestCase {
+    func testMinimumTenPreservesSmallNumbersAndConvertsWholeExpressions() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "I was talking to one of my clients about four hundred ninety seven files", language: "en", minimumValue: 10),
+            "I was talking to one of my clients about 497 files"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "Zero, Three, nine, ten, eleven", language: "en", minimumValue: 10),
+            "Zero, Three, nine, 10, 11"
+        )
+    }
+
+    func testMinimumHundredPreservesEntireExpressionAndOriginalSeparators() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "Twenty-Three, ninety\nnine, one hundred, one hundred and one", language: "en", minimumValue: 100),
+            "Twenty-Three, ninety\nnine, 100, 101"
+        )
+    }
+
+    func testThresholdAppliesToMagnitudeAndOrdinals() {
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "minus nine, minus ten, negative one hundred", language: "en", minimumValue: 10),
+            "minus nine, -10, -100"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "fourth, ninth, tenth, twenty-first", language: "en", minimumValue: 10),
+            "fourth, ninth, 10th, 21st"
+        )
+        XCTAssertEqual(
+            NumberWordNormalizer.normalize(text: "twenty-first, one hundred first", language: "en", minimumValue: 100),
+            "twenty-first, 101st"
+        )
+    }
+
+    func testThresholdPreservesDigitSequencesAndTheirLeadingZeros() {
+        for (spoken, expected) in [
+            ("zero zero zero one", "0001"),
+            ("zero zero zero zero", "0000"),
+            ("four oh oh two", "4002"),
+            ("one two three", "one two three")
+        ] {
+            XCTAssertEqual(NumberWordNormalizer.normalize(text: spoken, language: "en", minimumValue: 100), expected)
+        }
+    }
+
+    func testThresholdKeepsDecimalsNormalizedAcrossLanguages() {
+        for (language, spoken, expected) in [
+            ("en", "minus two point five", "-2.5"),
+            ("de", "minus zwei komma fünf", "-2,5"),
+            ("fr", "deux virgule cinq", "2,5"),
+            ("fr", "3 point 14", "3.14"),
+            ("es", "dos coma cinco", "2,5"),
+            ("nl", "twee komma vijf", "2,5"),
+            ("zh", "二点五", "2.5"),
+            ("ja", "二点五", "2.5")
+        ] {
+            XCTAssertEqual(NumberWordNormalizer.normalize(text: spoken, language: language, minimumValue: 100), expected, language)
+        }
+    }
+
+    func testThresholdAcrossSupportedLanguages() {
+        for (language, spoken, expected) in [
+            ("de", "drei, neun, zehn, siebenundneunzig", "drei, neun, 10, 97"),
+            ("fr", "trois, neuf, dix", "trois, neuf, 10"),
+            ("es", "tres, nueve, diez", "tres, nueve, 10"),
+            ("nl", "drie, negen, tien", "drie, negen, 10"),
+            ("zh", "三，九，十", "三，九，10"),
+            ("ja", "三、九、十", "三、九、10")
+        ] {
+            XCTAssertEqual(NumberWordNormalizer.normalize(text: spoken, language: language, minimumValue: 10), expected, language)
+        }
+    }
+
+    func testAlwaysConvertsSmallNumbersAndThresholdLeavesExistingDigitsAlone() {
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "zero, three, minus nine", language: "en", minimumValue: 0), "0, 3, -9")
+        XCTAssertEqual(NumberWordNormalizer.normalize(text: "1 of my clients, 3rd, -2.5, 0001", language: "en", minimumValue: 100), "1 of my clients, 3rd, -2.5, 0001")
+    }
+
     func testEnglishSimpleNumbersNormalizeToDigits() {
         XCTAssertEqual(NumberWordNormalizer.normalize(text: "I have two questions", language: "en"), "I have 2 questions")
     }

--- a/TypeWhisperTests/SettingsBackupExporterTests.swift
+++ b/TypeWhisperTests/SettingsBackupExporterTests.swift
@@ -492,6 +492,86 @@ final class SettingsBackupExporterTests: XCTestCase {
         }
     }
 
+    func testNumberNormalizationPreferencesRoundTrip() async throws {
+        for minimumValue in [0, 10, 100] {
+            let source = try makeFixture()
+            let destination = try makeFixture()
+            defer { teardown(source); teardown(destination) }
+            let enabled = minimumValue == 10
+            source.userDefaults.set(enabled, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            source.userDefaults.set(minimumValue, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+            let backup = try SettingsBackupExporter.buildBackup(
+                workflowService: source.workflowService,
+                dictionaryService: source.dictionaryService,
+                snippetService: source.snippetService,
+                profileService: source.profileService,
+                promptActionService: source.promptActionService,
+                pluginManager: source.pluginManager,
+                historyService: source.historyService,
+                userDefaults: source.userDefaults
+            )
+            let decoded = try SettingsBackupExporter.parse(SettingsBackupExporter.encodedJSON(backup))
+            XCTAssertEqual(decoded.preferences.transcriptionNumberNormalizationEnabled, enabled)
+            XCTAssertEqual(decoded.preferences.transcriptionNumberNormalizationMinimumValue, minimumValue)
+            destination.userDefaults.set(!enabled, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            destination.userDefaults.set(999, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+            await SettingsBackupExporter.importBackup(
+                decoded,
+                workflowService: destination.workflowService,
+                dictionaryService: destination.dictionaryService,
+                snippetService: destination.snippetService,
+                profileService: destination.profileService,
+                promptActionService: destination.promptActionService,
+                pluginManager: destination.pluginManager,
+                pluginRegistryService: destination.pluginRegistryService,
+                historyService: destination.historyService,
+                usageStatisticsService: destination.usageStatisticsService,
+                userDefaults: destination.userDefaults
+            )
+            XCTAssertEqual(destination.userDefaults.bool(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled), enabled)
+            XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue), minimumValue)
+            var preferences = SettingsBackupExporter.PreferencesDTO.empty
+            preferences.transcriptionNumberNormalizationEnabled = enabled
+            preferences.transcriptionNumberNormalizationMinimumValue = minimumValue
+            XCTAssertEqual(preferences.nonNilCount, 2)
+        }
+    }
+
+    func testMissingAndInvalidBackupThresholdsPreserveDestinationPreferences() async throws {
+        for minimumValue: Int? in [nil, -1, 3, 999] {
+            let destination = try makeFixture()
+            defer { teardown(destination) }
+            destination.userDefaults.set(false, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+            destination.userDefaults.set(100, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+            var preferences = SettingsBackupExporter.PreferencesDTO.empty
+            preferences.transcriptionNumberNormalizationMinimumValue = minimumValue
+            let backup = SettingsBackupExporter.SettingsBackup(
+                schemaVersion: SettingsBackupExporter.schemaVersion,
+                exportedAt: Date(), appVersion: "1.0",
+                workflows: [], dictionaryEntries: [], snippets: [], promptActions: [], profiles: [],
+                hotkeys: [:], plugins: [], history: [], updateChannel: nil, preferences: preferences
+            )
+            // Optional fields are omitted from JSON, matching older settings backups.
+            let decoded = try SettingsBackupExporter.parse(SettingsBackupExporter.encodedJSON(backup))
+            let result = await SettingsBackupExporter.importBackup(
+                decoded,
+                workflowService: destination.workflowService,
+                dictionaryService: destination.dictionaryService,
+                snippetService: destination.snippetService,
+                profileService: destination.profileService,
+                promptActionService: destination.promptActionService,
+                pluginManager: destination.pluginManager,
+                pluginRegistryService: destination.pluginRegistryService,
+                historyService: destination.historyService,
+                usageStatisticsService: destination.usageStatisticsService,
+                userDefaults: destination.userDefaults
+            )
+            XCTAssertEqual(result.preferencesApplied, 0)
+            XCTAssertFalse(destination.userDefaults.bool(forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled))
+            XCTAssertEqual(destination.userDefaults.integer(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue), 100)
+        }
+    }
+
     func testUpdateChannelAndPreferencesRoundTrip() async throws {
         let source = try makeFixture()
         defer { teardown(source) }

--- a/TypeWhisperTests/SpeechPunctuationServiceTests.swift
+++ b/TypeWhisperTests/SpeechPunctuationServiceTests.swift
@@ -3,6 +3,23 @@ import TypeWhisperPluginSDK
 @testable import TypeWhisper
 
 final class SpeechPunctuationServiceTests: XCTestCase {
+    private var originalNumberNormalizationMinimumValue: Any?
+
+    override func setUp() {
+        super.setUp()
+        originalNumberNormalizationMinimumValue = UserDefaults.standard.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        UserDefaults.standard.set(10, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+    }
+
+    override func tearDown() {
+        if let originalNumberNormalizationMinimumValue {
+            UserDefaults.standard.set(originalNumberNormalizationMinimumValue, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        }
+        super.tearDown()
+    }
+
     @MainActor
     func testRepeatedNormalizationKeepsLanguageRulesAndAliasesSeparate() {
         let service = SpeechPunctuationService(rulesLoader: makeRulesLoader())

--- a/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
+++ b/TypeWhisperTests/TranscriptionNormalizationServiceTests.swift
@@ -4,7 +4,7 @@ import TypeWhisperPluginSDK
 
 final class TranscriptionNormalizationServiceTests: XCTestCase {
     @MainActor
-    func testDefaultOnNormalizesBeforePostProcessing() async throws {
+    func testDefaultOnPreservesSmallNumbersBeforePostProcessing() async throws {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)
         defer { defaults.removePersistentDomain(forName: #function) }
@@ -15,11 +15,11 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
             defaults: defaults
         )
 
-        XCTAssertEqual(result, "I have 2 questions")
+        XCTAssertEqual(result, "I have two questions")
     }
 
     @MainActor
-    func testDutchLocaleNormalizesBeforePostProcessing() async throws {
+    func testDutchLocalePreservesSmallNumbersBeforePostProcessing() async throws {
         let defaults = UserDefaults(suiteName: #function)!
         defaults.removePersistentDomain(forName: #function)
         defer { defaults.removePersistentDomain(forName: #function) }
@@ -30,7 +30,7 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
             defaults: defaults
         )
 
-        XCTAssertEqual(result, "ik heb 2 vragen")
+        XCTAssertEqual(result, "ik heb twee vragen")
     }
 
     @MainActor
@@ -41,12 +41,12 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: #function) }
 
         let result = TranscriptionNormalizationService.normalizeText(
-            "I have two questions",
+            "I have twenty three questions",
             language: "en",
             defaults: defaults
         )
 
-        XCTAssertEqual(result, "I have two questions")
+        XCTAssertEqual(result, "I have twenty three questions")
     }
 
     @MainActor
@@ -57,13 +57,13 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
         defer { defaults.removePersistentDomain(forName: #function) }
 
         let result = TranscriptionNormalizationService.normalizeText(
-            "I have two questions",
+            "I have twenty three questions",
             language: "en",
             normalizeNumbers: false,
             defaults: defaults
         )
 
-        XCTAssertEqual(result, "I have two questions")
+        XCTAssertEqual(result, "I have twenty three questions")
     }
 
     @MainActor
@@ -105,5 +105,69 @@ final class TranscriptionNormalizationServiceTests: XCTestCase {
 
         XCTAssertEqual(result.text, "Set the value to 23")
         XCTAssertEqual(result.segments.first?.text, "23")
+    }
+
+    func testMinimumValueDefaultsAndInvalidSettings() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        XCTAssertEqual(TranscriptionNormalizationService.numberNormalizationMinimumValue(defaults: defaults), 10)
+        for value in [0, 10, 100] {
+            defaults.set(value, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+            XCTAssertEqual(TranscriptionNormalizationService.numberNormalizationMinimumValue(defaults: defaults), value)
+        }
+        for value in [-1, 3, 999] {
+            defaults.set(value, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+            XCTAssertEqual(TranscriptionNormalizationService.numberNormalizationMinimumValue(defaults: defaults), 10)
+        }
+    }
+
+    func testAlwaysRestoresSmallNumberNormalization() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(0, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        XCTAssertEqual(TranscriptionNormalizationService.normalizeText("one of my clients", language: "en", defaults: defaults), "1 of my clients")
+    }
+
+    func testWorkflowOverrideOnUsesGlobalThresholdEvenWhenGlobalNormalizationIsOff() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(false, forKey: UserDefaultsKeys.transcriptionNumberNormalizationEnabled)
+        defaults.set(100, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let text = "three, ten, one hundred"
+        XCTAssertEqual(TranscriptionNormalizationService.normalizeText(text, language: "en", defaults: defaults), text)
+        XCTAssertEqual(TranscriptionNormalizationService.normalizeText(text, language: "en", normalizeNumbers: true, defaults: defaults), "three, ten, 100")
+    }
+
+    func testThresholdAppliesConsistentlyToTextAndSegments() {
+        let defaults = UserDefaults(suiteName: #function)!
+        defaults.removePersistentDomain(forName: #function)
+        defaults.set(100, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        defer { defaults.removePersistentDomain(forName: #function) }
+
+        let result = TranscriptionNormalizationService.normalizeResult(
+            text: "Three, twenty-three, one hundred",
+            detectedLanguage: "en",
+            configuredLanguage: "en",
+            duration: 3,
+            processingTime: 0.1,
+            engineUsed: "test",
+            segments: [
+                TranscriptionSegment(text: "Three, twenty-three", start: 0, end: 1),
+                TranscriptionSegment(text: "one hundred", start: 1, end: 3)
+            ],
+            task: .transcribe,
+            defaults: defaults
+        )
+
+        XCTAssertEqual(result.text, "Three, twenty-three, 100")
+        XCTAssertEqual(result.segments.map(\.text), ["Three, twenty-three", "100"])
+        XCTAssertEqual(result.segments.map(\.start), [0, 1])
+        XCTAssertEqual(result.segments.map(\.end), [1, 3])
     }
 }

--- a/TypeWhisperTests/TypeWhisperIntegrationTests.swift
+++ b/TypeWhisperTests/TypeWhisperIntegrationTests.swift
@@ -162,11 +162,14 @@ final class SecureInputDiagnosticsProviderTests: XCTestCase {
 
 final class TypeWhisperIntegrationTests: XCTestCase {
     private var originalCancellationBehavior: Any?
+    private var originalNumberNormalizationMinimumValue: Any?
 
     override func setUp() {
         super.setUp()
         originalCancellationBehavior = UserDefaults.standard.object(forKey: UserDefaultsKeys.cancellationBehavior)
         UserDefaults.standard.set(CancellationBehavior.doubleEscape.rawValue, forKey: UserDefaultsKeys.cancellationBehavior)
+        originalNumberNormalizationMinimumValue = UserDefaults.standard.object(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        UserDefaults.standard.set(10, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
     }
 
     override func tearDown() {
@@ -174,6 +177,11 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             UserDefaults.standard.set(originalCancellationBehavior, forKey: UserDefaultsKeys.cancellationBehavior)
         } else {
             UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.cancellationBehavior)
+        }
+        if let originalNumberNormalizationMinimumValue {
+            UserDefaults.standard.set(originalNumberNormalizationMinimumValue, forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
+        } else {
+            UserDefaults.standard.removeObject(forKey: UserDefaultsKeys.transcriptionNumberNormalizationMinimumValue)
         }
         super.tearDown()
     }
@@ -2457,7 +2465,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
         XCTAssertEqual(MockTranscriptionPlugin.lastPrompt, "TypeWhisper, WhisperKit")
     }
 
-    func testTranscribeEndpointNormalizesNumbersByDefault() async throws {
+    func testTranscribeEndpointUsesDefaultNumberThreshold() async throws {
         let appSupportDirectory = try TestSupport.makeTemporaryDirectory()
         var context: APIContext?
         defer {
@@ -2467,7 +2475,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
-        MockTranscriptionPlugin.setResponseText("two")
+        MockTranscriptionPlugin.setResponseText("two, ten, one hundred")
         context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
@@ -2485,7 +2493,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             )
         ))
 
-        XCTAssertEqual(response["text"] as? String, "2")
+        XCTAssertEqual(response["text"] as? String, "two, 10, 100")
     }
 
     func testTranscribeEndpointNormalizeNumbersFalsePreservesRawText() async throws {
@@ -2498,7 +2506,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
 
         MockTranscriptionPlugin.reset()
         defer { MockTranscriptionPlugin.reset() }
-        MockTranscriptionPlugin.setResponseText("two")
+        MockTranscriptionPlugin.setResponseText("two, ten, one hundred")
         context = await MainActor.run {
             Self.makeAPIContext(appSupportDirectory: appSupportDirectory, withMockTranscriptionPlugin: true)
         }
@@ -2520,7 +2528,7 @@ final class TypeWhisperIntegrationTests: XCTestCase {
             )
         ))
 
-        XCTAssertEqual(response["text"] as? String, "two")
+        XCTAssertEqual(response["text"] as? String, "two, ten, one hundred")
     }
 
     func testTranscribeEndpointAppliesDictionaryCorrectionsByDefault() async throws {

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,0 +1,3 @@
+# Unreleased
+
+- Number formatting now offers Always, 10 and above (the default), and 100 and above under Settings → Dictation → Output Formatting. Smaller spoken whole numbers and ordinals keep their original wording. Negative numbers use their magnitude; decimals and recognized digit sequences still convert to digits. The threshold also applies when a workflow enables number normalization. Existing digits are unchanged. (#1304)

--- a/docs/release-notes/unreleased.md
+++ b/docs/release-notes/unreleased.md
@@ -1,3 +1,3 @@
 # Unreleased
 
-- Number formatting now offers Always, 10 and above (the default), and 100 and above under Settings → Dictation → Output Formatting. Smaller spoken whole numbers and ordinals keep their original wording. Negative numbers use their magnitude; decimals and recognized digit sequences still convert to digits. The threshold also applies when a workflow enables number normalization. Existing digits are unchanged. (#1304)
+- Number formatting now offers Always, 10 and above (the default), and 100 and above under Settings → Dictation → Output Formatting. Smaller spoken whole numbers and ordinals keep their original wording. Negative numbers use their magnitude; decimals and recognized digit sequences still convert to digits. The threshold also applies when a workflow enables number normalization. Settings backups preserve both the number-normalization toggle and threshold. Existing digits are unchanged. (#1304)


### PR DESCRIPTION
## Summary

Closes #1304.

Number normalization previously changed small spoken numbers in ordinary prose, such as "one of my clients", into digits. Add an **Always / 10 and above / 100 and above** picker under Settings → Dictation → Output Formatting, defaulting to **10 and above**. With that default, "one of my clients" stays unchanged while "four hundred ninety seven" becomes `497`.

The threshold is applied to each complete parsed whole-number or ordinal expression, using magnitude for negative numbers. Decimals and recognized digit sequences remain normalized, including leading zeros in PINs. Existing digits are unchanged. Text and timestamped segments share the global threshold, including when a workflow enables normalization. Settings export/import preserves both the normalization toggle and threshold through optional, backward-compatible backup fields. Includes translated settings strings and an unreleased note.

## Test plan

- [x] 352 targeted app tests passed (42 number-parser, 10 normalization-service, 23 punctuation/pipeline, 255 integration, and 22 settings-backup tests):

```sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -skipPackagePluginValidation -project TypeWhisper.xcodeproj -scheme TypeWhisper -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/typewhisper-1304-tests -parallel-testing-enabled NO -only-testing:TypeWhisperTests/NumberWordNormalizerTests -only-testing:TypeWhisperTests/TranscriptionNormalizationServiceTests -only-testing:TypeWhisperTests/SpeechPunctuationServiceTests -only-testing:TypeWhisperTests/TypeWhisperIntegrationTests -only-testing:TypeWhisperTests/SettingsBackupExporterTests CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO > /tmp/typewhisper-1307-merge-tests.log 2>&1
bash scripts/check_first_party_warnings.sh /tmp/typewhisper-1307-merge-tests.log
git diff --check origin/main...HEAD
```

- [x] API tests cover the new default threshold and the explicit normalization-off override. Pipeline and integration suites save and restore the threshold preference so local settings do not affect their expectations.
- [x] Backup tests verify all three thresholds and both toggle states through JSON export/import; absent and invalid thresholds preserve destination preferences.
- [x] No first-party build warnings. New settings strings have German, Japanese, and Simplified Chinese translations.
- [x] Marco manually verified all three options in the signed development app and confirmed they work. Suggested dictation: "Ich habe drei Kunden, zehn Termine und einhundert Rechnungen." Expected numeric forms: Always → 3 / 10 / 100; 10 and above → drei / 10 / 100; 100 and above → drei / zehn / 100.
- [ ] Repository-wide `python3 scripts/check_localization_completeness.py` reports 60 existing missing Simplified Chinese strings in AuthenticatedCLIPlugin and MetaPlugin. Both catalogs are unchanged from `main`; the main-app catalog passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable number normalization thresholds: Always, 10+, or 100+.
  * Small spoken numbers can remain in words while larger values convert to digits.
  * Supports decimals, ordinals, negatives, digit sequences, and multiple languages.
  * Added German, Japanese, and Simplified Chinese translations for related settings.
  * Number normalization preferences are included in settings backups and restores.

* **Bug Fixes**
  * Improved consistency when applying number formatting across transcriptions and workflows.

* **Documentation**
  * Documented the new number formatting threshold options and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
